### PR TITLE
🆕 : – add implement prompt doc

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -31,6 +31,8 @@ Includes [`scripts/scan-secrets.py`](../scripts/scan-secrets.py).
 | [docs/prompts/codex/localization.md#upgrade-prompt][localization-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/performance.md][performance-doc] | Codex Performance Prompt | evergreen | yes |
 | [docs/prompts/codex/performance.md#upgrade-prompt][performance-up] | Upgrade Prompt | evergreen | yes |
+| [docs/prompts/codex/implement.md][implement-doc] | Codex Implement Prompt | evergreen | yes |
+| [docs/prompts/codex/implement.md#upgrade-prompt][implement-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/refactor.md][refactor-doc] | Codex Refactor Prompt | evergreen | yes |
 | [docs/prompts/codex/refactor.md#upgrade-prompt][refactor-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/security.md][security-doc] | Codex Security Prompt | evergreen | yes |
@@ -58,6 +60,8 @@ Includes [`scripts/scan-secrets.py`](../scripts/scan-secrets.py).
 [feature-up]: prompts/codex/feature.md#upgrade-prompt
 [fix-doc]: prompts/codex/fix.md
 [fix-up]: prompts/codex/fix.md#upgrade-prompt
+[implement-doc]: prompts/codex/implement.md
+[implement-up]: prompts/codex/implement.md#upgrade-prompt
 [localization-doc]: prompts/codex/localization.md
 [localization-up]: prompts/codex/localization.md#upgrade-prompt
 [performance-doc]: prompts/codex/performance.md

--- a/docs/prompts/codex/implement.md
+++ b/docs/prompts/codex/implement.md
@@ -1,0 +1,89 @@
+---
+title: 'Codex Implement Prompt'
+slug: 'codex-implement'
+---
+
+# Codex Implement Prompt
+Prompt name: `prompt-implement`.
+
+Use this prompt when turning jobbot3000's future-work notes into shipped features.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Close the loop on documented-but-unshipped functionality in jobbot3000.
+
+CONTEXT:
+- Follow [README.md](../../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
+- Consult [DESIGN.md](../../../DESIGN.md) for architectural guidelines.
+- Tests live in [test/](../../../test) and run with
+  [Vitest](https://vitest.dev/).
+- Install dependencies with `npm ci` if needed.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Use `rg` (ripgrep) to inventory TODO, FIXME, "future work", and similar
+  markers across code, tests, and docs.
+- Prefer items that can be completed in one PR and unblock user value without
+  multi-step migrations.
+- Design a robust test strategy: add a failing test first, cover happy and edge
+  paths, and document the test matrix in the PR description.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py`.
+- Update references to [prompt-docs-summary.md](../../prompt-docs-summary.md)
+  when adding or relocating prompt docs.
+
+REQUEST:
+1. List candidate future-work items you discover and explain why the chosen
+   item is actionable now.
+2. Write a failing test in [test/](../../../test) (or an equivalent check)
+   that captures the promised behavior, then add additional tests to harden the
+   implementation.
+3. Implement the smallest change that fulfills the promise while keeping
+   existing behavior intact and removing stale TODOs/comments.
+4. Update related docs or inline commentary to reflect the shipped feature and
+   summarize the test strategy.
+5. Run the commands above and resolve any failures; include the results in the
+   PR body.
+
+OUTPUT:
+A pull request URL summarizing the implemented functionality, associated tests,
+updated documentation, and test results.
+```
+
+Copy this block whenever converting planned jobbot3000 work into reality.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt to refine jobbot3000's prompt documentation.
+
+```text
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Improve or expand the repository's prompt docs.
+
+CONTEXT:
+- Follow [README.md](../../../README.md); see the
+  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI
+  checks.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py`.
+- Confirm referenced files exist; update
+  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt
+  docs.
+
+REQUEST:
+1. Select a file under `docs/prompts/` to update or create a new prompt type.
+2. Clarify context, refresh links, and ensure referenced files exist.
+3. Run the commands above and fix any failures.
+
+OUTPUT:
+A pull request that updates the selected prompt doc with passing checks.
+```


### PR DESCRIPTION
what: add implement doc and summary entry; rename file to docs/prompts/codex/implement.md
why: guide agents to ship planned functionality with tests while matching prompt naming
how to test: npm run lint && npm run test:ci
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68c9f4474138832f9b638e52aad1765d