### PR TITLE
🧪: cover resume loader and exporters

### DIFF
--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { toJson, toMarkdownSummary, toMarkdownMatch } from '../src/exporters.js';
+
+describe('exporters', () => {
+  it('converts data to pretty JSON', () => {
+    const json = toJson({ a: 1 });
+    expect(json).toBe('{\n  "a": 1\n}');
+  });
+
+  it('builds markdown summary with optional sections', () => {
+    const md = toMarkdownSummary({
+      title: 'Developer',
+      company: 'ACME',
+      summary: 'Great job',
+      requirements: ['JS', 'Node']
+    });
+    const expected = [
+      '# Developer',
+      '**Company**: ACME',
+      '',
+      'Great job',
+      '',
+      '## Requirements',
+      '- JS',
+      '- Node'
+    ].join('\n');
+    expect(md).toBe(expected);
+  });
+
+  it('builds markdown match report', () => {
+    const md = toMarkdownMatch({
+      title: 'Engineer',
+      company: 'ACME',
+      score: 50,
+      matched: ['JS'],
+      missing: ['Python']
+    });
+    const expected = [
+      '# Engineer',
+      '**Company**: ACME',
+      '**Fit Score**: 50%',
+      '',
+      '## Matched',
+      '- JS',
+      '',
+      '## Missing',
+      '- Python'
+    ].join('\n');
+    expect(md).toBe(expected);
+  });
+
+  it('omits sections when data is missing', () => {
+    expect(toMarkdownSummary({})).toBe('');
+    expect(toMarkdownMatch({})).toBe('');
+  });
+});

--- a/test/fixtures/resume.md
+++ b/test/fixtures/resume.md
@@ -1,0 +1,2 @@
+# Jane Doe
+**Role**: Developer

--- a/test/resume.test.js
+++ b/test/resume.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { loadResume } from '../src/resume.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+describe('loadResume', () => {
+  it('loads and trims plain text resumes', async () => {
+    const file = path.resolve(__dirname, 'fixtures', 'resume.txt');
+    const text = await loadResume(file);
+    expect(text).toBe('I am an engineer with JavaScript experience.');
+  });
+
+  it('strips markdown formatting for .md files', async () => {
+    const file = path.resolve(__dirname, 'fixtures', 'resume.md');
+    const text = await loadResume(file);
+    expect(text).toBe('Jane Doe\nRole: Developer');
+  });
+});


### PR DESCRIPTION
what: add unit tests for resume loading and markdown exporters
why: verify markdown stripping and output formatting
how to test:
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68c11d4b52a8832f903b76cef923142f