### PR TITLE
Support dash-separated job parser headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,9 @@ Common honorifics such as `Mr.` and `Dr.` are recognized so summaries aren't cut
 Example: `summarize('"Hi!" Bye.')` returns `"Hi!"`.
 
 Job titles can be parsed from lines starting with `Title`, `Job Title`, `Position`, or `Role`.
+Headers can use colons or dash separators (for example, `Role - Staff Engineer`), and the same
+separators work for `Company` and `Location`. Parser unit tests cover both colon and dash cases so
+this behavior stays locked in.
 
 Job requirements may appear under headers like `Requirements`, `Qualifications`,
 `What you'll need`, or `Responsibilities` (used if no other requirement headers are present).

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,16 +1,19 @@
-const TITLE_PATTERNS = [
-  /\bTitle\s*:\s*(.+)/i,
-  /\bJob Title\s*:\s*(.+)/i,
-  /\bPosition\s*:\s*(.+)/i,
-  /\bRole\s*:\s*(.+)/i
-];
+function escapeForRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
-const COMPANY_PATTERNS = [
-  /\bCompany\s*:\s*(.+)/i,
-  /\bEmployer\s*:\s*(.+)/i
-];
+const FIELD_SEPARATOR = '\\s*(?::|[-\\u2013\\u2014])\\s*';
 
-const LOCATION_PATTERNS = [/\bLocation\s*:\s*(.+)/i];
+function createFieldPattern(label) {
+  const escaped = escapeForRegex(label).replace(/\s+/g, '\\s+');
+  return new RegExp(`^\\s*${escaped}${FIELD_SEPARATOR}(.+)`, 'i');
+}
+
+const TITLE_PATTERNS = ['Title', 'Job Title', 'Position', 'Role'].map(createFieldPattern);
+
+const COMPANY_PATTERNS = ['Company', 'Employer'].map(createFieldPattern);
+
+const LOCATION_PATTERNS = ['Location'].map(createFieldPattern);
 
 const REQUIREMENTS_HEADERS = [
   /\bRequirements\b/i,

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -43,6 +43,21 @@ Job Title: Senior Dev
     });
   });
 
+  it('extracts fields when headers use dash separators', () => {
+    const text = `
+Role - Staff Engineer
+Company — Example Inc
+Location – Remote
+Requirements:
+- Build things
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.title).toBe('Staff Engineer');
+    expect(parsed.company).toBe('Example Inc');
+    expect(parsed.location).toBe('Remote');
+    expect(parsed.requirements).toEqual(['Build things']);
+  });
+
   it('extracts company from Employer header', () => {
     const text = `Title: Engineer\nEmployer: ACME Corp`;
     expect(parseJobText(text)).toMatchObject({ company: 'ACME Corp' });


### PR DESCRIPTION
## Summary
- build parser field patterns dynamically so `Title`/`Job Title`/`Position`/`Role`, `Company`, and `Location` accept either colon or dash separators
- add a regression test covering ASCII hyphen, en dash, and em dash headers while ensuring requirements parsing stays intact
- document the dash support in the README and call out the parser tests that lock the behavior in

## Future Work Inventory
- README promises that lines beginning with `Title`/`Job Title`/`Position`/`Role` yield titles; dash-separated headers were skipped before, and the small regex/test update here makes this item immediately actionable
- DESIGN.md sketches integrations for ATS job board fetchers (Greenhouse, Lever, Ashby, Workable, SmartRecruiters); these multi-service pipelines remain larger follow-up work and stay out of scope for this PR

## Testing
- npm run lint
- npm run test:ci

## Test Matrix
- Title/Company/Location headers using colon separators (existing coverage)
- Title/Company/Location headers using ASCII hyphen, en dash, and em dash separators (new coverage)


------
https://chatgpt.com/codex/tasks/task_e_68c9f7f94edc832f8b9d97eec9f4213f