### PR TITLE
✨: – track application lifecycle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ node_modules/
 .env
 coverage/
 dist/
+data/
 

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ are scanned without regex or temporary arrays, improving large input performance
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.
 
+## Tracking Application Lifecycle
+
+Application statuses such as `no_response`, `rejected`, and `next_round` are saved to
+`data/applications.json`, a gitignored file. Set `JOBBOT_DATA_DIR` to change the directory.
+These records power local Sankey diagrams so progress isn't lost between sessions.
+
 ## Documentation
 
 - [DESIGN.md](DESIGN.md) – architecture details and roadmap

--- a/src/index.js
+++ b/src/index.js
@@ -116,3 +116,5 @@ export function summarize(text, count = 1) {
 
   return summary.replace(/\s+/g, ' ').trim();
 }
+
+export { recordApplication, getLifecycleCounts, STATUSES } from './lifecycle.js';

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -1,0 +1,42 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export const STATUSES = ['no_response', 'rejected', 'next_round'];
+
+function paths() {
+  const dir = process.env.JOBBOT_DATA_DIR || path.resolve('data');
+  return { dir, file: path.join(dir, 'applications.json') };
+}
+
+export async function recordApplication(id, status) {
+  if (!STATUSES.includes(status)) {
+    throw new Error(`unknown status: ${status}`);
+  }
+  const { dir, file } = paths();
+  await fs.mkdir(dir, { recursive: true });
+  let data = {};
+  try {
+    data = JSON.parse(await fs.readFile(file, 'utf8'));
+  } catch {
+    /* ignore missing file */
+  }
+  data[id] = status;
+  await fs.writeFile(file, JSON.stringify(data, null, 2));
+  return data[id];
+}
+
+export async function getLifecycleCounts() {
+  const { file } = paths();
+  let data = {};
+  try {
+    data = JSON.parse(await fs.readFile(file, 'utf8'));
+  } catch {
+    /* ignore missing file */
+  }
+  const counts = {};
+  for (const s of STATUSES) counts[s] = 0;
+  for (const s of Object.values(data)) {
+    if (counts[s] !== undefined) counts[s] += 1;
+  }
+  return counts;
+}

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -1,0 +1,24 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { beforeEach, afterEach, test, expect } from 'vitest';
+import { recordApplication, getLifecycleCounts } from '../src/lifecycle.js';
+
+const tmp = path.resolve('test', 'tmp-data');
+
+beforeEach(async () => {
+  process.env.JOBBOT_DATA_DIR = tmp;
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+test('records and summarizes application statuses', async () => {
+  await recordApplication('abc', 'rejected');
+  await recordApplication('def', 'no_response');
+  const counts = await getLifecycleCounts();
+  expect(counts).toEqual({ no_response: 1, rejected: 1, next_round: 0 });
+  const raw = await fs.readFile(path.join(tmp, 'applications.json'), 'utf8');
+  expect(JSON.parse(raw)).toEqual({ abc: 'rejected', def: 'no_response' });
+});


### PR DESCRIPTION
what: persist job statuses in data/applications.json
why: maintain sankey diagram state across sessions
how to test: npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c48a07e1f0832f96227bfb63fa9b68