### PR TITLE
🧹 : – simplify parser and scoring loops

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -15,6 +15,14 @@ const REQUIREMENTS_HEADERS = [
   /\bWhat you(?:'|’)ll need\b/i
 ];
 
+function matchLine(line, patterns) {
+  for (const pattern of patterns) {
+    const m = line.match(pattern);
+    if (m) return m[1].trim();
+  }
+  return '';
+}
+
 export function parseJobText(rawText) {
   if (!rawText) {
     return { title: '', company: '', requirements: [], body: '' };
@@ -25,14 +33,9 @@ export function parseJobText(rawText) {
   let title = '';
   let company = '';
   for (const line of lines) {
-    for (const pattern of TITLE_PATTERNS) {
-      const m = line.match(pattern);
-      if (m) { title = m[1].trim(); break; }
-    }
-    for (const pattern of COMPANY_PATTERNS) {
-      const m = line.match(pattern);
-      if (m) { company = m[1].trim(); break; }
-    }
+    if (!title) title = matchLine(line, TITLE_PATTERNS);
+    if (!company) company = matchLine(line, COMPANY_PATTERNS);
+    if (title && company) break;
   }
 
   // Extract requirements bullets after a known header

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -6,20 +6,16 @@ function tokenize(text) {
     .filter(Boolean);
 }
 
-function toSet(tokens) {
-  return new Set(tokens);
-}
-
 export function computeFitScore(resumeText, requirements) {
   const requirementBullets = Array.isArray(requirements) ? requirements : [];
   if (requirementBullets.length === 0) return { score: 0, matched: [], missing: [] };
 
-  const resumeTokens = toSet(tokenize(resumeText));
+  const resumeTokens = new Set(tokenize(resumeText));
   const matchedBullets = [];
   const missingBullets = [];
   for (const bullet of requirementBullets) {
-    const tokens = new Set(tokenize(bullet));
-    const hasOverlap = Array.from(tokens).some(t => resumeTokens.has(t));
+    const tokens = tokenize(bullet);
+    const hasOverlap = tokens.some(t => resumeTokens.has(t));
     if (hasOverlap) matchedBullets.push(bullet);
     else missingBullets.push(bullet);
   }


### PR DESCRIPTION
what: deduplicate pattern matching and remove redundant Set usage
why: improve readability and reduce unnecessary allocations
how to test: npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bbda0eb0d0832f879b4b02f13c821f