### PR TITLE
♻️: – centralize sentence terminator checks in summarize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,8 @@ const spaceRe = /\s/;
 const isSpace = (c) => spaceRe.test(c);
 const closers = new Set(['"', "'", ')', ']', '}']);
 const openers = new Set(['(', '[', '{']);
+// Sentence-ending punctuation characters.
+const terminators = new Set(['.', '!', '?', '…']);
 const isDigit = (c) => c >= '0' && c <= '9';
 const isAlpha = (c) => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
 const abbreviations = new Set(['mr', 'mrs', 'ms', 'dr', 'prof', 'sr', 'jr', 'st', 'vs']);
@@ -53,7 +55,7 @@ export function summarize(text, count = 1) {
       else if (!quote) quote = ch;
     }
 
-    if (ch === '.' || ch === '!' || ch === '?' || ch === '…') {
+    if (terminators.has(ch)) {
       // Skip decimals like 3.14
       if (ch === '.' && i > 0 && isDigit(text[i - 1]) && i + 1 < len && isDigit(text[i + 1])) {
         continue;
@@ -71,10 +73,7 @@ export function summarize(text, count = 1) {
       let j = i + 1;
 
       // absorb consecutive punctuation like ?!
-      while (
-        j < len &&
-        (text[j] === '.' || text[j] === '!' || text[j] === '?' || text[j] === '…')
-      ) {
+      while (j < len && terminators.has(text[j])) {
         j++;
       }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -77,6 +77,11 @@ describe('summarize', () => {
     expect(summarize(text)).toBe('Wait…');
   });
 
+  it('handles ellipsis combined with other terminators', () => {
+    const text = 'Wait…? Another.';
+    expect(summarize(text)).toBe('Wait…?');
+  });
+
   it('does not split after common abbreviations', () => {
     const text = 'Mr. Smith went home. Another.';
     expect(summarize(text)).toBe('Mr. Smith went home.');


### PR DESCRIPTION
## Summary
- refactor summarize to reuse a Set for sentence terminators
- document terminator set and add test for ellipsis plus punctuation

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c65d448cb8832fb466cb7b737a9316