### PR TITLE
📝 docs: fix README link in feature prompt

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -3,6 +3,8 @@
 
 This index lists prompt documents for the jobbot3000 repository, organized by task type.
 
+Each prompt doc should reference the root [README.md](../README.md) using a valid relative path.
+
 ## jobbot3000
 
 | Path | Prompt | Type | One-click? |

--- a/docs/prompts/codex/feature.md
+++ b/docs/prompts/codex/feature.md
@@ -14,7 +14,8 @@ PURPOSE:
 Implement a minimal feature in jobbot3000.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 
@@ -43,11 +44,13 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the
+- Follow [README.md](../../../README.md); see the
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`.
+- Update [prompt-docs-summary.md](../../prompt-docs-summary.md) when modifying prompt docs.
 
 REQUEST:
 1. Select a file under `docs/prompts/` to update or create a new prompt type.


### PR DESCRIPTION
## Summary
- correct README.md path in feature prompt
- note CI workflow checks and summary reference

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c11d3bbad0832fbbeb4009ae544c96