### PR TITLE
docs: clarify summarize usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,25 @@ npm run test:ci
 # Summarize a job description
 # Works with sentences ending in ., ?, or !
 echo "First sentence? Second sentence." | npm run summarize
-
-# In code, pass the number of sentences to keep
-# summarize(text, 2) returns the first two sentences
 ```
 
-The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation, and ignores bare newlines.
+In code, import `summarize` and pass the number of sentences to keep:
 
-Job requirements may start with `-`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped when parsing job text.
+```js
+import { summarize } from './src/index.js';
 
-See [DESIGN.md](DESIGN.md) for architecture details and roadmap.  
+const text = 'First sentence? Second sentence. Third!';
+console.log(summarize(text, 2));
+// → First sentence? Second sentence.
+```
+
+The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation,
+and ignores bare newlines.
+
+Job requirements may start with `-`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers
+are stripped when parsing job text.
+
+See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.
 
 ## Documentation


### PR DESCRIPTION
## Summary
- document how to import and call `summarize`
- explain job requirement marker handling

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68be3fc603f0832fb16fb237f51a7a32