### PR TITLE
📝: add accessibility prompt doc

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -12,6 +12,8 @@ All links are verified to reference existing files.
 
 | Path | Prompt | Type | One-click? |
 |------|--------|------|------------|
+| [docs/prompts/codex/accessibility.md][accessibility-doc] | Codex Accessibility Prompt | evergreen | yes |
+| [docs/prompts/codex/accessibility.md#upgrade-prompt][accessibility-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/automation.md][automation-doc] | Codex Automation Prompt | evergreen | yes |
 | [docs/prompts/codex/automation.md#upgrade-prompt][automation-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/chore.md][chore-doc] | Codex Chore Prompt | evergreen | yes |
@@ -35,6 +37,8 @@ All links are verified to reference existing files.
 | [docs/prompts/codex/upgrade.md][upgrade-doc] | Codex Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/upgrade.md#upgrade-prompt][upgrade-up] | Upgrade Prompt | evergreen | yes |
 
+[accessibility-doc]: prompts/codex/accessibility.md
+[accessibility-up]: prompts/codex/accessibility.md#upgrade-prompt
 [automation-doc]: prompts/codex/automation.md
 [automation-up]: prompts/codex/automation.md#upgrade-prompt
 [chore-doc]: prompts/codex/chore.md

--- a/docs/prompts/codex/accessibility.md
+++ b/docs/prompts/codex/accessibility.md
@@ -1,0 +1,68 @@
+---
+title: 'Codex Accessibility Prompt'
+slug: 'codex-accessibility'
+---
+
+# Codex Accessibility Prompt
+Use this prompt to improve accessibility features in jobbot3000.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Enhance accessibility, ensuring inclusive and usable interfaces.
+
+CONTEXT:
+- Follow [README.md](../../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
+- Install dependencies with `npm ci` if needed.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Confirm referenced files exist; update
+  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+
+REQUEST:
+1. Identify accessibility gaps such as missing alt text or ARIA labels.
+2. Apply minimal changes to meet accessibility standards.
+3. Add or update tests verifying accessible behavior.
+4. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request summarizing the accessibility improvements with passing checks.
+```
+
+Copy this block whenever improving accessibility in jobbot3000.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine jobbot3000's prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Improve or expand the repository's prompt docs.
+
+CONTEXT:
+- Follow [README.md](../../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
+- Install dependencies with `npm ci` if needed.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Confirm referenced files exist and update
+  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+
+REQUEST:
+1. Select a file under `docs/prompts/` to update or create a new prompt type.
+2. Clarify context, refresh links, and ensure referenced files exist.
+3. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request that updates the selected prompt doc with passing checks.
+```


### PR DESCRIPTION
what: add accessibility prompt doc and index it
why: broaden guidance for inclusive contributions
how to test: npm run lint && npm run test:ci

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68c25d5ee998832fadd4259fabe7b5e8