### PR TITLE
🐛 : – Avoid splitting dotted abbreviations in summarize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const closers = new Set(['"', "'", ')', ']', '}']);
 const openers = new Set(['(', '[', '{']);
 const isDigit = (c) => c >= '0' && c <= '9';
 const isAlpha = (c) => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+const isUpperAlpha = (c) => c >= 'A' && c <= 'Z';
 const abbreviations = new Set(['mr', 'mrs', 'ms', 'dr', 'prof', 'sr', 'jr', 'st', 'vs']);
 
 export function summarize(text, count = 1) {
@@ -57,6 +58,16 @@ export function summarize(text, count = 1) {
       // Skip decimals like 3.14
       if (ch === '.' && i > 0 && isDigit(text[i - 1]) && i + 1 < len && isDigit(text[i + 1])) {
         continue;
+      }
+
+      if (ch === '.') {
+        const next = text[i + 1];
+        if (next && isUpperAlpha(next) && i + 2 < len && text[i + 2] === '.') {
+          continue;
+        }
+        if (i >= 2 && text[i - 2] === '.' && isUpperAlpha(text[i - 1])) {
+          continue;
+        }
       }
 
       if (ch === '.') {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -101,4 +101,9 @@ describe('summarize', () => {
     const text = 'Alert (check logs.';
     expect(summarize(text)).toBe(text);
   });
+
+  it('does not split within dotted abbreviations', () => {
+    const text = 'The U.S. economy is growing. Another sentence.';
+    expect(summarize(text)).toBe('The U.S. economy is growing.');
+  });
 });


### PR DESCRIPTION
what: prevent summarize from cutting dotted abbreviations
why: keep sentences like U.S. intact in summaries
how to test: npm run lint && npm run test:ci
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68ca4bac3294832fa0308496923fb608