### PR TITLE
🔧: cancel superseded CI runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,10 @@ on:
   schedule:
     - cron: '0 0 * * 0'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ npm run test:ci
 echo "First. Second. Third." | jobbot summarize - --sentences 2 --text
 ```
 
+CI auto-cancels superseded runs to keep builds fast and reliable.
+
 In code, import the `summarize` function and pass the number of sentences to keep:
 
 ```js


### PR DESCRIPTION
what: add concurrency to CI and CodeQL workflows, note in docs
why: cancel superseded runs to save time and resources
how to test:
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68c65cd21854832fab84b425a0f59519