### PR TITLE
📝 docs: – fix console font placeholder and dictionary

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -26,6 +26,8 @@
     "YOURNAME",
     "sandboxing",
     "Upgrader",
-    "alnum"
+    "alnum",
+    "consolefonts",
+    "Sankey"
   ]
 }

--- a/test/console-font.test.js
+++ b/test/console-font.test.js
@@ -8,11 +8,11 @@ describe('ensureDefaultConsoleFont', () => {
   it('creates default font from fallback when missing', async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'font-'));
     const fallback = path.join(dir, 'Lat15-TerminusBold14.psf.gz');
-    await fs.writeFile(fallback, 'fontdata');
+    await fs.writeFile(fallback, 'font data');
     const defaultPath = await ensureDefaultConsoleFont(dir);
     const data = await fs.readFile(defaultPath, 'utf8');
     expect(defaultPath).toBe(path.join(dir, 'default.psf.gz'));
-    expect(data).toBe('fontdata');
+    expect(data).toBe('font data');
   });
 
   it('keeps existing default font', async () => {


### PR DESCRIPTION
## Summary
- use spaced font data string in console font test
- allow consolefonts and Sankey in cspell dictionary

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c65d6169dc832f9c7924a9fcecfb7d