### PR TITLE
📝 : fix feature prompt links

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -3,6 +3,8 @@
 
 This index lists prompt documents for the jobbot3000 repository, organized by task type.
 
+All links are verified to reference existing files.
+
 ## jobbot3000
 
 | Path | Prompt | Type | One-click? |

--- a/docs/prompts/codex/feature.md
+++ b/docs/prompts/codex/feature.md
@@ -14,9 +14,10 @@ PURPOSE:
 Implement a minimal feature in jobbot3000.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see
+  [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 
 REQUEST:
 1. Write a failing test capturing the new behavior.
@@ -43,11 +44,12 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the
+- Follow [README.md](../../../README.md); see the
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`.
+  `git diff --cached | ./scripts/scan-secrets.py` (see
+  [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 
 REQUEST:
 1. Select a file under `docs/prompts/` to update or create a new prompt type.


### PR DESCRIPTION
what: fix README path and link to scan-secrets script in feature prompt
why: avoid broken docs and guide secret scans
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68c11d0b4258832fb5c0a062ef4c4314