### PR TITLE
Draft: docs: link scan-secrets script in upgrade prompt

### DIFF
--- a/docs/prompts/codex/upgrade.md
+++ b/docs/prompts/codex/upgrade.md
@@ -19,8 +19,10 @@ CONTEXT:
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Link-check the updated doc, e.g., `npx markdown-link-check <file>`.
+- Ensure any code samples compile with `node` or `ts-node`.
 - Confirm referenced files exist.
 - Update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
@@ -51,7 +53,8 @@ CONTEXT:
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Verify links with `npx markdown-link-check docs/prompts/codex/upgrade.md`.
 
 REQUEST:


### PR DESCRIPTION
## Summary
- link scan-secrets script in upgrade prompt
- note to compile code samples

## Testing
- `npx markdown-link-check docs/prompts/codex/upgrade.md`
- `npm run lint`
- `npm run test:ci` *(fails: expected 1729.4398350000001 < 1300; needs triage)*


------
https://chatgpt.com/codex/tasks/task_e_68c398489fcc832faf3ef2d050a32081