### PR TITLE
✨: handle closing quotes and parentheses in summarizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ echo "First sentence? Second sentence." | npm run summarize
 # summarize(text, 2) returns the first two sentences
 ```
 
-The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation, and ignores bare newlines.
+The summarizer returns the first sentence, handling `.`, `!`, `?`, and trailing closing quotes or parentheses.
+It ignores bare newlines.
 
 Job requirements may start with `-`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped when parsing job text.
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 /**
  * Return the first N sentences from the given text.
- * Sentences end with '.', '!' or '?' followed by whitespace or a newline.
+ * Sentences end with '.', '!' or '?' optionally followed by closing quotes or parentheses.
  *
  * @param {string} text
  * @param {number} count
@@ -8,6 +8,28 @@
  */
 export function summarize(text, count = 1) {
   if (!text) return '';
-  const sentences = text.split(/(?<=[.!?])\s+/).slice(0, count);
-  return sentences.join(' ').replace(/\s+/g, ' ').trim();
+  const sentences = [];
+  let start = 0;
+  let i = 0;
+  while (i < text.length && sentences.length < count) {
+    const ch = text[i];
+    if (ch === '.' || ch === '!' || ch === '?') {
+      i++;
+      while (
+        i < text.length &&
+        "\"'\u201d\u2019)".includes(text[i])
+      ) {
+        i++;
+      }
+      sentences.push(text.slice(start, i));
+      while (i < text.length && /\s/.test(text[i])) i++;
+      start = i;
+    } else {
+      i++;
+    }
+  }
+  return sentences
+    .map((s) => s.replace(/\s+/g, ' ').trim())
+    .join(' ')
+    .trim();
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,4 +21,11 @@ describe('summarize', () => {
     const text = 'First line\nSecond line.';
     expect(summarize(text)).toBe('First line Second line.');
   });
+
+  it('handles punctuation before closing quotes or parentheses', () => {
+    const text = 'He said "Hi!" Another.';
+    expect(summarize(text)).toBe('He said "Hi!"');
+    const text2 = 'Do it now.) Another.';
+    expect(summarize(text2)).toBe('Do it now.)');
+  });
 });


### PR DESCRIPTION
## Summary
- handle punctuation followed by closing quotes or parentheses in summarize
- replace polynomial regex with linear scan to avoid ReDoS
- document parentheses support in README

## Testing
- `npm run lint`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68be3fe13828832f8b22da212a62650c