### PR TITLE
Fix newline handling in summarizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ echo "First sentence? Second sentence." | npm run summarize
 # summarize(text, 2) returns the first two sentences
 ```
 
-The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation.
+The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation and ignores
+bare newlines.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,6 @@
  */
 export function summarize(text, count = 1) {
   if (!text) return '';
-  const sentences = text.split(/(?<=[.!?])\s+|\n/).slice(0, count);
-  return sentences.join(' ').trim();
+  const sentences = text.split(/(?<=[.!?])\s+/).slice(0, count);
+  return sentences.join(' ').replace(/\s+/g, ' ').trim();
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,4 +16,9 @@ describe('summarize', () => {
     const text = 'First. Second. Third.';
     expect(summarize(text, 2)).toBe('First. Second.');
   });
+
+  it('ignores bare newlines without punctuation', () => {
+    const text = 'First line\nSecond line.';
+    expect(summarize(text)).toBe('First line Second line.');
+  });
 });


### PR DESCRIPTION
What: ignore bare newlines when extracting sentences.
Why: avoid splitting sentences at plain line breaks.
How to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68bd09fd8d08832f82032f55d05ce760