### PR TITLE
support .mdx resumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,23 @@ console.log(text);
 // "Hello"
 ```
 
+Load resume files and return plain text:
+
+```js
+import { loadResume } from './src/resume.js';
+
+const run = async () => {
+  const text = await loadResume('resume.mdx');
+  console.log(text);
+  // "Plain text resume"
+};
+
+run();
+```
+
+`loadResume` supports `.pdf`, `.md`, `.markdown`, and `.mdx` files; other
+extensions are read as plain text.
+
 Format parsed results as Markdown:
 
 ```js

--- a/src/resume.js
+++ b/src/resume.js
@@ -24,11 +24,15 @@ const LOADERS = {
     const raw = await fs.readFile(filePath, 'utf-8');
     return removeMarkdown(raw).trim();
   },
+  async '.mdx'(filePath) {
+    const raw = await fs.readFile(filePath, 'utf-8');
+    return removeMarkdown(raw).trim();
+  },
 };
 
 /**
  * Load a resume file and return its plain text content.
- * Supports `.pdf`, `.md`, and `.markdown` formats; other files are read as plain text.
+ * Supports `.pdf`, `.md`, `.markdown`, and `.mdx` formats; other files are read as plain text.
  *
  * @param {string} filePath
  * @returns {Promise<string>}

--- a/test/resume.test.js
+++ b/test/resume.test.js
@@ -38,6 +38,12 @@ describe('loadResume', () => {
     expect(result).toBe('Title\n\nbold text');
   });
 
+  it('strips markdown formatting for .mdx files', async () => {
+    const md = '# Title\n\n**bold** text\n';
+    const result = await withTempFile('.mdx', md, loadResume);
+    expect(result).toBe('Title\n\nbold text');
+  });
+
   it('handles .markdown extension case-insensitively', async () => {
     const md = '# Heading\n\n*italic* text';
     const result = await withTempFile('.MARKDOWN', md, loadResume);


### PR DESCRIPTION
## Summary
- add .mdx handler to resume loader
- document supported resume formats

## Testing
- `npm run lint`
- `npm run test:ci`


------
https://chatgpt.com/codex/tasks/task_e_68c65cd937f8832fa7560b93cd03be20