### PR TITLE
🐛 : – fix leading newline in toMarkdownMatch sections

### DIFF
--- a/src/exporters.js
+++ b/src/exporters.js
@@ -73,7 +73,7 @@ export function toMarkdownMatch({
   if (location) lines.push(`**Location**: ${location}`);
   if (url) lines.push(`**URL**: ${url}`);
   if (typeof score === 'number') lines.push(`**Fit Score**: ${score}%`);
-  appendListSection(lines, 'Matched', matched, { leadingNewline: true });
-  appendListSection(lines, 'Missing', missing, { leadingNewline: true });
+  appendListSection(lines, 'Matched', matched, { leadingNewline: lines.length > 0 });
+  appendListSection(lines, 'Missing', missing, { leadingNewline: lines.length > 0 });
   return lines.join('\n');
 }

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -102,4 +102,13 @@ describe('exporters', () => {
     const output = toMarkdownMatch({ title: 'Dev', score: 0 });
     expect(output).toBe('# Dev\n**Fit Score**: 0%');
   });
+  it('does not prepend newline when only matched section exists', () => {
+    const output = toMarkdownMatch({ matched: ['JS'] });
+    expect(output).toBe('## Matched\n- JS');
+  });
+
+  it('does not prepend newline when only missing section exists', () => {
+    const output = toMarkdownMatch({ missing: ['Rust'] });
+    expect(output).toBe('## Missing\n- Rust');
+  });
 });


### PR DESCRIPTION
what: avoid blank first line when match report has no headers
why: toMarkdownMatch prepended newline when only results were provided
how to test: npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c65cdcb03c832fb557177f956ea459