### PR TITLE
fix spelling for console fonts and Sankey references

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -26,6 +26,8 @@
     "YOURNAME",
     "sandboxing",
     "Upgrader",
-    "alnum"
+    "alnum",
+    "consolefonts",
+    "Sankey"
   ]
 }

--- a/test/console-font.test.js
+++ b/test/console-font.test.js
@@ -8,11 +8,11 @@ describe('ensureDefaultConsoleFont', () => {
   it('creates default font from fallback when missing', async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'font-'));
     const fallback = path.join(dir, 'Lat15-TerminusBold14.psf.gz');
-    await fs.writeFile(fallback, 'fontdata');
+    await fs.writeFile(fallback, 'font data');
     const defaultPath = await ensureDefaultConsoleFont(dir);
     const data = await fs.readFile(defaultPath, 'utf8');
     expect(defaultPath).toBe(path.join(dir, 'default.psf.gz'));
-    expect(data).toBe('fontdata');
+    expect(data).toBe('font data');
   });
 
   it('keeps existing default font', async () => {


### PR DESCRIPTION
## Summary
- replace `fontdata` test placeholder with `font data`
- add `consolefonts` and `Sankey` to the spell-check dictionary

## Testing
- `npx -y cspell "**"`
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c65d7ae644832fac817fb54c691347