### PR TITLE
🐛 : – parse 'Responsibilities' header

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ echo "First sentence? Second sentence." | npm run summarize
 
 The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation, and ignores bare newlines.
 
-Job requirements may start with `-`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped when parsing job text.
+Job requirements may appear under headers like `Requirements`, `Qualifications`,
+`What you'll need`, or `Responsibilities` (used if no other requirement headers are present).
+Bullet markers such as `-`, `*`, `•`, `–` (en dash), or `—` (em dash) are stripped when parsing job
+text.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.  
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/parser.js
+++ b/src/parser.js
@@ -15,6 +15,8 @@ const REQUIREMENTS_HEADERS = [
   /\bWhat you(?:'|’)ll need\b/i
 ];
 
+const FALLBACK_REQUIREMENTS_HEADERS = [/\bResponsibilities\b/i];
+
 function findFirstMatch(lines, patterns) {
   for (const line of lines) {
     for (const pattern of patterns) {
@@ -35,9 +37,13 @@ export function parseJobText(rawText) {
   const title = findFirstMatch(lines, TITLE_PATTERNS);
   const company = findFirstMatch(lines, COMPANY_PATTERNS);
 
-  // Extract requirements bullets after a known header
+  // Extract requirements bullets after a known header. Prefer primary headers, but fall back to
+  // "Responsibilities" if none are present.
   let requirements = [];
-  const idx = lines.findIndex(l => REQUIREMENTS_HEADERS.some(h => h.test(l)));
+  let idx = lines.findIndex(l => REQUIREMENTS_HEADERS.some(h => h.test(l)));
+  if (idx === -1) {
+    idx = lines.findIndex(l => FALLBACK_REQUIREMENTS_HEADERS.some(h => h.test(l)));
+  }
   if (idx !== -1) {
     for (let i = idx + 1; i < lines.length; i += 1) {
       const line = lines[i].trim();

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -18,4 +18,29 @@ Requirements:
       'Familiarity with testing'
     ]);
   });
+
+  it('parses requirements after a Responsibilities header', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+Responsibilities:
+- Build features
+- Fix bugs
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual(['Build features', 'Fix bugs']);
+  });
+
+  it('prefers Requirements section when Responsibilities appears first', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+Responsibilities:
+- Build features
+Requirements:
+- Must do things
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual(['Must do things']);
+  });
 });


### PR DESCRIPTION
## Summary
- fall back to Responsibilities header only if no requirement headers present
- document fallback behavior for Responsibilities header
- test Requirements section takes precedence over Responsibilities

## Testing
- `npm run lint`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68be3f920a24832f9620500720463bf1