### PR TITLE
📝: clarify fetch example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,13 @@ console.log(summary);
 // "First sentence. Second sentence?"
 ```
 
-Fetch remote job listings and normalize HTML to plain text:
+Fetch remote job listings, normalize HTML to plain text, and print the result:
 
 ```js
 import { fetchTextFromUrl } from './src/fetch.js';
 
 const text = await fetchTextFromUrl('https://example.com/job');
+console.log(text);
 ```
 `fetchTextFromUrl` strips scripts, styles, navigation, and footer content and collapses
 whitespace to single spaces.


### PR DESCRIPTION
what: document printing fetched job text in README example
why: readers see full flow for fetchTextFromUrl usage
how to test:
- npm run lint
- npm run test:ci

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c11cece810832f9e7aac0a95628ac1