### PR TITLE
🧪: cover console font fallback edge cases

### DIFF
--- a/test/console-font.test.js
+++ b/test/console-font.test.js
@@ -25,4 +25,22 @@ describe('ensureDefaultConsoleFont', () => {
     const data = await fs.readFile(defaultFile, 'utf8');
     expect(data).toBe('original');
   });
+
+  it('uses provided fallback font name', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'font-'));
+    const fallbackName = 'custom.psf.gz';
+    const fallback = path.join(dir, fallbackName);
+    await fs.writeFile(fallback, 'custom');
+    const defaultPath = await ensureDefaultConsoleFont(dir, fallbackName);
+    const data = await fs.readFile(defaultPath, 'utf8');
+    expect(defaultPath).toBe(path.join(dir, 'default.psf.gz'));
+    expect(data).toBe('custom');
+  });
+
+  it('throws when fallback font is missing', async () => {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'font-'));
+    await expect(
+      ensureDefaultConsoleFont(dir, 'missing.psf.gz')
+    ).rejects.toMatchObject({ code: 'ENOENT' });
+  });
 });


### PR DESCRIPTION
## Summary
- test provided fallback font name
- test error when fallback font missing

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c65da3c360832f98ae3c04e9a04df4