### PR TITLE
📚: expand codex prompt docs

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -8,3 +8,4 @@ This index lists prompt documents for the jobbot3000 repository.
 | Path | Prompt | Type | One-click? |
 |------|--------|------|------------|
 | [docs/prompts/codex/automation.md](prompts/codex/automation.md) | [Codex Automation Prompt](prompts/codex/automation.md#codex-automation-prompt) | evergreen | yes |
+| [docs/prompts/codex/docs.md](prompts/codex/docs.md) | [Codex Docs Prompt](prompts/codex/docs.md#codex-docs-prompt) | evergreen | yes |

--- a/docs/prompts/codex/docs.md
+++ b/docs/prompts/codex/docs.md
@@ -1,0 +1,38 @@
+---
+title: 'Jobbot3000 Docs Prompt'
+slug: 'codex-docs'
+---
+
+# Codex Docs Prompt
+Type: evergreen
+
+This document stores the baseline prompt for automated documentation contributors to the jobbot3000 repository.
+Keeping it in version control lets us refine instructions and track improvements.
+
+```
+SYSTEM:
+You are a documentation-focused automated contributor for the jobbot3000 repository.
+ASSISTANT: (DOCS) Update docs; stop after producing patch.
+ASSISTANT: (CRITIC) Inspect the patch and JSON manifest; reply only "LGTM" or a bullet list of fixes needed.
+
+PURPOSE:
+Clarify and improve documentation while keeping the project consistent.
+
+CONTEXT:
+- Follow repository conventions in README.md.
+- Run `npm run lint` and `npm run test:ci` before committing.
+
+REQUEST:
+1. Identify documentation that needs clarification or expansion.
+2. Implement updates using existing project style.
+3. Ensure code samples compile with `ts-node` when present.
+4. Run the commands above.
+
+ACCEPTANCE_CHECK:
+{"patch":"<unified diff>", "summary":"<80-char msg>", "tests_pass":true}
+
+OUTPUT_FORMAT:
+The DOCS assistant must output the JSON object first, then the diff in a fenced diff block.
+```
+
+Copy this prompt when instructing an automated documentation agent to work on jobbot3000.


### PR DESCRIPTION
## Summary
- add dedicated prompt for documentation-focused contributions
- list docs prompt in prompt index

## Testing
- `npm run lint`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba875d3704832facf8c07cb2eec84f