### PR TITLE
✨: allow custom selectors in HTML extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ console.log(text);
 // "Hello"
 ```
 
+Extend the default ignore list by passing html-to-text options:
+
+```js
+const stripped = extractTextFromHtml('<aside>skip</aside><p>Main</p>', {
+  selectors: [{ selector: 'p', format: 'skip' }],
+});
+console.log(stripped);
+// ""
+```
+
 Format parsed results as Markdown:
 
 ```js

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -30,11 +30,19 @@ export const HTML_TO_TEXT_OPTIONS = {
  * Returns '' for falsy input.
  *
  * @param {string} html
+ * @param {object} [options] Additional html-to-text options merged with defaults.
  * @returns {string}
  */
-export function extractTextFromHtml(html) {
+export function extractTextFromHtml(html, options = {}) {
   if (!html) return '';
-  return htmlToText(html, HTML_TO_TEXT_OPTIONS)
+  const merged = { ...HTML_TO_TEXT_OPTIONS, ...options };
+  if (options.selectors) {
+    merged.selectors = [
+      ...HTML_TO_TEXT_OPTIONS.selectors,
+      ...options.selectors,
+    ];
+  }
+  return htmlToText(html, merged)
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -78,6 +78,14 @@ describe('extractTextFromHtml', () => {
     expect(extractTextFromHtml(html)).toBe('Start End');
   });
 
+  it('allows custom selectors to extend defaults', () => {
+    const html = '<aside>Ignored</aside><p>Main</p>';
+    const text = extractTextFromHtml(html, {
+      selectors: [{ selector: 'p', format: 'skip' }],
+    });
+    expect(text).toBe('');
+  });
+
   it('returns empty string for falsy input', () => {
     expect(extractTextFromHtml('')).toBe('');
     // @ts-expect-error testing null input


### PR DESCRIPTION
what: allow extra html-to-text options when extracting text
why: let consumers skip additional tags
test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68c65cd937f8832fa7560b93cd03be20