### PR TITLE
📝 fix prompt docs table formatting

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -7,10 +7,18 @@ This index lists prompt documents for the jobbot3000 repository.
 
 | Path | Prompt | Type | One-click? |
 |------|--------|------|------------|
-| [docs/prompts/codex/automation.md](prompts/codex/automation.md) | [Codex Automation Prompt](prompts/codex/automation.md#codex-automation-prompt) | evergreen | yes |
-| [docs/prompts/codex/spellcheck.md](prompts/codex/spellcheck.md) | [Codex Spellcheck Prompt](prompts/codex/spellcheck.md#codex-spellcheck-prompt) | evergreen | yes |
-| [docs/prompts/codex/chore.md](prompts/codex/chore.md) | [Codex Chore Prompt](prompts/codex/chore.md#codex-chore-prompt) | evergreen | yes |
-| [docs/prompts/codex/docs.md](prompts/codex/docs.md) | [Codex Docs Prompt](prompts/codex/docs.md#codex-docs-prompt) | evergreen | yes |
-| [docs/prompts/codex/feature.md](prompts/codex/feature.md) | [Codex Feature Prompt](prompts/codex/feature.md#codex-feature-prompt) | evergreen | yes |
-| [docs/prompts/codex/fix.md](prompts/codex/fix.md) | [Codex Fix Prompt](prompts/codex/fix.md#codex-fix-prompt) | evergreen | yes |
-| [docs/prompts/codex/refactor.md](prompts/codex/refactor.md) | [Codex Refactor Prompt](prompts/codex/refactor.md#codex-refactor-prompt) | evergreen | yes |
+| [docs/prompts/codex/automation.md][automation-doc] | Codex Automation Prompt | evergreen | yes |
+| [docs/prompts/codex/spellcheck.md][spellcheck-doc] | Codex Spellcheck Prompt | evergreen | yes |
+| [docs/prompts/codex/chore.md][chore-doc] | Codex Chore Prompt | evergreen | yes |
+| [docs/prompts/codex/docs.md][docs-doc] | Codex Docs Prompt | evergreen | yes |
+| [docs/prompts/codex/feature.md][feature-doc] | Codex Feature Prompt | evergreen | yes |
+| [docs/prompts/codex/fix.md][fix-doc] | Codex Fix Prompt | evergreen | yes |
+| [docs/prompts/codex/refactor.md][refactor-doc] | Codex Refactor Prompt | evergreen | yes |
+
+[automation-doc]: prompts/codex/automation.md
+[spellcheck-doc]: prompts/codex/spellcheck.md
+[chore-doc]: prompts/codex/chore.md
+[docs-doc]: prompts/codex/docs.md
+[feature-doc]: prompts/codex/feature.md
+[fix-doc]: prompts/codex/fix.md
+[refactor-doc]: prompts/codex/refactor.md


### PR DESCRIPTION
## What
- keep words intact in docs/prompt-docs-summary table

## Why
- prevent split words like "ever green" and "ye s"

## How to test
- `npx cspell $(git ls-files '*.md')`
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68bd09ec9550832fa49f77d1d007f5c7