### PR TITLE
📝 : clarify test prompt context

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -25,8 +25,8 @@ This index lists prompt documents for the jobbot3000 repository, organized by ta
 | [docs/prompts/codex/security.md#upgrade-prompt][security-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/spellcheck.md][spellcheck-doc] | Codex Spellcheck Prompt | evergreen | yes |
 | [docs/prompts/codex/spellcheck.md#upgrade-prompt][spellcheck-up] | Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/test.md][test-doc] | Codex Test Prompt | evergreen | yes |
-| [docs/prompts/codex/test.md#upgrade-prompt][test-up] | Upgrade Prompt | evergreen | yes |
+| [docs/prompts/codex/test.md][test-doc] | Codex Test Prompt (Vitest) | evergreen | yes |
+| [docs/prompts/codex/test.md#upgrade-prompt][test-up] | Upgrade Prompt (docs) | evergreen | yes |
 | [docs/prompts/codex/upgrade.md][upgrade-doc] | Codex Upgrade Prompt | evergreen | yes |
 
 [automation-doc]: prompts/codex/automation.md

--- a/docs/prompts/codex/test.md
+++ b/docs/prompts/codex/test.md
@@ -15,9 +15,11 @@ Improve or expand test coverage without altering runtime behavior.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
-- Existing tests live in [test/](../../../test).
+- Install dependencies with `npm ci` if needed.
+- Existing tests live in [test/](../../../test) and use [Vitest](https://vitest.dev/).
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)).
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see
+  [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)).
 - Update [prompt-docs-summary.md](../../prompt-docs-summary.md) when modifying prompt docs.
 
 REQUEST:
@@ -45,7 +47,7 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the
+- Follow [README.md](../../../README.md); see the
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with


### PR DESCRIPTION
## Summary
- mention npm ci and Vitest in Codex Test Prompt and fix README link
- tag test upgrade entry as docs in prompt summary

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: summarize.repeat.perf.test.js exceeds threshold)*

------
https://chatgpt.com/codex/tasks/task_e_68c11d504950832faf90b30d70e67c27