### PR TITLE
📚: clarify test prompt naming convention

### DIFF
--- a/docs/prompts/codex/test.md
+++ b/docs/prompts/codex/test.md
@@ -5,7 +5,7 @@ slug: 'codex-test'
 
 # Codex Test Prompt
 Use this prompt when adding or improving tests in jobbot3000.
-Tests live under [test](../../../test).
+Tests live under [test/](../../../test) and use the `*.test.js` naming convention.
 
 ```text
 SYSTEM:
@@ -18,7 +18,8 @@ CONTEXT:
 - Follow [README.md](../../../README.md); see the
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
-- Tests live in [test/](../../../test) and run with [Vitest](https://vitest.dev/).
+- Tests live in [test/](../../../test) and use the `*.test.js` naming convention.
+- Run tests with [Vitest](https://vitest.dev/).
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
@@ -26,7 +27,7 @@ CONTEXT:
   (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Confirm referenced files exist; update
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
-- Ensure any code samples compile with `node` or `ts-node`.
+- Ensure any code samples compile with `node` (v20+) or `ts-node`.
 
 REQUEST:
 1. Identify missing or weak tests.
@@ -63,7 +64,8 @@ CONTEXT:
 REQUEST:
 1. Select a file under `docs/prompts/` to update or create a new prompt type.
 2. Clarify context, refresh links, and ensure referenced files exist.
-3. Run the commands above and fix any failures.
+3. Ensure any code samples compile with `node` (v20+) or `ts-node`.
+4. Run the commands above and fix any failures.
 
 OUTPUT:
 A pull request that updates the selected prompt doc with passing checks.


### PR DESCRIPTION
what: note *.test.js naming and Vitest usage in test prompt
why: clarify test file guidance
how to test: npm run lint && npm run test:ci
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68c398ab4060832f9c4d856429c5009e