### PR TITLE
test: expand parser and summarizer coverage

### DIFF
--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -74,6 +74,18 @@ Qualifications:
     expect(parsed.requirements).toEqual(['Strong communication', 'Teamwork']);
   });
 
+  it('parses requirements after a "What you\u2019ll need" header', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+What you’ll need:
+- Node.js
+- Testing
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual(['Node.js', 'Testing']);
+  });
+
   it('captures inline requirement text after a Responsibilities header', () => {
     const text = `
 Title: Developer

--- a/test/summarize.baseline.test.js
+++ b/test/summarize.baseline.test.js
@@ -2,6 +2,24 @@ import { describe, it, expect } from 'vitest';
 import { summarizeBaseline } from '../src/summarize.baseline.js';
 
 describe('summarizeBaseline', () => {
+  it('returns first sentence by default and trims whitespace', () => {
+    const text = ' First sentence.  Second sentence! Third?';
+    expect(summarizeBaseline(text)).toBe('First sentence.');
+  });
+
+  it('limits output to requested number of sentences', () => {
+    const text = 'One. Two. Three.';
+    expect(summarizeBaseline(text, 2)).toBe('One. Two.');
+  });
+
+  it('returns empty string when text is falsy', () => {
+    expect(summarizeBaseline('')).toBe('');
+    // @ts-expect-error testing null input
+    expect(summarizeBaseline(null)).toBe('');
+    // @ts-expect-error testing undefined input
+    expect(summarizeBaseline()).toBe('');
+  });
+
   it('returns empty string when count is 0', () => {
     const text = 'First. Second.';
     expect(summarizeBaseline(text, 0)).toBe('');


### PR DESCRIPTION
## Summary
- add test ensuring "What you’ll need" headers extract requirements
- broaden baseline summarizer tests for defaults and falsy input

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c398bddcac832f803932611a77f0c9