### PR TITLE
♻️: centralize HTML-to-text options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ const text = await fetchTextFromUrl('https://example.com/job', { timeoutMs: 5000
 `fetchTextFromUrl` strips scripts, styles, navigation, footer, and aside content and
 collapses whitespace to single spaces. Pass `timeoutMs` (milliseconds) to override the 10s default.
 
+Normalize existing HTML without fetching:
+
+```js
+import { extractTextFromHtml } from './src/fetch.js';
+
+const text = extractTextFromHtml('<p>Hello</p>');
+```
+
 Format parsed results as Markdown:
 
 ```js

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -2,23 +2,28 @@ import fetch from 'node-fetch';
 import { htmlToText } from 'html-to-text';
 
 /**
- * Convert HTML to plain text, skipping non-content tags and collapsing whitespace.
+ * Options for html-to-text that ignore non-content tags.
+ */
+const HTML_TO_TEXT_OPTIONS = {
+  wordwrap: false,
+  selectors: [
+    { selector: 'script', format: 'skip' },
+    { selector: 'style', format: 'skip' },
+    { selector: 'nav', format: 'skip' },
+    { selector: 'footer', format: 'skip' },
+    { selector: 'aside', format: 'skip' }
+  ]
+};
+
+/**
+ * Convert HTML to plain text, returning '' for falsy input.
  *
  * @param {string} html
  * @returns {string}
  */
 export function extractTextFromHtml(html) {
   if (!html) return '';
-  return htmlToText(html, {
-    wordwrap: false,
-    selectors: [
-      { selector: 'script', format: 'skip' },
-      { selector: 'style', format: 'skip' },
-      { selector: 'nav', format: 'skip' },
-      { selector: 'footer', format: 'skip' },
-      { selector: 'aside', format: 'skip' }
-    ]
-  })
+  return htmlToText(html, HTML_TO_TEXT_OPTIONS)
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -35,6 +35,11 @@ describe('extractTextFromHtml', () => {
     `;
     expect(extractTextFromHtml(html)).toBe('Main');
   });
+
+  it('returns empty string for falsy input', () => {
+    expect(extractTextFromHtml('')).toBe('');
+    expect(extractTextFromHtml()).toBe('');
+  });
 });
 
 describe('fetchTextFromUrl', () => {


### PR DESCRIPTION
## Summary
- reuse html-to-text options and document extractTextFromHtml
- cover falsy HTML input

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: scoring.large.perf.test.js > scores 50k unique requirements efficiently)*

------
https://chatgpt.com/codex/tasks/task_e_68c25d43aea4832fa00f4054b1e3858d