### PR TITLE
docs: clarify summarize fallback behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,16 @@ console.log(summary);
 
 Pass `0` to `summarize` to return an empty string.
 
+Requesting more sentences than exist returns the entire text.
+
+The example below demonstrates this behavior:
+
+```js
+const all = summarize('Only one sentence.', 5);
+console.log(all);
+// "Only one sentence."
+```
+
 Fetch remote job listings, normalize HTML to plain text, and log the result using an async helper:
 
 ```js


### PR DESCRIPTION
## Summary
- document that requesting more sentences than available returns full text

## Testing
- `npx --yes markdown-link-check README.md`
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c65cd53cac832faf1942fbc4d59730