### PR TITLE
♿: ignore hidden image alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,10 +58,11 @@ run();
 ```
 
 `fetchTextFromUrl` strips scripts, styles, navigation, header, footer, aside,
-and noscript content, preserves image alt text, and collapses whitespace to
-single spaces. Pass `timeoutMs` (milliseconds) to override the 10s default,
-and `headers` to send custom HTTP headers. Only `http` and `https` URLs are
-supported; other protocols throw an error.
+and noscript content, preserves image alt text unless the image is hidden with
+`aria-hidden="true"` or a `presentation`/`none` role, and collapses whitespace to single
+spaces. Pass `timeoutMs` (milliseconds) to override the 10s default, and `headers` to send
+custom HTTP headers. Only `http` and `https` URLs are supported; other protocols throw an
+error.
 
 Normalize existing HTML without fetching and log the result:
 

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -3,7 +3,11 @@ import { htmlToText } from 'html-to-text';
 
 function formatImageAlt(elem, walk, builder) {
   const alt = elem.attribs?.alt;
-  if (alt) builder.addInline(alt, { noWordTransform: true });
+  const ariaHidden = elem.attribs?.['aria-hidden'] === 'true';
+  const role = elem.attribs?.role;
+  if (!ariaHidden && role !== 'presentation' && role !== 'none' && alt) {
+    builder.addInline(alt, { noWordTransform: true });
+  }
 }
 
 /**

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -78,6 +78,24 @@ describe('extractTextFromHtml', () => {
     expect(extractTextFromHtml(html)).toBe('Start End');
   });
 
+  it('omits img alt text when aria-hidden is true', () => {
+    const html = `
+      <p>Start</p>
+      <img src="logo.png" alt="Logo" aria-hidden="true" />
+      <p>End</p>
+    `;
+    expect(extractTextFromHtml(html)).toBe('Start End');
+  });
+
+  it('omits img alt text when role is presentation', () => {
+    const html = `
+      <p>Start</p>
+      <img src="logo.png" alt="Logo" role="presentation" />
+      <p>End</p>
+    `;
+    expect(extractTextFromHtml(html)).toBe('Start End');
+  });
+
   it('returns empty string for falsy input', () => {
     expect(extractTextFromHtml('')).toBe('');
     // @ts-expect-error testing null input


### PR DESCRIPTION
## Summary
- skip aria-hidden and presentation-role images when extracting text
- document decorative image handling
- test ignoring alt text for hidden images

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c65cc269f4832fb9fa024dd74f9085