### PR TITLE
✨: add sentence count flag and cache scoring tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ npm run test:ci
 
 # Summarize a job description
 # Works with sentences ending in ., ?, or !
-echo "First sentence? Second sentence." | npm run summarize
+# Keep two sentences with --sentences
+echo "First. Second. Third." | jobbot summarize - --sentences 2
 ```
 
 In code, pass the number of sentences to keep:

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -24,7 +24,9 @@ function getFlag(args, name, fallback) {
   const idx = args.indexOf(name);
   if (idx === -1) return fallback;
   const val = args[idx + 1];
-  if (!val || val.startsWith('--')) return true; // boolean flag
+  if (!val || val.startsWith('--')) {
+    return typeof fallback === 'boolean' ? true : fallback;
+  }
   return val;
 }
 
@@ -32,11 +34,12 @@ async function cmdSummarize(args) {
   const input = args[0] || '-';
   const format = args.includes('--json') ? 'json' : 'md';
   const timeoutMs = Number(getFlag(args, '--timeout', 10000));
+  const count = Number(getFlag(args, '--sentences', 1));
   const raw = isHttpUrl(input)
     ? await fetchTextFromUrl(input, { timeoutMs })
     : await readSource(input);
   const parsed = parseJobText(raw);
-  const summary = summarizeFirstSentence(raw);
+  const summary = summarizeFirstSentence(raw, count);
   const payload = { ...parsed, summary };
   if (format === 'json') console.log(toJson(payload));
   else console.log(toMarkdownSummary(payload));

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,6 +1,14 @@
+const tokenCache = new Map();
+
 function tokenize(text) {
-  // Use regex matching to avoid replace/split allocations and speed up tokenization.
-  return new Set((text || '').toLowerCase().match(/[a-z0-9]+/g) || []);
+  // Cache tokens to avoid repeated allocations for the same strings.
+  const key = text || '';
+  const cached = tokenCache.get(key);
+  if (cached) return cached;
+  const tokens = new Set(key.toLowerCase().match(/[a-z0-9]+/g) || []);
+  tokenCache.set(key, tokens);
+  if (tokenCache.size > 100) tokenCache.clear();
+  return tokens;
 }
 
 export function computeFitScore(resumeText, requirements) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -16,6 +16,14 @@ describe('jobbot CLI', () => {
     expect(out).toMatch(/First sentence\./);
   });
 
+  it('summarizes multiple sentences when count provided', () => {
+    const out = runCli(
+      ['summarize', '-', '--sentences', '2'],
+      'First. Second. Third.'
+    );
+    expect(out.trim()).toBe('First. Second.');
+  });
+
   it('match from local files', () => {
     const job = 'Title: Engineer\nCompany: ACME\nRequirements\n- JavaScript\n- Node.js\n';
     const resume = 'I am an engineer with JavaScript experience.';


### PR DESCRIPTION
## What
- add `--sentences` to CLI summarize command
- cache tokens in scoring for faster repeat evaluations
- document new CLI flag

## Why
- allow richer summaries from CLI
- keep scoring performance within CI limits

## How to Test
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68bf4e27ea10832f9b54a28c6a74d635