### PR TITLE
Refactor fetch protocol validation into constants

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,6 +1,12 @@
 import fetch from 'node-fetch';
 import { htmlToText } from 'html-to-text';
 
+/** Allowed URL protocols for fetchTextFromUrl. */
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+
+/** Default timeout for fetchTextFromUrl in milliseconds. */
+export const DEFAULT_TIMEOUT_MS = 10000;
+
 function formatImageAlt(elem, walk, builder) {
   const alt = elem.attribs?.alt;
   if (alt) builder.addInline(alt, { noWordTransform: true });
@@ -47,9 +53,12 @@ export function extractTextFromHtml(html) {
  * @param {{ timeoutMs?: number, headers?: Record<string, string> }} [opts]
  * @returns {Promise<string>}
  */
-export async function fetchTextFromUrl(url, { timeoutMs = 10000, headers } = {}) {
+export async function fetchTextFromUrl(
+  url,
+  { timeoutMs = DEFAULT_TIMEOUT_MS, headers } = {}
+) {
   const { protocol } = new URL(url);
-  if (protocol !== 'http:' && protocol !== 'https:') {
+  if (!ALLOWED_PROTOCOLS.has(protocol)) {
     throw new Error(`Unsupported protocol: ${protocol}`);
   }
 

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -188,4 +188,16 @@ describe('fetchTextFromUrl', () => {
       .rejects.toThrow('Unsupported protocol: file:');
     expect(fetch).not.toHaveBeenCalled();
   });
+
+  it('allows uppercase HTTP protocol', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('ok'),
+    });
+    const text = await fetchTextFromUrl('HTTP://example.com');
+    expect(text).toBe('ok');
+  });
 });


### PR DESCRIPTION
what: centralize allowed protocols and default timeout for fetchTextFromUrl
why: clarifies supported schemes and documents timeout configuration
how to test: npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c65d448cb8832fb466cb7b737a9316