### PR TITLE
✨: allow summarizing multiple sentences

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ npm run test:ci
 
 # Summarize a job description
 echo "First sentence. Second sentence." | npm run summarize
+
+# In code, pass the number of sentences to keep
+# summarize(text, 2) returns the first two sentences
 ```
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-export function summarize(text) {
+export function summarize(text, count = 1) {
   if (!text) return '';
-  const firstSentence = text.split(/(?<=\.)\s|\n/)[0];
-  return firstSentence.trim();
+  const sentences = text.split(/(?<=\.)\s|\n/).slice(0, count);
+  return sentences.join(' ').trim();
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,4 +6,9 @@ describe('summarize', () => {
     const text = 'First sentence. Second sentence.';
     expect(summarize(text)).toBe('First sentence.');
   });
+
+  it('returns the first N sentences when count provided', () => {
+    const text = 'First. Second. Third.';
+    expect(summarize(text, 2)).toBe('First. Second.');
+  });
 });


### PR DESCRIPTION
what: add optional count to summarize to return multiple sentences
why: let callers capture more context
how to test: npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bbda05a5c4832f93a5c1ab73dc8f06