### PR TITLE
Collapse HTML whitespace when extracting text

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ console.log(summarize(text, 2));
 // → "First sentence. Second sentence?"
 ```
 
+Fetch remote job listings and normalize HTML to plain text:
+
+```js
+import { fetchTextFromUrl } from './src/fetch.js';
+
+const text = await fetchTextFromUrl('https://example.com/job');
+```
+`fetchTextFromUrl` strips scripts, styles, navigation, and footer content and collapses
+whitespace to single spaces.
+
 The summarizer extracts the first sentence, handling `.`, `!`, `?`, and consecutive terminal
 punctuation like `?!`, including when followed by closing quotes or parentheses. Terminators apply
 only when followed by whitespace or the end of text, so decimals like `1.99` remain intact.  

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,6 +1,12 @@
 import fetch from 'node-fetch';
 import { htmlToText } from 'html-to-text';
 
+/**
+ * Convert HTML to plain text, skipping non-content tags and collapsing whitespace.
+ *
+ * @param {string} html
+ * @returns {string}
+ */
 export function extractTextFromHtml(html) {
   if (!html) return '';
   return htmlToText(html, {
@@ -11,7 +17,9 @@ export function extractTextFromHtml(html) {
       { selector: 'nav', format: 'skip' },
       { selector: 'footer', format: 'skip' }
     ]
-  }).trim();
+  })
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 export async function fetchTextFromUrl(url, { timeoutMs = 10000 } = {}) {

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { extractTextFromHtml } from '../src/fetch.js';
+
+describe('extractTextFromHtml', () => {
+  it('collapses whitespace and skips non-content tags', () => {
+    const html = `
+      <html>
+        <head>
+          <style>.a {}</style>
+          <script>1</script>
+        </head>
+        <body>
+          <nav>ignored</nav>
+          <p>First   line</p>
+          <p>Second line</p>
+          <footer>ignored</footer>
+        </body>
+      </html>
+    `;
+    expect(extractTextFromHtml(html)).toBe('First line Second line');
+  });
+});


### PR DESCRIPTION
## Summary
- normalize HTML extraction by collapsing whitespace and skipping non-content tags
- document fetchTextFromUrl usage and whitespace handling
- add unit test for extractTextFromHtml

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: computeFitScore processes large requirement lists within 1200ms)*


------
https://chatgpt.com/codex/tasks/task_e_68bf4e27ea10832f9b54a28c6a74d635