### PR TITLE
🐛: ignore non-string requirements in scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ They may start with `-`, `+`, `*`, `•`, `–` (en dash), `—` (em dash), or n
 or `(1)`; these markers are stripped when parsing job text, even when the first requirement follows
 the header on the same line. Leading numbers without punctuation remain intact. Requirement headers
 are located in a single pass to avoid re-scanning large job postings, and resume scoring tokenizes
-via a manual scanner and caches tokens (up to 60k lines) to avoid repeated work. Requirement bullets
-are scanned without regex or temporary arrays, improving large input performance. Blank
-requirement entries are skipped so empty bullets don't affect scoring.
+via a manual scanner and caches tokens (up to 60k lines) to avoid repeated work. Requirement
+bullets are scanned without regex or temporary arrays, improving large input performance. Blank or
+non-string requirement entries are skipped so invalid bullets don't affect scoring.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -61,8 +61,9 @@ function hasOverlap(line, resumeSet) {
  * @returns {{ score: number, matched: string[], missing: string[] }}
  */
 export function computeFitScore(resumeText, requirements) {
+  // Ignore non-string or empty requirement entries so malformed data doesn't skew scores.
   const bullets = Array.isArray(requirements)
-    ? requirements.filter(r => typeof r !== 'string' || r.trim())
+    ? requirements.filter(r => typeof r === 'string' && r.trim())
     : [];
   if (!bullets.length) return { score: 0, matched: [], missing: [] };
 

--- a/test/scoring.test.js
+++ b/test/scoring.test.js
@@ -23,9 +23,9 @@ describe('computeFitScore', () => {
     const resume = 'Strong in Go';
     const requirements = ['Go', null, 123, undefined];
     const result = computeFitScore(resume, requirements);
-    expect(result.score).toBe(25);
+    expect(result.score).toBe(100);
     expect(result.matched).toEqual(['Go']);
-    expect(result.missing).toEqual([null, 123, undefined]);
+    expect(result.missing).toEqual([]);
   });
 
   it('treats non-string resume input as empty string', () => {


### PR DESCRIPTION
## Summary
- skip non-string and blank requirement bullets when computing fit scores
- document that invalid requirement entries are ignored

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c65ccc4508832fa69ae39b78560d5d