### PR TITLE
Handle C++/C# tokens in fit scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Example: `summarize('"Hi!" Bye.')` returns `"Hi!"`.
 Job requirements may appear under headers like `Requirements`, `Qualifications`,
 `What you'll need`, or `Responsibilities` (used if no other requirement headers are present).
 They may start with `-`, `+`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped
-when parsing job text. Tokenization in resume scoring uses a single regex pass for performance.
+when parsing job text. Tokenization in resume scoring uses a single regex pass for performance
+and recognizes symbols like `+` or `#` in language names such as C++ or C#.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,6 +1,14 @@
+const tokenCache = new Map();
+
 function tokenize(text) {
-  // Use regex matching to avoid replace/split allocations and speed up tokenization.
-  return new Set((text || '').toLowerCase().match(/[a-z0-9]+/g) || []);
+  // Memoize tokens and support symbols common in language names like C++ or C#.
+  const key = text || '';
+  let tokens = tokenCache.get(key);
+  if (!tokens) {
+    tokens = new Set(key.toLowerCase().match(/[a-z0-9+#]+/g) || []);
+    tokenCache.set(key, tokens);
+  }
+  return tokens;
 }
 
 export function computeFitScore(resumeText, requirements) {

--- a/test/scoring.test.js
+++ b/test/scoring.test.js
@@ -12,6 +12,24 @@ describe('computeFitScore', () => {
     expect(result.missing).toEqual(['Python']);
   });
 
+  it('does not conflate C with C++ or C#', () => {
+    const resume = 'Experience with C and Python.';
+    const requirements = ['C++', 'C#'];
+    const result = computeFitScore(resume, requirements);
+    expect(result.score).toBe(0);
+    expect(result.matched).toEqual([]);
+    expect(result.missing).toEqual(['C++', 'C#']);
+  });
+
+  it('matches C++ and C# tokens exactly', () => {
+    const resume = 'Worked with C++ and C#.';
+    const requirements = ['C++', 'C#'];
+    const result = computeFitScore(resume, requirements);
+    expect(result.score).toBe(100);
+    expect(result.matched).toEqual(['C++', 'C#']);
+    expect(result.missing).toEqual([]);
+  });
+
   it('processes large requirement lists within 1200ms', () => {
     const resume = 'skill '.repeat(1000);
     const requirements = Array(100).fill('skill');


### PR DESCRIPTION
what: memoize tokenization and allow +/# in tokens
why: avoid matching C with C++/C# and speed repeated scoring
how to test: npm run lint && npm run test:ci
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68bf4e27ea10832f9b54a28c6a74d635