### PR TITLE
🩹 fix: strip triangular bullets in parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,11 @@ Example: `summarize('"Hi!" Bye.')` returns `"Hi!"`.
 
 Job requirements may appear under headers like `Requirements`, `Qualifications`,
 `What you'll need`, or `Responsibilities` (used if no other requirement headers are present).
-They may start with `-`, `+`, `*`, `•`, `–` (en dash), `—` (em dash), or numeric markers like `1.`
-or `(1)`; these markers are stripped when parsing job text, even when the first requirement follows
-the header on the same line. Leading numbers without punctuation remain intact. Resume scoring
-tokenizes via a manual scanner and caches tokens to avoid repeated work.
+They may start with `-`, `+`, `*`, `•`, `‣`, `–` (en dash),
+`—` (em dash), or numeric markers like `1.` or `(1)`; these markers are stripped when parsing
+job text, even when the first requirement follows the header on the same line. Leading numbers
+without punctuation remain intact. Resume scoring tokenizes via a manual scanner and caches tokens
+to avoid repeated work.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/parser.js
+++ b/src/parser.js
@@ -17,10 +17,10 @@ const REQUIREMENTS_HEADERS = [
 
 const FALLBACK_REQUIREMENTS_HEADERS = [/\bResponsibilities\b/i];
 
-// Common bullet prefix regex. Strips '-', '+', '*', '•', '·', en/em dashes,
+// Common bullet prefix regex. Strips '-', '+', '*', '•', '‣', '·', en/em dashes,
 // numeric markers like `1.` or `1)` and parenthetical numbers like `(1)`.
 // Preserves leading digits that are part of the requirement text itself.
-const BULLET_PREFIX_RE = /^(?:[-+*•\u00B7\u2013\u2014]\s*|\d+[.)]\s*|\(\d+\)\s*)/;
+const BULLET_PREFIX_RE = /^(?:[-+*•\u2023\u00B7\u2013\u2014]\s*|\d+[.)]\s*|\(\d+\)\s*)/;
 
 /** Strip common bullet characters and surrounding whitespace from a line. */
 function stripBullet(line) {

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -98,6 +98,17 @@ Requirements: Proficient in JS
     ]);
   });
 
+  it('strips triangular bullets', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+Requirements:
+‣ Innovative mindset
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual(['Innovative mindset']);
+  });
+
   it('strips numeric and parenthetical bullets', () => {
     const text = `
 Title: Developer


### PR DESCRIPTION
what: strip triangular bullets in parser and docs
why: handle job posts using ‣ markers
how: npm run lint && npm run test:ci
refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68c25d0587e8832f8890db2c2059317c