### PR TITLE
Optimize computeFitScore overlap to reduce allocations

### DIFF
--- a/src/scoring.js
+++ b/src/scoring.js
@@ -1,5 +1,5 @@
 const TOKEN_CACHE = new Map();
-const ARRAY_TOKEN_CACHE = new Map();
+const WORD_RE = /[a-z0-9]+/g;
 
 // Tokenize text into a Set of lowercase alphanumeric tokens, with caching to avoid
 // repeated regex and Set allocations.
@@ -9,7 +9,8 @@ function tokenize(text) {
   if (cached) return cached;
 
   // Use regex matching to avoid replace/split allocations and speed up tokenization.
-  const tokens = new Set(key.toLowerCase().match(/[a-z0-9]+/g) || []);
+  WORD_RE.lastIndex = 0;
+  const tokens = new Set(key.toLowerCase().match(WORD_RE) || []);
 
   // Simple cache eviction to bound memory.
   if (TOKEN_CACHE.size > 1000) TOKEN_CACHE.clear();
@@ -17,15 +18,17 @@ function tokenize(text) {
   return tokens;
 }
 
-// Tokenize into an array for lines where we only need iteration.
-function tokenizeArray(text) {
-  const key = text || '';
-  const cached = ARRAY_TOKEN_CACHE.get(key);
-  if (cached) return cached;
-  const tokens = key.toLowerCase().match(/[a-z0-9]+/g) || [];
-  if (ARRAY_TOKEN_CACHE.size > 1000) ARRAY_TOKEN_CACHE.clear();
-  ARRAY_TOKEN_CACHE.set(key, tokens);
-  return tokens;
+// Iterate tokens in a line and check for overlap with resume tokens without allocating arrays.
+// Using a streaming regex avoids per-line array creation, improving performance for large,
+// unique requirement lists.
+function hasOverlap(line, resumeSet) {
+  WORD_RE.lastIndex = 0;
+  const lower = line.toLowerCase();
+  let match;
+  while ((match = WORD_RE.exec(lower))) {
+    if (resumeSet.has(match[0])) return true;
+  }
+  return false;
 }
 
 // Cache tokens for the most recent resume to avoid repeated tokenization when the same resume
@@ -38,16 +41,6 @@ function resumeTokens(text) {
   cachedTokens = tokenize(text);
   cachedResume = text;
   return cachedTokens;
-}
-
-// Check if a line overlaps with tokens in the resume set.
-// Inline tokenization avoids Set allocations for each bullet line.
-function hasOverlap(line, resumeSet) {
-  const tokens = tokenizeArray(line);
-  for (let i = 0; i < tokens.length; i++) {
-    if (resumeSet.has(tokens[i])) return true;
-  }
-  return false;
 }
 
 export function computeFitScore(resumeText, requirements) {

--- a/test/scoring.unique.perf.test.js
+++ b/test/scoring.unique.perf.test.js
@@ -1,0 +1,16 @@
+import { performance } from 'node:perf_hooks';
+import { computeFitScore } from '../src/scoring.js';
+import { describe, it, expect } from 'vitest';
+
+describe('computeFitScore unique requirements performance', () => {
+  it('avoids per-line allocations', () => {
+    const resume = 'Skilled in JavaScript and Node.js development';
+    const bullets = Array.from({ length: 50000 }, (_, i) => `Requirement ${i} needs JS`);
+    const start = performance.now();
+    for (let i = 0; i < 5; i++) {
+      computeFitScore(resume, bullets);
+    }
+    const duration = performance.now() - start;
+    expect(duration).toBeLessThan(300);
+  });
+});


### PR DESCRIPTION
## Summary
- stream tokens in computeFitScore overlap check to avoid per-line arrays
- add perf test for 50k unique requirements

## Testing
- `npm run lint`
- `npm run test:ci`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c25d32ed9c832f92e397b420fbef49