### PR TITLE
📝 docs: mention npm audit in security prompt

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -6,7 +6,7 @@ Ensure each document's links reference existing files.
 
 Each prompt doc should reference the root [README.md](../README.md) using a valid relative path.
 
-All links were verified on 2025-09-11 to reference existing files.
+All links were verified on 2025-09-12 to reference existing files.
 Includes [`scripts/scan-secrets.py`](../scripts/scan-secrets.py).
 
 ## jobbot3000

--- a/docs/prompts/codex/security.md
+++ b/docs/prompts/codex/security.md
@@ -14,23 +14,26 @@ PURPOSE:
 Address security issues and harden the project.
 
 CONTEXT:
-- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Consult [SECURITY.md](../../../SECURITY.md) for reporting and disclosure guidance.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
+- Run `npm audit` to identify known vulnerabilities.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`
   (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
-- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md)
-  when adding prompt docs.
+- Confirm referenced files exist; update
+  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
 1. Reproduce the vulnerability or describe the weakness.
 2. Apply the minimal fix to mitigate the issue.
 3. Add or update tests covering the security case.
 4. Update docs or advisories if needed.
-5. Run the commands above and fix any failures.
+5. Run `npm audit` to confirm no high-severity vulnerabilities remain.
+6. Run the commands above and fix any failures.
 
 OUTPUT:
 A pull request summarizing the security fix with passing checks.


### PR DESCRIPTION
what: add npm audit step to security prompt and refresh summary date
why: highlight vulnerability checks and keep index current
how to test: npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c398b56380832fb26d37e4f1fe2248