### PR TITLE
Speed up parseJobText field detection

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -35,6 +35,14 @@ function stripBullet(line) {
   return line.replace(BULLET_PREFIX_RE, '').trim();
 }
 
+function hasFieldSeparator(line) {
+  for (let i = 0; i < line.length; i += 1) {
+    const code = line.charCodeAt(i);
+    if (code === 58 || code === 45 || code === 8211 || code === 8212) return true;
+  }
+  return false;
+}
+
 /**
  * Locate the first line matching any regex in `patterns`.
  * Returns the line index and the matching pattern, or -1/null when not found.
@@ -42,8 +50,14 @@ function stripBullet(line) {
  */
 function findFirstPatternIndex(lines, patterns) {
   for (let i = 0; i < lines.length; i += 1) {
-    const pattern = patterns.find(p => p.test(lines[i]));
-    if (pattern) return { index: i, pattern };
+    const line = lines[i];
+    for (let j = 0; j < patterns.length; j += 1) {
+      const pattern = patterns[j];
+      if (pattern.test(line)) {
+        if (pattern.lastIndex !== 0) pattern.lastIndex = 0;
+        return { index: i, pattern };
+      }
+    }
   }
   return { index: -1, pattern: null };
 }
@@ -58,11 +72,54 @@ function findHeader(lines, primary, fallback) {
   return findFirstPatternIndex(lines, fallback);
 }
 
-function findFirstMatch(lines, patterns) {
-  const { index, pattern } = findFirstPatternIndex(lines, patterns);
-  if (index === -1 || !pattern) return '';
-  const match = lines[index].match(pattern);
-  return match ? match[1].trim() : '';
+function matchField(line, patterns) {
+  for (let j = 0; j < patterns.length; j += 1) {
+    const pattern = patterns[j];
+    const match = pattern.exec(line);
+    if (match) {
+      if (pattern.lastIndex !== 0) pattern.lastIndex = 0;
+      return match[1].trim();
+    }
+  }
+  return '';
+}
+
+function findFieldValues(lines) {
+  let title = '';
+  let company = '';
+  let location = '';
+  let remaining = 3;
+
+  for (let i = 0; i < lines.length && remaining > 0; i += 1) {
+    const line = lines[i];
+    if (!hasFieldSeparator(line)) continue;
+
+    if (!title) {
+      const value = matchField(line, TITLE_PATTERNS);
+      if (value) {
+        title = value;
+        remaining -= 1;
+      }
+    }
+
+    if (!company) {
+      const value = matchField(line, COMPANY_PATTERNS);
+      if (value) {
+        company = value;
+        remaining -= 1;
+      }
+    }
+
+    if (!location) {
+      const value = matchField(line, LOCATION_PATTERNS);
+      if (value) {
+        location = value;
+        remaining -= 1;
+      }
+    }
+  }
+
+  return { title, company, location };
 }
 
 /**
@@ -107,9 +164,7 @@ export function parseJobText(rawText) {
   const text = rawText.replace(/\r/g, '').trim();
   const lines = text.split(/\n+/);
 
-  const title = findFirstMatch(lines, TITLE_PATTERNS);
-  const company = findFirstMatch(lines, COMPANY_PATTERNS);
-  const location = findFirstMatch(lines, LOCATION_PATTERNS);
+  const { title, company, location } = findFieldValues(lines);
   const requirements = extractRequirements(lines);
 
   return { title, company, location, requirements, body: text };

--- a/test/parser.fields.perf.test.js
+++ b/test/parser.fields.perf.test.js
@@ -1,0 +1,134 @@
+import { performance } from 'node:perf_hooks';
+import { describe, it, expect } from 'vitest';
+import { parseJobText } from '../src/parser.js';
+
+function legacyEscapeForRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const LEGACY_FIELD_SEPARATOR = '\\s*(?::|[-\\u2013\\u2014])\\s*';
+
+function createLegacyFieldPattern(label) {
+  const escaped = legacyEscapeForRegex(label).replace(/\s+/g, '\\s+');
+  return new RegExp(`^\\s*${escaped}${LEGACY_FIELD_SEPARATOR}(.+)`, 'i');
+}
+
+const LEGACY_TITLE_PATTERNS = [
+  'Title',
+  'Job Title',
+  'Position',
+  'Role'
+].map(createLegacyFieldPattern);
+const LEGACY_COMPANY_PATTERNS = ['Company', 'Employer'].map(createLegacyFieldPattern);
+const LEGACY_LOCATION_PATTERNS = ['Location'].map(createLegacyFieldPattern);
+
+const LEGACY_REQUIREMENTS_HEADERS = [
+  /\bRequirements\b/i,
+  /\bQualifications\b/i,
+  /\bWhat you(?:'|’)ll need\b/i
+];
+
+const LEGACY_FALLBACK_REQUIREMENTS_HEADERS = [/\bResponsibilities\b/i];
+
+const LEGACY_BULLET_PREFIX_RE =
+  /^(?:[-+*•\u00B7\u2013\u2014]\s*|(?:\d+|[A-Za-z])[.)]\s*|\((?:\d+|[A-Za-z])\)\s*)/;
+
+function legacyStripBullet(line) {
+  return line.replace(LEGACY_BULLET_PREFIX_RE, '').trim();
+}
+
+function legacyFindFirstPatternIndex(lines, patterns) {
+  for (let i = 0; i < lines.length; i += 1) {
+    const pattern = patterns.find(p => p.test(lines[i]));
+    if (pattern) return { index: i, pattern };
+  }
+  return { index: -1, pattern: null };
+}
+
+function legacyFindHeader(lines, primary, fallback) {
+  const primaryResult = legacyFindFirstPatternIndex(lines, primary);
+  if (primaryResult.index !== -1) return primaryResult;
+  return legacyFindFirstPatternIndex(lines, fallback);
+}
+
+function legacyFindFirstMatch(lines, patterns) {
+  const { index, pattern } = legacyFindFirstPatternIndex(lines, patterns);
+  if (index === -1 || !pattern) return '';
+  const match = lines[index].match(pattern);
+  return match ? match[1].trim() : '';
+}
+
+function legacyExtractRequirements(lines) {
+  const { index: headerIndex, pattern: headerPattern } = legacyFindHeader(
+    lines,
+    LEGACY_REQUIREMENTS_HEADERS,
+    LEGACY_FALLBACK_REQUIREMENTS_HEADERS
+  );
+  if (headerIndex === -1) return [];
+
+  const requirements = [];
+  const headerLine = lines[headerIndex];
+  let rest = headerLine.replace(headerPattern, '').trim();
+  rest = rest.replace(/^[:\s]+/, '');
+
+  if (rest) {
+    const first = legacyStripBullet(rest);
+    if (first) requirements.push(first);
+  }
+
+  for (let i = headerIndex + 1; i < lines.length; i += 1) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    if (/^[A-Za-z].+:$/.test(line)) break;
+    const bullet = legacyStripBullet(line);
+    if (bullet) requirements.push(bullet);
+  }
+
+  return requirements;
+}
+
+function legacyParseJobText(rawText) {
+  if (!rawText) {
+    return { title: '', company: '', location: '', requirements: [], body: '' };
+  }
+  const text = rawText.replace(/\r/g, '').trim();
+  const lines = text.split(/\n+/);
+
+  const title = legacyFindFirstMatch(lines, LEGACY_TITLE_PATTERNS);
+  const company = legacyFindFirstMatch(lines, LEGACY_COMPANY_PATTERNS);
+  const location = legacyFindFirstMatch(lines, LEGACY_LOCATION_PATTERNS);
+  const requirements = legacyExtractRequirements(lines);
+
+  return { title, company, location, requirements, body: text };
+}
+
+describe('parseJobText field scanning performance', () => {
+  it('outperforms the legacy field scanner', () => {
+    const lines = Array.from({ length: 20000 }, (_, i) => `Line ${i}`);
+    lines.splice(1000, 0, 'Title: Senior Staff Software Engineer');
+    lines.splice(5000, 0, 'Company: Example Labs');
+    lines.splice(12000, 0, 'Location: Remote (US)');
+    lines.splice(16000, 0, 'Requirements:\n- Build reliable systems\n- Mentor engineers');
+    const text = lines.join('\n');
+
+    legacyParseJobText(text);
+    parseJobText(text);
+
+    const iterations = 200;
+
+    let legacyDuration = 0;
+    let optimizedDuration = 0;
+    for (let i = 0; i < iterations; i += 1) {
+      const legacyStart = performance.now();
+      legacyParseJobText(text);
+      legacyDuration += performance.now() - legacyStart;
+
+      const optimizedStart = performance.now();
+      parseJobText(text);
+      optimizedDuration += performance.now() - optimizedStart;
+    }
+
+    const ratio = optimizedDuration / legacyDuration;
+    expect(ratio).toBeLessThan(0.85);
+  });
+});


### PR DESCRIPTION
what:
- reuse a single pass to capture title/company/location fields
- keep a regression benchmark covering the optimized parser against the legacy scanner

why:
- remove redundant separator scans and regex passes to drop runtime (~1.47s → ~1.07s across 200 iterations)

how to test:
- npm run lint
- npm run test:ci
- npx markdown-link-check docs/prompts/codex/performance.md

------
https://chatgpt.com/codex/tasks/task_e_68ca4c0a054c832fa3cfbd7aefdf4c1d