### PR TITLE
🐛: – avoid leading newline for summary-only markdown

### DIFF
--- a/src/exporters.js
+++ b/src/exporters.js
@@ -27,6 +27,9 @@ function appendListSection(lines, header, items, { leadingNewline = false } = {}
  * @param {string[]} [params.requirements]
  * @param {string} [params.summary]
  * @returns {string}
+ *
+ * When called with only a summary, the output begins directly with the "## Summary" header
+ * without a leading blank line.
  */
 export function toMarkdownSummary({ title, company, location, url, requirements, summary }) {
   const lines = [];
@@ -36,7 +39,8 @@ export function toMarkdownSummary({ title, company, location, url, requirements,
   if (url) lines.push(`**URL**: ${url}`);
 
   if (summary) {
-    lines.push('', '## Summary', '', summary);
+    if (lines.length > 0) lines.push('', '## Summary', '', summary);
+    else lines.push('## Summary', '', summary);
     if (!requirements || !requirements.length) lines.push('');
   }
 

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -59,6 +59,11 @@ describe('exporters', () => {
     expect(output).toBe('# Dev\n**Company**: Acme\n\n## Summary\n\nBuild\n');
   });
 
+  it('does not prepend newline when only summary provided', () => {
+    const output = toMarkdownSummary({ summary: 'Solo' });
+    expect(output).toBe('## Summary\n\nSolo\n');
+  });
+
   it('formats markdown match reports with score', () => {
     const output = toMarkdownMatch({
       title: 'Dev',


### PR DESCRIPTION
what: fix toMarkdownSummary so summary-only output starts with header
why: remove unexpected blank line
how to test:
- npm run lint
- npm run test:ci

Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68c65cdcb03c832fb557177f956ea459