### PR TITLE
Refactor lifecycle file handling

### DIFF
--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -8,6 +8,16 @@ function paths() {
   return { dir, file: path.join(dir, 'applications.json') };
 }
 
+// Read lifecycle JSON from disk, returning an empty object when the file is missing.
+async function readLifecycleFile(file) {
+  try {
+    return JSON.parse(await fs.readFile(file, 'utf8'));
+  } catch (err) {
+    if (err.code === 'ENOENT') return {};
+    throw err;
+  }
+}
+
 // Serialize writes to avoid clobbering entries when recordApplication is invoked concurrently.
 let writeLock = Promise.resolve();
 
@@ -23,12 +33,7 @@ export function recordApplication(id, status) {
 
   const run = async () => {
     await fs.mkdir(dir, { recursive: true });
-    let data = {};
-    try {
-      data = JSON.parse(await fs.readFile(file, 'utf8'));
-    } catch (err) {
-      if (err.code !== 'ENOENT') throw err;
-    }
+    const data = await readLifecycleFile(file);
     data[id] = status;
     const tmp = `${file}.tmp`;
     await fs.writeFile(tmp, JSON.stringify(data, null, 2));
@@ -46,16 +51,10 @@ export function recordApplication(id, status) {
  */
 export async function getLifecycleCounts() {
   const { file } = paths();
-  let data = {};
-  try {
-    data = JSON.parse(await fs.readFile(file, 'utf8'));
-  } catch (err) {
-    if (err.code !== 'ENOENT') throw err;
-  }
-  const counts = {};
-  for (const s of STATUSES) counts[s] = 0;
-  for (const s of Object.values(data)) {
-    if (counts[s] !== undefined) counts[s] += 1;
+  const data = await readLifecycleFile(file);
+  const counts = Object.fromEntries(STATUSES.map(s => [s, 0]));
+  for (const status of Object.values(data)) {
+    if (counts[status] !== undefined) counts[status] += 1;
   }
   return counts;
 }

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -23,6 +23,11 @@ test('records and summarizes application statuses', async () => {
   expect(JSON.parse(raw)).toEqual({ abc: 'rejected', def: 'no_response' });
 });
 
+test('returns zero counts when lifecycle file is missing', async () => {
+  const counts = await getLifecycleCounts();
+  expect(counts).toEqual({ no_response: 0, rejected: 0, next_round: 0 });
+});
+
 test('throws when lifecycle file has invalid JSON', async () => {
   await fs.mkdir(tmp, { recursive: true });
   await fs.writeFile(path.join(tmp, 'applications.json'), '{');


### PR DESCRIPTION
## Summary
- consolidate lifecycle JSON loading into shared helper
- test getLifecycleCounts when lifecycle file is missing

## Testing
- `npm run lint`
- `npm run test:ci`

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68c65d385d04832f80bffa00bf9da42c