### PR TITLE
📝 docs: add npm ci note to automation prompt

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -6,7 +6,7 @@ Ensure each document's links reference existing files.
 
 Each prompt doc should reference the root [README.md](../README.md) using a valid relative path.
 
-All links were verified on 2025-09-11 to reference existing files.
+All links were verified on 2025-09-12 to reference existing files.
 Includes [`scripts/scan-secrets.py`](../scripts/scan-secrets.py).
 
 ## jobbot3000

--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -20,6 +20,7 @@ CONTEXT:
 - Follow the [repository README](../../../README.md) and the
   [AGENTS spec](https://agentsmd.net/AGENTS.md).
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
+- Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
   `git diff --cached | ./scripts/scan-secrets.py`


### PR DESCRIPTION
## Summary
- mention `npm ci` in automation prompt
- refresh prompt docs index verification date

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c39843baf0832fa57426b9781b5293