### PR TITLE
📝 docs: add codex task prompts

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -8,3 +8,8 @@ This index lists prompt documents for the jobbot3000 repository.
 | Path | Prompt | Type | One-click? |
 |------|--------|------|------------|
 | [docs/prompts/codex/automation.md](prompts/codex/automation.md) | [Codex Automation Prompt](prompts/codex/automation.md#codex-automation-prompt) | evergreen | yes |
+| [docs/prompts/codex/chore.md](prompts/codex/chore.md) | [Codex Chore Prompt](prompts/codex/chore.md#codex-chore-prompt) | evergreen | yes |
+| [docs/prompts/codex/docs.md](prompts/codex/docs.md) | [Codex Docs Prompt](prompts/codex/docs.md#codex-docs-prompt) | evergreen | yes |
+| [docs/prompts/codex/feature.md](prompts/codex/feature.md) | [Codex Feature Prompt](prompts/codex/feature.md#codex-feature-prompt) | evergreen | yes |
+| [docs/prompts/codex/fix.md](prompts/codex/fix.md) | [Codex Fix Prompt](prompts/codex/fix.md#codex-fix-prompt) | evergreen | yes |
+| [docs/prompts/codex/refactor.md](prompts/codex/refactor.md) | [Codex Refactor Prompt](prompts/codex/refactor.md#codex-refactor-prompt) | evergreen | yes |

--- a/docs/prompts/codex/chore.md
+++ b/docs/prompts/codex/chore.md
@@ -1,0 +1,30 @@
+---
+title: 'Codex Chore Prompt'
+slug: 'codex-chore'
+---
+
+# Codex Chore Prompt
+Use this prompt for dependency bumps or other routine upkeep in jobbot3000.
+
+```
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Perform maintenance tasks such as dependency updates or configuration cleanup.
+
+CONTEXT:
+- Follow repository conventions in README.md.
+- Run `npm run lint` and `npm run test:ci` before committing.
+
+REQUEST:
+1. Make a minimal maintenance change.
+2. Update documentation if necessary.
+3. Run the commands above.
+4. Commit changes and open a pull request.
+
+OUTPUT:
+A pull request URL describing the chore and confirming passing checks.
+```
+
+Copy this block whenever performing maintenance on jobbot3000.

--- a/docs/prompts/codex/docs.md
+++ b/docs/prompts/codex/docs.md
@@ -1,0 +1,31 @@
+---
+title: 'Codex Docs Prompt'
+slug: 'codex-docs'
+---
+
+# Codex Docs Prompt
+Use this prompt to improve jobbot3000 documentation.
+
+```
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+GOAL:
+Enhance documentation accuracy, links, or readability.
+
+CONTEXT:
+- Follow repository conventions in README.md.
+- Run `npm run lint` and `npm run test:ci` before committing.
+
+REQUEST:
+1. Identify outdated, unclear, or missing docs.
+2. Apply minimal edits with correct style.
+3. Update cross references or links as needed.
+4. Run the commands above.
+5. Commit changes and open a pull request.
+
+OUTPUT:
+A pull request URL summarizing documentation improvements.
+```
+
+Copy this block whenever updating jobbot3000 docs.

--- a/docs/prompts/codex/feature.md
+++ b/docs/prompts/codex/feature.md
@@ -1,0 +1,31 @@
+---
+title: 'Codex Feature Prompt'
+slug: 'codex-feature'
+---
+
+# Codex Feature Prompt
+Use this prompt when adding a small feature to jobbot3000.
+
+```
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+GOAL:
+Implement a minimal feature in jobbot3000.
+
+CONTEXT:
+- Follow repository conventions in README.md.
+- Run `npm run lint` and `npm run test:ci` before committing.
+
+REQUEST:
+1. Write a failing test that captures the new behavior.
+2. Implement the feature with minimal changes.
+3. Update any relevant docs or prompts.
+4. Run the commands above.
+5. Commit changes and open a pull request.
+
+OUTPUT:
+A pull request URL summarizing the feature addition.
+```
+
+Copy this block whenever implementing a feature in jobbot3000.

--- a/docs/prompts/codex/fix.md
+++ b/docs/prompts/codex/fix.md
@@ -1,0 +1,31 @@
+---
+title: 'Codex Fix Prompt'
+slug: 'codex-fix'
+---
+
+# Codex Fix Prompt
+Use this prompt to reproduce and fix bugs in jobbot3000.
+
+```
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+GOAL:
+Diagnose and resolve a bug in jobbot3000.
+
+CONTEXT:
+- Follow repository conventions in README.md.
+- Run `npm run lint` and `npm run test:ci` before committing.
+
+REQUEST:
+1. Reproduce the bug with a failing test or script.
+2. Apply the smallest fix that resolves the issue.
+3. Update docs or prompts if needed.
+4. Run the commands above.
+5. Commit changes and open a pull request.
+
+OUTPUT:
+A pull request URL summarizing the fix.
+```
+
+Copy this block whenever fixing a bug in jobbot3000.

--- a/docs/prompts/codex/refactor.md
+++ b/docs/prompts/codex/refactor.md
@@ -1,0 +1,31 @@
+---
+title: 'Codex Refactor Prompt'
+slug: 'codex-refactor'
+---
+
+# Codex Refactor Prompt
+Use this prompt to restructure code in jobbot3000 without changing behavior.
+
+```
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+GOAL:
+Improve code clarity without altering behavior.
+
+CONTEXT:
+- Follow repository conventions in README.md.
+- Run `npm run lint` and `npm run test:ci` before committing.
+
+REQUEST:
+1. Identify code that can be simplified.
+2. Refactor while preserving functionality.
+3. Adjust tests if refactor requires it.
+4. Run the commands above.
+5. Commit changes and open a pull request.
+
+OUTPUT:
+A pull request URL summarizing the refactor.
+```
+
+Copy this block whenever refactoring jobbot3000.


### PR DESCRIPTION
## Summary
- add codex templates for feature, fix, refactor, docs, and chore tasks
- expand prompt-docs summary to index new prompts

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68ba875d3704832facf8c07cb2eec84f