### PR TITLE
✨: handle trailing quotes in summarizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ echo "First sentence? Second sentence." | npm run summarize
 # summarize(text, 2) returns the first two sentences
 ```
 
-The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation, and ignores bare newlines.
+The summarizer returns the first sentence, handling `.`, `!`, `?`, and trailing closing quotes.
+It ignores bare newlines.
 
 Job requirements may start with `-`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped when parsing job text.
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 /**
  * Return the first N sentences from the given text.
- * Sentences end with '.', '!' or '?' followed by whitespace or a newline.
+ * Sentences end with '.', '!' or '?' optionally followed by a closing quote and whitespace.
  *
  * @param {string} text
  * @param {number} count
@@ -8,6 +8,8 @@
  */
 export function summarize(text, count = 1) {
   if (!text) return '';
-  const sentences = text.split(/(?<=[.!?])\s+/).slice(0, count);
+  const sentences = text
+    .split(/(?<=[.!?]["'\u201d\u2019]?)\s+/)
+    .slice(0, count);
   return sentences.join(' ').replace(/\s+/g, ' ').trim();
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,4 +21,9 @@ describe('summarize', () => {
     const text = 'First line\nSecond line.';
     expect(summarize(text)).toBe('First line Second line.');
   });
+
+  it('handles sentences ending with quotes', () => {
+    const text = '"First sentence." Second sentence.';
+    expect(summarize(text)).toBe('"First sentence."');
+  });
 });


### PR DESCRIPTION
## Summary
- handle punctuation followed by closing quotes in summarize
- document quoted sentence support

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68be3fe13828832f8b22da212a62650c