### PR TITLE
📝: expand codex prompts

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -8,17 +8,23 @@ This index lists prompt documents for the jobbot3000 repository.
 | Path | Prompt | Type | One-click? |
 |------|--------|------|------------|
 | [docs/prompts/codex/automation.md][automation-doc] | Codex Automation Prompt | evergreen | yes |
-| [docs/prompts/codex/spellcheck.md][spellcheck-doc] | Codex Spellcheck Prompt | evergreen | yes |
 | [docs/prompts/codex/chore.md][chore-doc] | Codex Chore Prompt | evergreen | yes |
 | [docs/prompts/codex/docs.md][docs-doc] | Codex Docs Prompt | evergreen | yes |
 | [docs/prompts/codex/feature.md][feature-doc] | Codex Feature Prompt | evergreen | yes |
 | [docs/prompts/codex/fix.md][fix-doc] | Codex Fix Prompt | evergreen | yes |
+| [docs/prompts/codex/performance.md][performance-doc] | Codex Performance Prompt | evergreen | yes |
 | [docs/prompts/codex/refactor.md][refactor-doc] | Codex Refactor Prompt | evergreen | yes |
+| [docs/prompts/codex/security.md][security-doc] | Codex Security Prompt | evergreen | yes |
+| [docs/prompts/codex/spellcheck.md][spellcheck-doc] | Codex Spellcheck Prompt | evergreen | yes |
+| [docs/prompts/codex/upgrade.md][upgrade-doc] | Codex Upgrade Prompt | evergreen | yes |
 
 [automation-doc]: prompts/codex/automation.md
-[spellcheck-doc]: prompts/codex/spellcheck.md
 [chore-doc]: prompts/codex/chore.md
 [docs-doc]: prompts/codex/docs.md
 [feature-doc]: prompts/codex/feature.md
 [fix-doc]: prompts/codex/fix.md
+[performance-doc]: prompts/codex/performance.md
 [refactor-doc]: prompts/codex/refactor.md
+[security-doc]: prompts/codex/security.md
+[spellcheck-doc]: prompts/codex/spellcheck.md
+[upgrade-doc]: prompts/codex/upgrade.md

--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -1,14 +1,12 @@
 ---
-title: 'Jobbot3000 Codex Prompt'
+title: 'Codex Automation Prompt'
 slug: 'codex-automation'
 ---
 
 # Codex Automation Prompt
-Type: evergreen
+Use this prompt to guide LLM-based contributors when working on jobbot3000.
 
-This document stores the baseline prompt for automated contributors to the jobbot3000 repository. Keeping it in version control lets us refine instructions and track what works best.
-
-```
+```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 ASSISTANT: (DEV) Implement code; stop after producing patch.
@@ -18,20 +16,19 @@ PURPOSE:
 Keep the project healthy by making small, well-tested improvements.
 
 CONTEXT:
-- Follow repository conventions in README.md.
+- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 
 REQUEST:
 1. Identify a straightforward improvement or bug fix.
 2. Implement the change using existing project style.
 3. Update documentation when needed.
-4. Run the commands above.
+4. Run the commands above and address any failures.
 
-ACCEPTANCE_CHECK:
-{"patch":"<unified diff>", "summary":"<80-char msg>", "tests_pass":true}
-
-OUTPUT_FORMAT:
-The DEV assistant must output the JSON object first, then the diff in a fenced diff block.
+OUTPUT:
+The DEV assistant must output `{ "patch": "<unified diff>", "summary": "<80-char msg>", "tests_pass": true }`
+followed by the diff in a fenced diff block. The CRITIC responds with "LGTM" or required fixes.
 ```
 
-Copy this prompt when instructing an automated coding agent to work on jobbot3000.
+Copy this block when instructing an automated coding agent to work on jobbot3000.

--- a/docs/prompts/codex/chore.md
+++ b/docs/prompts/codex/chore.md
@@ -4,27 +4,28 @@ slug: 'codex-chore'
 ---
 
 # Codex Chore Prompt
-Use this prompt for dependency bumps or other routine upkeep in jobbot3000.
+Use this prompt to handle maintenance tasks in jobbot3000.
 
-```
+```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Perform maintenance tasks such as dependency updates or configuration cleanup.
+Perform routine housekeeping such as dependency bumps or config tweaks.
 
 CONTEXT:
-- Follow repository conventions in README.md.
+- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 
 REQUEST:
-1. Make a minimal maintenance change.
-2. Update documentation if necessary.
-3. Run the commands above.
-4. Commit changes and open a pull request.
+1. Explain the maintenance change to perform.
+2. Apply the smallest viable update.
+3. Update documentation or scripts if required.
+4. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request URL describing the chore and confirming passing checks.
+A pull request URL summarizing the maintenance task.
 ```
 
-Copy this block whenever performing maintenance on jobbot3000.
+Copy this block whenever performing chores in jobbot3000.

--- a/docs/prompts/codex/docs.md
+++ b/docs/prompts/codex/docs.md
@@ -4,28 +4,28 @@ slug: 'codex-docs'
 ---
 
 # Codex Docs Prompt
-Use this prompt to improve jobbot3000 documentation.
+Use this prompt when clarifying or extending documentation in jobbot3000.
 
-```
+```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
-GOAL:
-Enhance documentation accuracy, links, or readability.
+PURPOSE:
+Improve project documentation without modifying code behavior.
 
 CONTEXT:
-- Follow repository conventions in README.md.
+- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 
 REQUEST:
-1. Identify outdated, unclear, or missing docs.
-2. Apply minimal edits with correct style.
-3. Update cross references or links as needed.
-4. Run the commands above.
-5. Commit changes and open a pull request.
+1. Identify the doc section to update.
+2. Revise text or examples for clarity.
+3. Ensure any code samples compile with `node` or `ts-node`.
+4. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request URL summarizing documentation improvements.
+A pull request URL summarizing the documentation update.
 ```
 
-Copy this block whenever updating jobbot3000 docs.
+Copy this block whenever updating docs in jobbot3000.

--- a/docs/prompts/codex/feature.md
+++ b/docs/prompts/codex/feature.md
@@ -6,23 +6,23 @@ slug: 'codex-feature'
 # Codex Feature Prompt
 Use this prompt when adding a small feature to jobbot3000.
 
-```
+```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
-GOAL:
+PURPOSE:
 Implement a minimal feature in jobbot3000.
 
 CONTEXT:
-- Follow repository conventions in README.md.
+- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 
 REQUEST:
-1. Write a failing test that captures the new behavior.
-2. Implement the feature with minimal changes.
-3. Update any relevant docs or prompts.
-4. Run the commands above.
-5. Commit changes and open a pull request.
+1. Write a failing test capturing the new behavior.
+2. Implement the smallest change to make the test pass.
+3. Update relevant docs or prompts.
+4. Run the commands above and fix any failures.
 
 OUTPUT:
 A pull request URL summarizing the feature addition.

--- a/docs/prompts/codex/fix.md
+++ b/docs/prompts/codex/fix.md
@@ -6,26 +6,26 @@ slug: 'codex-fix'
 # Codex Fix Prompt
 Use this prompt to reproduce and fix bugs in jobbot3000.
 
-```
+```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
-GOAL:
-Diagnose and resolve a bug in jobbot3000.
+PURPOSE:
+Diagnose and resolve bugs in jobbot3000.
 
 CONTEXT:
-- Follow repository conventions in README.md.
+- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 
 REQUEST:
 1. Reproduce the bug with a failing test or script.
 2. Apply the smallest fix that resolves the issue.
 3. Update docs or prompts if needed.
-4. Run the commands above.
-5. Commit changes and open a pull request.
+4. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request URL summarizing the fix.
+A pull request URL summarizing the bug fix.
 ```
 
-Copy this block whenever fixing a bug in jobbot3000.
+Copy this block whenever fixing bugs in jobbot3000.

--- a/docs/prompts/codex/performance.md
+++ b/docs/prompts/codex/performance.md
@@ -1,0 +1,32 @@
+---
+title: 'Codex Performance Prompt'
+slug: 'codex-performance'
+---
+
+# Codex Performance Prompt
+Use this prompt to improve runtime performance in jobbot3000.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Enhance performance without altering external behavior.
+
+CONTEXT:
+- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Include benchmarks if changes might affect speed.
+
+REQUEST:
+1. Write a failing benchmark or test showing the slowdown.
+2. Optimize the code while keeping functionality the same.
+3. Update docs or comments explaining the improvement.
+4. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request URL summarizing the performance improvement.
+```
+
+Copy this block whenever optimizing performance in jobbot3000.

--- a/docs/prompts/codex/refactor.md
+++ b/docs/prompts/codex/refactor.md
@@ -4,25 +4,26 @@ slug: 'codex-refactor'
 ---
 
 # Codex Refactor Prompt
-Use this prompt to restructure code in jobbot3000 without changing behavior.
+Use this prompt to improve internal structure without changing behavior.
 
-```
+```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
-GOAL:
-Improve code clarity without altering behavior.
+PURPOSE:
+Refactor code for clarity or maintainability.
 
 CONTEXT:
-- Follow repository conventions in README.md.
+- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Include before/after benchmarks if performance might change.
 
 REQUEST:
-1. Identify code that can be simplified.
-2. Refactor while preserving functionality.
-3. Adjust tests if refactor requires it.
-4. Run the commands above.
-5. Commit changes and open a pull request.
+1. Add tests or ensure existing tests cover the refactor.
+2. Restructure code without altering public behavior.
+3. Update related docs or comments.
+4. Run the commands above and address any failures.
 
 OUTPUT:
 A pull request URL summarizing the refactor.

--- a/docs/prompts/codex/security.md
+++ b/docs/prompts/codex/security.md
@@ -1,0 +1,32 @@
+---
+title: 'Codex Security Prompt'
+slug: 'codex-security'
+---
+
+# Codex Security Prompt
+Use this prompt to fix security vulnerabilities in jobbot3000.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Address security issues and harden the project.
+
+CONTEXT:
+- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+
+REQUEST:
+1. Reproduce the vulnerability or describe the weakness.
+2. Apply the minimal fix to mitigate the issue.
+3. Add or update tests covering the security case.
+4. Update docs or advisories if needed.
+5. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request URL summarizing the security fix.
+```
+
+Copy this block whenever addressing security in jobbot3000.

--- a/docs/prompts/codex/spellcheck.md
+++ b/docs/prompts/codex/spellcheck.md
@@ -4,32 +4,27 @@ slug: 'codex-spellcheck'
 ---
 
 # Codex Spellcheck Prompt
-Type: evergreen
-
-Use this prompt to find and fix spelling mistakes in Markdown docs before opening a pull request.
+Use this prompt to fix spelling mistakes in jobbot3000.
 
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Keep Markdown documentation free of spelling errors.
+Correct typos and enforce consistent spelling.
 
 CONTEXT:
-- Run `npx cspell "$(git ls-files '*.md')"` to check spelling.
+- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Follow repository conventions in `README.md`.
-- Run `git diff --cached | ./scripts/scan-secrets.py` before committing.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 
 REQUEST:
-1. Spell-check Markdown files using the command above.
-2. Correct spelling errors or update dictionaries as needed.
+1. Locate spelling errors in code or docs.
+2. Fix the typos without altering meaning.
+3. Run the commands above and resolve any failures.
 
-ACCEPTANCE_CHECK:
-{"patch":"<unified diff>", "summary":"<80-char msg>", "tests_pass":true}
-
-OUTPUT_FORMAT:
-Output the JSON object first, then the diff in a fenced diff block.
+OUTPUT:
+A pull request URL summarizing the spelling corrections.
 ```
 
-Copy this prompt when instructing an automated coding agent to spell-check jobbot3000.
+Copy this block whenever correcting spelling in jobbot3000.

--- a/docs/prompts/codex/upgrade.md
+++ b/docs/prompts/codex/upgrade.md
@@ -1,0 +1,30 @@
+---
+title: 'Codex Upgrade Prompt'
+slug: 'codex-upgrade'
+---
+
+# Codex Upgrade Prompt
+Use this prompt to refine jobbot3000's prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Improve or expand the repository's prompt docs.
+
+CONTEXT:
+- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+
+REQUEST:
+1. Select a file under `docs/prompts/` to update or create a new prompt type.
+2. Clarify context, refresh links, and ensure referenced files exist.
+3. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request that updates the selected prompt doc with passing checks.
+```
+
+Copy this block whenever upgrading prompts in jobbot3000.


### PR DESCRIPTION
## Summary
- refresh codex prompt docs with AGENTS spec context
- add performance, security, and upgrade prompt types
- index new prompts in prompt-docs-summary.md

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68bd1ab44d58832f9d50db065c004f9a