### PR TITLE
✨ : – handle Windows line endings in summarize

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ echo "First sentence? Second sentence." | npm run summarize
 # summarize(text, 2) returns the first two sentences
 ```
 
-The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation.
+The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation, and it
+supports both Unix and Windows line endings.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,6 @@
  */
 export function summarize(text, count = 1) {
   if (!text) return '';
-  const sentences = text.split(/(?<=[.!?])\s+|\n/).slice(0, count);
+  const sentences = text.split(/(?<=[.!?])\s+|\r?\n|\r/).slice(0, count);
   return sentences.join(' ').trim();
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,4 +16,9 @@ describe('summarize', () => {
     const text = 'First. Second. Third.';
     expect(summarize(text, 2)).toBe('First. Second.');
   });
+
+  it('handles Windows newlines', () => {
+    const text = 'First sentence\r\nSecond sentence\r\nThird sentence';
+    expect(summarize(text, 2)).toBe('First sentence Second sentence');
+  });
 });


### PR DESCRIPTION
What: split text on \r?\n to drop carriage returns
Why: summarizer previously left \r in output on Windows files
How to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68bd09ccfdbc832f9bbe7453c2b0b78d