### PR TITLE
🧹 chore: add license field and tidy README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ It was bootstrapped from
 [futuroptimist/flywheel](https://github.com/futuroptimist/flywheel) and uses its
 practices for linting, testing, and documentation.
 
-Requires [Node.js](https://nodejs.org) 20.
-
 ## Getting Started
 
 Requires [Node.js](https://nodejs.org/) 20 or newer.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "jobbot3000",
   "version": "0.1.0",
+  "license": "MIT",
   "type": "module",
   "bin": {
     "jobbot": "bin/jobbot.js"


### PR DESCRIPTION
what: add MIT license field to package.json and remove duplicate Node.js requirement
why: ensure package metadata is complete and docs concise
how to test: npm run lint && npm run test:ci

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bd0a0ceefc832f9964036579c62c63