### PR TITLE
🔧 : cancel duplicate CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
what: add concurrency group to cancel in-progress runs on same ref
why: reduce redundant builds and speed up feedback
how to test: npm run lint && npm run test:ci
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68c65cd21854832fab84b425a0f59519