### PR TITLE
♿: – include image aria-labels in text extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ run();
 ```
 
 `fetchTextFromUrl` strips scripts, styles, navigation, header, footer, aside,
-and noscript content, preserves image alt text, and collapses whitespace to
+and noscript content, preserves image alt text and aria-labels, and collapses whitespace to
 single spaces. Pass `timeoutMs` (milliseconds) to override the 10s default,
 and `headers` to send custom HTTP headers. Only `http` and `https` URLs are
 supported; other protocols throw an error.

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -3,7 +3,12 @@ import { htmlToText } from 'html-to-text';
 
 function formatImageAlt(elem, walk, builder) {
   const alt = elem.attribs?.alt;
-  if (alt) builder.addInline(alt, { noWordTransform: true });
+  if (alt) {
+    builder.addInline(alt, { noWordTransform: true });
+    return;
+  }
+  const ariaLabel = elem.attribs?.['aria-label'];
+  if (ariaLabel) builder.addInline(ariaLabel, { noWordTransform: true });
 }
 
 /**

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -69,6 +69,15 @@ describe('extractTextFromHtml', () => {
     expect(extractTextFromHtml(html)).toBe('Start Logo End');
   });
 
+  it('includes img aria-label when alt missing', () => {
+    const html = `
+      <p>Start</p>
+      <img src="logo.png" aria-label="Logo" />
+      <p>End</p>
+    `;
+    expect(extractTextFromHtml(html)).toBe('Start Logo End');
+  });
+
   it('omits img without alt text', () => {
     const html = `
       <p>Start</p>


### PR DESCRIPTION
what: handle aria-label for image text extraction.
why: include accessible names when alt is missing.
how to test: npm run lint && npm run test:ci
Refs: #000

------
https://chatgpt.com/codex/tasks/task_e_68c65cc3edd0832fa308f38cae3bb6dd