### PR TITLE
Refactor fetch selectors and document scoring

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,6 +1,14 @@
 import fetch from 'node-fetch';
 import { htmlToText } from 'html-to-text';
 
+const SKIP_SELECTORS = [
+  { selector: 'script', format: 'skip' },
+  { selector: 'style', format: 'skip' },
+  { selector: 'nav', format: 'skip' },
+  { selector: 'footer', format: 'skip' },
+  { selector: 'aside', format: 'skip' }
+];
+
 /**
  * Convert HTML to plain text, skipping non-content tags and collapsing whitespace.
  *
@@ -11,13 +19,7 @@ export function extractTextFromHtml(html) {
   if (!html) return '';
   return htmlToText(html, {
     wordwrap: false,
-    selectors: [
-      { selector: 'script', format: 'skip' },
-      { selector: 'style', format: 'skip' },
-      { selector: 'nav', format: 'skip' },
-      { selector: 'footer', format: 'skip' },
-      { selector: 'aside', format: 'skip' }
-    ]
+    selectors: SKIP_SELECTORS
   })
     .replace(/\s+/g, ' ')
     .trim();

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -50,6 +50,13 @@ function hasOverlap(line, resumeSet) {
   return false;
 }
 
+/**
+ * Compute how well a resume matches a list of job requirements.
+ *
+ * @param {string} resumeText
+ * @param {string[] | undefined} requirements
+ * @returns {{ score: number, matched: string[], missing: string[] }}
+ */
 export function computeFitScore(resumeText, requirements) {
   const bullets = Array.isArray(requirements) ? requirements : [];
   if (!bullets.length) return { score: 0, matched: [], missing: [] };

--- a/test/scoring.test.js
+++ b/test/scoring.test.js
@@ -24,6 +24,11 @@ describe('computeFitScore', () => {
     expect(result).toEqual({ score: 0, matched: [], missing: [] });
   });
 
+  it('handles undefined requirements', () => {
+    const result = computeFitScore('anything');
+    expect(result).toEqual({ score: 0, matched: [], missing: [] });
+  });
+
   // Allow slower CI environments by using a relaxed threshold.
   it('processes large requirement lists within 2500ms', () => {
     const resume = 'skill '.repeat(1000);


### PR DESCRIPTION
## Summary
- extract reusable HTML skip selector list
- document computeFitScore and test undefined requirements

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: scoring.large.perf.test.js expected <650ms)*


------
https://chatgpt.com/codex/tasks/task_e_68c25d43aea4832fa00f4054b1e3858d