### PR TITLE
📝 : add link-check guidance to docs prompt

### DIFF
--- a/docs/prompts/codex/docs.md
+++ b/docs/prompts/codex/docs.md
@@ -21,14 +21,16 @@ CONTEXT:
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Verify links with `npx markdown-link-check <file>`; fix or remove broken URLs.
 - Confirm referenced files exist; update
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
 1. Identify the doc section to update.
 2. Revise text or examples for clarity.
-3. Ensure any code samples compile with `node` or `ts-node`.
-4. Run the commands above and fix any failures.
+3. Check links with `npx markdown-link-check <file>`.
+4. Ensure any code samples compile with `node` or `ts-node`.
+5. Run the commands above and fix any failures.
 
 OUTPUT:
 A pull request URL summarizing the documentation update.
@@ -56,14 +58,16 @@ CONTEXT:
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`.
+- Verify links with `npx markdown-link-check <file>`; fix or remove broken URLs.
 - Confirm referenced files exist; update
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
 1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
-3. Ensure any code samples compile with `node` or `ts-node`.
-4. Run the commands above and fix any failures.
+2. Clarify context and ensure referenced files exist.
+3. Check links with `npx markdown-link-check <file>`.
+4. Ensure any code samples compile with `node` or `ts-node`.
+5. Run the commands above and fix any failures.
 
 OUTPUT:
 A pull request that updates the selected prompt doc with passing checks.


### PR DESCRIPTION
## Summary
- note markdown-link-check step in docs prompt and upgrade prompt

## Testing
- `npx markdown-link-check docs/prompts/codex/docs.md`
- `npm run lint`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c398cf0864832faa866a81f25d5015