### PR TITLE
📝 docs: sync test upgrade prompt guidance

### DIFF
--- a/docs/prompts/codex/test.md
+++ b/docs/prompts/codex/test.md
@@ -55,10 +55,15 @@ Improve or expand the repository's prompt docs.
 CONTEXT:
 - Follow [README.md](../../../README.md); see the
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
+- Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`
   (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Confirm referenced files exist; update
+  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Ensure any code samples compile with `node` or `ts-node`.
 
 REQUEST:
 1. Select a file under `docs/prompts/` to update or create a new prompt type.


### PR DESCRIPTION
## Summary
- expand upgrade prompt in test doc to match repository guidelines

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c398b56380832fb26d37e4f1fe2248