### PR TITLE
Improve scoring tokenization performance

### DIFF
--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,11 +1,6 @@
 function tokenize(text) {
-  return new Set(
-    (text || '')
-      .toLowerCase()
-      .replace(/[^a-z0-9\s]/g, ' ')
-      .split(/\s+/)
-      .filter(Boolean)
-  );
+  // Match alphanumeric sequences directly to avoid split/filter overhead
+  return new Set(((text || '').toLowerCase().match(/[a-z0-9]+/g)) || []);
 }
 
 export function computeFitScore(resumeText, requirements) {

--- a/test/performance.test.js
+++ b/test/performance.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { performance } from 'node:perf_hooks';
+import { computeFitScore } from '../src/scoring.js';
+
+describe('computeFitScore performance', () => {
+  it('processes many requirements within 700ms', () => {
+    const resume =
+      'I know JavaScript, Node.js, TypeScript, Python, Ruby, Java, and C++.';
+    const requirements = [];
+    for (let i = 0; i < 100; i += 1) {
+      requirements.push('JavaScript', 'Node.js', 'TypeScript', 'Python', 'Ruby', 'Java', 'C++');
+    }
+    const iterations = 1000;
+    const start = performance.now();
+    for (let i = 0; i < iterations; i += 1) {
+      computeFitScore(resume, requirements);
+    }
+    const duration = performance.now() - start;
+    expect(duration).toBeLessThan(700);
+  });
+});


### PR DESCRIPTION
## Summary
- tokenize using regex word match to drop split/filter overhead
- add performance test for computeFitScore

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68be4020cf10832fafcbf0ba9f7d0405