### PR TITLE
✨: parse Skills header in job parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ is lost. Parenthetical abbreviations like `(M.Sc.)` remain attached to their sur
 
 Example: `summarize('"Hi!" Bye.')` returns `"Hi!"`.
 
-Job requirements may appear under headers like `Requirements`, `Qualifications`,
+Job requirements may appear under headers like `Requirements`, `Qualifications`, `Skills`,
 `What you'll need`, or `Responsibilities` (used if no other requirement headers are present).
 They may start with `-`, `+`, `*`, `•`, `–` (en dash), `—` (em dash), or numeric markers like `1.`
 or `(1)`; these markers are stripped when parsing job text, even when the first requirement follows

--- a/src/parser.js
+++ b/src/parser.js
@@ -12,7 +12,8 @@ const COMPANY_PATTERNS = [
 const REQUIREMENTS_HEADERS = [
   /\bRequirements\b/i,
   /\bQualifications\b/i,
-  /\bWhat you(?:'|’)ll need\b/i
+  /\bWhat you(?:'|’)ll need\b/i,
+  /\bSkills\b/i
 ];
 
 const FALLBACK_REQUIREMENTS_HEADERS = [/\bResponsibilities\b/i];

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -50,6 +50,18 @@ Responsibilities:
     expect(parsed.requirements).toEqual(['Build features', 'Fix bugs']);
   });
 
+  it('parses requirements after a Skills header', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+Skills:
+- Build features
+- Fix bugs
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual(['Build features', 'Fix bugs']);
+  });
+
   it('prefers Requirements section when Responsibilities appears first', () => {
     const text = `
 Title: Developer


### PR DESCRIPTION
what: support `Skills` header when extracting requirements
why: parse job postings that label requirements as Skills
how to test:
- npm run lint
- npm run test:ci

Refs: #123

------
https://chatgpt.com/codex/tasks/task_e_68c11d07be84832f89d0e981170ffeaa