### PR TITLE
📝 : – clarify security prompt context

### DIFF
--- a/docs/prompts/codex/security.md
+++ b/docs/prompts/codex/security.md
@@ -14,11 +14,16 @@ PURPOSE:
 Address security issues and harden the project.
 
 CONTEXT:
-- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Consult [SECURITY.md](../../../SECURITY.md) for reporting and disclosure guidance.
-- Confirm referenced files exist to avoid broken links.
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md)
+  when adding prompt docs.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py`
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 
 REQUEST:
 1. Reproduce the vulnerability or describe the weakness.
@@ -46,11 +51,15 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the
+- Follow [README.md](../../../README.md); see the
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`.
+  See [scripts/scan-secrets.py](../../../scripts/scan-secrets.py).
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md)
+  when adding prompt docs.
 
 REQUEST:
 1. Select a file under `docs/prompts/` to update or create a new prompt type.


### PR DESCRIPTION
what: fix README path and add CI guidance in security prompt
why: keep docs consistent and links valid
how: npm ci && npm run lint && npm run test:ci
(fails: scoring.large.perf.test.js)
Refs: #0
Status: draft, needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68c25d808348832fbf380eca7cca19a7