### PR TITLE
⚡️ : – optimize fit score tokenization

### DIFF
--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,11 +1,6 @@
 function tokenize(text) {
-  return new Set(
-    (text || '')
-      .toLowerCase()
-      .replace(/[^a-z0-9\s]/g, ' ')
-      .split(/\s+/)
-      .filter(Boolean)
-  );
+  // Use regex matching to avoid replace/split allocations and speed up tokenization.
+  return new Set((text || '').toLowerCase().match(/[a-z0-9]+/g) || []);
 }
 
 export function computeFitScore(resumeText, requirements) {
@@ -18,7 +13,13 @@ export function computeFitScore(resumeText, requirements) {
 
   for (const bullet of bullets) {
     const tokens = tokenize(bullet);
-    const hasOverlap = [...tokens].some(t => resumeTokens.has(t));
+    let hasOverlap = false;
+    for (const t of tokens) {
+      if (resumeTokens.has(t)) {
+        hasOverlap = true;
+        break;
+      }
+    }
     (hasOverlap ? matched : missing).push(bullet);
   }
 

--- a/test/scoring.test.js
+++ b/test/scoring.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { performance } from 'node:perf_hooks';
 import { computeFitScore } from '../src/scoring.js';
 
 describe('computeFitScore', () => {
@@ -9,5 +10,16 @@ describe('computeFitScore', () => {
     expect(result.score).toBe(50);
     expect(result.matched).toEqual(['JavaScript']);
     expect(result.missing).toEqual(['Python']);
+  });
+
+  it('processes large requirement lists within 1200ms', () => {
+    const resume = 'skill '.repeat(1000);
+    const requirements = Array(100).fill('skill');
+    const start = performance.now();
+    for (let i = 0; i < 10000; i += 1) {
+      computeFitScore(resume, requirements);
+    }
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeLessThan(1200);
   });
 });


### PR DESCRIPTION
## Summary
- speed up resume tokenization using regex match and early-set iteration
- add performance regression test for computeFitScore

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68be4020cf10832fafcbf0ba9f7d0405