### PR TITLE
✨: skip aside content in HTML extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ import { fetchTextFromUrl } from './src/fetch.js';
 
 const text = await fetchTextFromUrl('https://example.com/job');
 ```
-`fetchTextFromUrl` strips scripts, styles, navigation, and footer content and collapses
-whitespace to single spaces.
+`fetchTextFromUrl` strips scripts, styles, navigation, footer, and aside content and
+collapses whitespace to single spaces.
 
 The summarizer extracts the first sentence, handling `.`, `!`, `?`, and consecutive terminal
 punctuation like `?!`, including when followed by closing quotes or parentheses. Terminators apply

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -15,7 +15,8 @@ export function extractTextFromHtml(html) {
       { selector: 'script', format: 'skip' },
       { selector: 'style', format: 'skip' },
       { selector: 'nav', format: 'skip' },
-      { selector: 'footer', format: 'skip' }
+      { selector: 'footer', format: 'skip' },
+      { selector: 'aside', format: 'skip' }
     ]
   })
     .replace(/\s+/g, ' ')

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -19,4 +19,16 @@ describe('extractTextFromHtml', () => {
     `;
     expect(extractTextFromHtml(html)).toBe('First line Second line');
   });
+
+  it('omits aside content', () => {
+    const html = `
+      <html>
+        <body>
+          <p>Main</p>
+          <aside>ignored</aside>
+        </body>
+      </html>
+    `;
+    expect(extractTextFromHtml(html)).toBe('Main');
+  });
 });


### PR DESCRIPTION
## Summary
- ignore aside elements when extracting HTML text
- document aside filtering in README

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c11d07be84832f89d0e981170ffeaa