### PR TITLE
📝 : clarify fix prompt context

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -2,6 +2,7 @@
 # Prompt Docs Summary
 
 This index lists prompt documents for the jobbot3000 repository, organized by task type.
+Ensure each document's links reference existing files.
 
 ## jobbot3000
 

--- a/docs/prompts/codex/fix.md
+++ b/docs/prompts/codex/fix.md
@@ -14,9 +14,11 @@ PURPOSE:
 Diagnose and resolve bugs in jobbot3000.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Existing tests live in [test/](../../../test).
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Update [prompt-docs-summary.md](../../prompt-docs-summary.md) when modifying prompt docs.
 
 REQUEST:
 1. Reproduce the bug with a failing test or script.


### PR DESCRIPTION
what: fix Codex Fix Prompt's README link and add test/summary pointers
why: keep prompt docs accurate and link-safe
how to test:
- npm run lint
- npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c11d1511b4832fa16ac5fef5d60251