### PR TITLE
✨ : Avoid filtering overhead in computeFitScore

### DIFF
--- a/src/scoring.js
+++ b/src/scoring.js
@@ -77,19 +77,25 @@ function hasOverlap(line, resumeSet) {
  * @returns {{ score: number, matched: string[], missing: string[] }}
  */
 export function computeFitScore(resumeText, requirements) {
-  const bullets = Array.isArray(requirements)
-    ? requirements.filter(r => typeof r === 'string' && r.trim())
-    : [];
-  if (!bullets.length) return { score: 0, matched: [], missing: [] };
+  if (!Array.isArray(requirements) || requirements.length === 0) {
+    return { score: 0, matched: [], missing: [] };
+  }
 
   const resumeSet = resumeTokens(resumeText);
   const matched = [];
   const missing = [];
+  let total = 0;
 
-  for (const bullet of bullets) {
-    (hasOverlap(bullet, resumeSet) ? matched : missing).push(bullet);
+  for (const entry of requirements) {
+    if (typeof entry !== 'string') continue;
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    total += 1;
+    (hasOverlap(trimmed, resumeSet) ? matched : missing).push(trimmed);
   }
 
-  const score = Math.round((matched.length / bullets.length) * 100);
+  if (total === 0) return { score: 0, matched: [], missing: [] };
+
+  const score = Math.round((matched.length / total) * 100);
   return { score, matched, missing };
 }

--- a/test/scoring.requirements.perf.test.js
+++ b/test/scoring.requirements.perf.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { computeFitScore } from '../src/scoring.js';
+
+describe('computeFitScore requirement filtering performance', () => {
+  it('avoids repeated array filtering for mixed inputs', () => {
+    const skills = Array.from({ length: 5000 }, (_, i) => `Skill ${i}`);
+    const mixed = skills.concat(Array.from({ length: 5000 }, () => null));
+    const iterations = 200;
+
+    const originalFilter = Array.prototype.filter;
+    let filterCalls = 0;
+    Array.prototype.filter = function patchedFilter(...args) {
+      filterCalls += 1;
+      return originalFilter.apply(this, args);
+    };
+
+    try {
+      for (let i = 0; i < iterations; i += 1) {
+        computeFitScore('Skill resume', mixed);
+      }
+    } finally {
+      Array.prototype.filter = originalFilter;
+    }
+
+    expect(filterCalls).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- stream requirement validation inside `computeFitScore` to avoid repeated array filtering
- normalize entries while computing match/missing lists and early exit when nothing usable remains
- add a perf regression test that guards against accidental `Array.prototype.filter` usage for mixed requirement arrays

## Testing
- npm run lint
- npm run test:ci
- npx markdown-link-check docs/prompts/codex/performance.md

------
https://chatgpt.com/codex/tasks/task_e_68ca4c0a054c832fa3cfbd7aefdf4c1d