### PR TITLE
✨: handle punctuation edge cases in summarizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ echo "First sentence? Second sentence." | npm run summarize
 # summarize(text, 2) returns the first two sentences
 ```
 
-The summarizer extracts the first sentence, handling `.`, `!`, and `?` punctuation, and ignores bare newlines.
+The summarizer returns the first sentence, handling `.`, `!`, `?`, consecutive terminal punctuation
+like `?!`, and trailing closing quotes or parentheses. Terminators apply only when followed by
+whitespace or the end of text, so decimals like `1.99` remain intact. It ignores bare newlines and
+returns the whole text if no terminator is found.
 
 Job requirements may start with `-`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped when parsing job text.
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 /**
  * Return the first N sentences from the given text.
- * Sentences end with '.', '!' or '?' followed by whitespace or a newline.
+ * Sentences end with '.', '!' or '?', optionally followed by closing quotes
+ * or parentheses. If no terminator is found, the entire text is returned.
  *
  * @param {string} text
  * @param {number} count
@@ -8,6 +9,33 @@
  */
 export function summarize(text, count = 1) {
   if (!text) return '';
-  const sentences = text.split(/(?<=[.!?])\s+/).slice(0, count);
-  return sentences.join(' ').replace(/\s+/g, ' ').trim();
+  const sentences = [];
+  let start = 0;
+  let i = 0;
+  while (i < text.length && sentences.length < count) {
+    const ch = text[i];
+    if (ch === '.' || ch === '!' || ch === '?') {
+      let j = i + 1;
+      while (j < text.length && (text[j] === '.' || text[j] === '!' || text[j] === '?')) j++;
+      while (j < text.length && "\"'\u201d\u2019)".includes(text[j])) j++;
+      if (j === text.length || /\s/.test(text[j])) {
+        sentences.push(text.slice(start, j));
+        j++;
+        while (j < text.length && /\s/.test(text[j])) j++;
+        start = j;
+        i = j;
+      } else {
+        i++;
+      }
+    } else {
+      i++;
+    }
+  }
+  if (sentences.length < count && start < text.length) {
+    sentences.push(text.slice(start));
+  }
+  return sentences
+    .map((s) => s.replace(/\s+/g, ' ').trim())
+    .join(' ')
+    .trim();
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,4 +21,26 @@ describe('summarize', () => {
     const text = 'First line\nSecond line.';
     expect(summarize(text)).toBe('First line Second line.');
   });
+
+  it('handles punctuation before closing quotes or parentheses', () => {
+    const text = 'He said "Hi!" Another.';
+    expect(summarize(text)).toBe('He said "Hi!"');
+    const text2 = 'Do it now.) Another.';
+    expect(summarize(text2)).toBe('Do it now.)');
+  });
+
+  it('preserves consecutive terminal punctuation', () => {
+    const text = 'What?! Another.';
+    expect(summarize(text)).toBe('What?!');
+  });
+
+  it('does not split on decimal points', () => {
+    const text = 'The price is $1.99 today but it may change.';
+    expect(summarize(text)).toBe(text);
+  });
+
+  it('returns the whole text when no terminator is present', () => {
+    const text = 'No punctuation here';
+    expect(summarize(text)).toBe(text);
+  });
 });


### PR DESCRIPTION
## Summary
- preserve consecutive terminal punctuation in sentence extraction
- avoid splitting decimals by requiring whitespace after terminators
- document punctuation handling and expand tests

## Testing
- `npm run lint`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68be3fe13828832f8b22da212a62650c