### PR TITLE
🐛 fix: handle dash bullets in job parser

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -43,7 +43,9 @@ export function parseJobText(rawText) {
       const line = lines[i].trim();
       if (!line) continue;
       if (/^[A-Za-z].+:$/.test(line)) break; // next section header
-      const bullet = line.replace(/^[-*•\d.)(\s]+/, '').trim();
+      // Remove common bullet prefixes: hyphen, en dash, em dash, asterisk,
+      // bullet, numbers, or parentheses.
+      const bullet = line.replace(/^[-–—*•\d.)(\s]+/, '').trim();
       if (bullet) requirements.push(bullet);
     }
   }

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { parseJobText } from '../src/parser.js';
+
+describe('parseJobText', () => {
+  it('extracts requirements with dash bullets', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+Requirements:
+– Experience with Node.js
+— Familiarity with testing
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual([
+      'Experience with Node.js',
+      'Familiarity with testing'
+    ]);
+  });
+});


### PR DESCRIPTION
what: strip dash bullets when parsing requirements
why: job posts may use en/em dash bullets
how to test: npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bd09fd8d08832f82032f55d05ce760