### PR TITLE
🩹 fix: avoid splitting inside unclosed quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ It ignores bare newlines.
 It scans text character-by-character to avoid large intermediate arrays and regex performance
 pitfalls, falling back to the trimmed input when no sentence punctuation is found.
 Trailing quotes or parentheses are included when they immediately follow punctuation, and all
-Unicode whitespace is treated as a sentence boundary.
+Unicode whitespace is treated as a sentence boundary. Punctuation inside unclosed quotes does not
+end a sentence.
 If fewer complete sentences than requested exist, any remaining text is appended so no content
 is lost. Parenthetical abbreviations like `(M.Sc.)` remain attached to their surrounding sentence.
 Common honorifics such as `Mr.` and `Dr.` are recognized so summaries aren't cut mid-sentence.

--- a/src/index.js
+++ b/src/index.js
@@ -43,14 +43,15 @@ export function summarize(text, count = 1) {
     const ch = text[i];
 
     // Track nesting
-    if (openers.has(ch)) parenDepth++;
-    else if (closers.has(ch)) {
+    if (ch === '"' || ch === "'") {
+      if (quote === ch) quote = null;
+      else if (!quote) quote = ch;
+    } else if (openers.has(ch)) {
+      parenDepth++;
+    } else if (closers.has(ch)) {
       if (ch === ')' || ch === ']' || ch === '}') {
         if (parenDepth > 0) parenDepth--;
       }
-    } else if (ch === '"' || ch === "'") {
-      if (quote === ch) quote = null;
-      else if (!quote) quote = ch;
     }
 
     if (ch === '.' || ch === '!' || ch === '?' || ch === '…') {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -72,6 +72,11 @@ describe('summarize', () => {
     expect(summarize(text)).toBe('"Wow!"');
   });
 
+  it('does not split on punctuation inside unclosed quotes', () => {
+    const text = '"First. Second.';
+    expect(summarize(text)).toBe(text);
+  });
+
   it('recognizes unicode ellipsis as terminator', () => {
     const text = 'Wait… Next sentence.';
     expect(summarize(text)).toBe('Wait…');


### PR DESCRIPTION
## Summary
- track quote state before other closers
- document sentence behavior with unclosed quotes
- add regression test for open quotes

## Testing
- `npm run lint`
- `npm run test:ci` *(fails: parseJobText requirements header performance > finds requirement headers in a single pass)*

------
https://chatgpt.com/codex/tasks/task_e_68c39826b048832fbb21b59c78452e43