### PR TITLE
🧹: – consolidate parser pattern matching

### DIFF
--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -12,6 +12,11 @@ describe('parseJobText', () => {
     });
   });
 
+  it('returns trimmed original text in body', () => {
+    const text = '\nTitle: Dev\nCompany: ACME\n';
+    expect(parseJobText(text).body).toBe('Title: Dev\nCompany: ACME');
+  });
+
   it('extracts location when present', () => {
     const text = `
 Title: Developer


### PR DESCRIPTION
## Summary
- share helper to locate patterns in job text
- test body field retains trimmed source

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c65d448cb8832fb466cb7b737a9316