### PR TITLE
🔒 fix: block non-http redirects in fetch helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ run();
 and noscript content, preserves image alt text, and collapses whitespace to
 single spaces. Pass `timeoutMs` (milliseconds) to override the 10s default,
 and `headers` to send custom HTTP headers. Only `http` and `https` URLs are
-supported; other protocols throw an error.
+supported; redirects to other protocols throw an error.
 
 Normalize existing HTML without fetching and log the result:
 

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -41,7 +41,7 @@ export function extractTextFromHtml(html) {
 
 /**
  * Fetch a URL and return its text content. HTML responses are converted to plain text.
- * Supports only `http:` and `https:` protocols.
+ * Supports only `http:` and `https:` protocols, including after redirects.
  *
  * @param {string} url
  * @param {{ timeoutMs?: number, headers?: Record<string, string> }} [opts]
@@ -65,6 +65,10 @@ export async function fetchTextFromUrl(url, { timeoutMs = 10000, headers } = {})
       signal: controller.signal,
       headers: headers || {},
     });
+    const { protocol: finalProtocol } = new URL(response.url || url);
+    if (finalProtocol !== 'http:' && finalProtocol !== 'https:') {
+      throw new Error(`Unsupported protocol: ${finalProtocol}`);
+    }
     if (!response.ok) {
       throw new Error(`Failed to fetch ${url}: ${response.status} ${response.statusText}`);
     }

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -188,4 +188,17 @@ describe('fetchTextFromUrl', () => {
       .rejects.toThrow('Unsupported protocol: file:');
     expect(fetch).not.toHaveBeenCalled();
   });
+
+  it('rejects redirects to disallowed protocols', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('secret'),
+      url: 'file:///etc/passwd',
+    });
+    await expect(fetchTextFromUrl('http://example.com'))
+      .rejects.toThrow('Unsupported protocol: file:');
+  });
 });


### PR DESCRIPTION
what: validate final response protocol and document non-http redirect rejection
why: prevent SSRF via redirects to file or other protocols
how to test: npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c65d559f04832f901b9056fa3331ca