### PR TITLE
🔒 : – escape markdown injection in markdown exporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ run();
 `loadResume` supports `.pdf`, `.md`, `.markdown`, and `.mdx` files; other
 extensions are read as plain text.
 
-Format parsed results as Markdown:
+Format parsed results as Markdown. The exporters escape Markdown control characters so job
+content cannot inject arbitrary links or formatting when rendered downstream:
 
 ```js
 import { toMarkdownSummary } from './src/exporters.js';

--- a/src/exporters.js
+++ b/src/exporters.js
@@ -4,6 +4,51 @@ export function toJson(data) {
   return JSON.stringify(data, null, 2);
 }
 
+const MARKDOWN_ESCAPE_CHARS = [
+  '\\',
+  '`',
+  '*',
+  '_',
+  '{',
+  '}',
+  '[',
+  ']',
+  '(',
+  ')',
+  '<',
+  '>',
+  '#',
+  '+',
+  '-',
+  '!',
+  '|',
+];
+
+const CHAR_CLASS_ESCAPE_RE = /[\\\-\]]/g;
+
+function escapeForCharClass(ch) {
+  if (ch === '[') return '\\[';
+  return ch.replace(CHAR_CLASS_ESCAPE_RE, '\\$&');
+}
+
+const MARKDOWN_ESCAPE_RE = new RegExp(
+  `[${MARKDOWN_ESCAPE_CHARS.map(escapeForCharClass).join('')}]`,
+  'g'
+);
+
+function escapeMarkdown(value) {
+  if (value === null || value === undefined) return '';
+  return String(value).replace(MARKDOWN_ESCAPE_RE, '\\$&');
+}
+
+function escapeMarkdownMultiline(value) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .split('\n')
+    .map(escapeMarkdown)
+    .join('\n');
+}
+
 /**
  * Append a Markdown header and bullet list if `items` exist.
  * @param {string[]} lines Accumulator array of lines.
@@ -16,7 +61,10 @@ function appendListSection(lines, header, items, { leadingNewline = false } = {}
   if (!items || !items.length) return;
   const prefix = leadingNewline ? '\n' : '';
   lines.push(`${prefix}## ${header}`);
-  for (const item of items) lines.push(`- ${item}`);
+  for (const item of items) {
+    const safeItem = escapeMarkdownMultiline(item);
+    if (safeItem) lines.push(`- ${safeItem}`);
+  }
 }
 
 /**
@@ -40,13 +88,19 @@ export function toMarkdownSummary({
   locale = DEFAULT_LOCALE,
 }) {
   const lines = [];
-  if (title) lines.push(`# ${title}`);
-  if (company) lines.push(`**${t('company', locale)}**: ${company}`);
-  if (location) lines.push(`**${t('location', locale)}**: ${location}`);
-  if (url) lines.push(`**${t('url', locale)}**: ${url}`);
+  const safeTitle = escapeMarkdown(title);
+  const safeCompany = escapeMarkdown(company);
+  const safeLocation = escapeMarkdown(location);
+  const safeUrl = escapeMarkdown(url);
 
-  if (summary) {
-    lines.push('', `## ${t('summary', locale)}`, '', summary);
+  if (safeTitle) lines.push(`# ${safeTitle}`);
+  if (safeCompany) lines.push(`**${t('company', locale)}**: ${safeCompany}`);
+  if (safeLocation) lines.push(`**${t('location', locale)}**: ${safeLocation}`);
+  if (safeUrl) lines.push(`**${t('url', locale)}**: ${safeUrl}`);
+
+  const safeSummary = escapeMarkdownMultiline(summary);
+  if (safeSummary) {
+    lines.push('', `## ${t('summary', locale)}`, '', safeSummary);
     if (!requirements || !requirements.length) lines.push('');
   }
 
@@ -81,10 +135,15 @@ export function toMarkdownMatch({
   locale = DEFAULT_LOCALE,
 }) {
   const lines = [];
-  if (title) lines.push(`# ${title}`);
-  if (company) lines.push(`**${t('company', locale)}**: ${company}`);
-  if (location) lines.push(`**${t('location', locale)}**: ${location}`);
-  if (url) lines.push(`**${t('url', locale)}**: ${url}`);
+  const safeTitle = escapeMarkdown(title);
+  const safeCompany = escapeMarkdown(company);
+  const safeLocation = escapeMarkdown(location);
+  const safeUrl = escapeMarkdown(url);
+
+  if (safeTitle) lines.push(`# ${safeTitle}`);
+  if (safeCompany) lines.push(`**${t('company', locale)}**: ${safeCompany}`);
+  if (safeLocation) lines.push(`**${t('location', locale)}**: ${safeLocation}`);
+  if (safeUrl) lines.push(`**${t('url', locale)}**: ${safeUrl}`);
   if (typeof score === 'number')
     lines.push(`**${t('fitScore', locale)}**: ${score}%`);
   appendListSection(lines, t('matched', locale), matched, { leadingNewline: true });

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -103,6 +103,43 @@ describe('exporters', () => {
     expect(output).toBe('# Dev\n**Fit Score**: 0%');
   });
 
+  it('escapes markdown control characters to prevent injection in summaries', () => {
+    const output = toMarkdownSummary({
+      title: '[Lead](javascript:alert(1))',
+      company: 'ACME [Corp](javascript:alert(2))',
+      location: 'Remote > Anywhere',
+      summary: 'Build [danger](javascript:alert(3))\n# Bonus',
+      requirements: ['[Exploit](javascript:alert(4))', 'Hands-on with CI/CD'],
+    });
+    expect(output).toBe(
+      '# \\[Lead\\]\\(javascript:alert\\(1\\)\\)\n' +
+        '**Company**: ACME \\[Corp\\]\\(javascript:alert\\(2\\)\\)\n' +
+        '**Location**: Remote \\> Anywhere\n\n' +
+        '## Summary\n\n' +
+        'Build \\[danger\\]\\(javascript:alert\\(3\\)\\)\n\\# Bonus\n\n' +
+        '## Requirements\n' +
+        '- \\[Exploit\\]\\(javascript:alert\\(4\\)\\)\n' +
+        '- Hands\\-on with CI/CD'
+    );
+  });
+
+  it('escapes markdown control characters to prevent injection in match reports', () => {
+    const output = toMarkdownMatch({
+      title: 'Engineer [Sr](javascript:alert(1))',
+      url: '[https://evil](javascript:alert(2))',
+      matched: ['[JS](javascript:alert(3))'],
+      missing: ['#Urgent'],
+      score: 42,
+    });
+    expect(output).toBe(
+      '# Engineer \\[Sr\\]\\(javascript:alert\\(1\\)\\)\n' +
+        '**URL**: \\[https://evil\\]\\(javascript:alert\\(2\\)\\)\n' +
+        '**Fit Score**: 42%\n\n' +
+        '## Matched\n- \\[JS\\]\\(javascript:alert\\(3\\)\\)\n\n' +
+        '## Missing\n- \\#Urgent'
+    );
+  });
+
   it('supports spanish locale in markdown summaries', () => {
     const output = toMarkdownSummary({
       title: 'Dev',


### PR DESCRIPTION
what: escape markdown control characters before rendering CLI markdown.
why: malicious job content could inject links/formatting into downstream viewers.
how to test: npm run lint && npm run test:ci && npm audit

------
https://chatgpt.com/codex/tasks/task_e_68ca4c1983e4832f99c76bfeb6a6118f