### PR TITLE
📝 docs: clarify security token example

### DIFF
--- a/docs/prompts/codex/security.md
+++ b/docs/prompts/codex/security.md
@@ -46,12 +46,17 @@ Copy this block whenever addressing security in jobbot3000.
 ### Example: Generating a secure token
 
 ```js
-import { randomBytes } from 'crypto'
+import { randomBytes } from 'node:crypto';
 
-export function generateToken () {
-  return randomBytes(32).toString('hex')
+export function generateToken() {
+  return randomBytes(32).toString('hex');
 }
+
+console.log(generateToken().length); // 64
 ```
+
+Run it with `node --input-type=module` to verify the output is 64.
+See [`randomBytes`](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) for details.
 
 ## Upgrade Prompt
 Type: evergreen


### PR DESCRIPTION
## What
- clarify security prompt token example

## Why
- demonstrate secure token usage and link to Node docs

## How to test
- `npm run lint`
- `npm run test:ci`
- `npx -y markdown-link-check docs/prompts/codex/security.md`


------
https://chatgpt.com/codex/tasks/task_e_68c65daa436c832fb4359608ccceca28