### PR TITLE
🧹 chore: bump remove-markdown to 0.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "html-to-text": "9.0.5",
         "node-fetch": "^3.3.2",
         "pdf-parse": "^1.1.1",
-        "remove-markdown": "^0.5.0"
+        "remove-markdown": "^0.6.2"
       },
       "bin": {
         "jobbot": "bin/jobbot.js"
@@ -2586,9 +2586,10 @@
       "license": "MIT"
     },
     "node_modules/remove-markdown": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.5.5.tgz",
-      "integrity": "sha512-lMR8tOtDqazFT6W2bZidoXwkptMdF3pCxpri0AEokHg0sZlC2GdoLqnoaxsEj1o7/BtXV1MKtT3YviA1t7rW7g=="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/remove-markdown/-/remove-markdown-0.6.2.tgz",
+      "integrity": "sha512-EijDXJZbzpGbQBd852ViUzcqgpMujthM+SAEHiWCMcZonRbZ+xViWKLJA/vrwbDwYdxrs1aFDjpBhcGrZoJRGA==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "html-to-text": "9.0.5",
     "node-fetch": "^3.3.2",
     "pdf-parse": "^1.1.1",
-    "remove-markdown": "^0.5.0"
+    "remove-markdown": "^0.6.2"
   },
   "devDependencies": {
     "eslint": "^8.57.0",


### PR DESCRIPTION
what: bump remove-markdown to 0.6.2
why: pick up latest fixes
how: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68bbda004b38832faf78ceea15087f6c