### PR TITLE
[Draft] ♻️ : refactor requirements parsing helpers

### DIFF
--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -2,6 +2,15 @@ import { describe, it, expect } from 'vitest';
 import { parseJobText } from '../src/parser.js';
 
 describe('parseJobText', () => {
+  it('returns empty fields for missing input', () => {
+    expect(parseJobText(undefined)).toEqual({
+      title: '',
+      company: '',
+      requirements: [],
+      body: ''
+    });
+  });
+
   it('strips dash, en dash, and em dash bullets', () => {
     const text = `
 Title: Developer


### PR DESCRIPTION
what: centralizes header lookup and bullet stripping in parser
why: reduces duplication and clarifies requirement extraction
how to test: npm run lint && npm run test:ci (fails: scoring perf >1200ms)
Refs: #000
Labels: needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68bf4fd4402c832fa01bc91a0893c1d7