### PR TITLE
🛡️: prevent SSRF in fetchTextFromUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ run();
 and noscript content, preserves image alt text, and collapses whitespace to
 single spaces. Pass `timeoutMs` (milliseconds) to override the 10s default,
 and `headers` to send custom HTTP headers. Only `http` and `https` URLs are
-supported; other protocols throw an error.
+supported, and requests to `localhost` or private network addresses are
+rejected to avoid SSRF; other protocols throw an error.
 
 Normalize existing HTML without fetching and log the result:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,11 @@
     "": {
       "name": "jobbot3000",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "html-to-text": "9.0.5",
+        "ipaddr.js": "^2.2.0",
         "node-fetch": "^3.3.2",
         "pdf-parse": "^1.1.1",
         "remove-markdown": "^0.6.2"
@@ -1936,6 +1938,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
+      "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/is-extglob": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "html-to-text": "9.0.5",
+    "ipaddr.js": "^2.2.0",
     "node-fetch": "^3.3.2",
     "pdf-parse": "^1.1.1",
     "remove-markdown": "^0.6.2"

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -175,6 +175,16 @@ describe('fetchTextFromUrl', () => {
     );
   });
 
+  it.each([
+    'http://localhost',
+    'http://127.0.0.1',
+    'http://192.168.0.1',
+  ])('rejects private URLs: %s', async (url) => {
+    fetch.mockClear();
+    await expect(fetchTextFromUrl(url)).rejects.toThrow('Refusing to fetch');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it('rejects non-http/https URLs', async () => {
     fetch.mockClear();
     fetch.mockResolvedValue({


### PR DESCRIPTION
## Summary
- block localhost and private network URLs in `fetchTextFromUrl`
- cover SSRF guard with tests
- document URL restrictions and add ipaddr.js dependency

## Testing
- `npm run lint`
- `npm run test:ci`
- `npm audit`
- `git diff --cached | ./scripts/scan-secrets.py`

------
https://chatgpt.com/codex/tasks/task_e_68c65d559f04832f901b9056fa3331ca