### PR TITLE
Enforce HTTPS-only URL fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ import { fetchTextFromUrl } from './src/fetch.js';
 
 const text = await fetchTextFromUrl('https://example.com/job');
 ```
-`fetchTextFromUrl` strips scripts, styles, navigation, and footer content and collapses
-whitespace to single spaces.
+`fetchTextFromUrl` only accepts HTTPS URLs, strips scripts, styles, navigation, and footer
+content, and collapses whitespace to single spaces.
 
 The summarizer extracts the first sentence, handling `.`, `!`, `?`, and consecutive terminal
 punctuation like `?!`, including when followed by closing quotes or parentheses. Terminators apply

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -8,12 +8,12 @@ import { loadResume } from '../src/resume.js';
 import { computeFitScore } from '../src/scoring.js';
 import { toJson, toMarkdownSummary, toMarkdownMatch } from '../src/exporters.js';
 
-function isHttpUrl(s) {
-  return /^https?:\/\//i.test(s);
+function isHttpsUrl(s) {
+  return /^https:\/\//i.test(s);
 }
 
 async function readSource(input) {
-  if (isHttpUrl(input)) return fetchTextFromUrl(input);
+  if (isHttpsUrl(input)) return fetchTextFromUrl(input);
   if (input === '-' || input === '/dev/stdin') {
     return fs.readFileSync(0, 'utf-8');
   }
@@ -35,7 +35,7 @@ async function cmdSummarize(args) {
   const format = args.includes('--json') ? 'json' : 'md';
   const timeoutMs = Number(getFlag(args, '--timeout', 10000));
   const count = Number(getFlag(args, '--sentences', 1));
-  const raw = isHttpUrl(input)
+  const raw = isHttpsUrl(input)
     ? await fetchTextFromUrl(input, { timeoutMs })
     : await readSource(input);
   const parsed = parseJobText(raw);
@@ -61,7 +61,7 @@ async function cmdMatch(args) {
   const resumePath = args[resumeIdx + 1];
   const jobInput = args[jobIdx + 1];
   const resumeText = await loadResume(resumePath);
-  const jobRaw = isHttpUrl(jobInput)
+  const jobRaw = isHttpsUrl(jobInput)
     ? await fetchTextFromUrl(jobInput, { timeoutMs })
     : await readSource(jobInput);
   const parsed = parseJobText(jobRaw);

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -23,12 +23,17 @@ export function extractTextFromHtml(html) {
 }
 
 export async function fetchTextFromUrl(url, { timeoutMs = 10000 } = {}) {
+  const parsed = new URL(url);
+  if (parsed.protocol !== 'https:') {
+    throw new Error('Only HTTPS URLs are supported');
+  }
+
   const controller = new AbortController();
   const timer = setTimeout(
     () => controller.abort(new Error(`Timeout after ${timeoutMs}ms`)),
     timeoutMs
   );
-  const response = await fetch(url, { redirect: 'follow', signal: controller.signal })
+  const response = await fetch(parsed, { redirect: 'follow', signal: controller.signal })
     .finally(() => clearTimeout(timer));
   if (!response.ok) {
     throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractTextFromHtml } from '../src/fetch.js';
+import { extractTextFromHtml, fetchTextFromUrl } from '../src/fetch.js';
 
 describe('extractTextFromHtml', () => {
   it('collapses whitespace and skips non-content tags', () => {
@@ -18,5 +18,11 @@ describe('extractTextFromHtml', () => {
       </html>
     `;
     expect(extractTextFromHtml(html)).toBe('First line Second line');
+  });
+});
+
+describe('fetchTextFromUrl', () => {
+  it('rejects non-HTTPS URLs', async () => {
+    await expect(fetchTextFromUrl('http://example.invalid')).rejects.toThrow(/HTTPS/);
   });
 });


### PR DESCRIPTION
## Summary
- reject non-HTTPS URLs in `fetchTextFromUrl`
- gate CLI URL handling on HTTPS
- document HTTPS-only requirement and add regression test

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c11d33a96c832f8879e5a843488c1e