### PR TITLE
🐛: handle punctuation before closing quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ echo "First sentence? Second sentence." | npm run summarize
 # summarize(text, 2) returns the first two sentences
 ```
 
-The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation, and ignores bare newlines.
+The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation—even when
+followed by closing quotes or parentheses—and ignores bare newlines.
 
 Job requirements may start with `-`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped when parsing job text.
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /**
  * Return the first N sentences from the given text.
- * Sentences end with '.', '!' or '?' followed by whitespace or a newline.
+ * Sentences end with '.', '!' or '?' optionally followed by a closing quote or
+ * parenthesis, then whitespace or a newline.
  *
  * @param {string} text
  * @param {number} count
@@ -8,6 +9,8 @@
  */
 export function summarize(text, count = 1) {
   if (!text) return '';
-  const sentences = text.split(/(?<=[.!?])\s+/).slice(0, count);
+  const sentences = text
+    .split(/(?<=[.!?]["')\]])\s+|(?<=[.!?])\s+/)
+    .slice(0, count);
   return sentences.join(' ').replace(/\s+/g, ' ').trim();
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,4 +21,9 @@ describe('summarize', () => {
     const text = 'First line\nSecond line.';
     expect(summarize(text)).toBe('First line Second line.');
   });
+
+  it('handles punctuation before closing quotes', () => {
+    const text = 'He said, "Hello." Another sentence.';
+    expect(summarize(text)).toBe('He said, "Hello."');
+  });
 });


### PR DESCRIPTION
## What
- fix summarize sentence boundary after closing quotes

## Why
- quoted sentences were merged and summarizer returned extra text

## How to Test
- npm run lint
- npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68be4010d8a4832f81b162852c3e9255