### PR TITLE
📝 : mention npm ci in automation prompt

### DIFF
--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -4,7 +4,8 @@ slug: 'codex-automation'
 ---
 
 # Codex Automation Prompt
-Use this prompt to guide LLM-based contributors when working on jobbot3000.
+Use this prompt to guide automated contributors when performing routine maintenance in
+jobbot3000.
 
 ```text
 SYSTEM:
@@ -20,6 +21,7 @@ CONTEXT:
 - Follow the [repository README](../../../README.md) and the
   [AGENTS spec](https://agentsmd.net/AGENTS.md).
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
+- Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`
@@ -58,6 +60,7 @@ CONTEXT:
 - Follow [README.md](../../../README.md); see the
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
+- Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`


### PR DESCRIPTION
what: add npm ci reminder and clarify automation prompt context.
why: ensure contributors install dependencies before checks.
how to test: npm run lint && npm run test:ci
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68c398489fcc832faf3ef2d050a32081