### PR TITLE
📝 : add cspell dictionary and fix docs typos

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,27 @@
+{
+  "version": "0.2",
+  "words": [
+    "Ashby",
+    "CAPD",
+    "Coqui",
+    "ESCO",
+    "FAISS",
+    "Ingestors",
+    "Jobbot",
+    "Ollama",
+    "Pandoc",
+    "Pydantic",
+    "Qwen",
+    "SHRM",
+    "Typst",
+    "changeme",
+    "futuroptimist",
+    "jobbot",
+    "moderncv",
+    "pgvector",
+    "polyrepo",
+    "sandboxing",
+    "shadcn",
+    "vllm"
+  ]
+}

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -118,7 +118,7 @@ Each ATS = a module returning a normalized `JobPosting`. Add basic backoff, ETag
 **Outputs**
 - Score (0–100), plus **explanation** array:
   - `must_haves_missed`: `["Kubernetes", "Terraform"]`
-  - `skills_hit`: `["SRE", "Postgres", "Oncall"]` with confidence bars
+   - `skills_hit`: `["SRE", "Postgres", "On-call"]` with confidence bars
   - `evidence`: snippets with sources (job text spans).
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```bash
 # Clone your fork
-git clone git@github.com:YOURNAME/jobbot3000.git
+git clone git@github.com:<YOUR_NAME>/jobbot3000.git
 cd jobbot3000
 
 # Install dependencies


### PR DESCRIPTION
## What
- add cspell dictionary for project terms
- fix placeholders in README and DESIGN

## Why
- keep markdown spell checks passing

## How to Test
- `npx cspell "$(git ls-files '*.md')"`
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68bbd9fd9ce8832faf68e77b3f64c613