### PR TITLE
🐛: preserve leading numbers in requirement lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Job requirements may appear under headers like `Requirements`, `Qualifications`,
 `What you'll need`, or `Responsibilities` (used if no other requirement headers are present).
 They may start with `-`, `+`, `*`, `•`, `–` (en dash), `—` (em dash), or numeric markers like `1.`
 or `(1)`; these markers are stripped when parsing job text, even when the first requirement follows
-the header on the same line. Resume scoring tokenizes via a manual scanner and caches tokens to
-avoid repeated work.
+the header on the same line. Leading numbers without punctuation remain intact. Resume scoring
+tokenizes via a manual scanner and caches tokens to avoid repeated work.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/parser.js
+++ b/src/parser.js
@@ -17,8 +17,10 @@ const REQUIREMENTS_HEADERS = [
 
 const FALLBACK_REQUIREMENTS_HEADERS = [/\bResponsibilities\b/i];
 
-// Common bullet prefix regex, supports -, +, *, •, ·, en dash, em dash, digits, punctuation, etc.
-const BULLET_PREFIX_RE = /^[-+*•\u00B7\u2013\u2014\d.)(\s]+/;
+// Common bullet prefix regex. Strips '-', '+', '*', '•', '·', en/em dashes,
+// numeric markers like `1.` or `1)` and parenthetical numbers like `(1)`.
+// Preserves leading digits that are part of the requirement text itself.
+const BULLET_PREFIX_RE = /^(?:[-+*•\u00B7\u2013\u2014]\s*|\d+[.)]\s*|\(\d+\)\s*)/;
 
 /** Strip common bullet characters and surrounding whitespace from a line. */
 function stripBullet(line) {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -103,4 +103,19 @@ Requirements:
       'Third skill'
     ]);
   });
+
+  it('preserves leading numbers in requirement text', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+Requirements:
+5+ years experience
+10G networking knowledge
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual([
+      '5+ years experience',
+      '10G networking knowledge'
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- refine bullet regex to avoid stripping leading digits in requirements
- document that plain leading numbers stay intact
- test parsing when requirements start with numbers

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c11d0e76cc832fad7be5b9047627df