### PR TITLE
Refine fetch timeout defaults

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -67,20 +67,21 @@ export function extractTextFromHtml(html) {
  *
  * @param {string} url
  * @param {{ timeoutMs?: number, headers?: Record<string, string>, maxBytes?: number }} [opts]
- *   Invalid timeout values fall back to 10000ms.
+ *   Invalid timeout values fall back to DEFAULT_TIMEOUT_MS.
  * @returns {Promise<string>}
  */
 export async function fetchTextFromUrl(
   url,
-  { timeoutMs = 10000, headers, maxBytes = 1024 * 1024 } = {}
+  { timeoutMs = DEFAULT_TIMEOUT_MS, headers, maxBytes = 1024 * 1024 } = {}
 ) {
   const { protocol } = new URL(url);
   if (!ALLOWED_PROTOCOLS.has(protocol)) {
     throw new Error(`Unsupported protocol: ${protocol}`);
   }
 
-  // Normalize timeout: fallback to 10000ms if invalid
-  const ms = Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 10000;
+  // Normalize timeout: fallback to DEFAULT_TIMEOUT_MS if invalid
+  const ms =
+    Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_TIMEOUT_MS;
 
   const controller = new AbortController();
   const timer = setTimeout(


### PR DESCRIPTION
## Summary
- reuse DEFAULT_TIMEOUT_MS constant for fetch timeout defaults
- document the fallback using the shared constant

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ca4c2a28b4832f92212475c700045a