### PR TITLE
♿️ Preserve image alt text in text extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ console.log(text);
 // "<job description text>"
 ```
 
-`fetchTextFromUrl` strips scripts, styles, navigation, footer, and aside content and
-collapses whitespace to single spaces. Pass `timeoutMs` (milliseconds) to override the 10s default,
+`fetchTextFromUrl` strips scripts, styles, navigation, footer, and aside content, preserves image
+alt text, and collapses whitespace to single spaces. Pass `timeoutMs` (milliseconds) to override the
+10s default,
 and `headers` to send custom HTTP headers. Only `http` and `https` URLs are supported; other
 protocols throw an error.
 

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,12 +1,18 @@
 import fetch from 'node-fetch';
 import { htmlToText } from 'html-to-text';
 
+function formatImageAlt(elem, walk, builder) {
+  const alt = elem.attribs?.alt;
+  if (alt) builder.addInline(alt, { noWordTransform: true });
+}
+
 /**
  * Options for html-to-text that ignore non-content tags.
  * Exported for reuse in other HTML parsing utilities.
  */
 export const HTML_TO_TEXT_OPTIONS = {
   wordwrap: false,
+  formatters: { imgAlt: formatImageAlt },
   selectors: [
     { selector: 'script', format: 'skip' },
     { selector: 'style', format: 'skip' },
@@ -14,6 +20,7 @@ export const HTML_TO_TEXT_OPTIONS = {
     { selector: 'header', format: 'skip' },
     { selector: 'footer', format: 'skip' },
     { selector: 'aside', format: 'skip' },
+    { selector: 'img', format: 'imgAlt' },
   ],
 };
 

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -48,6 +48,24 @@ describe('extractTextFromHtml', () => {
     expect(extractTextFromHtml(html)).toBe('Main');
   });
 
+  it('includes img alt text without src', () => {
+    const html = `
+      <p>Start</p>
+      <img src="logo.png" alt="Logo" />
+      <p>End</p>
+    `;
+    expect(extractTextFromHtml(html)).toBe('Start Logo End');
+  });
+
+  it('omits img without alt text', () => {
+    const html = `
+      <p>Start</p>
+      <img src="logo.png" />
+      <p>End</p>
+    `;
+    expect(extractTextFromHtml(html)).toBe('Start End');
+  });
+
   it('returns empty string for falsy input', () => {
     expect(extractTextFromHtml('')).toBe('');
     // @ts-expect-error testing null input


### PR DESCRIPTION
## Summary
- ensure `extractTextFromHtml` keeps image alt text and omits src noise
- document alt text preservation
- test alt text inclusion and missing-alt omission

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c3981f8a60832fb5be1acb975084e0