### PR TITLE
📝 : – Clarify automation prompt guidance

### DIFF
--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -7,6 +7,13 @@ slug: 'codex-automation'
 Use this prompt to guide automated contributors when performing routine maintenance in
 jobbot3000.
 
+Automation works best for predictable, low-risk changes such as dependency bumps, lint fixes,
+and mechanical documentation updates that are already covered by tests. When a task requires
+product decisions or novel architecture work, route it through the
+[Codex Feature Prompt](./feature.md) or [Codex Fix Prompt](./fix.md) instead.
+
+## Prompt template
+
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
@@ -20,7 +27,8 @@ Keep the project healthy by making small, well-tested improvements.
 CONTEXT:
 - Follow the [repository README](../../../README.md) and the
   [AGENTS spec](https://agentsmd.net/AGENTS.md).
-- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks and mirror the
+  commands those jobs run.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
@@ -30,18 +38,22 @@ CONTEXT:
   [`ts-node`](https://typestrong.org/ts-node).
 - Confirm referenced files exist; update
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Link to adjacent prompts, such as
+  [Codex Feature](./feature.md) or [Codex Fix](./fix.md), when work should be redirected.
 
 REQUEST:
-1. Identify a straightforward improvement or bug fix.
-2. Implement the change using existing project style.
-3. Update documentation when needed.
+1. Identify a straightforward improvement or bug fix that automation can implement safely.
+2. Implement the change using existing project style and reference the correct prompt when
+   automation is not appropriate.
+3. Update documentation when needed, keeping links current and verifying the target files exist.
 4. Run the commands above and address any failures.
 
 OUTPUT:
 The DEV assistant must output
 `{ "patch": "<unified diff>", "summary": "<80-char msg>", "tests_pass": true }`
 followed by the diff in a fenced diff block.
-The CRITIC responds with "LGTM" or required fixes.
+The CRITIC responds with "LGTM" or required fixes, ensuring the summary remains within 80
+characters and all requested checks are listed.
 ```
 
 Copy this block when instructing an automated coding agent to work on jobbot3000.


### PR DESCRIPTION
what: clarify automation prompt scope and cross-links
why: redirect larger work to feature or fix prompts
how to test: npm run lint && npm run test:ci
             npx markdown-link-check docs/prompts/codex/automation.md

------
https://chatgpt.com/codex/tasks/task_e_68c9f7fa7960832fb3389905b9221fd8