### PR TITLE
♻️ : extract bullet stripping helper

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -17,6 +17,22 @@ const REQUIREMENTS_HEADERS = [
 
 const FALLBACK_REQUIREMENTS_HEADERS = [/\bResponsibilities\b/i];
 
+// Strip common bullet characters including hyphen, plus, asterisk, bullet,
+// en dash (\u2013), em dash (\u2014), digits, punctuation and whitespace
+const BULLET_PREFIX_RE = /^[-*•\u2013\u2014\d.)(\s]+/;
+const BULLET_PREFIX_WITH_PLUS_RE = /^[-+*•\u2013\u2014\d.)(\s]+/;
+
+/**
+ * Remove bullet characters from the start of a line.
+ * @param {string} line - line to clean
+ * @param {boolean} [allowPlus=true] - whether to strip leading '+'
+ * @returns {string}
+ */
+function stripBullet(line, allowPlus = true) {
+  const re = allowPlus ? BULLET_PREFIX_WITH_PLUS_RE : BULLET_PREFIX_RE;
+  return line.replace(re, '').trim();
+}
+
 function findFirstMatch(lines, patterns) {
   for (const line of lines) {
     for (const pattern of patterns) {
@@ -55,7 +71,7 @@ export function parseJobText(rawText) {
     }
     rest = rest.replace(/^[:\s]+/, '');
     if (rest) {
-      const first = rest.replace(/^[-*•\u2013\u2014\d.)(\s]+/, '').trim();
+      const first = stripBullet(rest, false);
       if (first) requirements.push(first);
     }
 
@@ -65,7 +81,7 @@ export function parseJobText(rawText) {
       if (/^[A-Za-z].+:$/.test(line)) break; // next section header
       // Strip common bullet characters including hyphen, plus, asterisk, bullet,
       // en dash (\u2013), em dash (\u2014), digits, punctuation and whitespace
-      const bullet = line.replace(/^[-+*•\u2013\u2014\d.)(\s]+/, '').trim();
+      const bullet = stripBullet(line);
       if (bullet) requirements.push(bullet);
     }
   }

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -65,4 +65,16 @@ Requirements: Proficient in JS
       'Excellent communication'
     ]);
   });
+  it('strips numeric bullets with dots or parentheses', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+Requirements:
+1) First item
+2. Second item
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual(['First item', 'Second item']);
+  });
+
 });


### PR DESCRIPTION
what: deduplicate bullet stripping in parser and add numeric bullet test
why: clarify requirement parsing and improve maintainability
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68bf4fd4402c832fa01bc91a0893c1d7