### PR TITLE
📝: fix README link in fix prompt

### DIFF
--- a/docs/prompts/codex/fix.md
+++ b/docs/prompts/codex/fix.md
@@ -14,9 +14,12 @@ PURPOSE:
 Diagnose and resolve bugs in jobbot3000.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py`
+  (see [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)).
 
 REQUEST:
 1. Reproduce the bug with a failing test or script.
@@ -43,11 +46,12 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the
+- Follow [README.md](../../../README.md); see the
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`.
+  `git diff --cached | ./scripts/scan-secrets.py`
+  (see [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)).
 
 REQUEST:
 1. Select a file under `docs/prompts/` to update or create a new prompt type.


### PR DESCRIPTION
## Summary
- fix README path and add explicit secret scan link in Codex Fix Prompt

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: summarize.repeat.perf.test.js > handles 10k short texts under 200ms)*


------
https://chatgpt.com/codex/tasks/task_e_68c11ceec660832f893fd3f6d0904ddc