### PR TITLE
✨ : preserve ellipsis in summarize – avoid early split

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ echo "First sentence? Second sentence." | npm run summarize
 ```
 
 The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation.
+It preserves ellipses (`...`) within sentences.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,11 @@
  */
 export function summarize(text, count = 1) {
   if (!text) return '';
-  const sentences = text.split(/(?<=[.!?])\s+|\n/).slice(0, count);
-  return sentences.join(' ').trim();
+  const placeholder = '\u2026';
+  const safe = text.replace(/\.{3}/g, placeholder);
+  const sentences = safe.split(/(?<=[.!?])\s+|\n/).slice(0, count);
+  return sentences
+    .map((s) => s.replace(new RegExp(placeholder, 'g'), '...'))
+    .join(' ')
+    .trim();
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,4 +16,9 @@ describe('summarize', () => {
     const text = 'First. Second. Third.';
     expect(summarize(text, 2)).toBe('First. Second.');
   });
+
+  it('does not split within ellipsis', () => {
+    const text = 'Wait... still thinking. Another.';
+    expect(summarize(text)).toBe('Wait... still thinking.');
+  });
 });


### PR DESCRIPTION
what: keep ellipses inside sentences in summarize
why: summaries should not cut off thought trailing with ellipsis
how: run npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bd09ccfdbc832f9bbe7453c2b0b78d