### PR TITLE
♿: use descriptive link text for job URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ console.log(md);
 // # Engineer
 // **Company**: ACME
 // **Location**: Remote
-// **URL**: https://example.com/job
+// **URL**: [Job posting](https://example.com/job)
 //
 // ## Summary
 //
@@ -101,7 +101,7 @@ console.log(md);
 // - 3+ years JS
 ```
 
-Pass `url` to include a source link in the rendered Markdown output.
+Pass `url` to include a source link with accessible text in the rendered Markdown output.
 `toMarkdownMatch` accepts the same `url` field to link match reports back to the job posting.
 If `summary` is omitted, the requirements section is still separated by a blank line.
 
@@ -120,7 +120,7 @@ const md = toMarkdownMatch({
 
 console.log(md);
 // # Engineer
-// **URL**: https://example.com/job
+// **URL**: [Job posting](https://example.com/job)
 // **Fit Score**: 75%
 //
 // ## Matched

--- a/src/exporters.js
+++ b/src/exporters.js
@@ -33,7 +33,7 @@ export function toMarkdownSummary({ title, company, location, url, requirements,
   if (title) lines.push(`# ${title}`);
   if (company) lines.push(`**Company**: ${company}`);
   if (location) lines.push(`**Location**: ${location}`);
-  if (url) lines.push(`**URL**: ${url}`);
+  if (url) lines.push(`**URL**: [Job posting](${url})`);
 
   if (summary) {
     lines.push('', '## Summary', '', summary);
@@ -71,7 +71,7 @@ export function toMarkdownMatch({
   if (title) lines.push(`# ${title}`);
   if (company) lines.push(`**Company**: ${company}`);
   if (location) lines.push(`**Location**: ${location}`);
-  if (url) lines.push(`**URL**: ${url}`);
+  if (url) lines.push(`**URL**: [Job posting](${url})`);
   if (typeof score === 'number') lines.push(`**Fit Score**: ${score}%`);
   appendListSection(lines, 'Matched', matched, { leadingNewline: true });
   appendListSection(lines, 'Missing', missing, { leadingNewline: true });

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -31,7 +31,7 @@ describe('exporters', () => {
     expect(output).toBe(expected);
   });
 
-  it('includes url in markdown summaries', () => {
+  it('includes accessible url link in markdown summaries', () => {
     const output = toMarkdownSummary({
       title: 'Dev',
       company: 'Acme',
@@ -40,8 +40,8 @@ describe('exporters', () => {
       requirements: ['JS']
     });
     expect(output).toBe(
-      '# Dev\n**Company**: Acme\n**URL**: https://example.com/job\n\n## Summary\n\nBuild things\n' +
-        '\n## Requirements\n- JS'
+      '# Dev\n**Company**: Acme\n**URL**: [Job posting](https://example.com/job)' +
+        '\n\n## Summary\n\nBuild things\n\n## Requirements\n- JS'
     );
   });
 
@@ -83,7 +83,7 @@ describe('exporters', () => {
     expect(output).toBe(expected);
   });
 
-  it('includes url in markdown match reports', () => {
+  it('includes accessible url link in markdown match reports', () => {
     const output = toMarkdownMatch({
       title: 'Dev',
       company: 'Acme',
@@ -93,8 +93,8 @@ describe('exporters', () => {
       score: 80,
     });
     expect(output).toBe(
-      '# Dev\n**Company**: Acme\n**URL**: https://example.com/job\n**Fit Score**: 80%\n' +
-        '\n## Matched\n- JS\n\n## Missing\n- Rust'
+      '# Dev\n**Company**: Acme\n**URL**: [Job posting](https://example.com/job)' +
+        '\n**Fit Score**: 80%\n\n## Matched\n- JS\n\n## Missing\n- Rust'
     );
   });
 


### PR DESCRIPTION
## Summary
- replace bare markdown URLs with descriptive link text
- update docs and tests for accessible link formatting

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c65cc269f4832fb9fa024dd74f9085