### PR TITLE
✨: – support Role header in job parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,8 @@ Common honorifics such as `Mr.` and `Dr.` are recognized so summaries aren't cut
 
 Example: `summarize('"Hi!" Bye.')` returns `"Hi!"`.
 
+Job titles can be parsed from lines starting with `Title`, `Job Title`, `Position`, or `Role`.
+
 Job requirements may appear under headers like `Requirements`, `Qualifications`,
 `What you'll need`, or `Responsibilities` (used if no other requirement headers are present).
 They may start with `-`, `+`, `*`, `•`, `–` (en dash), `—` (em dash), or numeric markers like `1.`

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,7 +1,8 @@
 const TITLE_PATTERNS = [
   /\bTitle\s*:\s*(.+)/i,
   /\bJob Title\s*:\s*(.+)/i,
-  /\bPosition\s*:\s*(.+)/i
+  /\bPosition\s*:\s*(.+)/i,
+  /\bRole\s*:\s*(.+)/i
 ];
 
 const COMPANY_PATTERNS = [

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -35,7 +35,8 @@ Job Title: Senior Dev
   it('extracts title from alternate headers', () => {
     [
       ['Job Title', 'Engineer'],
-      ['Position', 'Developer']
+      ['Position', 'Developer'],
+      ['Role', 'Programmer']
     ].forEach(([header, role]) => {
       const text = `${header}: ${role}\nCompany: Example`;
       expect(parseJobText(text)).toMatchObject({ title: role });


### PR DESCRIPTION
## Summary
- parse `Role:` lines as job titles
- document supported title headers

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c65cd937f8832fa7560b93cd03be20