### PR TITLE
🐛 : ignore non-string requirement entries in fit scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ or `(1)`; these markers are stripped when parsing job text, even when the first 
 the header on the same line. Leading numbers without punctuation remain intact. Requirement headers
 are located in a single pass to avoid re-scanning large job postings, and resume scoring tokenizes
 via a manual scanner and caches tokens (up to 60k lines) to avoid repeated work. Requirement bullets
-are scanned without regex or temporary arrays, improving large input performance. Blank
-requirement entries are skipped so empty bullets don't affect scoring.
+are scanned without regex or temporary arrays, improving large input performance. Blank or
+non-string requirement entries are skipped so invalid bullets don't affect scoring.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -57,12 +57,12 @@ function hasOverlap(line, resumeSet) {
  * Compute how well a resume matches a list of job requirements.
  *
  * @param {any} resumeText Non-string values are stringified.
- * @param {string[] | undefined} requirements
+ * @param {string[] | undefined} requirements Non-string entries are ignored.
  * @returns {{ score: number, matched: string[], missing: string[] }}
  */
 export function computeFitScore(resumeText, requirements) {
   const bullets = Array.isArray(requirements)
-    ? requirements.filter(r => typeof r !== 'string' || r.trim())
+    ? requirements.filter(r => typeof r === 'string' && r.trim())
     : [];
   if (!bullets.length) return { score: 0, matched: [], missing: [] };
 

--- a/test/scoring.test.js
+++ b/test/scoring.test.js
@@ -23,9 +23,7 @@ describe('computeFitScore', () => {
     const resume = 'Strong in Go';
     const requirements = ['Go', null, 123, undefined];
     const result = computeFitScore(resume, requirements);
-    expect(result.score).toBe(25);
-    expect(result.matched).toEqual(['Go']);
-    expect(result.missing).toEqual([null, 123, undefined]);
+    expect(result).toEqual({ score: 100, matched: ['Go'], missing: [] });
   });
 
   it('treats non-string resume input as empty string', () => {


### PR DESCRIPTION
what: skip non-string requirement bullets during fit scoring
why: avoid skewed match percentages from invalid data
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68c65ccc4508832fa69ae39b78560d5d