### PR TITLE
Refactor parser header detection

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -25,13 +25,21 @@ function stripBullet(line) {
   return line.replace(BULLET_PREFIX_RE, '').trim();
 }
 
+/** Check if a line matches any pattern in the provided array. */
+function matchAny(line, patterns) {
+  return patterns.some(pattern => pattern.test(line));
+}
+
 /**
  * Find the index of the first header in `primary` or fall back to headers in `fallback`.
  * Returns -1 if no headers match.
  */
 function findHeaderIndex(lines, primary, fallback) {
-  const idx = lines.findIndex(l => primary.some(h => h.test(l)));
-  return idx !== -1 ? idx : lines.findIndex(l => fallback.some(h => h.test(l)));
+  for (const group of [primary, fallback]) {
+    const idx = lines.findIndex(line => matchAny(line, group));
+    if (idx !== -1) return idx;
+  }
+  return -1;
 }
 
 function findFirstMatch(lines, patterns) {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -103,4 +103,14 @@ Requirements:
       'Third skill'
     ]);
   });
+
+  it('returns no requirements when header is absent', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+Just some description without requirement section.
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual([]);
+  });
 });


### PR DESCRIPTION
## Summary
- refactor header search logic into reusable helper
- cover missing case where job text lacks requirement section

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: summarize repeated calls performance > expected 540.759248 to be less than 350)*

needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68c11d26ed84832fb669dfe07eb387c0