### PR TITLE
✨ : support more sentence delimiters in summarize

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ npm run lint
 npm run test:ci
 
 # Summarize a job description
-echo "First sentence. Second sentence." | npm run summarize
+echo "First sentence? Second sentence." | npm run summarize
 ```
+
+Summaries stop after `.`, `?`, or `!`.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 export function summarize(text) {
   if (!text) return '';
-  const firstSentence = text.split(/(?<=\.)\s|\n/)[0];
+  const firstSentence = text.split(/(?<=[.!?])\s+|\n/)[0];
   return firstSentence.trim();
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,4 +6,9 @@ describe('summarize', () => {
     const text = 'First sentence. Second sentence.';
     expect(summarize(text)).toBe('First sentence.');
   });
+
+  it('supports "?" and "!" as sentence boundaries', () => {
+    expect(summarize('What? Next.')).toBe('What?');
+    expect(summarize('Wow! Next.')).toBe('Wow!');
+  });
 });


### PR DESCRIPTION
what: handle '?' and '!' in summarize; add tests and docs
why: summarizer only split on periods
how to test: npm run lint && npm run test:ci
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68bbd9f95b34832fb23d163284042ea5