### PR TITLE
🔧: refactor fetch timeout handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ Fetch remote job listings and normalize HTML to plain text:
 ```js
 import { fetchTextFromUrl } from './src/fetch.js';
 
-const text = await fetchTextFromUrl('https://example.com/job');
+const text = await fetchTextFromUrl('https://example.com/job', { timeoutMs: 5000 });
 ```
 `fetchTextFromUrl` strips scripts, styles, navigation, and footer content and collapses
-whitespace to single spaces.
+whitespace to single spaces. Pass `timeoutMs` (milliseconds) to override the 10s default.
 
 The summarizer extracts the first sentence, handling `.`, `!`, `?`, and consecutive terminal
 punctuation like `?!`, including when followed by closing quotes or parentheses. Terminators apply

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -22,23 +22,33 @@ export function extractTextFromHtml(html) {
     .trim();
 }
 
+/**
+ * Fetch a URL and return its text content. HTML responses are converted to plain text.
+ *
+ * @param {string} url
+ * @param {{ timeoutMs?: number }} [opts]
+ * @returns {Promise<string>}
+ */
 export async function fetchTextFromUrl(url, { timeoutMs = 10000 } = {}) {
   const controller = new AbortController();
   const timer = setTimeout(
     () => controller.abort(new Error(`Timeout after ${timeoutMs}ms`)),
     timeoutMs
   );
-  const response = await fetch(url, { redirect: 'follow', signal: controller.signal })
-    .finally(() => clearTimeout(timer));
-  if (!response.ok) {
-    throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+
+  try {
+    const response = await fetch(url, { redirect: 'follow', signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
+    }
+    const contentType = response.headers.get('content-type') || '';
+    const body = await response.text();
+    return contentType.includes('text/html')
+      ? extractTextFromHtml(body)
+      : body.trim();
+  } finally {
+    clearTimeout(timer);
   }
-  const contentType = response.headers.get('content-type') || '';
-  const body = await response.text();
-  if (contentType.includes('text/html')) {
-    return extractTextFromHtml(body);
-  }
-  return body.trim();
 }
 
 

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -1,5 +1,9 @@
-import { describe, it, expect } from 'vitest';
-import { extractTextFromHtml } from '../src/fetch.js';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('node-fetch', () => ({ default: vi.fn() }));
+
+import fetch from 'node-fetch';
+import { extractTextFromHtml, fetchTextFromUrl } from '../src/fetch.js';
 
 describe('extractTextFromHtml', () => {
   it('collapses whitespace and skips non-content tags', () => {
@@ -18,5 +22,43 @@ describe('extractTextFromHtml', () => {
       </html>
     `;
     expect(extractTextFromHtml(html)).toBe('First line Second line');
+  });
+});
+
+describe('fetchTextFromUrl', () => {
+  it('returns extracted text for HTML responses', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/html' },
+      text: () => Promise.resolve('<p>Hello</p>')
+    });
+    const text = await fetchTextFromUrl('http://example.com');
+    expect(text).toBe('Hello');
+  });
+
+  it('returns plain text for non-HTML responses', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('  hi  ')
+    });
+    const text = await fetchTextFromUrl('http://example.com');
+    expect(text).toBe('hi');
+  });
+
+  it('throws on HTTP errors', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('error')
+    });
+    await expect(fetchTextFromUrl('http://example.com'))
+      .rejects.toThrow('Failed to fetch http://example.com: 500 Server Error');
   });
 });


### PR DESCRIPTION
what: use try/finally in fetchTextFromUrl, add tests, doc timeout option
why: clarify timer cleanup and ensure fetch behavior stays stable
how to test: npm run lint && npm run test:ci (fails: summarize.repeat.perf)

Refs: #0
needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68c11d26ed84832fb669dfe07eb387c0