### PR TITLE
Draft: 📚 : refine codex upgrade prompt

### DIFF
--- a/docs/prompts/codex/upgrade.md
+++ b/docs/prompts/codex/upgrade.md
@@ -14,12 +14,14 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md).
+- See the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
-- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Confirm referenced files exist.
+- Update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
 1. Select a file under `docs/prompts/` to update or create a new prompt type.
@@ -44,8 +46,10 @@ PURPOSE:
 Refine the `docs/prompts/codex/upgrade.md` document.
 
 CONTEXT:
-- Follow [README.md](../../README.md).
+- Follow [README.md](../../../README.md).
 - See the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
+- Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 


### PR DESCRIPTION
Clarifies instructions and fixes relative links in the Codex upgrade prompt.

## How to Test
- `npm run lint`
- `npm run test:ci` *(fails: computeFitScore large input performance)*

Refs: #0

needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68c25d8c6a1c832f8a1a4e561c46c817