### PR TITLE
📝 docs: fix scan-secrets links in prompts

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -7,6 +7,7 @@ Ensure each document's links reference existing files.
 Each prompt doc should reference the root [README.md](../README.md) using a valid relative path.
 
 All links are verified to reference existing files.
+Includes [`scripts/scan-secrets.py`](../scripts/scan-secrets.py).
 
 ## jobbot3000
 

--- a/docs/prompts/codex/fix.md
+++ b/docs/prompts/codex/fix.md
@@ -20,7 +20,7 @@ CONTEXT:
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../scripts/scan-secrets.py)).
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Confirm referenced files exist; update
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 

--- a/docs/prompts/codex/test.md
+++ b/docs/prompts/codex/test.md
@@ -20,7 +20,7 @@ CONTEXT:
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../scripts/scan-secrets.py)).
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Confirm referenced files exist; update
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 


### PR DESCRIPTION
what: fix scan-secrets.py paths in fix and test prompts
why: ensure prompt docs link to existing scripts
how to test: npm run lint && npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68c25d791d04832f9e5d414bb33a5967