### PR TITLE
🐛 : – ensure toJson serializes undefined

### DIFF
--- a/src/exporters.js
+++ b/src/exporters.js
@@ -1,7 +1,7 @@
 import { t, DEFAULT_LOCALE } from './i18n.js';
 
 export function toJson(data) {
-  return JSON.stringify(data, null, 2);
+  return JSON.stringify(data ?? null, null, 2);
 }
 
 /**

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -7,6 +7,11 @@ describe('exporters', () => {
     expect(result).toBe('{\n  "a": 1\n}');
   });
 
+  it('returns null string for undefined input', () => {
+    const result = toJson(undefined);
+    expect(result).toBe('null');
+  });
+
   it('formats markdown summaries', () => {
     const output = toMarkdownSummary({
       title: 'Dev',


### PR DESCRIPTION
what: ensure toJson converts undefined inputs to null
why: CLI should emit valid JSON instead of "undefined"
how to test: npm run lint && npm run test:ci
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68ca4b168274832fa05f01b845b07fd4