### PR TITLE
📝: refresh test prompt doc links

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -16,6 +16,7 @@ This index lists prompt documents for the jobbot3000 repository.
 | [docs/prompts/codex/refactor.md][refactor-doc] | Codex Refactor Prompt | evergreen | yes |
 | [docs/prompts/codex/security.md][security-doc] | Codex Security Prompt | evergreen | yes |
 | [docs/prompts/codex/spellcheck.md][spellcheck-doc] | Codex Spellcheck Prompt | evergreen | yes |
+| [docs/prompts/codex/test.md][test-doc] | Codex Test Prompt | evergreen | yes |
 | [docs/prompts/codex/upgrade.md][upgrade-doc] | Codex Upgrade Prompt | evergreen | yes |
 
 [automation-doc]: prompts/codex/automation.md
@@ -27,4 +28,5 @@ This index lists prompt documents for the jobbot3000 repository.
 [refactor-doc]: prompts/codex/refactor.md
 [security-doc]: prompts/codex/security.md
 [spellcheck-doc]: prompts/codex/spellcheck.md
+[test-doc]: prompts/codex/test.md
 [upgrade-doc]: prompts/codex/upgrade.md

--- a/docs/prompts/codex/test.md
+++ b/docs/prompts/codex/test.md
@@ -14,10 +14,11 @@ PURPOSE:
 Improve or expand test coverage without altering runtime behavior.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
-- Existing tests live in [test/](../../test).
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Existing tests live in [test/](../../../test).
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)).
+- Update [prompt-docs-summary.md](../../prompt-docs-summary.md) when modifying prompt docs.
 
 REQUEST:
 1. Identify missing or weak tests.


### PR DESCRIPTION
## Summary
- fix broken relative paths in Codex test prompt doc
- index test prompt in prompt-docs summary

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: computeFitScore performance test exceeds threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68bf4fdf2ee4832fa9150c166d0f2556