### PR TITLE
📝 : add upgrader prompt for upgrade doc

### DIFF
--- a/docs/prompts/codex/upgrade.md
+++ b/docs/prompts/codex/upgrade.md
@@ -14,7 +14,8 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../README.md).
+- See the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 
@@ -28,3 +29,31 @@ A pull request that updates the selected prompt doc with passing checks.
 ```
 
 Copy this block whenever upgrading prompts in jobbot3000.
+
+## Upgrader Prompt
+
+Use this prompt to refine `docs/prompts/codex/upgrade.md` itself.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Refine the `docs/prompts/codex/upgrade.md` document.
+
+CONTEXT:
+- Follow [README.md](../../README.md).
+- See the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+
+REQUEST:
+1. Keep this doc accurate and link-check.
+2. Ensure examples and references are up to date.
+3. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request that updates this doc with passing checks.
+```
+
+Copy this block when improving the upgrade prompt itself.


### PR DESCRIPTION
what: add Upgrader Prompt section to upgrade doc
why: enable self-upgrades of prompt documentation
how: npm run lint && npm run test:ci (fails: summarize perf limit)
Refs: #0
status: draft, needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68c11d75ae14832f94f960313d3cf0af