### PR TITLE
Ignore blank requirement strings in resume scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ or `(1)`; these markers are stripped when parsing job text, even when the first 
 the header on the same line. Leading numbers without punctuation remain intact. Requirement headers
 are located in a single pass to avoid rescanning large job postings, and resume scoring tokenizes
 via a manual scanner and caches tokens (up to 60k lines) to avoid repeated work. Requirement bullets
-are scanned without regex or temporary arrays, improving large input performance.
+are scanned without regex or temporary arrays, improving large input performance. Blank
+requirement entries are skipped so empty bullets don't affect scoring.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -60,7 +60,9 @@ function hasOverlap(line, resumeSet) {
  * @returns {{ score: number, matched: string[], missing: string[] }}
  */
 export function computeFitScore(resumeText, requirements) {
-  const bullets = Array.isArray(requirements) ? requirements : [];
+  const bullets = Array.isArray(requirements)
+    ? requirements.filter(r => typeof r !== 'string' || r.trim())
+    : [];
   if (!bullets.length) return { score: 0, matched: [], missing: [] };
 
   const resumeSet = resumeTokens(resumeText);

--- a/test/scoring.test.js
+++ b/test/scoring.test.js
@@ -28,6 +28,13 @@ describe('computeFitScore', () => {
     expect(result.missing).toEqual([null, 123, undefined]);
   });
 
+  it('skips empty string requirement entries', () => {
+    const resume = 'Skilled in JavaScript';
+    const requirements = ['JavaScript', ''];
+    const result = computeFitScore(resume, requirements);
+    expect(result).toEqual({ score: 100, matched: ['JavaScript'], missing: [] });
+  });
+
   it('returns zero score when no requirements given', () => {
     const result = computeFitScore('anything', []);
     expect(result).toEqual({ score: 0, matched: [], missing: [] });


### PR DESCRIPTION
what: skip empty requirement entries when computing fit scores
why: blank bullets lowered scores and cluttered missing results
how: npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c39846c9b8832f891885b24c09aa3b