### PR TITLE
✅ : – Align fetch timeout defaults

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -67,20 +67,21 @@ export function extractTextFromHtml(html) {
  *
  * @param {string} url
  * @param {{ timeoutMs?: number, headers?: Record<string, string>, maxBytes?: number }} [opts]
- *   Invalid timeout values fall back to 10000ms.
+ *   Invalid timeout values fall back to DEFAULT_TIMEOUT_MS.
  * @returns {Promise<string>}
  */
 export async function fetchTextFromUrl(
   url,
-  { timeoutMs = 10000, headers, maxBytes = 1024 * 1024 } = {}
+  { timeoutMs = DEFAULT_TIMEOUT_MS, headers, maxBytes = 1024 * 1024 } = {}
 ) {
   const { protocol } = new URL(url);
   if (!ALLOWED_PROTOCOLS.has(protocol)) {
     throw new Error(`Unsupported protocol: ${protocol}`);
   }
 
-  // Normalize timeout: fallback to 10000ms if invalid
-  const ms = Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 10000;
+  // Normalize timeout: fallback to DEFAULT_TIMEOUT_MS if invalid
+  const ms =
+    Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : DEFAULT_TIMEOUT_MS;
 
   const controller = new AbortController();
   const timer = setTimeout(

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest';
 vi.mock('node-fetch', () => ({ default: vi.fn() }));
 
 import fetch from 'node-fetch';
-import { extractTextFromHtml, fetchTextFromUrl } from '../src/fetch.js';
+import { DEFAULT_TIMEOUT_MS, extractTextFromHtml, fetchTextFromUrl } from '../src/fetch.js';
 
 describe('extractTextFromHtml', () => {
   it('collapses whitespace and skips non-content tags', () => {
@@ -247,8 +247,8 @@ describe('fetchTextFromUrl', () => {
       })
     );
     const promise = fetchTextFromUrl('http://example.com', { timeoutMs: Number('foo') });
-    vi.advanceTimersByTime(10000);
-    await expect(promise).rejects.toThrow('Timeout after 10000ms');
+    vi.advanceTimersByTime(DEFAULT_TIMEOUT_MS);
+    await expect(promise).rejects.toThrow(`Timeout after ${DEFAULT_TIMEOUT_MS}ms`);
     vi.useRealTimers();
   });
 


### PR DESCRIPTION
what: replace fetch timeout magic numbers with DEFAULT_TIMEOUT_MS
why: keep fallback behavior single-sourced and simplify tests
how to test: npm run lint && npm run test:ci

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68ca4b168274832fa05f01b845b07fd4