### PR TITLE
docs: fix README link in fix prompt

### DIFF
--- a/docs/prompts/codex/fix.md
+++ b/docs/prompts/codex/fix.md
@@ -14,9 +14,12 @@ PURPOSE:
 Diagnose and resolve bugs in jobbot3000.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Confirm referenced files exist to avoid broken links.
 
 REQUEST:
 1. Reproduce the bug with a failing test or script.
@@ -43,7 +46,7 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the
+- Follow [README.md](../../../README.md); see the
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with


### PR DESCRIPTION
## Summary
- correct README path in Codex Fix prompt
- link to scan-secrets script and note verifying referenced files

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c11d3bbad0832fbbeb4009ae544c96