### PR TITLE
🐛: – ignore non-string requirements in scoring

### DIFF
--- a/src/scoring.js
+++ b/src/scoring.js
@@ -57,12 +57,12 @@ function hasOverlap(line, resumeSet) {
  * Compute how well a resume matches a list of job requirements.
  *
  * @param {any} resumeText Non-string values are stringified.
- * @param {string[] | undefined} requirements
+ * @param {string[] | undefined} requirements Non-string entries are ignored.
  * @returns {{ score: number, matched: string[], missing: string[] }}
  */
 export function computeFitScore(resumeText, requirements) {
   const bullets = Array.isArray(requirements)
-    ? requirements.filter(r => typeof r !== 'string' || r.trim())
+    ? requirements.filter(r => typeof r === 'string' && r.trim())
     : [];
   if (!bullets.length) return { score: 0, matched: [], missing: [] };
 

--- a/test/scoring.test.js
+++ b/test/scoring.test.js
@@ -19,13 +19,11 @@ describe('computeFitScore', () => {
     expect(result).toEqual({ score: 100, matched: ['python'], missing: [] });
   });
 
-  it('ignores non-string requirement entries', () => {
+  it('skips non-string requirement entries', () => {
     const resume = 'Strong in Go';
     const requirements = ['Go', null, 123, undefined];
     const result = computeFitScore(resume, requirements);
-    expect(result.score).toBe(25);
-    expect(result.matched).toEqual(['Go']);
-    expect(result.missing).toEqual([null, 123, undefined]);
+    expect(result).toEqual({ score: 100, matched: ['Go'], missing: [] });
   });
 
   it('treats non-string resume input as empty string', () => {


### PR DESCRIPTION
## Summary
- ensure computeFitScore skips non-string requirement entries
- add test covering malformed requirement data

## Testing
- `npm run lint`
- `npm run test:ci`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c65cdcb03c832fb557177f956ea459