### PR TITLE
docs: clarify test prompt links

### DIFF
--- a/docs/prompts/codex/test.md
+++ b/docs/prompts/codex/test.md
@@ -5,6 +5,7 @@ slug: 'codex-test'
 
 # Codex Test Prompt
 Use this prompt when adding or improving tests in jobbot3000.
+Tests live under [test](../../../test).
 
 ```text
 SYSTEM:
@@ -20,7 +21,7 @@ CONTEXT:
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../scripts/scan-secrets.py)).
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Confirm referenced files exist; update
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
@@ -53,7 +54,8 @@ CONTEXT:
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`.
+  `git diff --cached | ./scripts/scan-secrets.py`
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 
 REQUEST:
 1. Select a file under `docs/prompts/` to update or create a new prompt type.


### PR DESCRIPTION
## Summary
- mention test directory in Codex test prompt
- fix secret scan script links

## Testing
- `npm run lint`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c25d808348832fbf380eca7cca19a7