### PR TITLE
🎨 : – silence unused formatter arg

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -7,7 +7,7 @@ const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
 /** Default timeout for fetchTextFromUrl in milliseconds. */
 export const DEFAULT_TIMEOUT_MS = 10000;
 
-function formatImageAlt(elem, walk, builder) {
+function formatImageAlt(elem, _walk, builder) {
   const { alt, ['aria-label']: ariaLabel, ['aria-hidden']: ariaHidden, role } =
     elem.attribs || {};
   const hidden =


### PR DESCRIPTION
what: prefix html-to-text formatter's unused walk parameter with _
why: align with lint expectations for unused callback arguments
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ca4c2a28b4832f92212475c700045a