### PR TITLE
🔒 : restrict CI workflow token to read-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- limit CI workflow to read-only token permissions

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c65ccefcb8832fad8408c4d5fbe9fd