### PR TITLE
docs: clarify docs prompt context

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -16,6 +16,7 @@ This index lists prompt documents for the jobbot3000 repository.
 | [docs/prompts/codex/refactor.md][refactor-doc] | Codex Refactor Prompt | evergreen | yes |
 | [docs/prompts/codex/security.md][security-doc] | Codex Security Prompt | evergreen | yes |
 | [docs/prompts/codex/spellcheck.md][spellcheck-doc] | Codex Spellcheck Prompt | evergreen | yes |
+| [docs/prompts/codex/test.md][test-doc] | Codex Test Prompt | evergreen | yes |
 | [docs/prompts/codex/upgrade.md][upgrade-doc] | Codex Upgrade Prompt | evergreen | yes |
 
 [automation-doc]: prompts/codex/automation.md
@@ -27,4 +28,5 @@ This index lists prompt documents for the jobbot3000 repository.
 [refactor-doc]: prompts/codex/refactor.md
 [security-doc]: prompts/codex/security.md
 [spellcheck-doc]: prompts/codex/spellcheck.md
+[test-doc]: prompts/codex/test.md
 [upgrade-doc]: prompts/codex/upgrade.md

--- a/docs/prompts/codex/docs.md
+++ b/docs/prompts/codex/docs.md
@@ -14,7 +14,8 @@ PURPOSE:
 Improve project documentation without modifying code behavior.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.


### PR DESCRIPTION
## Summary
- fix README path and mention workflow review in docs prompt
- include missing test prompt in docs index

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: test/scoring.test.js > computeFitScore > processes large requirement lists within 1200ms)*


------
https://chatgpt.com/codex/tasks/task_e_68bf4fdf2ee4832fa9150c166d0f2556