### PR TITLE
📚: fix upgrade prompt README link

### DIFF
--- a/docs/prompts/codex/upgrade.md
+++ b/docs/prompts/codex/upgrade.md
@@ -4,7 +4,7 @@ slug: 'codex-upgrade'
 ---
 
 # Codex Upgrade Prompt
-Use this prompt to refine jobbot3000's prompt documentation.
+Use this prompt when updating or creating prompt docs in jobbot3000.
 
 ```text
 SYSTEM:
@@ -14,7 +14,8 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md)
+  for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 


### PR DESCRIPTION
what: clarify upgrade prompt and correct README link
why: ensure prompt docs reference existing files
how to test: npm run lint && npm run test:ci (perf test fails)
Refs: #0

Label: needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68c11d3063dc832f8f75140e6fa1b17a