### PR TITLE
💧 chore: align CI Node version with project engine

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
           cache: npm
       - run: npm ci
       - run: npm run lint


### PR DESCRIPTION
what: run CI on Node.js 20 to match project's required runtime.
why: keep CI consistent with docs and supported Node version.
how to test: npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c65ccefcb8832fad8408c4d5fbe9fd