### PR TITLE
docs: refresh Codex refactor prompt guidance

### DIFF
--- a/docs/prompts/codex/refactor.md
+++ b/docs/prompts/codex/refactor.md
@@ -16,16 +16,20 @@ Refactor code for clarity or maintainability.
 CONTEXT:
 - Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
+- Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
-- Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py`.
+- Scan staged changes for secrets with
+  `git diff --cached | ./scripts/scan-secrets.py`
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Confirm referenced files exist; update
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
 - Include before/after benchmarks if performance might change.
+- The project uses [Vitest](https://vitest.dev) for unit tests in [test/](../../../test).
 
 REQUEST:
-1. Add tests or ensure existing tests cover the refactor.
+1. Strengthen test coverage for the refactor (add or update tests as needed).
 2. Restructure code without altering public behavior.
-3. Update related docs or comments.
+3. Update related docs or comments if they describe the refactored area.
 4. Run the commands above and address any failures.
 
 OUTPUT:
@@ -53,9 +57,11 @@ CONTEXT:
 - Install dependencies with `npm ci` if needed.
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with
-  `git diff --cached | ./scripts/scan-secrets.py`.
+  `git diff --cached | ./scripts/scan-secrets.py`
+  (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Confirm referenced files exist; update
   [prompt-docs-summary.md](../../prompt-docs-summary.md) when adding prompt docs.
+- The project uses [Vitest](https://vitest.dev) for unit tests in [test/](../../../test).
 
 REQUEST:
 1. Revise `docs/prompts/codex/refactor.md` so this prompt stays accurate and actionable.


### PR DESCRIPTION
## Summary
- clarify refactor prompt context with npm ci, Vitest, and secret-scan references
- tighten request language to emphasize maintaining behavior and updating related docs
- align upgrade instructions with shared tooling references

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ca4c13c104832f959f742274deba75