### PR TITLE
🐛 strip '+' bullets in job parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ echo "First sentence? Second sentence." | npm run summarize
 
 The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation, and ignores bare newlines.
 
-Job requirements may start with `-`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped when parsing job text.
+Job requirements may start with `-`, `+`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped when parsing job text.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.  
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/parser.js
+++ b/src/parser.js
@@ -43,9 +43,9 @@ export function parseJobText(rawText) {
       const line = lines[i].trim();
       if (!line) continue;
       if (/^[A-Za-z].+:$/.test(line)) break; // next section header
-      // Strip common bullet characters including hyphen, asterisk, bullet,
+      // Strip common bullet characters including hyphen, plus, asterisk, bullet,
       // en dash (\u2013), em dash (\u2014), digits, punctuation and whitespace
-      const bullet = line.replace(/^[-*•\u2013\u2014\d.)(\s]+/, '').trim();
+      const bullet = line.replace(/^[-+*•\u2013\u2014\d.)(\s]+/, '').trim();
       if (bullet) requirements.push(bullet);
     }
   }

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -18,4 +18,21 @@ Requirements:
       'Familiarity with testing'
     ]);
   });
+
+  it('strips asterisk, bullet, and plus bullets', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+Requirements:
+* Basic JavaScript
+• Experience with Node.js
++ Familiarity with testing
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual([
+      'Basic JavaScript',
+      'Experience with Node.js',
+      'Familiarity with testing'
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- handle '+' requirements bullet in parser
- document plus bullet support

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68be3f920a24832f9620500720463bf1