### PR TITLE
✨: – preserve newline separators in summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ echo "First sentence? Second sentence." | npm run summarize
 # summarize(text, 2) returns the first two sentences
 ```
 
-The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation.
+The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation,
+and preserves any line breaks when returning multiple sentences.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,9 @@
  */
 export function summarize(text, count = 1) {
   if (!text) return '';
-  const sentences = text.split(/(?<=[.!?])\s+|\n/).slice(0, count);
-  return sentences.join(' ').trim();
+  const matches = text.match(/[^.!?]+[.!?](?:\s+)?/g);
+  if (matches) {
+    return matches.slice(0, count).join('').trim();
+  }
+  return text.trim();
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,4 +16,9 @@ describe('summarize', () => {
     const text = 'First. Second. Third.';
     expect(summarize(text, 2)).toBe('First. Second.');
   });
+
+  it('preserves newline separators between sentences', () => {
+    const text = 'First sentence.\nSecond sentence.';
+    expect(summarize(text, 2)).toBe('First sentence.\nSecond sentence.');
+  });
 });


### PR DESCRIPTION
## What
- preserve line breaks between sentences in summaries

## Why
- keep original formatting

## How to test
- npm run lint
- npm run test:ci

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bd09ccfdbc832f9bbe7453c2b0b78d