### PR TITLE
🐛 fix: handle closing quotes in summarizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ echo "First sentence? Second sentence." | npm run summarize
 # summarize(text, 2) returns the first two sentences
 ```
 
-The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation, and ignores bare newlines.
+The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation (even when
+followed by closing quotes or parentheses), and ignores bare newlines.
 
 Job requirements may start with `-`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped when parsing job text.
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,8 @@
  */
 export function summarize(text, count = 1) {
   if (!text) return '';
-  const sentences = text.split(/(?<=[.!?])\s+/).slice(0, count);
+  const sentences = text
+    .split(/(?<=[.!?]["')\]]?)\s+/)
+    .slice(0, count);
   return sentences.join(' ').replace(/\s+/g, ' ').trim();
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,6 +12,13 @@ describe('summarize', () => {
     expect(summarize('Wow! Another sentence.')).toBe('Wow!');
   });
 
+  it('handles punctuation before closing quotes or parentheses', () => {
+    const text = 'He said "Hi!" She left.';
+    expect(summarize(text)).toBe('He said "Hi!"');
+    const text2 = 'Do it now.) Another.';
+    expect(summarize(text2)).toBe('Do it now.)');
+  });
+
   it('returns the first N sentences when count provided', () => {
     const text = 'First. Second. Third.';
     expect(summarize(text, 2)).toBe('First. Second.');


### PR DESCRIPTION
what: handle punctuation before closing quotes or parentheses in summarize
why: sentences ending with quotes weren't split
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68be4010d8a4832f81b162852c3e9255