### PR TITLE
✨: recognize interrobang as sentence terminator

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ const md = toMarkdownSummary({
 });
 ```
 
-The summarizer extracts the first sentence, handling `.`, `!`, `?`, and consecutive terminal
-punctuation like `?!`, including when followed by closing quotes or parentheses. Terminators apply
+The summarizer extracts the first sentence, handling `.`, `!`, `?`, `…`, `‽`, and
+consecutive terminal punctuation like `?!`, including when followed by closing quotes or
+parentheses. Terminators apply
 only when followed by whitespace or the end of text, so decimals like `1.99` remain intact.
 It ignores bare newlines.  
 It scans text character-by-character to avoid large intermediate arrays and regex performance

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 /**
  * Return the first N sentences from the given text.
  * If `count` is zero or negative, returns an empty string.
- * Sentences end with '.', '!', '?', or '…', including consecutive punctuation (e.g. `?!`),
+ * Sentences end with '.', '!', '?', '…', or '‽', including consecutive punctuation (e.g. `?!`),
  * optionally followed by closing quotes or parentheses.
  * Falls back to returning the trimmed input when no such punctuation exists.
  * If fewer complete sentences than requested exist, any remaining text is appended
@@ -51,7 +51,7 @@ export function summarize(text, count = 1) {
       else if (!quote) quote = ch;
     }
 
-    if (ch === '.' || ch === '!' || ch === '?' || ch === '…') {
+    if (ch === '.' || ch === '!' || ch === '?' || ch === '…' || ch === '‽') {
       // Skip decimals like 3.14
       if (ch === '.' && i > 0 && isDigit(text[i - 1]) && i + 1 < len && isDigit(text[i + 1])) {
         continue;
@@ -62,7 +62,13 @@ export function summarize(text, count = 1) {
       // absorb consecutive punctuation like ?!
       while (
         j < len &&
-        (text[j] === '.' || text[j] === '!' || text[j] === '?' || text[j] === '…')
+        (
+          text[j] === '.' ||
+          text[j] === '!' ||
+          text[j] === '?' ||
+          text[j] === '…' ||
+          text[j] === '‽'
+        )
       ) {
         j++;
       }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -69,6 +69,11 @@ it('returns empty string when count is 0', () => {
     expect(summarize(text)).toBe('Wait…');
   });
 
+  it('recognizes interrobang as terminator', () => {
+    const text = 'Really‽ Another sentence.';
+    expect(summarize(text)).toBe('Really‽');
+  });
+
   it('treats non-breaking space as whitespace', () => {
     const text = 'One sentence.\u00A0Another.';
     expect(summarize(text)).toBe('One sentence.');


### PR DESCRIPTION
## Summary
- treat ‽ as a sentence terminator in the summarizer
- document interrobang support

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: expected 1059.478489 to be less than 650)*

------
https://chatgpt.com/codex/tasks/task_e_68c25d22631c832fb8db0aff1b65c3f8