### PR TITLE
feat: strip plus bullets on requirement header lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Example: `summarize('"Hi!" Bye.')` returns `"Hi!"`.
 Job requirements may appear under headers like `Requirements`, `Qualifications`,
 `What you'll need`, or `Responsibilities` (used if no other requirement headers are present).
 They may start with `-`, `+`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped
-when parsing job text. Tokenization in resume scoring uses a single regex pass for performance.
+when parsing job text, even if the first requirement appears on the same line as the header.
+Tokenization in resume scoring uses a single regex pass for performance.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/parser.js
+++ b/src/parser.js
@@ -55,7 +55,7 @@ export function parseJobText(rawText) {
     }
     rest = rest.replace(/^[:\s]+/, '');
     if (rest) {
-      const first = rest.replace(/^[-*•\u2013\u2014\d.)(\s]+/, '').trim();
+      const first = rest.replace(/^[-+*•\u2013\u2014\d.)(\s]+/, '').trim();
       if (first) requirements.push(first);
     }
 

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -65,4 +65,14 @@ Requirements: Proficient in JS
       'Excellent communication'
     ]);
   });
+
+  it('strips plus bullets when inline with the header', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+Requirements: + Strong skills
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual(['Strong skills']);
+  });
 });


### PR DESCRIPTION
## Summary
- strip '+' bullet when a requirement starts inline with its header
- document bullet stripping on header lines
- cover parseJobText with regression test

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: expected 1299.697968 to be less than 1200)*
- `npm run test:ci -- test/scoring.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf4fb6ceb4832fadc04b83b9bad2d4