### PR TITLE
📚 : clarify and refresh links in spellcheck prompt doc

### DIFF
--- a/docs/prompts/codex/spellcheck.md
+++ b/docs/prompts/codex/spellcheck.md
@@ -14,14 +14,17 @@ PURPOSE:
 Correct typos and enforce consistent spelling.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Ensure referenced files exist and update links as needed.
 
 REQUEST:
 1. Locate spelling errors in code or docs.
 2. Fix the typos without altering meaning.
-3. Run the commands above and resolve any failures.
+3. Verify referenced files exist and correct any broken links.
+4. Run the commands above and resolve any failures.
 
 OUTPUT:
 A pull request URL summarizing the spelling corrections.
@@ -42,11 +45,12 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the
+- Follow [README.md](../../../README.md); see the
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`.
+- Ensure referenced files exist and update links as needed.
 
 REQUEST:
 1. Select a file under `docs/prompts/` to update or create a new prompt type.


### PR DESCRIPTION
what: fix README path and add link verification note
why: ensure prompt docs reference existing files
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68c11ce97d34832f87994a6c26512293