### PR TITLE
📝: clarify docs prompt links

### DIFF
--- a/docs/prompts/codex/docs.md
+++ b/docs/prompts/codex/docs.md
@@ -46,8 +46,10 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the
+- Follow [README.md](../../../README.md); see the
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
+- Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`.


### PR DESCRIPTION
what: fix README link in docs prompt and add CI workflow guidance
why: keep prompt docs accurate and self-contained
how to test: npm run lint && npm run test:ci
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68c11d0b4258832fb5c0a062ef4c4314