### PR TITLE
🩹: fix placeholder spelling

### DIFF
--- a/scripts/scan-secrets.py
+++ b/scripts/scan-secrets.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# cspell:ignore AKIA
 import re
 import sys
 
@@ -6,7 +7,7 @@ PLACEHOLDER_VALUES = {
     'changeme',
     '<password>',
     'example',
-    'yourpass',
+    'your-password',
     'jobbot',
     'minio123',
 }


### PR DESCRIPTION
## Summary
- clarify placeholder password name
- silence cspell false positive on AWS key prefix

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68be405135f4832fb5e9ed04dda5af51