### PR TITLE
✏️ fix spelling in README and scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Job requirements may appear under headers like `Requirements`, `Qualifications`,
 They may start with `-`, `+`, `*`, `•`, `–` (en dash), `—` (em dash), or numeric markers like `1.`
 or `(1)`; these markers are stripped when parsing job text, even when the first requirement follows
 the header on the same line. Leading numbers without punctuation remain intact. Requirement headers
-are located in a single pass to avoid rescanning large job postings, and resume scoring tokenizes
+are located in a single pass to avoid re-scanning large job postings, and resume scoring tokenizes
 via a manual scanner and caches tokens (up to 60k lines) to avoid repeated work. Requirement bullets
 are scanned without regex or temporary arrays, improving large input performance.
 

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -39,10 +39,10 @@ function hasOverlap(line, resumeSet) {
   let start = -1;
   for (let i = 0; i < text.length; i++) {
     const code = text.charCodeAt(i);
-    const isAlnum =
+    const isAlphanumeric =
       (code >= 48 && code <= 57) || // 0-9
       (code >= 97 && code <= 122);  // a-z
-    if (isAlnum) {
+    if (isAlphanumeric) {
       if (start === -1) start = i;
     } else if (start !== -1) {
       if (resumeSet.has(text.slice(start, i))) return true;


### PR DESCRIPTION
## Summary
- hyphenate re-scanning in README
- rename isAlnum to isAlphanumeric

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: parseJobText requirements header performance > finds requirement headers in a single pass)*
- `npx -y cspell "**"`

Status: Draft
Label: needs-triage

------
https://chatgpt.com/codex/tasks/task_e_68c398abbfa0832fbbe74ba0121fe838