### PR TITLE
🐛: handle ! and ? in summarizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ npm run test:ci
 echo "First sentence. Second sentence." | npm run summarize
 ```
 
+The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation.
+
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 
 For security guidelines, read [SECURITY.md](SECURITY.md).

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 export function summarize(text) {
   if (!text) return '';
-  const firstSentence = text.split(/(?<=\.)\s|\n/)[0];
+  const firstSentence = text.split(/(?<=[.!?])\s|\n/)[0];
   return firstSentence.trim();
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,4 +6,9 @@ describe('summarize', () => {
     const text = 'First sentence. Second sentence.';
     expect(summarize(text)).toBe('First sentence.');
   });
+
+  it('handles exclamation and question marks', () => {
+    const text = 'First sentence! Second sentence? Third sentence.';
+    expect(summarize(text)).toBe('First sentence!');
+  });
 });


### PR DESCRIPTION
## What
- extend summarize delimiter regex to support '!' and '?'
- document punctuation coverage in README

## Why
- first sentences ending with '!' or '?' returned entire text

## How to test
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68bbda0951e8832f9cb0aac5baf3b917