### PR TITLE
♻️: refactor lifecycle JSON helpers

### DIFF
--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -8,6 +8,34 @@ function paths() {
   return { dir, file: path.join(dir, 'applications.json') };
 }
 
+/**
+ * Read and parse JSON from `file`. Returns an empty object when the file doesn't exist.
+ *
+ * @param {string} file
+ * @returns {Promise<object>}
+ */
+async function readJsonFile(file) {
+  try {
+    return JSON.parse(await fs.readFile(file, 'utf8'));
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+    return {};
+  }
+}
+
+/**
+ * Atomically write `data` as pretty JSON to `file`.
+ *
+ * @param {string} file
+ * @param {object} data
+ * @returns {Promise<void>}
+ */
+async function writeJsonFile(file, data) {
+  const tmp = `${file}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(data, null, 2));
+  await fs.rename(tmp, file);
+}
+
 // Serialize writes to avoid clobbering entries when recordApplication is invoked concurrently.
 let writeLock = Promise.resolve();
 
@@ -23,16 +51,9 @@ export function recordApplication(id, status) {
 
   const run = async () => {
     await fs.mkdir(dir, { recursive: true });
-    let data = {};
-    try {
-      data = JSON.parse(await fs.readFile(file, 'utf8'));
-    } catch (err) {
-      if (err.code !== 'ENOENT') throw err;
-    }
+    const data = await readJsonFile(file);
     data[id] = status;
-    const tmp = `${file}.tmp`;
-    await fs.writeFile(tmp, JSON.stringify(data, null, 2));
-    await fs.rename(tmp, file);
+    await writeJsonFile(file, data);
     return data[id];
   };
 
@@ -46,12 +67,7 @@ export function recordApplication(id, status) {
  */
 export async function getLifecycleCounts() {
   const { file } = paths();
-  let data = {};
-  try {
-    data = JSON.parse(await fs.readFile(file, 'utf8'));
-  } catch (err) {
-    if (err.code !== 'ENOENT') throw err;
-  }
+  const data = await readJsonFile(file);
   const counts = {};
   for (const s of STATUSES) counts[s] = 0;
   for (const s of Object.values(data)) {

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -47,3 +47,7 @@ test('handles concurrent status updates', async () => {
   const counts = await getLifecycleCounts();
   expect(counts).toEqual({ no_response: 1, rejected: 1, next_round: 1 });
 });
+
+test('rejects unknown application statuses', async () => {
+  await expect(recordApplication('z', 'pending')).rejects.toThrow('unknown status');
+});


### PR DESCRIPTION
what: dedupe lifecycle file JSON read/write helpers
why: reduce duplication and tighten status validation
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68c65d385d04832f80bffa00bf9da42c