### PR TITLE
docs: clarify summarize example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm run test:ci
 echo "First sentence? Second sentence." | npm run summarize
 ```
 
-In code, pass the number of sentences to keep:
+In code, `summarize(text, count = 1)` returns the first `count` sentences:
 
 ```js
 import { summarize } from './src/index.js';


### PR DESCRIPTION
## Summary
- clarify optional sentence count for `summarize`

## Testing
- `node --input-type=module <<'NODE'
import { summarize } from './src/index.js';

const text = 'First sentence. Second sentence? Third!';
console.log(summarize(text, 2));
NODE`
- `npm run lint`
- `npm run test:ci` *(fails: AssertionError in test/scoring.test.js > computeFitScore)*

Status: draft, needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68bf4facb0f8832fb93e0b6d4af972be