### PR TITLE
🧹 : – update dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ It was bootstrapped from
 [futuroptimist/flywheel](https://github.com/futuroptimist/flywheel) and uses its
 practices for linting, testing, and documentation.
 
-Requires [Node.js](https://nodejs.org) 20.
-
 ## Getting Started
 
 Requires [Node.js](https://nodejs.org/) 20 or newer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,11 @@
         "jobbot": "bin/jobbot.js"
       },
       "devDependencies": {
-        "eslint": "^8.57.0",
-        "vitest": "^1.5.0"
+        "eslint": "^8.57.1",
+        "vitest": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "remove-markdown": "^0.6.2"
   },
   "devDependencies": {
-    "eslint": "^8.57.0",
-    "vitest": "^1.5.0"
+    "eslint": "^8.57.1",
+    "vitest": "^1.6.1"
   }
 }


### PR DESCRIPTION
## What
- bump eslint to ^8.57.1 and vitest to ^1.6.1
- drop redundant Node.js note in README

## Why
- keep tooling current
- streamline docs

## How to Test
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68bd0a0ceefc832f9964036579c62c63