### PR TITLE
📝 docs: refresh upgrade prompt links

### DIFF
--- a/docs/prompts/codex/upgrade.md
+++ b/docs/prompts/codex/upgrade.md
@@ -14,9 +14,11 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md)
+  for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Verify that all referenced paths and links resolve to existing files.
 
 REQUEST:
 1. Select a file under `docs/prompts/` to update or create a new prompt type.


### PR DESCRIPTION
## What
- fix README link in upgrade prompt
- remind contributors to verify referenced paths

## Why
- broken links confuse contributors

## How to test
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c11d3bbad0832fbbeb4009ae544c96