### PR TITLE
🐛: default invalid numeric flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ npm run test:ci
 # Works with sentences ending in ., ?, or !
 # Keep two sentences with --sentences, output plain text with --text
 echo "First. Second. Third." | jobbot summarize - --sentences 2 --text
+# Non-numeric --sentences values fall back to 1 sentence
 ```
 
 In code, import the `summarize` function and pass the number of sentences to keep:

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -30,6 +30,12 @@ function getFlag(args, name, fallback) {
   return val;
 }
 
+function getNumberFlag(args, name, fallback) {
+  const raw = getFlag(args, name);
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : fallback;
+}
+
 async function cmdSummarize(args) {
   const input = args[0] || '-';
   const format = args.includes('--json')
@@ -37,8 +43,8 @@ async function cmdSummarize(args) {
     : args.includes('--text')
       ? 'text'
       : 'md';
-  const timeoutMs = Number(getFlag(args, '--timeout', 10000));
-  const count = Number(getFlag(args, '--sentences', 1));
+  const timeoutMs = getNumberFlag(args, '--timeout', 10000);
+  const count = getNumberFlag(args, '--sentences', 1);
   const raw = isHttpUrl(input)
     ? await fetchTextFromUrl(input, { timeoutMs })
     : await readSource(input);
@@ -62,7 +68,7 @@ async function cmdMatch(args) {
     process.exit(2);
   }
   const format = args.includes('--json') ? 'json' : 'md';
-  const timeoutMs = Number(getFlag(args, '--timeout', 10000));
+  const timeoutMs = getNumberFlag(args, '--timeout', 10000);
   const resumePath = args[resumeIdx + 1];
   const jobInput = args[jobIdx + 1];
   const resumeText = await loadResume(resumePath);

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -45,6 +45,7 @@ export function extractTextFromHtml(html) {
  *
  * @param {string} url
  * @param {{ timeoutMs?: number, headers?: Record<string, string> }} [opts]
+ *   Invalid timeout values fall back to 10000ms.
  * @returns {Promise<string>}
  */
 export async function fetchTextFromUrl(url, { timeoutMs = 10000, headers } = {}) {
@@ -53,10 +54,12 @@ export async function fetchTextFromUrl(url, { timeoutMs = 10000, headers } = {})
     throw new Error(`Unsupported protocol: ${protocol}`);
   }
 
+  const ms = Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 10000;
+
   const controller = new AbortController();
   const timer = setTimeout(
-    () => controller.abort(new Error(`Timeout after ${timeoutMs}ms`)),
-    timeoutMs
+    () => controller.abort(new Error(`Timeout after ${ms}ms`)),
+    ms
   );
 
   try {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -25,6 +25,14 @@ describe('jobbot CLI', () => {
     expect(out.trim()).toBe('## Summary\n\nFirst. Second.');
   });
 
+  it('defaults to one sentence when --sentences is invalid', () => {
+    const out = runCli(
+      ['summarize', '-', '--sentences', 'foo'],
+      'First. Second.'
+    );
+    expect(out.trim()).toBe('## Summary\n\nFirst.');
+  });
+
   it('outputs plain text summary with --text', () => {
     const input = 'Title: Engineer\nCompany: ACME\nFirst. Second.';
     const out = runCli(['summarize', '-', '--text'], input);

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -157,6 +157,19 @@ describe('fetchTextFromUrl', () => {
     vi.useRealTimers();
   });
 
+  it('falls back to default timeout when given NaN', async () => {
+    vi.useFakeTimers();
+    fetch.mockImplementation((url, { signal }) =>
+      new Promise((resolve, reject) => {
+        signal.addEventListener('abort', () => reject(signal.reason));
+      })
+    );
+    const promise = fetchTextFromUrl('http://example.com', { timeoutMs: Number('foo') });
+    vi.advanceTimersByTime(10000);
+    await expect(promise).rejects.toThrow('Timeout after 10000ms');
+    vi.useRealTimers();
+  });
+
   it('forwards headers to fetch', async () => {
     fetch.mockClear();
     fetch.mockResolvedValue({


### PR DESCRIPTION
## Summary
- default invalid CLI numeric flags to safe values
- fall back to 10s when fetchTextFromUrl receives invalid timeout
- document non-numeric --sentences behavior and add tests

## Testing
- `npm run lint`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68c65ccc4508832fa69ae39b78560d5d