### PR TITLE
📝 : add programmatic summarize example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,16 @@ npm run test:ci
 # Works with sentences ending in ., ?, or !
 echo "First sentence? Second sentence." | npm run summarize
 
-# In code, pass the number of sentences to keep
-# summarize(text, 2) returns the first two sentences
+# Programmatic usage
+cat <<'EOF' > example.js
+import { summarize } from './src/index.js';
+
+const text = 'First sentence. Second sentence. Third sentence.';
+console.log(summarize(text, 2));
+EOF
+
+node example.js
+rm example.js
 ```
 
 The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation, and ignores bare newlines.


### PR DESCRIPTION
What: document Node example for summarize API.
Why: show how to call summarize in code.
How to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68be3fc603f0832fb16fb237f51a7a32