### PR TITLE
📝 : fix disclosure wording

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,8 @@
 # Security Policy
 
 ## Reporting a Vulnerability
-Please open an issue describing the problem without including sensitive details. We'll respond with a secure channel for disclosure.
+Please open an issue describing the problem without including sensitive details.
+We'll respond with a secure channel for disclosure.
 
 ## Secret Handling
 Secrets such as API keys or tokens should never be committed. Use environment variables or `.env` files which are excluded via `.gitignore`.


### PR DESCRIPTION
## Summary
- fix split "disclosure" word in security policy

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: computeFitScore > processes large requirement lists within 1200ms)*


------
https://chatgpt.com/codex/tasks/task_e_68bf4fddb0d4832f8101f2dc3501469b