### PR TITLE
Align codex upgrade prompts with their files

### DIFF
--- a/docs/prompts/codex/accessibility.md
+++ b/docs/prompts/codex/accessibility.md
@@ -39,14 +39,14 @@ Copy this block whenever improving accessibility in jobbot3000.
 ## Upgrade Prompt
 Type: evergreen
 
-Use this prompt to refine jobbot3000's prompt documentation.
+Use this prompt to refine `docs/prompts/codex/accessibility.md`.
 
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Improve or expand the repository's prompt docs.
+Improve or expand the `docs/prompts/codex/accessibility.md` prompt.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the
@@ -59,10 +59,11 @@ CONTEXT:
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
+1. Revise `docs/prompts/codex/accessibility.md` so this prompt stays accurate and actionable.
+   Keep examples aligned with current project practices.
+2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request that updates the selected prompt doc with passing checks.
+A pull request that updates `docs/prompts/codex/accessibility.md` with passing checks.
 ```

--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -49,14 +49,14 @@ Copy this block when instructing an automated coding agent to work on jobbot3000
 ## Upgrade Prompt
 Type: evergreen
 
-Use this prompt to refine jobbot3000's prompt documentation.
+Use this prompt to refine `docs/prompts/codex/automation.md`.
 
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Improve or expand the repository's prompt docs.
+Improve or expand the `docs/prompts/codex/automation.md` prompt.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the
@@ -71,11 +71,12 @@ CONTEXT:
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
+1. Revise `docs/prompts/codex/automation.md` so this prompt stays accurate and actionable.
+   Keep examples aligned with current project practices.
+2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request that updates the selected prompt doc with passing checks.
+A pull request that updates `docs/prompts/codex/automation.md` with passing checks.
 ```
 

--- a/docs/prompts/codex/chore.md
+++ b/docs/prompts/codex/chore.md
@@ -40,14 +40,14 @@ Copy this block whenever performing chores in jobbot3000.
 ## Upgrade Prompt
 Type: evergreen
 
-Use this prompt to refine jobbot3000's prompt documentation.
+Use this prompt to refine `docs/prompts/codex/chore.md`.
 
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Improve or expand the repository's prompt docs.
+Improve or expand the `docs/prompts/codex/chore.md` prompt.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the
@@ -61,11 +61,12 @@ CONTEXT:
 - Update [prompt-docs-summary.md](../../prompt-docs-summary.md) when modifying prompt docs.
 
 REQUEST:
-1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
+1. Revise `docs/prompts/codex/chore.md` so this prompt stays accurate and actionable.
+   Keep examples aligned with current project practices.
+2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request that updates the selected prompt doc with passing checks.
+A pull request that updates `docs/prompts/codex/chore.md` with passing checks.
 ```
 

--- a/docs/prompts/codex/ci.md
+++ b/docs/prompts/codex/ci.md
@@ -40,14 +40,14 @@ Copy this block whenever updating CI workflows in jobbot3000.
 ## Upgrade Prompt
 Type: evergreen
 
-Use this prompt to refine jobbot3000's prompt documentation.
+Use this prompt to refine `docs/prompts/codex/ci.md`.
 
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Improve or expand the repository's prompt docs.
+Improve or expand the `docs/prompts/codex/ci.md` prompt.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the
@@ -63,10 +63,11 @@ CONTEXT:
   when adding prompt docs.
 
 REQUEST:
-1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
+1. Revise `docs/prompts/codex/ci.md` so this prompt stays accurate and actionable.
+   Keep examples aligned with current project practices.
+2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request that updates the selected prompt doc with passing checks.
+A pull request that updates `docs/prompts/codex/ci.md` with passing checks.
 ```

--- a/docs/prompts/codex/docs.md
+++ b/docs/prompts/codex/docs.md
@@ -54,14 +54,14 @@ Copy this block whenever updating docs in jobbot3000.
 ## Upgrade Prompt
 Type: evergreen
 
-Use this prompt to refine jobbot3000's prompt documentation.
+Use this prompt to refine `docs/prompts/codex/docs.md`.
 
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Improve or expand the repository's prompt docs.
+Improve or expand the `docs/prompts/codex/docs.md` prompt.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the
@@ -83,8 +83,9 @@ CONTEXT:
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
+1. Revise `docs/prompts/codex/docs.md` so this prompt stays accurate and actionable.
+   Keep examples aligned with current project practices.
+2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Check links with `npx markdown-link-check <file>`.
 4. Ensure any code samples compile with `node` or `ts-node`
    (see [Node.js](https://nodejs.org/en) and
@@ -92,6 +93,6 @@ REQUEST:
 5. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request that updates the selected prompt doc with passing checks.
+A pull request that updates `docs/prompts/codex/docs.md` with passing checks.
 ```
 

--- a/docs/prompts/codex/feature.md
+++ b/docs/prompts/codex/feature.md
@@ -40,14 +40,14 @@ Copy this block whenever implementing a feature in jobbot3000.
 ## Upgrade Prompt
 Type: evergreen
 
-Use this prompt to refine jobbot3000's prompt documentation.
+Use this prompt to refine `docs/prompts/codex/feature.md`.
 
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Improve or expand the repository's prompt docs.
+Improve or expand the `docs/prompts/codex/feature.md` prompt.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the
@@ -62,11 +62,12 @@ CONTEXT:
 
 
 REQUEST:
-1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
+1. Revise `docs/prompts/codex/feature.md` so this prompt stays accurate and actionable.
+   Keep examples aligned with current project practices.
+2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request that updates the selected prompt doc with passing checks.
+A pull request that updates `docs/prompts/codex/feature.md` with passing checks.
 ```
 

--- a/docs/prompts/codex/fix.md
+++ b/docs/prompts/codex/fix.md
@@ -40,14 +40,14 @@ Copy this block whenever fixing bugs in jobbot3000.
 ## Upgrade Prompt
 Type: evergreen
 
-Use this prompt to refine jobbot3000's prompt documentation.
+Use this prompt to refine `docs/prompts/codex/fix.md`.
 
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Improve or expand the repository's prompt docs.
+Improve or expand the `docs/prompts/codex/fix.md` prompt.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
@@ -58,10 +58,11 @@ CONTEXT:
   See [scripts/scan-secrets.py](../../../scripts/scan-secrets.py).
 
 REQUEST:
-1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
+1. Revise `docs/prompts/codex/fix.md` so this prompt stays accurate and actionable.
+   Keep examples aligned with current project practices.
+2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request that updates the selected prompt doc with passing checks.
+A pull request that updates `docs/prompts/codex/fix.md` with passing checks.
 ```

--- a/docs/prompts/codex/implement.md
+++ b/docs/prompts/codex/implement.md
@@ -58,14 +58,14 @@ Copy this block whenever converting planned jobbot3000 work into reality.
 ## Upgrade Prompt
 Type: evergreen
 
-Use this prompt to refine jobbot3000's prompt documentation.
+Use this prompt to refine `docs/prompts/codex/implement.md`.
 
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Improve or expand the repository's prompt docs.
+Improve or expand the `docs/prompts/codex/implement.md` prompt.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the
@@ -80,10 +80,11 @@ CONTEXT:
   docs.
 
 REQUEST:
-1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
+1. Revise `docs/prompts/codex/implement.md` so this prompt stays accurate and actionable.
+   Keep examples aligned with current project practices.
+2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request that updates the selected prompt doc with passing checks.
+A pull request that updates `docs/prompts/codex/implement.md` with passing checks.
 ```

--- a/docs/prompts/codex/localization.md
+++ b/docs/prompts/codex/localization.md
@@ -36,14 +36,14 @@ Copy this block whenever working on localization in jobbot3000.
 ## Upgrade Prompt
 Type: evergreen
 
-Use this prompt to refine jobbot3000's prompt documentation.
+Use this prompt to refine `docs/prompts/codex/localization.md`.
 
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Improve or expand the repository's prompt docs.
+Improve or expand the `docs/prompts/codex/localization.md` prompt.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
@@ -54,10 +54,11 @@ CONTEXT:
 - Confirm referenced files exist and update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
+1. Revise `docs/prompts/codex/localization.md` so this prompt stays accurate and actionable.
+   Keep examples aligned with current project practices.
+2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request that updates the selected prompt doc with passing checks.
+A pull request that updates `docs/prompts/codex/localization.md` with passing checks.
 ```

--- a/docs/prompts/codex/performance.md
+++ b/docs/prompts/codex/performance.md
@@ -53,14 +53,14 @@ Copy this block whenever optimizing performance in jobbot3000.
 ## Upgrade Prompt
 Type: evergreen
 
-Use this prompt to refine jobbot3000's prompt documentation.
+Use this prompt to refine `docs/prompts/codex/performance.md`.
 
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Improve or expand the repository's prompt docs.
+Improve or expand the `docs/prompts/codex/performance.md` prompt.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the
@@ -75,11 +75,12 @@ CONTEXT:
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
+1. Revise `docs/prompts/codex/performance.md` so this prompt stays accurate and actionable.
+   Keep examples aligned with current project practices.
+2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request that updates the selected prompt doc with passing checks.
+A pull request that updates `docs/prompts/codex/performance.md` with passing checks.
 ```
 

--- a/docs/prompts/codex/refactor.md
+++ b/docs/prompts/codex/refactor.md
@@ -37,14 +37,14 @@ Copy this block whenever refactoring jobbot3000.
 ## Upgrade Prompt
 Type: evergreen
 
-Use this prompt to refine jobbot3000's prompt documentation.
+Use this prompt to refine `docs/prompts/codex/refactor.md`.
 
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Improve or expand the repository's prompt docs.
+Improve or expand the `docs/prompts/codex/refactor.md` prompt.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the
@@ -58,11 +58,12 @@ CONTEXT:
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
+1. Revise `docs/prompts/codex/refactor.md` so this prompt stays accurate and actionable.
+   Keep examples aligned with current project practices.
+2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request that updates the selected prompt doc with passing checks.
+A pull request that updates `docs/prompts/codex/refactor.md` with passing checks.
 ```
 

--- a/docs/prompts/codex/security.md
+++ b/docs/prompts/codex/security.md
@@ -61,14 +61,14 @@ See [`randomBytes`](https://nodejs.org/api/crypto.html#cryptorandombytessize-cal
 ## Upgrade Prompt
 Type: evergreen
 
-Use this prompt to refine jobbot3000's prompt documentation.
+Use this prompt to refine `docs/prompts/codex/security.md`.
 
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Improve or expand the repository's prompt docs.
+Improve or expand the `docs/prompts/codex/security.md` prompt.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the
@@ -86,11 +86,12 @@ CONTEXT:
   when adding prompt docs.
 
 REQUEST:
-1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
+1. Revise `docs/prompts/codex/security.md` so this prompt stays accurate and actionable.
+   Keep examples aligned with current project practices.
+2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request that updates the selected prompt doc with passing checks.
+A pull request that updates `docs/prompts/codex/security.md` with passing checks.
 ```
 

--- a/docs/prompts/codex/spellcheck.md
+++ b/docs/prompts/codex/spellcheck.md
@@ -43,14 +43,14 @@ Copy this block whenever correcting spelling in jobbot3000.
 ## Upgrade Prompt
 Type: evergreen
 
-Use this prompt to refine jobbot3000's prompt documentation.
+Use this prompt to refine `docs/prompts/codex/spellcheck.md`.
 
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Improve or expand the repository's prompt docs.
+Improve or expand the `docs/prompts/codex/spellcheck.md` prompt.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the
@@ -65,11 +65,12 @@ CONTEXT:
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
+1. Revise `docs/prompts/codex/spellcheck.md` so this prompt stays accurate and actionable.
+   Keep examples aligned with current project practices.
+2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request that updates the selected prompt doc with passing checks.
+A pull request that updates `docs/prompts/codex/spellcheck.md` with passing checks.
 ```
 

--- a/docs/prompts/codex/style.md
+++ b/docs/prompts/codex/style.md
@@ -52,14 +52,14 @@ Run it with `node -e "const greet = (name) => \`Hi, ${name}!\`; console.log(gree
 ## Upgrade Prompt
 Type: evergreen
 
-Use this prompt to refine jobbot3000's prompt documentation.
+Use this prompt to refine `docs/prompts/codex/style.md`.
 
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Improve or expand the repository's prompt docs.
+Improve or expand the `docs/prompts/codex/style.md` prompt.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the
@@ -74,10 +74,11 @@ CONTEXT:
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
+1. Revise `docs/prompts/codex/style.md` so this prompt stays accurate and actionable.
+   Keep examples aligned with current project practices.
+2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request that updates the selected prompt doc with passing checks.
+A pull request that updates `docs/prompts/codex/style.md` with passing checks.
 ```

--- a/docs/prompts/codex/test.md
+++ b/docs/prompts/codex/test.md
@@ -63,14 +63,14 @@ Copy this block whenever working on tests in jobbot3000.
 ## Upgrade Prompt
 Type: evergreen
 
-Use this prompt to refine jobbot3000's prompt documentation.
+Use this prompt to refine `docs/prompts/codex/test.md`.
 
 ```text
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
-Improve or expand the repository's prompt docs.
+Improve or expand the `docs/prompts/codex/test.md` prompt.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the
@@ -86,12 +86,13 @@ CONTEXT:
 - Ensure any code samples compile with `node` or `ts-node`.
 
 REQUEST:
-1. Select a file under `docs/prompts/` to update or create a new prompt type.
-2. Clarify context, refresh links, and ensure referenced files exist.
+1. Revise `docs/prompts/codex/test.md` so this prompt stays accurate and actionable.
+   Keep examples aligned with current project practices.
+2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Ensure any code samples compile with `node` (v20+) or `ts-node`.
 4. Run the commands above and fix any failures.
 
 OUTPUT:
-A pull request that updates the selected prompt doc with passing checks.
+A pull request that updates `docs/prompts/codex/test.md` with passing checks.
 ```
 


### PR DESCRIPTION
## Summary
- update each codex upgrade prompt to reference its own markdown file
- emphasize keeping examples aligned with current practices when refining a prompt

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68c9f927dac4832f9290cf6e37844381