### PR TITLE
✨ : parse job location

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ npm run lint
 npm run test:ci
 
 # Summarize a job description
-echo "First sentence. Second sentence." | npm run summarize
+echo -e "Title: Engineer\nCompany: ACME\nLocation: Remote\nFirst sentence. Second sentence." | \
+  npm run summarize
 ```
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.

--- a/src/exporters.js
+++ b/src/exporters.js
@@ -2,10 +2,11 @@ export function toJson(data) {
   return JSON.stringify(data, null, 2);
 }
 
-export function toMarkdownSummary({ title, company, requirements, summary }) {
+export function toMarkdownSummary({ title, company, location, requirements, summary }) {
   const lines = [];
   if (title) lines.push(`# ${title}`);
   if (company) lines.push(`**Company**: ${company}`);
+  if (location) lines.push(`**Location**: ${location}`);
   if (summary) lines.push(`\n${summary}\n`);
   if (requirements && requirements.length) {
     lines.push('## Requirements');
@@ -14,10 +15,11 @@ export function toMarkdownSummary({ title, company, requirements, summary }) {
   return lines.join('\n');
 }
 
-export function toMarkdownMatch({ title, company, score, matched, missing }) {
+export function toMarkdownMatch({ title, company, location, score, matched, missing }) {
   const lines = [];
   if (title) lines.push(`# ${title}`);
   if (company) lines.push(`**Company**: ${company}`);
+  if (location) lines.push(`**Location**: ${location}`);
   if (typeof score === 'number') lines.push(`**Fit Score**: ${score}%`);
   if (matched && matched.length) {
     lines.push('\n## Matched');

--- a/src/parser.js
+++ b/src/parser.js
@@ -9,6 +9,11 @@ const COMPANY_PATTERNS = [
   /\bEmployer\s*:\s*(.+)/i
 ];
 
+const LOCATION_PATTERNS = [
+  /\bLocation\s*:\s*(.+)/i,
+  /\bJob Location\s*:\s*(.+)/i
+];
+
 const REQUIREMENTS_HEADERS = [
   /\bRequirements\b/i,
   /\bQualifications\b/i,
@@ -17,13 +22,14 @@ const REQUIREMENTS_HEADERS = [
 
 export function parseJobText(rawText) {
   if (!rawText) {
-    return { title: '', company: '', requirements: [], body: '' };
+    return { title: '', company: '', location: '', requirements: [], body: '' };
   }
   const text = rawText.replace(/\r/g, '').trim();
   const lines = text.split(/\n+/);
 
   let title = '';
   let company = '';
+  let location = '';
   for (const line of lines) {
     for (const pattern of TITLE_PATTERNS) {
       const m = line.match(pattern);
@@ -32,6 +38,10 @@ export function parseJobText(rawText) {
     for (const pattern of COMPANY_PATTERNS) {
       const m = line.match(pattern);
       if (m) { company = m[1].trim(); break; }
+    }
+    for (const pattern of LOCATION_PATTERNS) {
+      const m = line.match(pattern);
+      if (m) { location = m[1].trim(); break; }
     }
   }
 
@@ -48,7 +58,7 @@ export function parseJobText(rawText) {
     }
   }
 
-  return { title, company, requirements, body: text };
+  return { title, company, location, requirements, body: text };
 }
 
 

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { parseJobText } from '../src/parser.js';
+
+describe('parseJobText', () => {
+  it('extracts location from job text', () => {
+    const text = 'Title: Engineer\nCompany: ACME Corp\nLocation: Remote\n';
+    const parsed = parseJobText(text);
+    expect(parsed.location).toBe('Remote');
+  });
+});


### PR DESCRIPTION
what: extract location from job descriptions and expose in CLI exports
why: include location context in summaries and matches
how to test: npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bbda05a5c4832f93a5c1ab73dc8f06