### PR TITLE
♻️ simplify requirement header lookup

### DIFF
--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -50,6 +50,18 @@ Responsibilities:
     expect(parsed.requirements).toEqual(['Build features', 'Fix bugs']);
   });
 
+  it('parses requirements after a Qualifications header', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+Qualifications:
+- Strong communication
+- Teamwork
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual(['Strong communication', 'Teamwork']);
+  });
+
   it('captures inline requirement text after a Responsibilities header', () => {
     const text = `
 Title: Developer


### PR DESCRIPTION
## Summary
- refactor requirement extraction to avoid duplicate header scans
- add coverage for 'Qualifications' header

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: scoring.large.perf.test.js exceeded 650ms)*

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68c25d43aea4832fa00f4054b1e3858d