### PR TITLE
🔧: bump GitHub Action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
       - run: npm ci

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         language: ['javascript']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}

--- a/.github/workflows/pr-reaper.yml
+++ b/.github/workflows/pr-reaper.yml
@@ -9,7 +9,7 @@ jobs:
   close-stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: futuroptimist/pr-reaper@v1
         with:
           days-before-close: 30


### PR DESCRIPTION
## Summary
- use checkout@v4 and setup-node@v4 in CI workflow
- update other workflows to checkout@v4

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68be3f9d98a0832fa078323dcde00a6b