### PR TITLE
Add lifecycle count coverage for unknown statuses

### DIFF
--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -91,6 +91,21 @@ test('returns zero counts when lifecycle file is missing', async () => {
   expect(counts).toEqual(expectedCounts());
 });
 
+test('ignores unknown statuses when summarizing lifecycle data', async () => {
+  await fs.mkdir(tmp, { recursive: true });
+  const file = path.join(tmp, 'applications.json');
+  const payload = {
+    'job-known': 'no_response',
+    'job-unknown': 'coffee_chat',
+    'job-withdrawn': 'withdrawn',
+  };
+  await fs.writeFile(file, JSON.stringify(payload, null, 2));
+  const counts = await getLifecycleCounts();
+  expect(counts).toEqual(
+    expectedCounts({ no_response: 1, withdrawn: 1 })
+  );
+});
+
 test('rejects unknown application status', async () => {
   await expect(recordApplication('abc', 'maybe')).rejects.toThrow(
     /unknown status: maybe/,


### PR DESCRIPTION
what: add coverage ensuring lifecycle counts skip unknown statuses
why: guard against regressions from unexpected lifecycle data
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ca4c3754d4832f853cc8a25781d4ef