### PR TITLE
📝 : add upgrade prompts to codex docs

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -8,23 +8,45 @@ This index lists prompt documents for the jobbot3000 repository.
 | Path | Prompt | Type | One-click? |
 |------|--------|------|------------|
 | [docs/prompts/codex/automation.md][automation-doc] | Codex Automation Prompt | evergreen | yes |
+| [docs/prompts/codex/automation.md#upgrade-prompt][automation-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/chore.md][chore-doc] | Codex Chore Prompt | evergreen | yes |
+| [docs/prompts/codex/chore.md#upgrade-prompt][chore-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/docs.md][docs-doc] | Codex Docs Prompt | evergreen | yes |
+| [docs/prompts/codex/docs.md#upgrade-prompt][docs-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/feature.md][feature-doc] | Codex Feature Prompt | evergreen | yes |
+| [docs/prompts/codex/feature.md#upgrade-prompt][feature-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/fix.md][fix-doc] | Codex Fix Prompt | evergreen | yes |
+| [docs/prompts/codex/fix.md#upgrade-prompt][fix-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/performance.md][performance-doc] | Codex Performance Prompt | evergreen | yes |
+| [docs/prompts/codex/performance.md#upgrade-prompt][performance-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/refactor.md][refactor-doc] | Codex Refactor Prompt | evergreen | yes |
+| [docs/prompts/codex/refactor.md#upgrade-prompt][refactor-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/security.md][security-doc] | Codex Security Prompt | evergreen | yes |
+| [docs/prompts/codex/security.md#upgrade-prompt][security-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/spellcheck.md][spellcheck-doc] | Codex Spellcheck Prompt | evergreen | yes |
+| [docs/prompts/codex/spellcheck.md#upgrade-prompt][spellcheck-up] | Upgrade Prompt | evergreen | yes |
+| [docs/prompts/codex/test.md][test-doc] | Codex Test Prompt | evergreen | yes |
+| [docs/prompts/codex/test.md#upgrade-prompt][test-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/upgrade.md][upgrade-doc] | Codex Upgrade Prompt | evergreen | yes |
 
 [automation-doc]: prompts/codex/automation.md
+[automation-up]: prompts/codex/automation.md#upgrade-prompt
 [chore-doc]: prompts/codex/chore.md
+[chore-up]: prompts/codex/chore.md#upgrade-prompt
 [docs-doc]: prompts/codex/docs.md
+[docs-up]: prompts/codex/docs.md#upgrade-prompt
 [feature-doc]: prompts/codex/feature.md
+[feature-up]: prompts/codex/feature.md#upgrade-prompt
 [fix-doc]: prompts/codex/fix.md
+[fix-up]: prompts/codex/fix.md#upgrade-prompt
 [performance-doc]: prompts/codex/performance.md
+[performance-up]: prompts/codex/performance.md#upgrade-prompt
 [refactor-doc]: prompts/codex/refactor.md
+[refactor-up]: prompts/codex/refactor.md#upgrade-prompt
 [security-doc]: prompts/codex/security.md
+[security-up]: prompts/codex/security.md#upgrade-prompt
 [spellcheck-doc]: prompts/codex/spellcheck.md
+[spellcheck-up]: prompts/codex/spellcheck.md#upgrade-prompt
+[test-doc]: prompts/codex/test.md
+[test-up]: prompts/codex/test.md#upgrade-prompt
 [upgrade-doc]: prompts/codex/upgrade.md

--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -33,3 +33,32 @@ followed by the diff in a fenced diff block. The CRITIC responds with "LGTM" or 
 ```
 
 Copy this block when instructing an automated coding agent to work on jobbot3000.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine jobbot3000's prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Improve or expand the repository's prompt docs.
+
+CONTEXT:
+- Follow [README.md](../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py`.
+
+REQUEST:
+1. Select a file under `docs/prompts/` to update or create a new prompt type.
+2. Clarify context, refresh links, and ensure referenced files exist.
+3. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request that updates the selected prompt doc with passing checks.
+```
+

--- a/docs/prompts/codex/chore.md
+++ b/docs/prompts/codex/chore.md
@@ -29,3 +29,32 @@ A pull request URL summarizing the maintenance task.
 ```
 
 Copy this block whenever performing chores in jobbot3000.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine jobbot3000's prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Improve or expand the repository's prompt docs.
+
+CONTEXT:
+- Follow [README.md](../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py`.
+
+REQUEST:
+1. Select a file under `docs/prompts/` to update or create a new prompt type.
+2. Clarify context, refresh links, and ensure referenced files exist.
+3. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request that updates the selected prompt doc with passing checks.
+```
+

--- a/docs/prompts/codex/docs.md
+++ b/docs/prompts/codex/docs.md
@@ -31,3 +31,32 @@ A pull request URL summarizing the documentation update.
 ```
 
 Copy this block whenever updating docs in jobbot3000.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine jobbot3000's prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Improve or expand the repository's prompt docs.
+
+CONTEXT:
+- Follow [README.md](../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py`.
+
+REQUEST:
+1. Select a file under `docs/prompts/` to update or create a new prompt type.
+2. Clarify context, refresh links, and ensure referenced files exist.
+3. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request that updates the selected prompt doc with passing checks.
+```
+

--- a/docs/prompts/codex/feature.md
+++ b/docs/prompts/codex/feature.md
@@ -29,3 +29,32 @@ A pull request URL summarizing the feature addition.
 ```
 
 Copy this block whenever implementing a feature in jobbot3000.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine jobbot3000's prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Improve or expand the repository's prompt docs.
+
+CONTEXT:
+- Follow [README.md](../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py`.
+
+REQUEST:
+1. Select a file under `docs/prompts/` to update or create a new prompt type.
+2. Clarify context, refresh links, and ensure referenced files exist.
+3. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request that updates the selected prompt doc with passing checks.
+```
+

--- a/docs/prompts/codex/fix.md
+++ b/docs/prompts/codex/fix.md
@@ -29,3 +29,32 @@ A pull request URL summarizing the bug fix.
 ```
 
 Copy this block whenever fixing bugs in jobbot3000.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine jobbot3000's prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Improve or expand the repository's prompt docs.
+
+CONTEXT:
+- Follow [README.md](../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py`.
+
+REQUEST:
+1. Select a file under `docs/prompts/` to update or create a new prompt type.
+2. Clarify context, refresh links, and ensure referenced files exist.
+3. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request that updates the selected prompt doc with passing checks.
+```
+

--- a/docs/prompts/codex/performance.md
+++ b/docs/prompts/codex/performance.md
@@ -30,3 +30,32 @@ A pull request URL summarizing the performance improvement.
 ```
 
 Copy this block whenever optimizing performance in jobbot3000.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine jobbot3000's prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Improve or expand the repository's prompt docs.
+
+CONTEXT:
+- Follow [README.md](../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py`.
+
+REQUEST:
+1. Select a file under `docs/prompts/` to update or create a new prompt type.
+2. Clarify context, refresh links, and ensure referenced files exist.
+3. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request that updates the selected prompt doc with passing checks.
+```
+

--- a/docs/prompts/codex/refactor.md
+++ b/docs/prompts/codex/refactor.md
@@ -30,3 +30,32 @@ A pull request URL summarizing the refactor.
 ```
 
 Copy this block whenever refactoring jobbot3000.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine jobbot3000's prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Improve or expand the repository's prompt docs.
+
+CONTEXT:
+- Follow [README.md](../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py`.
+
+REQUEST:
+1. Select a file under `docs/prompts/` to update or create a new prompt type.
+2. Clarify context, refresh links, and ensure referenced files exist.
+3. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request that updates the selected prompt doc with passing checks.
+```
+

--- a/docs/prompts/codex/security.md
+++ b/docs/prompts/codex/security.md
@@ -31,3 +31,32 @@ A pull request URL summarizing the security fix.
 ```
 
 Copy this block whenever addressing security in jobbot3000.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine jobbot3000's prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Improve or expand the repository's prompt docs.
+
+CONTEXT:
+- Follow [README.md](../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py`.
+
+REQUEST:
+1. Select a file under `docs/prompts/` to update or create a new prompt type.
+2. Clarify context, refresh links, and ensure referenced files exist.
+3. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request that updates the selected prompt doc with passing checks.
+```
+

--- a/docs/prompts/codex/spellcheck.md
+++ b/docs/prompts/codex/spellcheck.md
@@ -28,3 +28,32 @@ A pull request URL summarizing the spelling corrections.
 ```
 
 Copy this block whenever correcting spelling in jobbot3000.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine jobbot3000's prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Improve or expand the repository's prompt docs.
+
+CONTEXT:
+- Follow [README.md](../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py`.
+
+REQUEST:
+1. Select a file under `docs/prompts/` to update or create a new prompt type.
+2. Clarify context, refresh links, and ensure referenced files exist.
+3. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request that updates the selected prompt doc with passing checks.
+```
+

--- a/docs/prompts/codex/test.md
+++ b/docs/prompts/codex/test.md
@@ -30,3 +30,32 @@ A pull request URL summarizing the test improvement.
 ```
 
 Copy this block whenever working on tests in jobbot3000.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine jobbot3000's prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Improve or expand the repository's prompt docs.
+
+CONTEXT:
+- Follow [README.md](../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py`.
+
+REQUEST:
+1. Select a file under `docs/prompts/` to update or create a new prompt type.
+2. Clarify context, refresh links, and ensure referenced files exist.
+3. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request that updates the selected prompt doc with passing checks.
+```
+


### PR DESCRIPTION
what: add Upgrade Prompt section to each codex prompt doc and summary
why: align docs with flywheel, enabling easier prompt maintenance
how to test:
- npm run lint
- npm run test:ci (fails computeFitScore perf; reran and still failing)
Refs: n/a
status: draft; needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68bf4f8fbbe8832f83765aa3c5158709