### PR TITLE
🧪 : test summarize handling of unclosed delimiters

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -91,4 +91,14 @@ describe('summarize', () => {
     const text = 'Candidates (M.Sc.) should apply.';
     expect(summarize(text)).toBe('Candidates (M.Sc.) should apply.');
   });
+
+  it('does not split when terminator inside unclosed quotes', () => {
+    const text = 'He said "Wait.';
+    expect(summarize(text)).toBe(text);
+  });
+
+  it('does not split when terminator inside unclosed parentheses', () => {
+    const text = 'Alert (check logs.';
+    expect(summarize(text)).toBe(text);
+  });
 });


### PR DESCRIPTION
## What
- add tests for summarize with unclosed quotes/parentheses

## Why
- ensure summarize handles unmatched delimiters without truncating text

## How to Test
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c398bddcac832f803932611a77f0c9