### PR TITLE
📝: clarify fix prompt instructions

### DIFF
--- a/docs/prompts/codex/fix.md
+++ b/docs/prompts/codex/fix.md
@@ -20,12 +20,12 @@ CONTEXT:
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../scripts/scan-secrets.py)).
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Confirm referenced files exist; update
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Reproduce the bug with a failing test or script.
+1. Reproduce the bug with a failing test or script in [test/](../../../test).
 2. Apply the smallest fix that resolves the issue.
 3. Update docs or prompts if needed.
 4. Run the commands above and fix any failures.


### PR DESCRIPTION
what: fix link in fix prompt doc; reference test directory
why: ensure instructions point to valid files and regression tests
how to test: npm run lint && npm run test:ci (fails scoring perf)
Refs: #000
needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68c25d808348832fbf380eca7cca19a7