### PR TITLE
✨ : track offer status in lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ font size immediately after logging in.
 
 ## Tracking Application Lifecycle
 
-Application statuses such as `no_response`, `rejected`, and `next_round` are saved to
+Application statuses such as `no_response`, `rejected`, `next_round`, and `offer` are saved to
 `data/applications.json`, a gitignored file. Set `JOBBOT_DATA_DIR` to change the directory.
 These records power local Sankey diagrams so progress isn't lost between sessions.
 Writes are serialized to avoid dropping entries when recording multiple applications at once.

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 
-export const STATUSES = ['no_response', 'rejected', 'next_round'];
+export const STATUSES = ['no_response', 'rejected', 'next_round', 'offer'];
 
 function paths() {
   const dir = process.env.JOBBOT_DATA_DIR || path.resolve('data');

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -17,10 +17,11 @@ afterEach(async () => {
 test('records and summarizes application statuses', async () => {
   await recordApplication('abc', 'rejected');
   await recordApplication('def', 'no_response');
+  await recordApplication('ghi', 'offer');
   const counts = await getLifecycleCounts();
-  expect(counts).toEqual({ no_response: 1, rejected: 1, next_round: 0 });
+  expect(counts).toEqual({ no_response: 1, rejected: 1, next_round: 0, offer: 1 });
   const raw = await fs.readFile(path.join(tmp, 'applications.json'), 'utf8');
-  expect(JSON.parse(raw)).toEqual({ abc: 'rejected', def: 'no_response' });
+  expect(JSON.parse(raw)).toEqual({ abc: 'rejected', def: 'no_response', ghi: 'offer' });
 });
 
 test('throws when lifecycle file has invalid JSON', async () => {
@@ -35,6 +36,7 @@ test('handles concurrent status updates', async () => {
     recordApplication('a', 'rejected'),
     recordApplication('b', 'no_response'),
     recordApplication('c', 'next_round'),
+    recordApplication('d', 'offer'),
   ]);
   const raw = JSON.parse(
     await fs.readFile(path.join(tmp, 'applications.json'), 'utf8'),
@@ -43,7 +45,8 @@ test('handles concurrent status updates', async () => {
     a: 'rejected',
     b: 'no_response',
     c: 'next_round',
+    d: 'offer',
   });
   const counts = await getLifecycleCounts();
-  expect(counts).toEqual({ no_response: 1, rejected: 1, next_round: 1 });
+  expect(counts).toEqual({ no_response: 1, rejected: 1, next_round: 1, offer: 1 });
 });


### PR DESCRIPTION
## Summary
- allow recording and summarizing an `offer` application status
- document new status

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c65cd937f8832fa7560b93cd03be20