### PR TITLE
🐛 : capture header-line job requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ echo "First sentence? Second sentence." | npm run summarize
 
 The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation, and ignores bare newlines.
 
-Job requirements may start with `-`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped when parsing job text.
+Job requirements may start with `-`, `*`, `•`, `–` (en dash), or `—` (em dash),
+and may appear on the same line as the requirements header; these markers are
+stripped when parsing job text.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.  
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/parser.js
+++ b/src/parser.js
@@ -39,6 +39,20 @@ export function parseJobText(rawText) {
   let requirements = [];
   const idx = lines.findIndex(l => REQUIREMENTS_HEADERS.some(h => h.test(l)));
   if (idx !== -1) {
+    const headerLine = lines[idx];
+    let rest = '';
+    for (const h of REQUIREMENTS_HEADERS) {
+      if (h.test(headerLine)) {
+        rest = headerLine.replace(h, '').trim();
+        break;
+      }
+    }
+    rest = rest.replace(/^[:\s]+/, '');
+    if (rest) {
+      const first = rest.replace(/^[-*•\u2013\u2014\d.)(\s]+/, '').trim();
+      if (first) requirements.push(first);
+    }
+
     for (let i = idx + 1; i < lines.length; i += 1) {
       const line = lines[i].trim();
       if (!line) continue;

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -18,4 +18,18 @@ Requirements:
       'Familiarity with testing'
     ]);
   });
+
+  it('captures requirement text on header line', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+Requirements: Proficient in JS
+- Experience with Node.js
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual([
+      'Proficient in JS',
+      'Experience with Node.js'
+    ]);
+  });
 });


### PR DESCRIPTION
what: parseJobText captures requirement text appearing on header line
why: some postings list first requirement on same line as the header
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68be3f920a24832f9620500720463bf1