### PR TITLE
🔒 : block private network SSRF

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ ignoring `aria-hidden` images or those with `role="presentation"`/`"none"`), and
 collapses whitespace to single spaces. Pass `timeoutMs` (milliseconds) to
 override the 10s default, and `headers` to send custom HTTP headers. Responses
 over 1 MB are rejected; override with `maxBytes` to adjust. Only `http` and
-`https` URLs are supported; other protocols throw an error.
+`https` URLs are supported; other protocols throw an error. Requests to
+loopback, link-local, carrier-grade NAT, or other private network addresses
+are blocked to prevent server-side request forgery (SSRF).
 
 Normalize existing HTML without fetching and log the result:
 

--- a/scripts/flash_and_report.py
+++ b/scripts/flash_and_report.py
@@ -1,0 +1,34 @@
+"""Utilities for flashing removable media and reporting device metadata."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+
+def _describe_device(info: dict[str, Any], devices: Iterable[Any], path: str) -> dict[str, Any]:
+    """Populate *info* with details about the device mounted at *path*.
+
+    The returned metadata mirrors the attributes exposed by
+    ``flash_pi_media.discover_devices``.  Downstream code reconstructs a
+    ``flash_pi_media.Device`` instance from this dictionary before invoking the
+    platform-specific auto-eject helpers.  Windows relies on ``system_id`` to
+    offline the disk, so we ensure that value is always present.
+    """
+
+    for device in devices:
+        if getattr(device, "path", None) == path:
+            info.update(
+                {
+                    "description": getattr(device, "description", None),
+                    "is_removable": getattr(device, "is_removable", None),
+                    "human_size": getattr(device, "human_size", None),
+                    "bus": getattr(device, "bus", None),
+                    "mountpoints": list(getattr(device, "mountpoints", None) or []),
+                    "system_id": getattr(device, "system_id", None),
+                }
+            )
+            break
+    return info
+
+
+__all__ = ["_describe_device"]

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,8 +1,61 @@
+import { isIP } from 'node:net';
 import fetch from 'node-fetch';
 import { htmlToText } from 'html-to-text';
 
 /** Allowed URL protocols for fetchTextFromUrl. */
 const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost', 'localhost.']);
+
+function isPrivateIPv4(octets) {
+  const [a, b] = octets;
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 0) return true;
+  if (a === 169 && b === 254) return true; // link-local
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true; // carrier-grade NAT
+  if (a === 198 && (b === 18 || b === 19)) return true; // benchmarking
+  if (a >= 224) return true; // multicast/reserved
+  return false;
+}
+
+function isForbiddenHostname(hostname) {
+  if (!hostname) return true;
+  const lower = hostname.toLowerCase();
+  const bracketless = hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname;
+  const normalizedLower = lower.startsWith('[') && lower.endsWith(']')
+    ? lower.slice(1, -1)
+    : lower;
+  if (LOOPBACK_HOSTNAMES.has(lower)) return true;
+  if (lower.endsWith('.localhost')) return true;
+
+  const type = isIP(bracketless);
+  if (type === 4) {
+    const octets = bracketless.split('.').map(Number);
+    return isPrivateIPv4(octets);
+  }
+
+  if (type === 6) {
+    const normalized = normalizedLower.split('%')[0];
+    if (normalized === '::1') return true;
+    if (normalized.startsWith('fc') || normalized.startsWith('fd')) return true; // unique local
+    if (normalized.startsWith('fe80')) return true; // link-local
+    if (normalized === '::' || normalized === '::ffff:0:0') return true;
+    if (normalized.startsWith('::ffff:')) {
+      const mapped = normalized.slice('::ffff:'.length);
+      if (isIP(mapped) === 4) {
+        const octets = mapped.split('.').map(Number);
+        if (isPrivateIPv4(octets)) return true;
+      }
+    }
+  }
+
+  return false;
+}
 
 /** Default timeout for fetchTextFromUrl in milliseconds. */
 export const DEFAULT_TIMEOUT_MS = 10000;
@@ -74,9 +127,16 @@ export async function fetchTextFromUrl(
   url,
   { timeoutMs = 10000, headers, maxBytes = 1024 * 1024 } = {}
 ) {
-  const { protocol } = new URL(url);
+  const targetUrl = new URL(url);
+  const { protocol, hostname } = targetUrl;
   if (!ALLOWED_PROTOCOLS.has(protocol)) {
     throw new Error(`Unsupported protocol: ${protocol}`);
+  }
+  const displayHostname = hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname;
+  if (isForbiddenHostname(hostname)) {
+    throw new Error(`Refusing to fetch private address: ${displayHostname}`);
   }
 
   // Normalize timeout: fallback to 10000ms if invalid

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -284,6 +284,45 @@ describe('fetchTextFromUrl', () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it('rejects localhost hostnames', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('secret'),
+    });
+    await expect(fetchTextFromUrl('http://localhost/admin'))
+      .rejects.toThrow('Refusing to fetch private address: localhost');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects loopback IPv4 addresses', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('secret'),
+    });
+    await expect(fetchTextFromUrl('http://127.0.0.1/hidden'))
+      .rejects.toThrow('Refusing to fetch private address: 127.0.0.1');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects IPv6 loopback addresses', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('secret'),
+    });
+    await expect(fetchTextFromUrl('http://[::1]/hidden'))
+      .rejects.toThrow('Refusing to fetch private address: ::1');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it('allows uppercase HTTP protocol', async () => {
     fetch.mockResolvedValue({
       ok: true,


### PR DESCRIPTION
what: deny fetchTextFromUrl from hitting private/loopback hosts; capture flash device system_id for Windows auto-eject
why: prevent SSRF when CLI fetches adversarial URLs; ensure post-hash eject succeeds on Windows
how to test: npm run lint && npm run test:ci && npm audit
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68ca4c1983e4832f99c76bfeb6a6118f