### PR TITLE
✅ : – add translator fallback coverage

### DIFF
--- a/test/i18n.test.js
+++ b/test/i18n.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+afterEach(() => {
+  vi.resetModules();
+  vi.clearAllMocks();
+  try {
+    vi.doUnmock('../src/locales/es.js');
+  } catch {
+    // ignore when module was not mocked
+  }
+});
+
+describe('t', () => {
+  it('returns default locale translations when locale omitted', async () => {
+    vi.resetModules();
+    const { t, DEFAULT_LOCALE } = await import('../src/i18n.js');
+    expect(DEFAULT_LOCALE).toBe('en');
+    expect(t('company')).toBe('Company');
+  });
+
+  it('returns translations for supported locales', async () => {
+    vi.resetModules();
+    const { t } = await import('../src/i18n.js');
+    expect(t('company', 'es')).toBe('Empresa');
+  });
+
+  it('falls back to default locale when locale missing', async () => {
+    vi.resetModules();
+    const { t } = await import('../src/i18n.js');
+    expect(t('company', 'fr')).toBe('Company');
+  });
+
+  it('falls back to default translation when key missing in locale', async () => {
+    vi.resetModules();
+    vi.doMock('../src/locales/es.js', () => ({
+      default: {
+        summary: 'Resumen',
+      },
+    }));
+    const { t } = await import('../src/i18n.js');
+    expect(t('company', 'es')).toBe('Company');
+  });
+
+  it('returns key when translation missing in all locales', async () => {
+    vi.resetModules();
+    const { t } = await import('../src/i18n.js');
+    expect(t('nonexistent_key')).toBe('nonexistent_key');
+  });
+});


### PR DESCRIPTION
what: add unit tests for translator fallback logic
why: ensure locale fallback behavior stays stable
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ca4c3754d4832f853cc8a25781d4ef