### PR TITLE
🔒 limit fetch response size to prevent DoS

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ Fetch remote job listings and normalize HTML to plain text:
 ```js
 import { fetchTextFromUrl } from './src/fetch.js';
 
-const text = await fetchTextFromUrl('https://example.com/job');
+const text = await fetchTextFromUrl('https://example.com/job', { maxBytes: 50_000 });
 ```
-`fetchTextFromUrl` strips scripts, styles, navigation, and footer content and collapses
+`fetchTextFromUrl` strips scripts, styles, navigation, and footer content, limits downloads to 1 MB
+by default (override with `maxBytes`), and collapses
 whitespace to single spaces.
 
 The summarizer extracts the first sentence, handling `.`, `!`, `?`, and consecutive terminal

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { extractTextFromHtml } from '../src/fetch.js';
+import http from 'http';
+import { extractTextFromHtml, fetchTextFromUrl } from '../src/fetch.js';
 
 describe('extractTextFromHtml', () => {
   it('collapses whitespace and skips non-content tags', () => {
@@ -18,5 +19,19 @@ describe('extractTextFromHtml', () => {
       </html>
     `;
     expect(extractTextFromHtml(html)).toBe('First line Second line');
+  });
+});
+
+describe('fetchTextFromUrl', () => {
+  it('enforces a maximum response size', async () => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('a'.repeat(20));
+    });
+    await new Promise(resolve => server.listen(0, resolve));
+    const { port } = server.address();
+    const url = `http://127.0.0.1:${port}`;
+    await expect(fetchTextFromUrl(url, { maxBytes: 10 })).rejects.toThrow();
+    server.close();
   });
 });


### PR DESCRIPTION
## Summary
- enforce 1 MB default response limit in fetchTextFromUrl
- document maxBytes option and add regression test

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c11d33a96c832f8879e5a843488c1e