### PR TITLE
📝: improve upgrade prompt guidance

### DIFF
--- a/docs/prompts/codex/upgrade.md
+++ b/docs/prompts/codex/upgrade.md
@@ -14,7 +14,8 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Review [prompt docs summary](../../prompt-docs-summary.md) for available prompt types.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 
@@ -27,4 +28,4 @@ OUTPUT:
 A pull request that updates the selected prompt doc with passing checks.
 ```
 
-Copy this block whenever upgrading prompts in jobbot3000.
+Copy this block whenever upgrading prompts in jobbot3000. Update the summary index if you add a new prompt.


### PR DESCRIPTION
what: fix README link and reference prompt index
why: keep prompt docs accurate
how to test: npm run lint && npm run test:ci
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68c11d0b4258832fb5c0a062ef4c4314