### PR TITLE
🐛: handle lowercase sentence starts after punctuation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ export function summarize(text, count = 1) {
       const next = text[k];
       const isLower = next && next.toLowerCase() === next && next.toUpperCase() !== next;
 
-      if (parenDepth === 0 && !quote && (k === len || !isLower)) {
+      if (parenDepth === 0 && !quote && (k === len || ch !== '.' || !isLower)) {
         sentences.push(text.slice(start, j));
         i = k;
         start = k;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -82,6 +82,11 @@ describe('summarize', () => {
     expect(summarize(text)).toBe('Mr. Smith went home.');
   });
 
+  it('splits when next sentence starts with lowercase', () => {
+    const text = 'hi! bye.';
+    expect(summarize(text)).toBe('hi!');
+  });
+
   it('treats non-breaking space as whitespace', () => {
     const text = 'One sentence.\u00A0Another.';
     expect(summarize(text)).toBe('One sentence.');


### PR DESCRIPTION
## Summary
- fix summarize not splitting when next sentence starts lowercase after ! or ?
- add regression test

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68c39846c9b8832f891885b24c09aa3b