### PR TITLE
📝 : clarify async fetch example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,21 @@ console.log(summary);
 
 Pass `0` to `summarize` to return an empty string.
 
-Fetch remote job listings, normalize HTML to plain text, and log the result:
+Fetch remote job listings, normalize HTML to plain text, and log the result using an async helper:
 
 ```js
 import { fetchTextFromUrl } from './src/fetch.js';
 
-const text = await fetchTextFromUrl('https://example.com/job', {
-  timeoutMs: 5000,
-  headers: { 'User-Agent': 'jobbot' }
-});
-console.log(text);
-// "<job description text>"
+const run = async () => {
+  const text = await fetchTextFromUrl('https://example.com', {
+    timeoutMs: 5000,
+    headers: { 'User-Agent': 'jobbot' }
+  });
+  console.log(text);
+  // "<job description text>"
+};
+
+run();
 ```
 
 `fetchTextFromUrl` strips scripts, styles, navigation, footer, and aside content and


### PR DESCRIPTION
## Summary
- clarify fetchTextFromUrl usage with an async helper
- document async call pattern in README

## Testing
- `node --check /tmp/snippet.mjs`
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c39834e0cc832fb4a736fba9efca3a