### PR TITLE
Limit fetch response size to prevent DoS

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ run();
 `fetchTextFromUrl` strips scripts, styles, navigation, header, footer, aside,
 and noscript content, preserves image alt text, and collapses whitespace to
 single spaces. Pass `timeoutMs` (milliseconds) to override the 10s default,
-and `headers` to send custom HTTP headers. Only `http` and `https` URLs are
+and `headers` to send custom HTTP headers. Responses over 1&nbsp;MB are
+rejected; override with `maxBytes` to adjust. Only `http` and `https` URLs are
 supported; other protocols throw an error.
 
 Normalize existing HTML without fetching and log the result:

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -188,4 +188,28 @@ describe('fetchTextFromUrl', () => {
       .rejects.toThrow('Unsupported protocol: file:');
     expect(fetch).not.toHaveBeenCalled();
   });
+
+  it('limits response size to 1MB by default', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('ok'),
+    });
+    await fetchTextFromUrl('http://example.com');
+    expect(fetch).toHaveBeenCalledWith(
+      'http://example.com',
+      expect.objectContaining({ size: 1024 * 1024 })
+    );
+  });
+
+  it('rejects when response exceeds maxBytes', async () => {
+    fetch.mockRejectedValue(
+      Object.assign(new Error('max size exceeded'), { type: 'max-size' })
+    );
+    await expect(
+      fetchTextFromUrl('http://example.com', { maxBytes: 5 })
+    ).rejects.toThrow('Response exceeded 5 bytes');
+  });
 });


### PR DESCRIPTION
## Summary
- cap node-fetch responses at 1 MB by default
- handle oversize responses with clear error
- document new maxBytes option

## Testing
- `npm run lint`
- `npm run test:ci`
- `npm audit`


------
https://chatgpt.com/codex/tasks/task_e_68c65d559f04832f901b9056fa3331ca