### PR TITLE
🔤 : fix README spelling and update dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ font size immediately after logging in.
 ## Tracking Application Lifecycle
 
 Application statuses such as `no_response`, `rejected`, and `next_round` are saved to
-`data/applications.json`, a gitignored file. Set `JOBBOT_DATA_DIR` to change the directory.
+`data/applications.json`, a git-ignored file. Set `JOBBOT_DATA_DIR` to change the directory.
 These records power local Sankey diagrams so progress isn't lost between sessions.
 Writes are serialized to avoid dropping entries when recording multiple applications at once.
 If the file is missing it will be created, but other file errors or malformed JSON will throw.

--- a/cspell.json
+++ b/cspell.json
@@ -26,6 +26,8 @@
     "YOURNAME",
     "sandboxing",
     "Upgrader",
-    "alnum"
+    "alnum",
+    "consolefonts",
+    "Sankey"
   ]
 }


### PR DESCRIPTION
what: fix README typo and add terms to cspell dictionary.
why: keep documentation and spellcheck accurate.
how to test: npm run lint && npm run test:ci
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68c65d7ae644832fac817fb54c691347