### PR TITLE
🐛: handle zero sentence summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ npm run test:ci
 # Summarize a job description
 # Works with sentences ending in ., ?, or !
 # Keep two sentences with --sentences
+# Use 0 to return an empty string
 echo "First. Second. Third." | jobbot summarize - --sentences 2
 ```
 
@@ -37,6 +38,8 @@ const summary = summarize(text, 2);
 console.log(summary);
 // "First sentence. Second sentence?"
 ```
+
+Passing `0` for the sentence count returns an empty string.
 
 Fetch remote job listings and normalize HTML to plain text:
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 /**
  * Return the first N sentences from the given text.
+ * If `count` is zero or negative, returns an empty string.
  * Sentences end with '.', '!', '?', or '…', including consecutive punctuation (e.g. `?!`),
  * optionally followed by closing quotes or parentheses.
  * Falls back to returning the trimmed input when no such punctuation exists.
@@ -18,7 +19,7 @@ const openers = new Set(['(', '[', '{']);
 const isDigit = (c) => c >= '0' && c <= '9';
 
 export function summarize(text, count = 1) {
-  if (!text) return '';
+  if (!text || count <= 0) return '';
 
   /**
    * Scan character-by-character to avoid costly regular expressions.

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -24,6 +24,10 @@ describe('summarize', () => {
     expect(summarize(text, 2)).toBe('First. Second.');
   });
 
+  it('returns empty string when count is 0', () => {
+    expect(summarize('First sentence.', 0)).toBe('');
+  });
+
   it('ignores bare newlines without punctuation', () => {
     const text = 'First line\nSecond line.';
     expect(summarize(text)).toBe('First line Second line.');


### PR DESCRIPTION
## What
- ensure summarize returns empty string when sentence count is 0
- document zero-sentence behavior

## Why
- count=0 previously returned full text

## How to Test
- `npm run lint`
- `npm run test:ci`

Refs: #123

------
https://chatgpt.com/codex/tasks/task_e_68c11d0e76cc832fad7be5b9047627df