### PR TITLE
♿️: include aria-label in image text extraction

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -2,7 +2,7 @@ import fetch from 'node-fetch';
 import { htmlToText } from 'html-to-text';
 
 function formatImageAlt(elem, walk, builder) {
-  const alt = elem.attribs?.alt;
+  const alt = elem.attribs?.alt || elem.attribs?.['aria-label'];
   if (alt) builder.addInline(alt, { noWordTransform: true });
 }
 

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -69,6 +69,15 @@ describe('extractTextFromHtml', () => {
     expect(extractTextFromHtml(html)).toBe('Start Logo End');
   });
 
+  it('includes img aria-label without alt', () => {
+    const html = `
+      <p>Start</p>
+      <img src="logo.png" aria-label="Logo" />
+      <p>End</p>
+    `;
+    expect(extractTextFromHtml(html)).toBe('Start Logo End');
+  });
+
   it('omits img without alt text', () => {
     const html = `
       <p>Start</p>


### PR DESCRIPTION
what: handle aria-label when extracting text from images
why: include accessible name for images lacking alt text
how to test:
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68c65cc269f4832fb9fa024dd74f9085