### PR TITLE
♿️ : – include aria-labels in HTML text extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ run();
 ```
 
 `fetchTextFromUrl` strips scripts, styles, navigation, header, footer, aside,
-and noscript content, preserves image alt text, and collapses whitespace to
-single spaces. Pass `timeoutMs` (milliseconds) to override the 10s default,
+and noscript content, preserves image alt text and aria-labels, and collapses
+whitespace to single spaces. Pass `timeoutMs` (milliseconds) to override the 10s default,
 and `headers` to send custom HTTP headers. Only `http` and `https` URLs are
 supported; other protocols throw an error.
 

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -2,7 +2,7 @@ import fetch from 'node-fetch';
 import { htmlToText } from 'html-to-text';
 
 function formatImageAlt(elem, walk, builder) {
-  const alt = elem.attribs?.alt;
+  const alt = elem.attribs?.alt || elem.attribs?.['aria-label'];
   if (alt) builder.addInline(alt, { noWordTransform: true });
 }
 
@@ -27,7 +27,7 @@ export const HTML_TO_TEXT_OPTIONS = {
 
 /**
  * Convert HTML to plain text, skipping non-content tags and collapsing whitespace.
- * Returns '' for falsy input.
+ * Preserves image alt text and aria-labels. Returns '' for falsy input.
  *
  * @param {string} html
  * @returns {string}

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -78,6 +78,15 @@ describe('extractTextFromHtml', () => {
     expect(extractTextFromHtml(html)).toBe('Start End');
   });
 
+  it('includes aria-label text when alt is missing', () => {
+    const html = `
+      <p>Start</p>
+      <img src="logo.png" aria-label="Logo" />
+      <p>End</p>
+    `;
+    expect(extractTextFromHtml(html)).toBe('Start Logo End');
+  });
+
   it('returns empty string for falsy input', () => {
     expect(extractTextFromHtml('')).toBe('');
     // @ts-expect-error testing null input


### PR DESCRIPTION
what: use aria-label when img alt is missing and update docs/tests
why: ensure accessible descriptions when alt text is absent
how to test: npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c65cc269f4832fb9fa024dd74f9085