### PR TITLE
📝 : fix prompt doc links

### DIFF
--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -55,7 +55,7 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the
+- Follow [README.md](../../../README.md); see the
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with

--- a/docs/prompts/codex/fix.md
+++ b/docs/prompts/codex/fix.md
@@ -20,7 +20,7 @@ CONTEXT:
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../scripts/scan-secrets.py)).
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Confirm referenced files exist; update
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 

--- a/docs/prompts/codex/refactor.md
+++ b/docs/prompts/codex/refactor.md
@@ -14,7 +14,7 @@ PURPOSE:
 Refactor code for clarity or maintainability.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
 - Include before/after benchmarks if performance might change.
@@ -44,7 +44,7 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the
+- Follow [README.md](../../../README.md); see the
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with

--- a/docs/prompts/codex/security.md
+++ b/docs/prompts/codex/security.md
@@ -46,7 +46,7 @@ PURPOSE:
 Improve or expand the repository's prompt docs.
 
 CONTEXT:
-- Follow [README.md](../../README.md); see the
+- Follow [README.md](../../../README.md); see the
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with

--- a/docs/prompts/codex/test.md
+++ b/docs/prompts/codex/test.md
@@ -20,7 +20,7 @@ CONTEXT:
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../scripts/scan-secrets.py)).
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Confirm referenced files exist; update
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 

--- a/docs/prompts/codex/upgrade.md
+++ b/docs/prompts/codex/upgrade.md
@@ -44,7 +44,7 @@ PURPOSE:
 Refine the `docs/prompts/codex/upgrade.md` document.
 
 CONTEXT:
-- Follow [README.md](../../README.md).
+- Follow [README.md](../../../README.md).
 - See the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.


### PR DESCRIPTION
what: correct README and scan-secrets links in prompt docs
why: broken paths hinder navigation
how: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68c25d5a2960832fa7f6a493a1557883