### PR TITLE
🔧 : add concurrency to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   push:
   pull_request:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ npm run test:ci
 echo "First. Second. Third." | jobbot summarize - --sentences 2 --text
 ```
 
+# Continuous integration
+GitHub Actions runs lint and test checks on each push and pull request. To keep builds fast,
+in-progress runs for the same branch are canceled when new commits arrive.
+
 In code, import the `summarize` function and pass the number of sentences to keep:
 
 ```js


### PR DESCRIPTION
## Summary
- cancel outdated CI runs via concurrency to keep builds fast
- note CI auto-cancels stale runs in README

## Testing
- `npm ci`
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c65cd21854832fab84b425a0f59519