### PR TITLE
Add initial prompt docs

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -1,0 +1,10 @@
+<!-- spellchecker: disable -->
+# Prompt Docs Summary
+
+This index lists prompt documents for the jobbot3000 repository.
+
+## jobbot3000
+
+| Path | Prompt | Type | One-click? |
+|------|--------|------|------------|
+| [docs/prompts/codex/automation.md](prompts/codex/automation.md) | [Codex Automation Prompt](prompts/codex/automation.md#codex-automation-prompt) | evergreen | yes |

--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -1,0 +1,37 @@
+---
+title: 'Jobbot3000 Codex Prompt'
+slug: 'codex-automation'
+---
+
+# Codex Automation Prompt
+Type: evergreen
+
+This document stores the baseline prompt for automated contributors to the jobbot3000 repository. Keeping it in version control lets us refine instructions and track what works best.
+
+```
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+ASSISTANT: (DEV) Implement code; stop after producing patch.
+ASSISTANT: (CRITIC) Inspect the patch and JSON manifest; reply only "LGTM" or a bullet list of fixes needed.
+
+PURPOSE:
+Keep the project healthy by making small, well-tested improvements.
+
+CONTEXT:
+- Follow repository conventions in README.md.
+- Run `npm run lint` and `npm run test:ci` before committing.
+
+REQUEST:
+1. Identify a straightforward improvement or bug fix.
+2. Implement the change using existing project style.
+3. Update documentation when needed.
+4. Run the commands above.
+
+ACCEPTANCE_CHECK:
+{"patch":"<unified diff>", "summary":"<80-char msg>", "tests_pass":true}
+
+OUTPUT_FORMAT:
+The DEV assistant must output the JSON object first, then the diff in a fenced diff block.
+```
+
+Copy this prompt when instructing an automated coding agent to work on jobbot3000.


### PR DESCRIPTION
## Summary
- add codex automation prompt for jobbot3000
- index prompt docs

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68ba84dcc0e0832fb32f155d82ffa703