### PR TITLE
⚡️: single-pass job field parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,11 @@ Job requirements may appear under headers like `Requirements`, `Qualifications`,
 `What you'll need`, or `Responsibilities` (used if no other requirement headers are present).
 They may start with `-`, `+`, `*`, `•`, `–` (en dash), `—` (em dash), or numeric markers like `1.`
 or `(1)`; these markers are stripped when parsing job text, even when the first requirement follows
-the header on the same line. Leading numbers without punctuation remain intact. Requirement headers
-are located in a single pass to avoid rescanning large job postings, and resume scoring tokenizes
-via a manual scanner and caches tokens (up to 60k lines) to avoid repeated work. Requirement bullets
-are scanned without regex or temporary arrays, improving large input performance.
+the header on the same line. Leading numbers without punctuation remain intact. Title, company, and
+location fields are extracted during the same scan, and requirement headers are located in a single
+pass to avoid rescanning large job postings. Resume scoring tokenizes via a manual scanner and
+caches tokens (up to 60k lines) to avoid repeated work. Requirement bullets are scanned without
+regex or temporary arrays, improving large input performance.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,15 +1,5 @@
-const TITLE_PATTERNS = [
-  /\bTitle\s*:\s*(.+)/i,
-  /\bJob Title\s*:\s*(.+)/i,
-  /\bPosition\s*:\s*(.+)/i
-];
-
-const COMPANY_PATTERNS = [
-  /\bCompany\s*:\s*(.+)/i,
-  /\bEmployer\s*:\s*(.+)/i
-];
-
-const LOCATION_PATTERNS = [/\bLocation\s*:\s*(.+)/i];
+// Single regex to match common field headers and capture the trailing value.
+const FIELD_PATTERN = /\b(Title|Job Title|Position|Company|Employer|Location)\s*:\s*(.+)/i;
 
 const REQUIREMENTS_HEADERS = [
   /\bRequirements\b/i,
@@ -29,15 +19,6 @@ function stripBullet(line) {
   return line.replace(BULLET_PREFIX_RE, '').trim();
 }
 
-/**
- * Find the index of the first header in `primary` or fall back to headers in `fallback`.
- * Returns an object with the line index and the matched pattern.
- * If no headers match, the index is -1 and the pattern is null.
- *
- * This implementation scans the lines once: if a primary header is found, it
- * returns immediately; otherwise, it tracks the first fallback match and uses
- * it if no primary headers matched.
- */
 function findHeader(lines, primary, fallback) {
   let fallbackIdx = -1;
   let fallbackPattern = null;
@@ -61,16 +42,6 @@ function findHeader(lines, primary, fallback) {
     index: fallbackIdx,
     pattern: fallbackIdx !== -1 ? fallbackPattern : null,
   };
-}
-
-function findFirstMatch(lines, patterns) {
-  for (const line of lines) {
-    for (const pattern of patterns) {
-      const match = line.match(pattern);
-      if (match) return match[1].trim();
-    }
-  }
-  return '';
 }
 
 /**
@@ -107,7 +78,10 @@ function extractRequirements(lines) {
   return requirements;
 }
 
-/** Parse raw job posting text into structured fields. */
+/**
+ * Parse raw job posting text into structured fields.
+ * Scans lines once to extract title, company, and location for efficiency.
+ */
 export function parseJobText(rawText) {
   if (!rawText) {
     return { title: '', company: '', location: '', requirements: [], body: '' };
@@ -115,9 +89,25 @@ export function parseJobText(rawText) {
   const text = rawText.replace(/\r/g, '').trim();
   const lines = text.split(/\n+/);
 
-  const title = findFirstMatch(lines, TITLE_PATTERNS);
-  const company = findFirstMatch(lines, COMPANY_PATTERNS);
-  const location = findFirstMatch(lines, LOCATION_PATTERNS);
+  let title = '';
+  let company = '';
+  let location = '';
+
+  for (const line of lines) {
+    if (title && company && location) break;
+    const match = line.match(FIELD_PATTERN);
+    if (!match) continue;
+    const key = match[1].toLowerCase();
+    const value = match[2].trim();
+    if (!title && (key === 'title' || key === 'job title' || key === 'position')) {
+      title = value;
+    } else if (!company && (key === 'company' || key === 'employer')) {
+      company = value;
+    } else if (!location && key === 'location') {
+      location = value;
+    }
+  }
+
   const requirements = extractRequirements(lines);
 
   return { title, company, location, requirements, body: text };

--- a/test/parser.fields.perf.test.js
+++ b/test/parser.fields.perf.test.js
@@ -1,0 +1,18 @@
+import { performance } from 'node:perf_hooks';
+import { parseJobText } from '../src/parser.js';
+import { describe, it, expect } from 'vitest';
+
+describe('parseJobText field extraction performance', () => {
+  it('extracts header fields in a single pass', () => {
+    const lines = Array.from({ length: 20000 }, (_, i) => `Line ${i}`);
+    lines.push('Responsibilities: do things');
+    const text = lines.join('\n');
+    const iterations = 500;
+    const start = performance.now();
+    for (let i = 0; i < iterations; i++) {
+      parseJobText(text);
+    }
+    const duration = performance.now() - start;
+    expect(duration).toBeLessThan(4000);
+  });
+});


### PR DESCRIPTION
## Summary
- speed up job field parsing by scanning once with a combined regex
- document single-pass extraction in README
- verify parser performance with a 20k-line benchmark

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c39852cac4832f90c1a45c5ad2f5ef