### PR TITLE
Skip header elements in HTML extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import { fetchTextFromUrl } from './src/fetch.js';
 
 const text = await fetchTextFromUrl('https://example.com/job');
 ```
-`fetchTextFromUrl` strips scripts, styles, navigation, and footer content and collapses
+`fetchTextFromUrl` strips scripts, styles, header, navigation, and footer content and collapses
 whitespace to single spaces.
 
 The summarizer extracts the first sentence, handling `.`, `!`, `?`, and consecutive terminal

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -14,6 +14,7 @@ export function extractTextFromHtml(html) {
     selectors: [
       { selector: 'script', format: 'skip' },
       { selector: 'style', format: 'skip' },
+      { selector: 'header', format: 'skip' },
       { selector: 'nav', format: 'skip' },
       { selector: 'footer', format: 'skip' }
     ]

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -10,6 +10,7 @@ describe('extractTextFromHtml', () => {
           <script>1</script>
         </head>
         <body>
+          <header>ignored</header>
           <nav>ignored</nav>
           <p>First   line</p>
           <p>Second line</p>


### PR DESCRIPTION
## Summary
- ignore <header> tags when converting HTML to text
- document header stripping in README
- ensure header elements are skipped in tests

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: handles 10k short texts under 200ms)*

------
https://chatgpt.com/codex/tasks/task_e_68c11cdfc09c832f8b173dfe9fe1fb34