### PR TITLE
♻️ Simplify token handling in computeFitScore

### DIFF
--- a/src/scoring.js
+++ b/src/scoring.js
@@ -6,20 +6,15 @@ function tokenize(text) {
     .filter(Boolean);
 }
 
-function toSet(tokens) {
-  return new Set(tokens);
-}
-
 export function computeFitScore(resumeText, requirements) {
   const requirementBullets = Array.isArray(requirements) ? requirements : [];
   if (requirementBullets.length === 0) return { score: 0, matched: [], missing: [] };
 
-  const resumeTokens = toSet(tokenize(resumeText));
+  const resumeTokens = new Set(tokenize(resumeText));
   const matchedBullets = [];
   const missingBullets = [];
   for (const bullet of requirementBullets) {
-    const tokens = new Set(tokenize(bullet));
-    const hasOverlap = Array.from(tokens).some(t => resumeTokens.has(t));
+    const hasOverlap = tokenize(bullet).some(t => resumeTokens.has(t));
     if (hasOverlap) matchedBullets.push(bullet);
     else missingBullets.push(bullet);
   }


### PR DESCRIPTION
what: inline Set creation and streamline overlap check
why: reduce indirection, clarify scoring logic
how to test:
- npm run lint
- npm run test:ci

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68bbda0eb0d0832f879b4b02f13c821f