### PR TITLE
🔧 chore: cache npm deps in CI – speed installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: npm
       - run: npm ci
       - run: npm run lint
       - run: npm run test:ci


### PR DESCRIPTION
what: enable npm cache in GitHub Actions
why: faster CI installs
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68c25d1054e4832f8533fd08f27dd8a8