### PR TITLE
Normalize aria-hidden filtering for HTML extraction

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -10,7 +10,19 @@ export const DEFAULT_TIMEOUT_MS = 10000;
 function formatImageAlt(elem, walk, builder) {
   const { alt, ['aria-label']: ariaLabel, ['aria-hidden']: ariaHidden, role } =
     elem.attribs || {};
-  if (ariaHidden === 'true' || role === 'presentation' || role === 'none') return;
+  const hidden =
+    typeof ariaHidden === 'string'
+      ? ariaHidden.trim().toLowerCase()
+      : '';
+  const decorativeRole =
+    typeof role === 'string'
+      ? role.trim().toLowerCase()
+      : '';
+  // Handle common aria-hidden values ("true", "1") and case-variant roles so
+  // decorative images never leak into summaries. Tests exercise uppercase and
+  // numeric variants to guard regressions.
+  if (hidden === 'true' || hidden === '1') return;
+  if (decorativeRole === 'presentation' || decorativeRole === 'none') return;
 
   const label = alt || ariaLabel;
   if (label) builder.addInline(label, { noWordTransform: true });

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -105,6 +105,24 @@ describe('extractTextFromHtml', () => {
     expect(extractTextFromHtml(html)).toBe('Start End');
   });
 
+  it('omits img alt text when aria-hidden uses uppercase true', () => {
+    const html = `
+      <p>Start</p>
+      <img src="logo.png" alt="Logo" aria-hidden="TRUE" />
+      <p>End</p>
+    `;
+    expect(extractTextFromHtml(html)).toBe('Start End');
+  });
+
+  it('omits img alt text when aria-hidden uses numeric true', () => {
+    const html = `
+      <p>Start</p>
+      <img src="logo.png" alt="Logo" aria-hidden="1" />
+      <p>End</p>
+    `;
+    expect(extractTextFromHtml(html)).toBe('Start End');
+  });
+
   it('omits img alt text when role is presentation', () => {
     const html = `
       <p>Start</p>
@@ -112,6 +130,25 @@ describe('extractTextFromHtml', () => {
       <p>End</p>
     `;
     expect(extractTextFromHtml(html)).toBe('Start End');
+  });
+
+  it('omits img alt text when role casing varies', () => {
+    const html = `
+      <p>Start</p>
+      <img src="logo.png" alt="Decorative" role="Presentation" />
+      <img src="logo.png" alt="Another" role="None" />
+      <p>End</p>
+    `;
+    expect(extractTextFromHtml(html)).toBe('Start End');
+  });
+
+  it('includes img alt text when aria-hidden is false-like', () => {
+    const html = `
+      <p>Start</p>
+      <img src="logo.png" alt="Logo" aria-hidden="FALSE" />
+      <p>End</p>
+    `;
+    expect(extractTextFromHtml(html)).toBe('Start Logo End');
   });
 
   it('includes aria-label text when alt is missing', () => {


### PR DESCRIPTION
## Summary
- close the README promise that decorative images stay out of summaries by normalizing aria-hidden/role checks in `formatImageAlt`
- extend `extractTextFromHtml` coverage to catch uppercase and numeric aria-hidden values while ensuring false-y variants still surface text
- document the guardrails inline so the new tests explain their purpose

## Test Matrix
- `extractTextFromHtml` drops `<img aria-hidden="TRUE">`
- `extractTextFromHtml` drops `<img aria-hidden="1">`
- `extractTextFromHtml` drops `<img role="Presentation">` and `<img role="None">`
- `extractTextFromHtml` keeps `<img aria-hidden="FALSE">`

## Testing
- npm run lint
- npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68c9f7f94edc832f8b9d97eec9f4213f