### PR TITLE
📝 : – tidy codex prompt docs

### DIFF
--- a/docs/prompts/codex/fix.md
+++ b/docs/prompts/codex/fix.md
@@ -16,7 +16,8 @@ Diagnose and resolve bugs in jobbot3000.
 CONTEXT:
 - Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+  (see [scripts/scan-secrets.py](../../scripts/scan-secrets.py)).
 
 REQUEST:
 1. Reproduce the bug with a failing test or script.
@@ -26,35 +27,5 @@ REQUEST:
 
 OUTPUT:
 A pull request URL summarizing the bug fix.
-```
-
-Copy this block whenever fixing bugs in jobbot3000.
-
-## Upgrade Prompt
-Type: evergreen
-
-Use this prompt to refine jobbot3000's prompt documentation.
-
-```text
-SYSTEM:
-You are an automated contributor for the jobbot3000 repository.
-
-PURPOSE:
-Improve or expand the repository's prompt docs.
-
-CONTEXT:
-- Follow [README.md](../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
-- Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`.
-
-REQUEST:
-1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
-3. Run the commands above and fix any failures.
-
-OUTPUT:
-A pull request that updates the selected prompt doc with passing checks.
 ```
 

--- a/docs/prompts/codex/upgrade.md
+++ b/docs/prompts/codex/upgrade.md
@@ -16,7 +16,8 @@ Improve or expand the repository's prompt docs.
 CONTEXT:
 - Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+  (see [scripts/scan-secrets.py](../../scripts/scan-secrets.py)).
 
 REQUEST:
 1. Select a file under `docs/prompts/` to update or create a new prompt type.
@@ -28,3 +29,4 @@ A pull request that updates the selected prompt doc with passing checks.
 ```
 
 Copy this block whenever upgrading prompts in jobbot3000.
+


### PR DESCRIPTION
## Summary
- remove stray upgrade prompt from fix doc and link secret scan script
- link secret scan script in upgrade doc and drop shell prompt footer

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c11d36ec20832f98830c4a132c8761