### PR TITLE
♻️: centralize lifecycle JSON reading

### DIFF
--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -47,3 +47,7 @@ test('handles concurrent status updates', async () => {
   const counts = await getLifecycleCounts();
   expect(counts).toEqual({ no_response: 1, rejected: 1, next_round: 1 });
 });
+
+test('rejects unknown statuses', async () => {
+  await expect(recordApplication('id', 'maybe')).rejects.toThrow('unknown status');
+});


### PR DESCRIPTION
what: dedupe lifecycle JSON parsing, document statuses, add guard test
why: improve maintainability by sharing file parsing, ensure status validation
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68c65d448cb8832fb466cb7b737a9316