### PR TITLE
📝 : clarify secret scan in chore prompt

### DIFF
--- a/docs/prompts/codex/chore.md
+++ b/docs/prompts/codex/chore.md
@@ -18,7 +18,9 @@ CONTEXT:
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Install dependencies with `npm ci` if needed.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
+  (see [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)).
 - Update [prompt-docs-summary.md](../../prompt-docs-summary.md) when modifying prompt docs.
 
 REQUEST:


### PR DESCRIPTION
## Summary
- add npm ci reminder to Codex Chore prompt
- link secret scanning instructions to scripts/scan-secrets.py

## Testing
- `npm ci`
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c39843baf0832fa57426b9781b5293