### PR TITLE
docs: restore codex prompt guidance

### DIFF
--- a/docs/prompts/codex/accessibility.md
+++ b/docs/prompts/codex/accessibility.md
@@ -4,25 +4,25 @@ slug: 'codex-accessibility'
 ---
 
 # Codex Accessibility Prompt
-Use this prompt to improve accessibility features in jobbot3000.
 
-```text
+```prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Enhance accessibility, ensuring inclusive and usable interfaces.
 
+USAGE NOTES:
+- Use this prompt to improve accessibility features in jobbot3000.
+- Copy this block whenever improving accessibility in jobbot3000.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
-- Confirm referenced files exist; update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
 1. Identify accessibility gaps such as missing alt text or ARIA labels.
@@ -34,33 +34,28 @@ OUTPUT:
 A pull request summarizing the accessibility improvements with passing checks.
 ```
 
-Copy this block whenever improving accessibility in jobbot3000.
+## Upgrade Instructions
 
-## Upgrade Prompt
-Type: evergreen
-
-Use this prompt to refine `docs/prompts/codex/accessibility.md`.
-
-```text
+```upgrade
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve or expand the `docs/prompts/codex/accessibility.md` prompt.
 
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/accessibility.md`.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
-- Confirm referenced files exist and update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Confirm referenced files exist and update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Revise `docs/prompts/codex/accessibility.md` so this prompt stays accurate and actionable.
-   Keep examples aligned with current project practices.
+1. Revise `docs/prompts/codex/accessibility.md` so this prompt stays accurate and actionable. Keep examples aligned with current project practices.
 2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 

--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -4,147 +4,89 @@ slug: 'codex-automation'
 ---
 
 # Codex Automation Prompt
-Use this prompt to guide automated contributors when performing routine maintenance in
-jobbot3000. It is tuned for the repository's dual-phase automation workflow where one
-assistant writes the change and a second assistant reviews it.
 
-Automation work typically includes:
+```prompt
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+ASSISTANT: (DEV) Implement code; stop after producing patch.
+ASSISTANT: (CRITIC) Inspect the patch and JSON manifest.
+ASSISTANT: (CRITIC) Reply only "LGTM" or a bullet list of fixes needed.
 
-- Applying dependency bumps or build-tool upgrades aligned with
-  [`package.json`](../../../package.json).
-- Synchronizing configuration files such as
-  [`eslint.config.js`](../../../eslint.config.js) or CI settings under
-  [.github/workflows](../../../.github/workflows).
-- Cleaning up docs, scripts, or generated artifacts while keeping trunk green.
+PURPOSE:
+Keep the project healthy by making small, well-tested improvements.
 
-Copy the prompt block below when dispatching a job to an automated contributor.
+USAGE NOTES:
+- Use this prompt to guide automated contributors when performing routine maintenance in jobbot3000.
+- Automation work typically includes:
+  - Applying dependency bumps or build-tool upgrades aligned with [`package.json`](../../../package.json).
+  - Synchronizing configuration files like [`eslint.config.js`](../../../eslint.config.js) or files under [.github/workflows](../../../.github/workflows).
+  - Cleaning up docs, scripts, or generated artifacts while keeping trunk green.
+- Automation works best for predictable, low-risk changes; redirect product or architectural work to [Codex Feature](./feature.md) or [Codex Fix](./fix.md).
+- Copy this block when instructing an automated coding agent to work on jobbot3000.
 
-Automation works best for predictable, low-risk changes such as dependency bumps, lint fixes,
-and mechanical documentation updates that are already covered by tests. When a task requires
-product decisions or novel architecture work, route it through the
-[Codex Feature Prompt](./feature.md) or [Codex Fix Prompt](./fix.md) instead.
+CONTEXT:
+- Follow the [repository README](../../../README.md) and the [AGENTS spec](https://agentsmd.net/AGENTS.md).
+- Review [DESIGN.md](../../../DESIGN.md) when implementation details or ownership are unclear.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
+- Install dependencies with `npm ci` if needed.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)).
+- Ensure any code samples compile with `node` or [`ts-node`](https://typestrong.org/ts-node).
+- Stage only the required files and keep diffs narrow.
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
-## Prompt template
+DEV RESPONSIBILITIES:
+- Gather context from the README, DESIGN doc, and workflows before editing.
+- Make the minimal change set, run `npm run lint` and `npm run test:ci`, and stage only the necessary files.
+- Populate the JSON manifest with an accurate summary and `tests_pass` value that reflects command results.
 
-```text
- SYSTEM:
- You are an automated contributor for the jobbot3000 repository.
- ASSISTANT: (DEV) Implement code; stop after producing patch.
- ASSISTANT: (CRITIC) Inspect the patch and JSON manifest.
- ASSISTANT: (CRITIC) Reply only "LGTM" or a bullet list of fixes needed.
+CRITIC RESPONSIBILITIES:
+- Inspect the diff for scope creep, missing tests, or skipped commands.
+- Ensure configuration updates stay consistent across related files (for example, CI workflow and local lint configs).
+- Reply with "LGTM" only when the patch, manifest, and testing evidence are satisfactory.
 
- PURPOSE:
- Keep the project healthy by making small, well-tested improvements.
+REQUEST:
+1. Identify a straightforward improvement or bug fix.
+2. Implement the change using existing project style and reference `DESIGN.md` as needed.
+3. Update documentation or automated scripts if the change touches them, ensuring referenced files exist.
+4. Run the commands above, document their outcomes, and address failures before requesting review.
+5. Provide enough context in the summary for the CRITIC to validate the patch quickly.
 
- CONTEXT:
- - Follow the [repository README](../../../README.md) and the
-   [AGENTS spec](https://agentsmd.net/AGENTS.md).
--- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks and mirror the
--  commands those jobs run.
-+- Review [DESIGN.md](../../../DESIGN.md) when implementation details or ownership are
-+  unclear.
-+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
- - Install dependencies with `npm ci` if needed.
- - Run `npm run lint` and `npm run test:ci` before committing.
- - Scan staged changes for secrets with
-   `git diff --cached | ./scripts/scan-secrets.py`
-   (see [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)).
- - Ensure any code samples compile with `node` or
-   [`ts-node`](https://typestrong.org/ts-node).
- - Stage only the required files and keep diffs narrow.
- - Confirm referenced files exist; update
-   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
--- Link to adjacent prompts, such as
--  [Codex Feature](./feature.md) or [Codex Fix](./fix.md), when work should be redirected.
--
--REQUEST:
--1. Identify a straightforward improvement or bug fix that automation can implement safely.
--2. Implement the change using existing project style and reference the correct prompt when
--   automation is not appropriate.
--3. Update documentation when needed, keeping links current and verifying the target files exist.
--4. Run the commands above and address any failures.
-+- Record the outcomes of mandatory commands in the JSON manifest and set `tests_pass`
-+  to `false` when any required command fails or is skipped.
-+
-+REQUEST:
-+1. Identify a straightforward improvement or bug fix.
-+2. Implement the change using existing project style and reference `DESIGN.md` as
-+   needed.
-+3. Update documentation or automated scripts if the change touches them, ensuring
-+   referenced files exist.
-+4. Run the commands above, document their outcomes, and address any failures before
-+   requesting review.
-+5. Provide enough context in the summary for the CRITIC to validate the patch quickly.
-
- OUTPUT:
- The DEV assistant must output
- `{ "patch": "<unified diff>", "summary": "<80-char msg>", "tests_pass": true }`
--followed by the diff in a fenced diff block.
--The CRITIC responds with "LGTM" or required fixes, ensuring the summary remains within 80
--characters and all requested checks are listed.
-+followed by the diff in a fenced diff block. Set `tests_pass` to `false` if lint or
-+tests fail, or if they were not run. The CRITIC responds with "LGTM" or a list of
-+required fixes.
-```
-
-Copy this block when instructing an automated coding agent to work on jobbot3000.
-
-## DEV and CRITIC responsibilities
-
-- **DEV assistant**
-  - Gather context from the README, DESIGN doc, and workflows before editing.
-  - Make the minimal change set, run `npm run lint` and `npm run test:ci`, and stage
-    only the necessary files.
-  - Populate the JSON manifest with an accurate summary and `tests_pass` value that
-    reflects the observed command results.
-- **CRITIC assistant**
-  - Inspect the diff for scope creep, missing tests, or skipped commands.
-  - Ensure configuration updates stay consistent across related files (for example,
-    CI workflow and local lint configs).
-  - Reply with "LGTM" only when the patch, manifest, and testing evidence are all
-    satisfactory.
-
-## Quick checklist before handing off to the CRITIC
-
+MANDATORY COMMANDS:
 - `npm run lint`
 - `npm run test:ci`
 - `git diff --cached | ./scripts/scan-secrets.py`
 - `npx markdown-link-check docs/prompts/codex/automation.md`
 
-Re-run any command that fails and document the outcome in the manifest before
-requesting review.
+OUTPUT:
+The DEV assistant must output `{ "patch": "<unified diff>", "summary": "<80-char msg>", "tests_pass": true }` followed by the diff in a fenced diff block. Set `tests_pass` to `false` if lint or tests fail, or if they were not run. The CRITIC responds with "LGTM" or a list of required fixes.
+```
 
-## Upgrade Prompt
-Type: evergreen
+## Upgrade Instructions
 
-Use this prompt to refine `docs/prompts/codex/automation.md`.
-
-```text
+```upgrade
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve or expand the `docs/prompts/codex/automation.md` prompt.
 
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/automation.md` so automation guidance stays current.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)).
-- Confirm referenced files exist; update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)).
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Revise `docs/prompts/codex/automation.md` so this prompt stays accurate and actionable.
-   Keep examples aligned with current project practices.
+1. Revise `docs/prompts/codex/automation.md` so this prompt stays accurate and actionable. Keep examples aligned with current project practices.
 2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
 A pull request that updates `docs/prompts/codex/automation.md` with passing checks.
 ```
-

--- a/docs/prompts/codex/chore.md
+++ b/docs/prompts/codex/chore.md
@@ -4,26 +4,25 @@ slug: 'codex-chore'
 ---
 
 # Codex Chore Prompt
-Use this prompt to handle maintenance tasks in jobbot3000.
 
-```text
+```prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Perform routine housekeeping such as dependency bumps or config tweaks.
 
+USAGE NOTES:
+- Use this prompt to handle maintenance tasks in jobbot3000.
+- Copy this block whenever performing chores in jobbot3000.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
-- Confirm referenced files exist; update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when modifying prompt docs.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when modifying prompt docs.
 
 REQUEST:
 1. Explain the maintenance change to perform.
@@ -35,38 +34,31 @@ OUTPUT:
 A pull request URL summarizing the maintenance task.
 ```
 
-Copy this block whenever performing chores in jobbot3000.
+## Upgrade Instructions
 
-## Upgrade Prompt
-Type: evergreen
-
-Use this prompt to refine `docs/prompts/codex/chore.md`.
-
-```text
+```upgrade
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve or expand the `docs/prompts/codex/chore.md` prompt.
 
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/chore.md`.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Update [prompt-docs-summary.md](../../prompt-docs-summary.md) when modifying prompt docs.
 
 REQUEST:
-1. Revise `docs/prompts/codex/chore.md` so this prompt stays accurate and actionable.
-   Keep examples aligned with current project practices.
+1. Revise `docs/prompts/codex/chore.md` so this prompt stays accurate and actionable. Keep examples aligned with current project practices.
 2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
 A pull request that updates `docs/prompts/codex/chore.md` with passing checks.
 ```
-

--- a/docs/prompts/codex/ci.md
+++ b/docs/prompts/codex/ci.md
@@ -4,24 +4,24 @@ slug: 'codex-ci'
 ---
 
 # Codex CI Prompt
-Use this prompt when modifying CI workflows in jobbot3000.
 
-```text
+```prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Adjust CI workflows to keep builds fast and reliable.
 
+USAGE NOTES:
+- Use this prompt when modifying CI workflows in jobbot3000.
+- Copy this block whenever updating CI workflows in jobbot3000.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Update [prompt-docs-summary.md](../../prompt-docs-summary.md) when modifying prompt docs.
 - Ensure workflow syntax is valid; see [GitHub Actions](https://docs.github.com/actions).
 
@@ -35,36 +35,28 @@ OUTPUT:
 A pull request summarizing the CI update with passing checks.
 ```
 
-Copy this block whenever updating CI workflows in jobbot3000.
+## Upgrade Instructions
 
-## Upgrade Prompt
-Type: evergreen
-
-Use this prompt to refine `docs/prompts/codex/ci.md`.
-
-```text
+```upgrade
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve or expand the `docs/prompts/codex/ci.md` prompt.
 
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/ci.md`.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
-- Confirm referenced files exist; update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md)
-  when adding prompt docs.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Revise `docs/prompts/codex/ci.md` so this prompt stays accurate and actionable.
-   Keep examples aligned with current project practices.
+1. Revise `docs/prompts/codex/ci.md` so this prompt stays accurate and actionable. Keep examples aligned with current project practices.
 2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 

--- a/docs/prompts/codex/docs.md
+++ b/docs/prompts/codex/docs.md
@@ -4,51 +4,47 @@ slug: 'codex-docs'
 ---
 
 # Codex Docs Prompt
-Use this prompt when clarifying or extending documentation in jobbot3000. It keeps documentation
-work aligned with repository guardrails and continuous integration checks.
 
-## When to use this prompt
-- Update existing guides, READMEs, or in-repo help text.
-- Add new documentation files or sections without touching executable code.
-- Refresh prompt docs referenced by contributors or automation.
-
-## Pre-flight checklist
-- Re-read the root [README.md](../../../README.md) for repository-wide conventions.
-- Inspect [.github/workflows](../../../.github/workflows) to understand which checks will run.
-- Confirm [docs/prompt-docs-summary.md](../../prompt-docs-summary.md) lists every prompt doc you
-  add or update.
-- Verify referenced paths exist before committing.
-
-## Link hygiene
-- Run `npx markdown-link-check <file>` to validate new or updated links.
-- For example: `npx markdown-link-check docs/prompts/codex/docs.md`.
-- Fix, update, or remove any broken links before opening a pull request.
-
-```text
+```prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve project documentation without modifying code behavior.
 
+USAGE NOTES:
+- Use this prompt when clarifying or extending documentation in jobbot3000 so work stays aligned with repository guardrails and CI checks.
+- Copy this block whenever updating docs in jobbot3000, and follow the checklist below before editing.
+
+WHEN TO USE:
+- Update existing guides, READMEs, or in-repo help text.
+- Add new documentation files or sections without touching executable code.
+- Refresh prompt docs referenced by contributors or automation.
+
+PRE-FLIGHT CHECKLIST:
+- Re-read the root [README.md](../../../README.md) for repository-wide conventions.
+- Inspect [.github/workflows](../../../.github/workflows) to understand which checks will run.
+- Confirm [docs/prompt-docs-summary.md](../../prompt-docs-summary.md) lists every prompt doc you add or update.
+- Verify referenced paths exist before committing.
+
+LINK HYGIENE:
+- Run `npx markdown-link-check <file>` to validate new or updated links.
+- For example: `npx markdown-link-check docs/prompts/codex/docs.md`.
+- Fix, update, or remove any broken links before opening a pull request.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Documentation lives in [docs/](../../); keep links relative and up to date.
-- Keep [docs/prompt-docs-summary.md](../../prompt-docs-summary.md) in sync when adding or removing
-  prompt docs.
+- Keep [docs/prompt-docs-summary.md](../../prompt-docs-summary.md) in sync when adding or removing prompt docs.
 - Install dependencies with `npm ci` if needed.
-- Use [Node.js](https://nodejs.org/en) or
-  [ts-node](https://typestrong.org/ts-node) to validate code samples. For example:
+- Use [Node.js](https://nodejs.org/en) or [ts-node](https://typestrong.org/ts-node) to validate code samples. For example:
 
   ```bash
   node -e "console.log('docs sample works')"
   ```
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Verify links with `npx markdown-link-check <file>`; fix or remove broken URLs.
 - Confirm referenced files exist before referencing them.
 
@@ -56,61 +52,47 @@ REQUEST:
 1. Identify the doc section to update and confirm all referenced files exist.
 2. Revise text or examples for clarity while keeping repository conventions intact.
 3. Check links with `npx markdown-link-check <file>` and repair any failures.
-4. Ensure any code samples compile with `node` or `ts-node`
-   (see [Node.js](https://nodejs.org/en) and
-   [ts-node](https://typestrong.org/ts-node)).
+4. Ensure any code samples compile with `node` or `ts-node` (see [Node.js](https://nodejs.org/en) and [ts-node](https://typestrong.org/ts-node)).
 5. Run the commands above, including `npm run lint` and `npm run test:ci`, and fix any failures.
 
 OUTPUT:
 A pull request URL summarizing the documentation update.
 ```
 
-Copy this block whenever updating docs in jobbot3000, and follow the checklist above before you
-start editing.
+## Upgrade Instructions
 
-## Upgrade Prompt
-Type: evergreen
-
-Use this prompt to refine `docs/prompts/codex/docs.md`.
-
-```text
+```upgrade
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve or expand the `docs/prompts/codex/docs.md` prompt.
 
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/docs.md`.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
-- Keep [docs/prompt-docs-summary.md](../../prompt-docs-summary.md) aligned with any new or relocated
-  prompt files.
+- Keep [docs/prompt-docs-summary.md](../../prompt-docs-summary.md) aligned with any new or relocated prompt files.
 - Install dependencies with `npm ci` if needed.
-- Use [Node.js](https://nodejs.org/en) or
-  [ts-node](https://typestrong.org/ts-node) to validate code samples. For example:
+- Use [Node.js](https://nodejs.org/en) or [ts-node](https://typestrong.org/ts-node) to validate code samples. For example:
 
   ```bash
   node -e "console.log('docs sample works')"
   ```
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Verify links with `npx markdown-link-check <file>`; fix or remove broken URLs.
 - Confirm referenced files exist before referencing them.
 
 REQUEST:
-1. Revise `docs/prompts/codex/docs.md` so this prompt stays accurate and actionable.
-   Keep examples aligned with current project practices.
+1. Revise `docs/prompts/codex/docs.md` so this prompt stays accurate and actionable. Keep examples aligned with current project practices.
 2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Check links with `npx markdown-link-check <file>`.
-4. Ensure any code samples compile with `node` or `ts-node`
-   (see [Node.js](https://nodejs.org/en) and
-   [ts-node](https://typestrong.org/ts-node)).
+4. Ensure any code samples compile with `node` or `ts-node` (see [Node.js](https://nodejs.org/en) and [ts-node](https://typestrong.org/ts-node)).
 5. Run the commands above, including `npm run lint` and `npm run test:ci`, and fix any failures.
 
 OUTPUT:
 A pull request that updates `docs/prompts/codex/docs.md` with passing checks.
 ```
-

--- a/docs/prompts/codex/feature.md
+++ b/docs/prompts/codex/feature.md
@@ -4,18 +4,20 @@ slug: 'codex-feature'
 ---
 
 # Codex Feature Prompt
-Use this prompt when adding a small feature to jobbot3000.
 
-```text
+```prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Implement a minimal feature in jobbot3000.
 
+USAGE NOTES:
+- Use this prompt when adding a small feature to jobbot3000.
+- Copy this block whenever implementing a feature in jobbot3000.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Consult [DESIGN.md](../../../DESIGN.md) for architectural guidelines.
 - Tests live in [test/](../../../test) and run with [Vitest](https://vitest.dev/).
@@ -35,39 +37,32 @@ OUTPUT:
 A pull request URL summarizing the feature addition.
 ```
 
-Copy this block whenever implementing a feature in jobbot3000.
+## Upgrade Instructions
 
-## Upgrade Prompt
-Type: evergreen
-
-Use this prompt to refine `docs/prompts/codex/feature.md`.
-
-```text
+```upgrade
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve or expand the `docs/prompts/codex/feature.md` prompt.
 
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/feature.md`.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Ensure any code samples compile with `node` or `ts-node`.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
-- Confirm referenced files exist; update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
-
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Revise `docs/prompts/codex/feature.md` so this prompt stays accurate and actionable.
-   Keep examples aligned with current project practices.
+1. Revise `docs/prompts/codex/feature.md` so this prompt stays accurate and actionable. Keep examples aligned with current project practices.
 2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
 A pull request that updates `docs/prompts/codex/feature.md` with passing checks.
 ```
-

--- a/docs/prompts/codex/fix.md
+++ b/docs/prompts/codex/fix.md
@@ -4,14 +4,17 @@ slug: 'codex-fix'
 ---
 
 # Codex Fix Prompt
-Use this prompt to reproduce and fix bugs in jobbot3000.
 
-```text
+```prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Diagnose and resolve bugs in jobbot3000.
+
+USAGE NOTES:
+- Use this prompt to reproduce and fix bugs in jobbot3000.
+- Copy this block whenever fixing bugs in jobbot3000.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
@@ -19,11 +22,8 @@ CONTEXT:
 - The project uses [Vitest](https://vitest.dev) for unit tests.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
-- Confirm referenced files exist; update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
 1. Reproduce the bug with a failing test or script in [test/](../../../test).
@@ -35,31 +35,26 @@ OUTPUT:
 A pull request URL summarizing the bug fix.
 ```
 
-Copy this block whenever fixing bugs in jobbot3000.
+## Upgrade Instructions
 
-## Upgrade Prompt
-Type: evergreen
-
-Use this prompt to refine `docs/prompts/codex/fix.md`.
-
-```text
+```upgrade
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve or expand the `docs/prompts/codex/fix.md` prompt.
 
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/fix.md`.
+
 CONTEXT:
 - Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`.
-  See [scripts/scan-secrets.py](../../../scripts/scan-secrets.py).
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 
 REQUEST:
-1. Revise `docs/prompts/codex/fix.md` so this prompt stays accurate and actionable.
-   Keep examples aligned with current project practices.
+1. Revise `docs/prompts/codex/fix.md` so this prompt stays accurate and actionable. Keep examples aligned with current project practices.
 2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 

--- a/docs/prompts/codex/implement.md
+++ b/docs/prompts/codex/implement.md
@@ -4,84 +4,64 @@ slug: 'codex-implement'
 ---
 
 # Codex Implement Prompt
-Prompt name: `prompt-implement`.
 
-Use this prompt when turning jobbot3000's future-work notes into shipped features.
-
-```text
+```prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Close the loop on documented-but-unshipped functionality in jobbot3000.
 
+USAGE NOTES:
+- Prompt name: `prompt-implement`.
+- Use this prompt when turning jobbot3000's future-work notes into shipped features.
+- Copy this block whenever converting planned jobbot3000 work into reality.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Consult [DESIGN.md](../../../DESIGN.md) for architectural guidelines.
-- Tests live in [test/](../../../test) and run with
-  [Vitest](https://vitest.dev/).
+- Tests live in [test/](../../../test) and run with [Vitest](https://vitest.dev/).
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Use `rg` (ripgrep) to inventory TODO, FIXME, "future work", and similar
-  markers across code, tests, and docs.
-- Prefer items that can be completed in one PR and unblock user value without
-  multi-step migrations.
-- Design a robust test strategy: add a failing test first, cover happy and edge
-  paths, and document the test matrix in the PR description.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`.
-- Update references to [prompt-docs-summary.md](../../prompt-docs-summary.md)
-  when adding or relocating prompt docs.
+- Use `rg` (ripgrep) to inventory TODO, FIXME, "future work", and similar markers across code, tests, and docs.
+- Prefer items that can be completed in one PR and unblock user value without multi-step migrations.
+- Design a robust test strategy: add a failing test first, cover happy and edge paths, and document the test matrix in the PR description.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Update references to [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding or relocating prompt docs.
 
 REQUEST:
-1. List candidate future-work items you discover and explain why the chosen
-   item is actionable now.
-2. Write a failing test in [test/](../../../test) (or an equivalent check)
-   that captures the promised behavior, then add additional tests to harden the
-   implementation.
-3. Implement the smallest change that fulfills the promise while keeping
-   existing behavior intact and removing stale TODOs/comments.
-4. Update related docs or inline commentary to reflect the shipped feature and
-   summarize the test strategy.
-5. Run the commands above and resolve any failures; include the results in the
-   PR body.
+1. List candidate future-work items you discover and explain why the chosen item is actionable now.
+2. Write a failing test in [test/](../../../test) (or an equivalent check) that captures the promised behavior, then add additional tests to harden the implementation.
+3. Implement the smallest change that fulfills the promise while keeping existing behavior intact and removing stale TODOs/comments.
+4. Update related docs or inline commentary to reflect the shipped feature and summarize the test strategy.
+5. Run the commands above and resolve any failures; include the results in the PR body.
 
 OUTPUT:
-A pull request URL summarizing the implemented functionality, associated tests,
-updated documentation, and test results.
+A pull request URL summarizing the implemented functionality, associated tests, updated documentation, and test results.
 ```
 
-Copy this block whenever converting planned jobbot3000 work into reality.
+## Upgrade Instructions
 
-## Upgrade Prompt
-Type: evergreen
-
-Use this prompt to refine `docs/prompts/codex/implement.md`.
-
-```text
+```upgrade
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve or expand the `docs/prompts/codex/implement.md` prompt.
 
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/implement.md`.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
-- Review [.github/workflows](../../../.github/workflows) to anticipate CI
-  checks.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`.
-- Confirm referenced files exist; update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt
-  docs.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Revise `docs/prompts/codex/implement.md` so this prompt stays accurate and actionable.
-   Keep examples aligned with current project practices.
+1. Revise `docs/prompts/codex/implement.md` so this prompt stays accurate and actionable. Keep examples aligned with current project practices.
 2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 

--- a/docs/prompts/codex/localization.md
+++ b/docs/prompts/codex/localization.md
@@ -4,14 +4,17 @@ slug: 'codex-localization'
 ---
 
 # Codex Localization Prompt
-Use this prompt to add or improve localization support in jobbot3000.
 
-```text
+```prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Implement localization or internationalization improvements.
+
+USAGE NOTES:
+- Use this prompt to add or improve localization support in jobbot3000.
+- Copy this block whenever working on localization in jobbot3000.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
@@ -31,19 +34,17 @@ OUTPUT:
 A pull request summarizing the localization changes with passing checks.
 ```
 
-Copy this block whenever working on localization in jobbot3000.
+## Upgrade Instructions
 
-## Upgrade Prompt
-Type: evergreen
-
-Use this prompt to refine `docs/prompts/codex/localization.md`.
-
-```text
+```upgrade
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve or expand the `docs/prompts/codex/localization.md` prompt.
+
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/localization.md`.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
@@ -54,8 +55,7 @@ CONTEXT:
 - Confirm referenced files exist and update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Revise `docs/prompts/codex/localization.md` so this prompt stays accurate and actionable.
-   Keep examples aligned with current project practices.
+1. Revise `docs/prompts/codex/localization.md` so this prompt stays accurate and actionable. Keep examples aligned with current project practices.
 2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 

--- a/docs/prompts/codex/performance.md
+++ b/docs/prompts/codex/performance.md
@@ -4,14 +4,17 @@ slug: 'codex-performance'
 ---
 
 # Codex Performance Prompt
-Use this prompt to improve runtime performance in jobbot3000.
 
-```text
+```prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Enhance performance without altering external behavior.
+
+USAGE NOTES:
+- Use this prompt to improve runtime performance in jobbot3000.
+- Copy this block whenever optimizing performance in jobbot3000.
 
 CONTEXT:
 - Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
@@ -19,14 +22,12 @@ CONTEXT:
 - Consult [DESIGN.md](../../../DESIGN.md) for architecture and performance guidelines.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)).
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)).
 - Link-check this doc with `npx markdown-link-check docs/prompts/codex/performance.md`.
 - Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
-- Link-check the updated doc with
-  `npx markdown-link-check docs/prompts/codex/performance.md`.
 - Measure performance with Node's `perf_hooks` API:
+
+  ```ts
   import { performance } from 'node:perf_hooks';
 
   const start = performance.now();
@@ -34,12 +35,13 @@ CONTEXT:
     // code under test
   }
   console.log(`elapsed: ${performance.now() - start}ms`);
+  ```
+
   Run with `node --input-type=module` for a quick baseline before formal benchmarks.
 
 REQUEST:
 1. Write a failing benchmark or test showing the slowdown.
-2. Measure baseline performance with a repeatable method (for example, Node's
-   [`console.time`](https://nodejs.org/api/console.html#consoletime)).
+2. Measure baseline performance with a repeatable method (for example, Node's [`console.time`](https://nodejs.org/api/console.html#consoletime)).
 3. Optimize the code while keeping functionality the same.
 4. Document before/after metrics in the PR or accompanying docs.
 5. Run the commands above and fix any failures.
@@ -48,39 +50,31 @@ OUTPUT:
 A pull request URL summarizing the performance improvement.
 ```
 
-Copy this block whenever optimizing performance in jobbot3000.
+## Upgrade Instructions
 
-## Upgrade Prompt
-Type: evergreen
-
-Use this prompt to refine `docs/prompts/codex/performance.md`.
-
-```text
+```upgrade
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve or expand the `docs/prompts/codex/performance.md` prompt.
 
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/performance.md`.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Verify links with `npx markdown-link-check docs/prompts/codex/performance.md`.
-- Confirm referenced files exist; update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Revise `docs/prompts/codex/performance.md` so this prompt stays accurate and actionable.
-   Keep examples aligned with current project practices.
+1. Revise `docs/prompts/codex/performance.md` so this prompt stays accurate and actionable. Keep examples aligned with current project practices.
 2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
 A pull request that updates `docs/prompts/codex/performance.md` with passing checks.
 ```
-

--- a/docs/prompts/codex/refactor.md
+++ b/docs/prompts/codex/refactor.md
@@ -4,22 +4,24 @@ slug: 'codex-refactor'
 ---
 
 # Codex Refactor Prompt
-Use this prompt to improve internal structure without changing behavior.
 
-```text
+```prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Refactor code for clarity or maintainability.
 
+USAGE NOTES:
+- Use this prompt to improve internal structure without changing behavior.
+- Copy this block whenever refactoring jobbot3000.
+
 CONTEXT:
 - Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
-- Confirm referenced files exist; update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 - Include before/after benchmarks if performance might change.
 
 REQUEST:
@@ -32,38 +34,31 @@ OUTPUT:
 A pull request URL summarizing the refactor.
 ```
 
-Copy this block whenever refactoring jobbot3000.
+## Upgrade Instructions
 
-## Upgrade Prompt
-Type: evergreen
-
-Use this prompt to refine `docs/prompts/codex/refactor.md`.
-
-```text
+```upgrade
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve or expand the `docs/prompts/codex/refactor.md` prompt.
 
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/refactor.md`.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`.
-- Confirm referenced files exist; update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Revise `docs/prompts/codex/refactor.md` so this prompt stays accurate and actionable.
-   Keep examples aligned with current project practices.
+1. Revise `docs/prompts/codex/refactor.md` so this prompt stays accurate and actionable. Keep examples aligned with current project practices.
 2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
 A pull request that updates `docs/prompts/codex/refactor.md` with passing checks.
 ```
-

--- a/docs/prompts/codex/security.md
+++ b/docs/prompts/codex/security.md
@@ -4,18 +4,20 @@ slug: 'codex-security'
 ---
 
 # Codex Security Prompt
-Use this prompt to address security vulnerabilities in jobbot3000.
 
-```text
+```prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Address security issues and harden the project.
 
+USAGE NOTES:
+- Use this prompt to address security vulnerabilities in jobbot3000.
+- Copy this block whenever addressing security in jobbot3000.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - GitHub's CodeQL analysis runs via [`codeql.yml`](../../../.github/workflows/codeql.yml).
 - Review [DESIGN.md](../../../DESIGN.md) for architecture context affecting security.
@@ -23,11 +25,8 @@ CONTEXT:
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Run `npm audit` to identify known vulnerabilities.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
-- Confirm referenced files exist; update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
 1. Reproduce the vulnerability or describe the weakness.
@@ -37,14 +36,7 @@ REQUEST:
 5. Update docs or advisories if needed.
 6. Run the commands above and fix any failures.
 
-OUTPUT:
-A pull request summarizing the security fix with passing checks.
-```
-
-Copy this block whenever addressing security in jobbot3000.
-
-### Example: Generating a secure token
-
+EXAMPLE: Generating a secure token
 ```js
 import { randomBytes } from 'node:crypto';
 
@@ -54,44 +46,40 @@ export function generateToken() {
 
 console.log(generateToken().length); // 64
 ```
+Run it with `node --input-type=module` to verify the output is 64. See [`randomBytes`](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) for details.
 
-Run it with `node --input-type=module` to verify the output is 64.
-See [`randomBytes`](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) for details.
+OUTPUT:
+A pull request summarizing the security fix with passing checks.
+```
 
-## Upgrade Prompt
-Type: evergreen
+## Upgrade Instructions
 
-Use this prompt to refine `docs/prompts/codex/security.md`.
-
-```text
+```upgrade
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve or expand the `docs/prompts/codex/security.md` prompt.
 
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/security.md`.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - GitHub's CodeQL analysis runs via [`codeql.yml`](../../../.github/workflows/codeql.yml).
 - Consult [SECURITY.md](../../../SECURITY.md) for reporting and disclosure guidance.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Check dependencies for known vulnerabilities with `npm audit`.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
-- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md)
-  when adding prompt docs.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Revise `docs/prompts/codex/security.md` so this prompt stays accurate and actionable.
-   Keep examples aligned with current project practices.
+1. Revise `docs/prompts/codex/security.md` so this prompt stays accurate and actionable. Keep examples aligned with current project practices.
 2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
 A pull request that updates `docs/prompts/codex/security.md` with passing checks.
 ```
-

--- a/docs/prompts/codex/spellcheck.md
+++ b/docs/prompts/codex/spellcheck.md
@@ -4,28 +4,27 @@ slug: 'codex-spellcheck'
 ---
 
 # Codex Spellcheck Prompt
-Use this prompt to fix spelling mistakes in jobbot3000. When editing the spelling
-dictionary, keep entries alphabetically sorted.
 
-```text
+```prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Correct typos and enforce consistent spelling.
 
+USAGE NOTES:
+- Use this prompt to fix spelling mistakes in jobbot3000.
+- When editing the spelling dictionary, keep entries alphabetically sorted.
+- Copy this block whenever correcting spelling in jobbot3000.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Refer to [cspell.json](../../../cspell.json) to update the spelling dictionary when needed.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
-- Confirm referenced files exist; update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
 1. Locate spelling errors in code or docs.
@@ -38,39 +37,31 @@ OUTPUT:
 A pull request URL summarizing the spelling corrections.
 ```
 
-Copy this block whenever correcting spelling in jobbot3000.
+## Upgrade Instructions
 
-## Upgrade Prompt
-Type: evergreen
-
-Use this prompt to refine `docs/prompts/codex/spellcheck.md`.
-
-```text
+```upgrade
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve or expand the `docs/prompts/codex/spellcheck.md` prompt.
 
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/spellcheck.md`.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
-- Confirm referenced files exist and update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Confirm referenced files exist and update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Revise `docs/prompts/codex/spellcheck.md` so this prompt stays accurate and actionable.
-   Keep examples aligned with current project practices.
+1. Revise `docs/prompts/codex/spellcheck.md` so this prompt stays accurate and actionable. Keep examples aligned with current project practices.
 2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 
 OUTPUT:
 A pull request that updates `docs/prompts/codex/spellcheck.md` with passing checks.
 ```
-

--- a/docs/prompts/codex/style.md
+++ b/docs/prompts/codex/style.md
@@ -4,27 +4,26 @@ slug: 'codex-style'
 ---
 
 # Codex Style Prompt
-Use this prompt when adjusting code style or formatting in jobbot3000.
 
-```text
+```prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Align code with the project's style without changing behavior.
 
+USAGE NOTES:
+- Use this prompt when adjusting code style or formatting in jobbot3000.
+- Copy this block whenever refining style in jobbot3000.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Ensure any code samples compile with `node` or `ts-node`.
-- Confirm referenced files exist; update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
 1. Spot style inconsistencies or linter errors.
@@ -32,50 +31,40 @@ REQUEST:
 3. Avoid altering runtime behavior.
 4. Run the commands above and fix any failures.
 
-OUTPUT:
-A pull request URL summarizing the style improvements.
-```
-
-Copy this block whenever refining style in jobbot3000.
-
-## Example
-
+EXAMPLE:
 Remove unnecessary code while keeping output stable:
-
 ```js
 const greet = (name) => `Hi, ${name}!`;
 console.log(greet('Codex'));
 ```
-
 Run it with `node -e "const greet = (name) => \`Hi, ${name}!\`; console.log(greet('Codex'))"`.
 
-## Upgrade Prompt
-Type: evergreen
+OUTPUT:
+A pull request URL summarizing the style improvements.
+```
 
-Use this prompt to refine `docs/prompts/codex/style.md`.
+## Upgrade Instructions
 
-```text
+```upgrade
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve or expand the `docs/prompts/codex/style.md` prompt.
 
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/style.md`.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
-- Confirm referenced files exist; update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
-1. Revise `docs/prompts/codex/style.md` so this prompt stays accurate and actionable.
-   Keep examples aligned with current project practices.
+1. Revise `docs/prompts/codex/style.md` so this prompt stays accurate and actionable. Keep examples aligned with current project practices.
 2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Run the commands above and fix any failures.
 

--- a/docs/prompts/codex/test.md
+++ b/docs/prompts/codex/test.md
@@ -4,15 +4,22 @@ slug: 'codex-test'
 ---
 
 # Codex Test Prompt
-Use this prompt when adding or improving tests in jobbot3000.
 
-Tests live under [test/](../../../test) and use the `*.test.js` naming convention.  
-Sample data for tests resides in [test/fixtures](../../../test/fixtures).
+```prompt
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
 
-## Example
+PURPOSE:
+Improve or expand test coverage without altering runtime behavior.
 
-The snippet below shows a minimal [Vitest](https://vitest.dev/) test:
+USAGE NOTES:
+- Use this prompt when adding or improving tests in jobbot3000.
+- Tests live under [test/](../../../test) and use the `*.test.js` naming convention.
+- Sample data for tests resides in [test/fixtures](../../../test/fixtures).
+- Copy this block whenever working on tests in jobbot3000.
 
+EXAMPLE:
+A minimal [Vitest](https://vitest.dev/) test:
 ```js
 import { test, expect } from 'vitest';
 
@@ -20,32 +27,18 @@ test('math works', () => {
   expect(1 + 1).toBe(2);
 });
 ```
-
 Run it with `npx vitest run path/to/test-file`.
 
-
-```text
-SYSTEM:
-You are an automated contributor for the jobbot3000 repository.
-
-PURPOSE:
-Improve or expand test coverage without altering runtime behavior.
-
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Tests live in [test/](../../../test) and use the `*.test.js` naming convention.
 - Run tests with [Vitest](https://vitest.dev/).
-- Sample data for tests resides in
-  [test/fixtures](../../../test/fixtures).
+- Sample data for tests resides in [test/fixtures](../../../test/fixtures).
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
-- Confirm referenced files exist; update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 - Ensure any code samples compile with `node` (v20+) or `ts-node`.
 
 REQUEST:
@@ -58,36 +51,29 @@ OUTPUT:
 A pull request URL summarizing the test improvement.
 ```
 
-Copy this block whenever working on tests in jobbot3000.
+## Upgrade Instructions
 
-## Upgrade Prompt
-Type: evergreen
-
-Use this prompt to refine `docs/prompts/codex/test.md`.
-
-```text
+```upgrade
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve or expand the `docs/prompts/codex/test.md` prompt.
 
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/test.md`.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
-- Confirm referenced files exist; update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Confirm referenced files exist; update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 - Ensure any code samples compile with `node` or `ts-node`.
 
 REQUEST:
-1. Revise `docs/prompts/codex/test.md` so this prompt stays accurate and actionable.
-   Keep examples aligned with current project practices.
+1. Revise `docs/prompts/codex/test.md` so this prompt stays accurate and actionable. Keep examples aligned with current project practices.
 2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Ensure any code samples compile with `node` (v20+) or `ts-node`.
 4. Run the commands above and fix any failures.
@@ -95,4 +81,3 @@ REQUEST:
 OUTPUT:
 A pull request that updates `docs/prompts/codex/test.md` with passing checks.
 ```
-

--- a/docs/prompts/codex/upgrade.md
+++ b/docs/prompts/codex/upgrade.md
@@ -5,38 +5,33 @@ slug: 'codex-upgrade'
 
 # Codex Upgrade Prompt
 
-Use this prompt whenever you revise, replace, or add prompt documentation inside `docs/prompts/`.
-
-## Before you copy the prompt
-
-- Keep Markdown links relative to the repository and confirm each target file exists.
-- Double-check [`docs/prompt-docs-summary.md`](../../prompt-docs-summary.md)
-  for any new prompt entries.
-- Run the repository checks listed below so CI matches your local results.
-- Prefer `npm exec <tool>` (or `npx`) to rely on the project's locked dependencies.
-
-```text
+```prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Improve or expand the repository's prompt docs.
 
+USAGE NOTES:
+- Use this prompt whenever you revise, replace, or add prompt documentation inside `docs/prompts/`.
+- Copy this block whenever upgrading prompts in jobbot3000.
+
+BEFORE YOU COPY THIS PROMPT:
+- Keep Markdown links relative to the repository and confirm each target file exists.
+- Double-check [`docs/prompt-docs-summary.md`](../../prompt-docs-summary.md) for any new prompt entries.
+- Run the repository checks listed below so CI matches your local results.
+- Prefer `npm exec <tool>` (or `npx`) to rely on the project's locked dependencies.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Prompt docs live in [`docs/prompts/`](../../); keep front matter titles/slugs unique.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Ensure any code samples compile with `node` or `ts-node`.
-- Use project-local tooling via `npm exec`, e.g.
-  `npm exec markdown-link-check docs/prompts/codex/<file>.md`.
-- Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`
-  (see [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)).
-- Confirm every referenced file exists and update
-  [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- Use project-local tooling via `npm exec`, e.g. `npm exec markdown-link-check docs/prompts/codex/<file>.md`.
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [`scripts/scan-secrets.py`](../../../scripts/scan-secrets.py)).
+- Confirm every referenced file exists and update [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 
 REQUEST:
 1. Inventory the target doc: note required updates and confirm referenced files exist.
@@ -48,40 +43,34 @@ OUTPUT:
 A pull request that updates the selected prompt doc with passing checks.
 ```
 
-Copy this block whenever upgrading prompts in jobbot3000.
+## Upgrade Instructions
 
-## Upgrade Prompt
-Type: evergreen
-
-Use this prompt to refine `docs/prompts/codex/upgrade.md` itself.
-
-Review the checklist above before running the prompt so this document stays authoritative.
-
-```text
+```upgrade
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
 PURPOSE:
 Refine the `docs/prompts/codex/upgrade.md` document.
 
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/upgrade.md` itself.
+- Review the checklist above before running the prompt so this document stays authoritative.
+
 CONTEXT:
-- Follow [README.md](../../../README.md); see the
-  [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
+- Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Keep this doc's front matter accurate and the slug unique within `docs/prompts/`.
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Ensure any code samples compile with `node` or `ts-node`.
 - Use `npm exec markdown-link-check docs/prompts/codex/upgrade.md` to verify links.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`
-  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
+- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 
 REQUEST:
 1. Keep this doc accurate and link-check.
 2. Ensure examples and references are up to date; confirm referenced files exist.
 3. Ensure any code samples compile with `node` or `ts-node`.
-4. Run `npm run lint`, `npm run test:ci`, and
-   `npm exec markdown-link-check docs/prompts/codex/upgrade.md`; fix any failures.
+4. Run `npm run lint`, `npm run test:ci`, and `npm exec markdown-link-check docs/prompts/codex/upgrade.md`; fix any failures.
 
 OUTPUT:
 A pull request that updates this doc with passing checks.


### PR DESCRIPTION
what: embed context and checklists into codex prompt code blocks
why: keep instructions self-contained per prompt doc guidelines
how to test: not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68ca4c8cf724832f9fbed8bdac85880a