### PR TITLE
docs: add Codex CI prompt doc

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -6,7 +6,7 @@ Ensure each document's links reference existing files.
 
 Each prompt doc should reference the root [README.md](../README.md) using a valid relative path.
 
-All links were verified on 2025-09-11 to reference existing files.
+All links were verified on 2025-09-12 to reference existing files.
 Includes [`scripts/scan-secrets.py`](../scripts/scan-secrets.py).
 
 ## jobbot3000
@@ -19,6 +19,8 @@ Includes [`scripts/scan-secrets.py`](../scripts/scan-secrets.py).
 | [docs/prompts/codex/automation.md#upgrade-prompt][automation-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/chore.md][chore-doc] | Codex Chore Prompt | evergreen | yes |
 | [docs/prompts/codex/chore.md#upgrade-prompt][chore-up] | Upgrade Prompt | evergreen | yes |
+| [docs/prompts/codex/ci.md][ci-doc] | Codex CI Prompt | evergreen | yes |
+| [docs/prompts/codex/ci.md#upgrade-prompt][ci-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/docs.md][docs-doc] | Codex Docs Prompt | evergreen | yes |
 | [docs/prompts/codex/docs.md#upgrade-prompt][docs-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/feature.md][feature-doc] | Codex Feature Prompt | evergreen | yes |
@@ -44,6 +46,8 @@ Includes [`scripts/scan-secrets.py`](../scripts/scan-secrets.py).
 [automation-up]: prompts/codex/automation.md#upgrade-prompt
 [chore-doc]: prompts/codex/chore.md
 [chore-up]: prompts/codex/chore.md#upgrade-prompt
+[ci-doc]: prompts/codex/ci.md
+[ci-up]: prompts/codex/ci.md#upgrade-prompt
 [docs-doc]: prompts/codex/docs.md
 [docs-up]: prompts/codex/docs.md#upgrade-prompt
 [feature-doc]: prompts/codex/feature.md

--- a/docs/prompts/codex/ci.md
+++ b/docs/prompts/codex/ci.md
@@ -1,0 +1,66 @@
+---
+title: 'Codex CI Prompt'
+slug: 'codex-ci'
+---
+
+# Codex CI Prompt
+Use this prompt when modifying CI workflows in jobbot3000.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Adjust CI workflows to keep builds fast and reliable.
+
+CONTEXT:
+- Follow [README.md](../../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
+- Install dependencies with `npm ci` if needed.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py`
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Update [prompt-docs-summary.md](../../prompt-docs-summary.md) when modifying prompt docs.
+- Ensure workflow syntax is valid; see [GitHub Actions](https://docs.github.com/actions).
+
+REQUEST:
+1. Explain the CI adjustment to make.
+2. Implement the change in `.github/workflows`.
+3. Update related documentation if necessary.
+4. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request URL summarizing the CI update.
+```
+
+Copy this block whenever tweaking CI workflows in jobbot3000.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine jobbot3000's prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Improve or expand the repository's prompt docs.
+
+CONTEXT:
+- Follow [README.md](../../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+
+REQUEST:
+1. Select a file under `docs/prompts/` to update or create a new prompt type.
+2. Clarify context, refresh links, and ensure referenced files exist.
+3. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request that updates the selected prompt doc with passing checks.
+```


### PR DESCRIPTION
## Summary
- add CI prompt doc for workflow updates
- index new doc in prompt summary

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: performance benchmarks exceed thresholds; please label needs-triage)*

------
https://chatgpt.com/codex/tasks/task_e_68c398489fcc832faf3ef2d050a32081