### PR TITLE
🌐 add Spanish localization for Markdown exporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ Pass `url` to include a source link in the rendered Markdown output.
 `toMarkdownMatch` accepts the same `url` field to link match reports back to the job posting.
 If `summary` is omitted, the requirements section is still separated by a blank line.
 
+Both exporters accept an optional `locale` field to translate labels.
+The default locale is `'en'`; Spanish (`'es'`) is also supported.
+
 Use `toMarkdownMatch` to format fit score results; it also accepts `url`:
 
 ```js

--- a/src/exporters.js
+++ b/src/exporters.js
@@ -1,3 +1,5 @@
+import { t, DEFAULT_LOCALE } from './i18n.js';
+
 export function toJson(data) {
   return JSON.stringify(data, null, 2);
 }
@@ -28,20 +30,30 @@ function appendListSection(lines, header, items, { leadingNewline = false } = {}
  * @param {string} [params.summary]
  * @returns {string}
  */
-export function toMarkdownSummary({ title, company, location, url, requirements, summary }) {
+export function toMarkdownSummary({
+  title,
+  company,
+  location,
+  url,
+  requirements,
+  summary,
+  locale = DEFAULT_LOCALE,
+}) {
   const lines = [];
   if (title) lines.push(`# ${title}`);
-  if (company) lines.push(`**Company**: ${company}`);
-  if (location) lines.push(`**Location**: ${location}`);
-  if (url) lines.push(`**URL**: ${url}`);
+  if (company) lines.push(`**${t('company', locale)}**: ${company}`);
+  if (location) lines.push(`**${t('location', locale)}**: ${location}`);
+  if (url) lines.push(`**${t('url', locale)}**: ${url}`);
 
   if (summary) {
-    lines.push('', '## Summary', '', summary);
+    lines.push('', `## ${t('summary', locale)}`, '', summary);
     if (!requirements || !requirements.length) lines.push('');
   }
 
   const needsNewline = lines.length > 0 && !lines[lines.length - 1].endsWith('\n');
-  appendListSection(lines, 'Requirements', requirements, { leadingNewline: needsNewline });
+  appendListSection(lines, t('requirements', locale), requirements, {
+    leadingNewline: needsNewline,
+  });
 
   return lines.join('\n');
 }
@@ -66,14 +78,16 @@ export function toMarkdownMatch({
   score,
   matched,
   missing,
+  locale = DEFAULT_LOCALE,
 }) {
   const lines = [];
   if (title) lines.push(`# ${title}`);
-  if (company) lines.push(`**Company**: ${company}`);
-  if (location) lines.push(`**Location**: ${location}`);
-  if (url) lines.push(`**URL**: ${url}`);
-  if (typeof score === 'number') lines.push(`**Fit Score**: ${score}%`);
-  appendListSection(lines, 'Matched', matched, { leadingNewline: true });
-  appendListSection(lines, 'Missing', missing, { leadingNewline: true });
+  if (company) lines.push(`**${t('company', locale)}**: ${company}`);
+  if (location) lines.push(`**${t('location', locale)}**: ${location}`);
+  if (url) lines.push(`**${t('url', locale)}**: ${url}`);
+  if (typeof score === 'number')
+    lines.push(`**${t('fitScore', locale)}**: ${score}%`);
+  appendListSection(lines, t('matched', locale), matched, { leadingNewline: true });
+  appendListSection(lines, t('missing', locale), missing, { leadingNewline: true });
   return lines.join('\n');
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -1,0 +1,16 @@
+import en from './locales/en.js';
+import es from './locales/es.js';
+
+/**
+ * Simple dictionary-based translator.
+ * Falls back to English when a key or locale is missing.
+ */
+
+export const DEFAULT_LOCALE = 'en';
+
+const TRANSLATIONS = { en, es };
+
+export function t(key, locale = DEFAULT_LOCALE) {
+  const lang = TRANSLATIONS[locale] || TRANSLATIONS[DEFAULT_LOCALE];
+  return lang[key] || TRANSLATIONS[DEFAULT_LOCALE][key] || key;
+}

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1,0 +1,10 @@
+export default {
+  company: 'Company',
+  location: 'Location',
+  url: 'URL',
+  summary: 'Summary',
+  requirements: 'Requirements',
+  fitScore: 'Fit Score',
+  matched: 'Matched',
+  missing: 'Missing'
+};

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -1,0 +1,10 @@
+export default {
+  company: 'Empresa',
+  location: 'Ubicación',
+  url: 'URL',
+  summary: 'Resumen',
+  requirements: 'Requisitos',
+  fitScore: 'Puntaje de Ajuste',
+  matched: 'Coincidencias',
+  missing: 'Faltantes'
+};

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -102,4 +102,53 @@ describe('exporters', () => {
     const output = toMarkdownMatch({ title: 'Dev', score: 0 });
     expect(output).toBe('# Dev\n**Fit Score**: 0%');
   });
+
+  it('supports spanish locale in markdown summaries', () => {
+    const output = toMarkdownSummary({
+      title: 'Dev',
+      company: 'Acme',
+      location: 'Remoto',
+      summary: 'Construir cosas',
+      requirements: ['JS'],
+      locale: 'es',
+    });
+    const expected = [
+      '# Dev',
+      '**Empresa**: Acme',
+      '**Ubicación**: Remoto',
+      '',
+      '## Resumen',
+      '',
+      'Construir cosas',
+      '',
+      '## Requisitos',
+      '- JS',
+    ].join('\n');
+    expect(output).toBe(expected);
+  });
+
+  it('supports spanish locale in markdown match reports', () => {
+    const output = toMarkdownMatch({
+      title: 'Dev',
+      company: 'Acme',
+      location: 'Remoto',
+      score: 85,
+      matched: ['JS'],
+      missing: ['Rust'],
+      locale: 'es',
+    });
+    const expected = [
+      '# Dev',
+      '**Empresa**: Acme',
+      '**Ubicación**: Remoto',
+      '**Puntaje de Ajuste**: 85%',
+      '',
+      '## Coincidencias',
+      '- JS',
+      '',
+      '## Faltantes',
+      '- Rust',
+    ].join('\n');
+    expect(output).toBe(expected);
+  });
 });


### PR DESCRIPTION
## Summary
- add dictionary-based i18n helper and Spanish locale
- localize markdown exporters with optional locale arg
- document locale support and cover translations with tests

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c65ce96c30832fb1e06c1e76c39771