### PR TITLE
🛡️ : – block SSRF in fetchTextFromUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ ignoring `aria-hidden` images or those with `role="presentation"`/`"none"`), and
 collapses whitespace to single spaces. Pass `timeoutMs` (milliseconds) to
 override the 10s default, and `headers` to send custom HTTP headers. Responses
 over 1 MB are rejected; override with `maxBytes` to adjust. Only `http` and
-`https` URLs are supported; other protocols throw an error.
+`https` URLs are supported; other protocols throw an error. Requests to
+localhost, link-local, or other private network addresses are blocked to avoid
+server-side request forgery (SSRF).
 
 Normalize existing HTML without fetching and log the result:
 

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,8 +1,101 @@
 import fetch from 'node-fetch';
+import { lookup as dnsLookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
 import { htmlToText } from 'html-to-text';
 
 /** Allowed URL protocols for fetchTextFromUrl. */
 const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+const BLOCKED_HOSTNAMES = new Set([
+  'localhost',
+  'localhost.localdomain',
+  'ip6-localhost',
+  'ip6-loopback',
+]);
+
+function ipv4ToInt(ip) {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return -1;
+  let value = 0;
+  for (const part of parts) {
+    const octet = Number(part);
+    if (!Number.isInteger(octet) || octet < 0 || octet > 255) return -1;
+    value = (value << 8) + octet;
+  }
+  return value;
+}
+
+const IPV4_BLOCKS = [
+  ['0.0.0.0', '0.255.255.255'],
+  ['10.0.0.0', '10.255.255.255'],
+  ['100.64.0.0', '100.127.255.255'],
+  ['127.0.0.0', '127.255.255.255'],
+  ['169.254.0.0', '169.254.255.255'],
+  ['172.16.0.0', '172.31.255.255'],
+  ['192.0.0.0', '192.0.0.255'],
+  ['192.0.2.0', '192.0.2.255'],
+  ['192.168.0.0', '192.168.255.255'],
+  ['198.18.0.0', '198.19.255.255'],
+  ['198.51.100.0', '198.51.100.255'],
+  ['203.0.113.0', '203.0.113.255'],
+  ['224.0.0.0', '255.255.255.255'],
+].map(([start, end]) => ({ start: ipv4ToInt(start), end: ipv4ToInt(end) }));
+
+function isPrivateIPv4(address) {
+  const value = ipv4ToInt(address);
+  if (value === -1) return false;
+  return IPV4_BLOCKS.some(({ start, end }) => value >= start && value <= end);
+}
+
+function isPrivateIPv6(address) {
+  const lower = address.toLowerCase();
+  if (lower === '::1' || lower === '::') return true;
+  if (lower.startsWith('fe80:') || lower.startsWith('fe80::')) return true;
+  if (lower.startsWith('fc') || lower.startsWith('fd')) return true;
+  if (lower.startsWith('ff')) return true;
+  if (lower.startsWith('2001:db8')) return true;
+  if (lower.startsWith('::ffff:')) {
+    const mapped = lower.slice(7);
+    if (mapped.includes(':')) return true;
+    return isPrivateIPv4(mapped);
+  }
+  return false;
+}
+
+function isPrivateAddress(address, family) {
+  if (family === 4) return isPrivateIPv4(address);
+  if (family === 6) return isPrivateIPv6(address);
+  const inferred = isIP(address);
+  if (inferred === 4) return isPrivateIPv4(address);
+  if (inferred === 6) return isPrivateIPv6(address);
+  return false;
+}
+
+function isBlockedHostname(hostname) {
+  const lower = hostname.toLowerCase();
+  if (BLOCKED_HOSTNAMES.has(lower)) return true;
+  if (lower.endsWith('.localhost') || lower.endsWith('.local')) return true;
+  if (lower === '::1') return true;
+  return false;
+}
+
+async function assertSafeDestination(urlObj) {
+  const hostname = urlObj.hostname;
+  if (!hostname) return;
+  if (isBlockedHostname(hostname)) {
+    throw new Error(`Refusing to fetch private network URL: ${hostname}`);
+  }
+  const directType = isIP(hostname);
+  if (directType && isPrivateAddress(hostname, directType)) {
+    throw new Error(`Refusing to fetch private network URL: ${hostname}`);
+  }
+  if (directType) return;
+  const addresses = await dnsLookup(hostname, { all: true });
+  for (const { address, family } of addresses) {
+    if (isPrivateAddress(address, family)) {
+      throw new Error(`Refusing to fetch private network URL: ${hostname}`);
+    }
+  }
+}
 
 /** Default timeout for fetchTextFromUrl in milliseconds. */
 export const DEFAULT_TIMEOUT_MS = 10000;
@@ -74,10 +167,11 @@ export async function fetchTextFromUrl(
   url,
   { timeoutMs = 10000, headers, maxBytes = 1024 * 1024 } = {}
 ) {
-  const { protocol } = new URL(url);
-  if (!ALLOWED_PROTOCOLS.has(protocol)) {
-    throw new Error(`Unsupported protocol: ${protocol}`);
+  const target = new URL(url);
+  if (!ALLOWED_PROTOCOLS.has(target.protocol)) {
+    throw new Error(`Unsupported protocol: ${target.protocol}`);
   }
+  await assertSafeDestination(target);
 
   // Normalize timeout: fallback to 10000ms if invalid
   const ms = Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 10000;


### PR DESCRIPTION
what: forbid fetchTextFromUrl from following localhost/private network targets and document the restriction; add tests that cover the SSRF guard and update timeout tests for fake timers.
why: mitigate server-side request forgery when untrusted URLs are ingested.
how to test: npm run lint && npm run test:ci && npm audit

------
https://chatgpt.com/codex/tasks/task_e_68ca4c1983e4832f99c76bfeb6a6118f