### PR TITLE
✨: add plain text summarize output

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ npm run test:ci
 
 # Summarize a job description
 # Works with sentences ending in ., ?, or !
-# Keep two sentences with --sentences
-echo "First. Second. Third." | jobbot summarize - --sentences 2
+# Keep two sentences with --sentences, output plain text with --text
+echo "First. Second. Third." | jobbot summarize - --sentences 2 --text
 ```
 
 In code, import the `summarize` function and pass the number of sentences to keep:

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -32,7 +32,11 @@ function getFlag(args, name, fallback) {
 
 async function cmdSummarize(args) {
   const input = args[0] || '-';
-  const format = args.includes('--json') ? 'json' : 'md';
+  const format = args.includes('--json')
+    ? 'json'
+    : args.includes('--text')
+      ? 'text'
+      : 'md';
   const timeoutMs = Number(getFlag(args, '--timeout', 10000));
   const count = Number(getFlag(args, '--sentences', 1));
   const raw = isHttpUrl(input)
@@ -42,6 +46,7 @@ async function cmdSummarize(args) {
   const summary = summarizeFirstSentence(raw, count);
   const payload = { ...parsed, summary };
   if (format === 'json') console.log(toJson(payload));
+  else if (format === 'text') console.log(summary);
   else console.log(toMarkdownSummary(payload));
 }
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import { summarize } from '../src/index.js';
 
 function runCli(args, input) {
   const bin = path.resolve('bin', 'jobbot.js');
@@ -22,6 +23,13 @@ describe('jobbot CLI', () => {
       'First. Second. Third.'
     );
     expect(out.trim()).toBe('First. Second.');
+  });
+
+  it('outputs plain text summary with --text', () => {
+    const input = 'Title: Engineer\nCompany: ACME\nFirst. Second.';
+    const out = runCli(['summarize', '-', '--text'], input);
+    expect(out.trim()).toBe(summarize(input));
+    expect(out).not.toMatch(/#|\*\*/);
   });
 
   it('match from local files', () => {


### PR DESCRIPTION
## Summary
- allow `jobbot summarize` to emit raw text via `--text`
- document and test the new flag

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c11d07be84832f89d0e981170ffeaa