### PR TITLE
🔒 Harden fetchTextFromUrl against SSRF

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ import { fetchTextFromUrl } from './src/fetch.js';
 const text = await fetchTextFromUrl('https://example.com/job', { timeoutMs: 5000 });
 ```
 `fetchTextFromUrl` strips scripts, styles, navigation, footer, and aside content and
-collapses whitespace to single spaces. Pass `timeoutMs` (milliseconds) to override the 10s default.
+collapses whitespace to single spaces. Only `http:` and `https:` URLs are allowed, and
+localhost or private-network hosts are blocked to limit SSRF risk. Pass `timeoutMs` (milliseconds)
+to override the 10s default.
 
 Format parsed results as Markdown:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,3 +9,7 @@ Secrets such as API keys or tokens should never be committed. Use environment va
 
 ## Data Privacy
 All job search data stays on your machine. Offline or encrypted LLM inference is encouraged for protecting personal information.
+
+## Network Access
+`fetchTextFromUrl` only permits `http` and `https` URLs and rejects localhost or private-network
+hosts to reduce server-side request forgery risk.

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -73,4 +73,10 @@ describe('fetchTextFromUrl', () => {
     await expect(fetchTextFromUrl('http://example.com'))
       .rejects.toThrow('Failed to fetch http://example.com: 500 Server Error');
   });
+
+  it('rejects localhost URLs', async () => {
+    fetch.mockReset();
+    await expect(fetchTextFromUrl('http://localhost')).rejects.toThrow(/disallowed/i);
+    expect(fetch).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- validate URL scheme and host before fetching
- document URL restrictions in README and SECURITY policy
- cover disallowed localhost URLs in tests

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c25d4f8098832fb8cc8d73e8df906b