### PR TITLE
📝: fix scan-secrets link in fix and test prompts

### DIFF
--- a/docs/prompts/codex/fix.md
+++ b/docs/prompts/codex/fix.md
@@ -16,11 +16,12 @@ Diagnose and resolve bugs in jobbot3000.
 CONTEXT:
 - Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
+- The project uses [Vitest](https://vitest.dev) for unit tests.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../scripts/scan-secrets.py)).
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Confirm referenced files exist; update
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 

--- a/docs/prompts/codex/test.md
+++ b/docs/prompts/codex/test.md
@@ -16,11 +16,12 @@ Improve or expand test coverage without altering runtime behavior.
 CONTEXT:
 - Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
+- The project uses [Vitest](https://vitest.dev) for unit tests.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../scripts/scan-secrets.py)).
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Confirm referenced files exist; update
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 


### PR DESCRIPTION
## What
- clarify Vitest usage in fix and test prompts
- fix relative path to scripts/scan-secrets.py

## Why
- link previously pointed to missing path
- ensure contributors know the test framework

## How to Test
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c25d808348832fbf380eca7cca19a7