### PR TITLE
🐛 : – normalize unicode dashes in job requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ echo "First sentence? Second sentence." | npm run summarize
 
 The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation.
 
+Job requirements may start with `-`, `*`, `•`, `–` (en dash), or `—` (em dash);
+these markers are stripped when parsing job text.
+
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -43,7 +43,11 @@ export function parseJobText(rawText) {
       const line = lines[i].trim();
       if (!line) continue;
       if (/^[A-Za-z].+:$/.test(line)) break; // next section header
-      const bullet = line.replace(/^[-*•\d.)(\s]+/, '').trim();
+      // Strip common bullet characters including hyphen, asterisk, bullet,
+      // en dash (\u2013), em dash (\u2014), digits, punctuation and whitespace
+      const bullet = line
+        .replace(/^[-*•\u2013\u2014\d.)(\s]+/, '')
+        .trim();
       if (bullet) requirements.push(bullet);
     }
   }

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { parseJobText } from '../src/parser.js';
+
+describe('parseJobText', () => {
+  it('strips en and em dash bullets', () => {
+    const raw = 'Title: Dev\nCompany: ACME\nRequirements\n– Node.js\n— React';
+    const { requirements } = parseJobText(raw);
+    expect(requirements).toEqual(['Node.js', 'React']);
+  });
+});


### PR DESCRIPTION
what: strip en/em dash bullet markers when parsing requirements
why: return clean bullet text
how to test: npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bd09fd8d08832f82032f55d05ce760