### PR TITLE
📝 : fix spelling in upgrade prompt

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -24,6 +24,7 @@
     "CAPD",
     "SHRM",
     "YOURNAME",
-    "sandboxing"
+    "sandboxing",
+    "Upgrader"
   ]
 }

--- a/docs/prompts/codex/upgrade.md
+++ b/docs/prompts/codex/upgrade.md
@@ -44,7 +44,7 @@ PURPOSE:
 Refine the `docs/prompts/codex/upgrade.md` document.
 
 CONTEXT:
-- Follow [README.md](../../README.md).
+- Follow [README.md](../../../README.md).
 - See the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.


### PR DESCRIPTION
what: add Upgrader to spelling dictionary and fix README link path
why: keep docs accurate and ensure cspell passes
how to test:
- npm run lint
- npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c25d5a2960832fa7f6a493a1557883