### PR TITLE
⚡: cache tokens in scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Example: `summarize('"Hi!" Bye.')` returns `"Hi!"`.
 Job requirements may appear under headers like `Requirements`, `Qualifications`,
 `What you'll need`, or `Responsibilities` (used if no other requirement headers are present).
 They may start with `-`, `+`, `*`, `•`, `–` (en dash), or `—` (em dash); these markers are stripped
-when parsing job text. Tokenization in resume scoring uses a single regex pass for performance.
+when parsing job text. Tokenization in resume scoring uses a single regex pass with a bounded
+cache for performance.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,7 +1,29 @@
+const TOKEN_CACHE_MAX = 100;
+const tokenCache = new Map();
+
 function tokenize(text) {
-  // Use regex matching to avoid replace/split allocations and speed up tokenization.
-  return new Set((text || '').toLowerCase().match(/[a-z0-9]+/g) || []);
+  // Cache regex tokenization to avoid repeated allocations on identical inputs.
+  const key = (text || '').toLowerCase();
+  let tokens = tokenCache.get(key);
+  if (tokens) {
+    // Refresh entry for simple LRU behaviour.
+    tokenCache.delete(key);
+    tokenCache.set(key, tokens);
+    return tokens;
+  }
+  tokens = new Set(key.match(/[a-z0-9]+/g) || []);
+  tokenCache.set(key, tokens);
+  if (tokenCache.size > TOKEN_CACHE_MAX) {
+    // Remove oldest cached entry to bound memory usage.
+    const oldestKey = tokenCache.keys().next().value;
+    tokenCache.delete(oldestKey);
+  }
+  return tokens;
 }
+
+export const __clearTokenCache = () => tokenCache.clear();
+export const __getTokenCacheSize = () => tokenCache.size;
+export const __TOKEN_CACHE_MAX = TOKEN_CACHE_MAX;
 
 export function computeFitScore(resumeText, requirements) {
   const bullets = Array.isArray(requirements) ? requirements : [];

--- a/test/scoring.test.js
+++ b/test/scoring.test.js
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import { performance } from 'node:perf_hooks';
-import { computeFitScore } from '../src/scoring.js';
+import {
+  computeFitScore,
+  __getTokenCacheSize,
+  __clearTokenCache,
+  __TOKEN_CACHE_MAX,
+} from '../src/scoring.js';
 
 describe('computeFitScore', () => {
   it('scores matched and missing requirements', () => {
@@ -21,5 +26,14 @@ describe('computeFitScore', () => {
     }
     const elapsed = performance.now() - start;
     expect(elapsed).toBeLessThan(1200);
+  });
+
+  it('bounds token cache size', () => {
+    __clearTokenCache();
+    for (let i = 0; i < __TOKEN_CACHE_MAX + 10; i += 1) {
+      const text = `skill-${i}`;
+      computeFitScore(text, [text]);
+    }
+    expect(__getTokenCacheSize()).toBeLessThanOrEqual(__TOKEN_CACHE_MAX);
   });
 });


### PR DESCRIPTION
what: reuse token sets with LRU-bounded cache and expose cache helpers for tests
why: avoid memory leak in scoring while retaining performance
how to test: npm run lint && npm run test:ci

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68bf4fc7b8c0832f94365e3ea9b0eebc