### PR TITLE
Draft: 📝 document link checking for docs prompt

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -6,7 +6,7 @@ Ensure each document's links reference existing files.
 
 Each prompt doc should reference the root [README.md](../README.md) using a valid relative path.
 
-All links were verified on 2025-09-11 to reference existing files.
+All links were verified on 2025-09-12 to reference existing files.
 Includes [`scripts/scan-secrets.py`](../scripts/scan-secrets.py).
 
 ## jobbot3000

--- a/docs/prompts/codex/docs.md
+++ b/docs/prompts/codex/docs.md
@@ -21,6 +21,7 @@ CONTEXT:
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Check links with `npx markdown-link-check <file>`.
 - Confirm referenced files exist; update
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
@@ -28,7 +29,8 @@ REQUEST:
 1. Identify the doc section to update.
 2. Revise text or examples for clarity.
 3. Ensure any code samples compile with `node` or `ts-node`.
-4. Run the commands above and fix any failures.
+4. Verify links with `npx markdown-link-check <file>`.
+5. Run the commands above and fix any failures.
 
 OUTPUT:
 A pull request URL summarizing the documentation update.


### PR DESCRIPTION
what: add link-check step to docs prompt; update summary date
why: encourage link validation for docs changes
how to test: npm run lint; npm run test:ci (fails: performance flake)
Refs: #0
needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68c398d375e0832f8464ebe587e9df95