### PR TITLE
📝: fix docs prompt links

### DIFF
--- a/docs/prompts/codex/docs.md
+++ b/docs/prompts/codex/docs.md
@@ -46,11 +46,14 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
-- Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`.
+  - Follow [README.md](../../../README.md); see the
+    [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+  - Install dependencies with `npm ci` if needed.
+  - Run `npm run lint` and `npm run test:ci` before committing.
+  - Scan staged changes for secrets with
+    `git diff --cached | ./scripts/scan-secrets.py`.
+  - Confirm referenced files exist; update
+    [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
 1. Select a file under `docs/prompts/` to update or create a new prompt type.


### PR DESCRIPTION
what: correct README path and add link checks
why: ensure prompt docs reference existing files and guide contributors
how to test: npm run lint && npm run test:ci
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68c11d3bbad0832fbbeb4009ae544c96