### PR TITLE
🐛: capture inline Responsibilities requirement – keep first bullet

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -44,14 +44,19 @@ function findFirstMatch(lines, patterns) {
   return '';
 }
 
-/** Extract requirement bullets after a known header line. */
+/**
+ * Extract requirement bullets after a known header line.
+ * Supports requirement text on the same line for both primary and fallback headers.
+ */
 function extractRequirements(lines) {
   const idx = findHeaderIndex(lines, REQUIREMENTS_HEADERS, FALLBACK_REQUIREMENTS_HEADERS);
   if (idx === -1) return [];
 
   const requirements = [];
   const headerLine = lines[idx];
-  const headerPattern = REQUIREMENTS_HEADERS.find(h => h.test(headerLine));
+  const headerPattern =
+    REQUIREMENTS_HEADERS.find(h => h.test(headerLine)) ||
+    FALLBACK_REQUIREMENTS_HEADERS.find(h => h.test(headerLine));
   let rest = headerPattern ? headerLine.replace(headerPattern, '').trim() : '';
   rest = rest.replace(/^[:\s]+/, '');
 

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -50,6 +50,17 @@ Responsibilities:
     expect(parsed.requirements).toEqual(['Build features', 'Fix bugs']);
   });
 
+  it('captures inline requirement text after a Responsibilities header', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+Responsibilities: Build features
+- Fix bugs
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual(['Build features', 'Fix bugs']);
+  });
+
   it('prefers Requirements section when Responsibilities appears first', () => {
     const text = `
 Title: Developer


### PR DESCRIPTION
what: ensure parser keeps requirement text when Responsibilities header shares line
why: first bullet was dropped because fallback header pattern wasn't stripped
how to test: npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c11d0e76cc832fad7be5b9047627df