### PR TITLE
Speed up resume scoring tokenization

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ echo "First sentence? Second sentence." | npm run summarize
 The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation, and ignores bare newlines.
 
 Job requirements may start with `-`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped when parsing job text.
+Tokenization in resume scoring uses a single regex pass for performance.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.  
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,11 +1,6 @@
 function tokenize(text) {
-  return new Set(
-    (text || '')
-      .toLowerCase()
-      .replace(/[^a-z0-9\s]/g, ' ')
-      .split(/\s+/)
-      .filter(Boolean)
-  );
+  // Regex-based tokenization avoids extra replace/split passes and is faster for large inputs
+  return new Set(((text || '').toLowerCase().match(/[a-z0-9]+/g)) || []);
 }
 
 export function computeFitScore(resumeText, requirements) {

--- a/test/scoring.perf.test.js
+++ b/test/scoring.perf.test.js
@@ -1,0 +1,18 @@
+import { performance } from 'node:perf_hooks';
+import { computeFitScore } from '../src/scoring.js';
+import { describe, it, expect } from 'vitest';
+
+describe('computeFitScore performance', () => {
+  it('tokenization is efficient', () => {
+    const resume =
+      'Experienced with JavaScript and Node.js frameworks along with other technologies';
+    const bullets = Array(200).fill('Looking for JavaScript and Node.js experience');
+    const iterations = 2000;
+    const start = performance.now();
+    for (let i = 0; i < iterations; i++) {
+      computeFitScore(resume, bullets);
+    }
+    const duration = performance.now() - start;
+    expect(duration).toBeLessThan(1100);
+  });
+});


### PR DESCRIPTION
## Summary
- replace replace/split tokenization with single regex pass for faster computeFitScore
- add perf test asserting computeFitScore runs under 1.1s for 2000 runs
- note regex-based tokenization in README

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68be4020cf10832fafcbf0ba9f7d0405