### PR TITLE
[Draft] docs: fix docs prompt README link

### DIFF
--- a/docs/prompts/codex/docs.md
+++ b/docs/prompts/codex/docs.md
@@ -14,7 +14,8 @@ PURPOSE:
 Improve project documentation without modifying code behavior.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow the repository [README.md](../../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.


### PR DESCRIPTION
what: fix README path in docs prompt and clarify context
why: link pointed to missing docs/README.md
how to test:
 - npm run lint
 - npm run test:ci # fails computeFitScore performance
Refs: #0
Status: draft, needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68bf4fdf2ee4832fa9150c166d0f2556