### PR TITLE
Handle sentence split after closing quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ echo "First sentence? Second sentence." | npm run summarize
 # summarize(text, 2) returns the first two sentences
 ```
 
-The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation, and ignores bare newlines.
+The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation, including when
+followed by closing quotes or parentheses, and ignores bare newlines.
+
+Example: `summarize('"Hi!" Bye.')` returns `"Hi!"`.
 
 Job requirements may start with `-`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped when parsing job text.
 

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,8 @@
  */
 export function summarize(text, count = 1) {
   if (!text) return '';
-  const sentences = text.split(/(?<=[.!?])\s+/).slice(0, count);
+  const sentences = text
+    .split(/(?<=[.!?]["')\]])\s+|(?<=[.!?])\s+/)
+    .slice(0, count);
   return sentences.join(' ').replace(/\s+/g, ' ').trim();
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,4 +21,9 @@ describe('summarize', () => {
     const text = 'First line\nSecond line.';
     expect(summarize(text)).toBe('First line Second line.');
   });
+
+  it('handles punctuation followed by closing quotes', () => {
+    const text = '"Wow!" Another sentence.';
+    expect(summarize(text)).toBe('"Wow!"');
+  });
 });


### PR DESCRIPTION
## Summary
- support splitting sentences when punctuation is followed by a closing quote
- document quote-aware summarizer behavior

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68be3fe13828832f8b22da212a62650c