### PR TITLE
✨ feat: strip plus sign bullets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ echo "First sentence? Second sentence." | npm run summarize
 
 The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation, and ignores bare newlines.
 
-Job requirements may start with `-`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped when parsing job text.
+Job requirements may start with `-`, `*`, `+`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped when parsing job text.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.  
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/parser.js
+++ b/src/parser.js
@@ -43,9 +43,9 @@ export function parseJobText(rawText) {
       const line = lines[i].trim();
       if (!line) continue;
       if (/^[A-Za-z].+:$/.test(line)) break; // next section header
-      // Strip common bullet characters including hyphen, asterisk, bullet,
-      // en dash (\u2013), em dash (\u2014), digits, punctuation and whitespace
-      const bullet = line.replace(/^[-*•\u2013\u2014\d.)(\s]+/, '').trim();
+      // Strip common bullet characters including hyphen, asterisk, plus,
+      // bullet, en dash (\u2013), em dash (\u2014), digits, punctuation and whitespace
+      const bullet = line.replace(/^[-*+•\u2013\u2014\d.)(\s]+/, '').trim();
       if (bullet) requirements.push(bullet);
     }
   }

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -18,4 +18,19 @@ Requirements:
       'Familiarity with testing'
     ]);
   });
+
+  it('strips plus sign bullets', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+Requirements:
++ Keen eye for detail
++ Excellent communication
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual([
+      'Keen eye for detail',
+      'Excellent communication'
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- support '+' as requirement bullet
- document plus sign marker
- test plus bullet parsing

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68be3fe13828832f8b22da212a62650c