### PR TITLE
refactor scoring tokenization

### DIFF
--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,25 +1,31 @@
 function tokenize(text) {
-  return (text || '')
-    .toLowerCase()
-    .replace(/[^a-z0-9\s]/g, ' ')
-    .split(/\s+/)
-    .filter(Boolean);
-}
-
-function toSet(tokens) {
-  return new Set(tokens);
+  return new Set(
+    (text || '')
+      .toLowerCase()
+      .replace(/[^a-z0-9\s]/g, ' ')
+      .split(/\s+/)
+      .filter(Boolean)
+  );
 }
 
 export function computeFitScore(resumeText, requirements) {
   const requirementBullets = Array.isArray(requirements) ? requirements : [];
-  if (requirementBullets.length === 0) return { score: 0, matched: [], missing: [] };
+  if (requirementBullets.length === 0) {
+    return { score: 0, matched: [], missing: [] };
+  }
 
-  const resumeTokens = toSet(tokenize(resumeText));
+  const resumeTokens = tokenize(resumeText);
   const matchedBullets = [];
   const missingBullets = [];
   for (const bullet of requirementBullets) {
-    const tokens = new Set(tokenize(bullet));
-    const hasOverlap = Array.from(tokens).some(t => resumeTokens.has(t));
+    const tokens = tokenize(bullet);
+    let hasOverlap = false;
+    for (const t of tokens) {
+      if (resumeTokens.has(t)) {
+        hasOverlap = true;
+        break;
+      }
+    }
     if (hasOverlap) matchedBullets.push(bullet);
     else missingBullets.push(bullet);
   }


### PR DESCRIPTION
## Summary
- streamline tokenization by returning sets directly
- simplify overlap detection in computeFitScore

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68bbda0eb0d0832f879b4b02f13c821f