### PR TITLE
🔒 : – harden fetchTextFromUrl IPv6 filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ ignoring `aria-hidden` images or those with `role="presentation"`/`"none"`), and
 collapses whitespace to single spaces. Pass `timeoutMs` (milliseconds) to
 override the 10s default, and `headers` to send custom HTTP headers. Responses
 over 1 MB are rejected; override with `maxBytes` to adjust. Only `http` and
-`https` URLs are supported; other protocols throw an error.
+`https` URLs are supported; other protocols throw an error. Requests to
+loopback, link-local, carrier-grade NAT, or other private network addresses
+are blocked to prevent server-side request forgery (SSRF).
 
 Normalize existing HTML without fetching and log the result:
 

--- a/scripts/flash_and_report.py
+++ b/scripts/flash_and_report.py
@@ -1,0 +1,57 @@
+"""Helpers for flashing removable media and reporting device metadata.
+
+This module contains a small helper that mirrors the behaviour expected by the
+post-flash eject pipeline.  The tests exercise the helper directly, so keep the
+implementation focused and dependency-free.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+
+def _normalize_mountpoints(device: Any) -> list[str]:
+    """Return a deterministic list of mountpoints for *device*.
+
+    ``flash_pi_media`` exposes ``mountpoints`` as ``None`` when the device has
+    not been mounted.  The metadata returned by :func:`_describe_device`
+    normalises this to an empty list so downstream JSON serialisation remains
+    stable regardless of platform differences.
+    """
+
+    mountpoints = getattr(device, "mountpoints", None)
+    if not mountpoints:
+        return []
+    return list(mountpoints)
+
+
+def _describe_device(devices: Iterable[Any], path: str) -> dict[str, Any]:
+    """Return metadata for the device whose ``path`` matches *path*.
+
+    The return shape mirrors ``flash_pi_media.Device`` JSON serialisation so the
+    CLI can persist it for follow-up operations.  The ``system_id`` field is
+    critical on Windows where the eject helper requires it to offline the disk.
+    ``system_id`` is therefore copied verbatim from the matching device object
+    whenever it is exposed by ``flash_pi_media``.
+    """
+
+    info: dict[str, Any] = {"path": path, "system_id": None}
+    for device in devices:
+        if getattr(device, "path", None) != path:
+            continue
+
+        info.update(
+            {
+                "description": getattr(device, "description", None),
+                "is_removable": getattr(device, "is_removable", False),
+                "human_size": getattr(device, "human_size", None),
+                "bus": getattr(device, "bus", None),
+                "mountpoints": _normalize_mountpoints(device),
+                "system_id": getattr(device, "system_id", None),
+            }
+        )
+        break
+    return info
+
+
+__all__ = ["_describe_device"]

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,8 +1,121 @@
+import { isIP } from 'node:net';
 import fetch from 'node-fetch';
 import { htmlToText } from 'html-to-text';
 
 /** Allowed URL protocols for fetchTextFromUrl. */
 const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost', 'localhost.']);
+
+function parseIPv6(address) {
+  const [withoutZone] = address.split('%');
+  const lower = withoutZone.toLowerCase();
+  const parts = lower.split('::');
+  if (parts.length > 2) return null;
+
+  const expandSection = (section) => {
+    if (!section) return [];
+    const pieces = section.split(':');
+    const expandedPieces = [];
+    for (const piece of pieces) {
+      if (!piece) continue;
+      if (piece.includes('.')) {
+        const octets = piece.split('.').map((value) => Number.parseInt(value, 10));
+        if (octets.length !== 4) return null;
+        if (octets.some((value) => !Number.isFinite(value) || value < 0 || value > 255)) {
+          return null;
+        }
+        expandedPieces.push(((octets[0] << 8) | octets[1]).toString(16));
+        expandedPieces.push(((octets[2] << 8) | octets[3]).toString(16));
+      } else {
+        expandedPieces.push(piece);
+      }
+    }
+    return expandedPieces;
+  };
+
+  const head = expandSection(parts[0]);
+  if (head === null) return null;
+  const tail = parts.length === 2 ? expandSection(parts[1]) : [];
+  if (tail === null) return null;
+
+  const missing = 8 - (head.length + tail.length);
+  if (missing < 0) return null;
+
+  const segments = [...head];
+  for (let i = 0; i < missing; i += 1) segments.push('0');
+  segments.push(...tail);
+  if (segments.length !== 8) return null;
+
+  const bytes = [];
+  for (const segment of segments) {
+    if (segment.length > 4) return null;
+    const value = parseInt(segment || '0', 16);
+    if (!Number.isFinite(value) || value < 0 || value > 0xffff) return null;
+    bytes.push((value >> 8) & 0xff, value & 0xff);
+  }
+  return bytes;
+}
+
+function isPrivateIPv4(octets) {
+  const [a, b] = octets;
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 0) return true;
+  if (a === 169 && b === 254) return true; // link-local
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true; // carrier-grade NAT
+  if (a === 198 && (b === 18 || b === 19)) return true; // benchmarking
+  if (a >= 224) return true; // multicast/reserved
+  return false;
+}
+
+function isForbiddenHostname(hostname) {
+  if (!hostname) return true;
+  const lower = hostname.toLowerCase();
+  const bracketless = hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname;
+  const normalizedLower = lower.startsWith('[') && lower.endsWith(']')
+    ? lower.slice(1, -1)
+    : lower;
+  if (LOOPBACK_HOSTNAMES.has(lower)) return true;
+  if (lower.endsWith('.localhost')) return true;
+
+  const type = isIP(bracketless);
+  if (type === 4) {
+    const octets = bracketless.split('.').map(Number);
+    return isPrivateIPv4(octets);
+  }
+
+  if (type === 6) {
+    const normalized = normalizedLower.split('%')[0];
+    const bytes = parseIPv6(normalized);
+    if (!bytes) return true;
+
+    const isUnspecified = bytes.every((byte) => byte === 0);
+    if (isUnspecified) return true;
+
+    const isLoopback = bytes.slice(0, 15).every((byte) => byte === 0) && bytes[15] === 1;
+    if (isLoopback) return true;
+
+    const firstByte = bytes[0];
+    if ((firstByte & 0xfe) === 0xfc) return true; // unique local fc00::/7
+
+    if (firstByte === 0xfe && (bytes[1] & 0xc0) === 0x80) return true; // fe80::/10 link-local
+
+    const isIPv4Mapped =
+      bytes.slice(0, 10).every((byte) => byte === 0) && bytes[10] === 0xff && bytes[11] === 0xff;
+    if (isIPv4Mapped) {
+      const mapped = bytes.slice(12);
+      const octets = mapped;
+      if (isPrivateIPv4(octets)) return true;
+    }
+  }
+
+  return false;
+}
 
 /** Default timeout for fetchTextFromUrl in milliseconds. */
 export const DEFAULT_TIMEOUT_MS = 10000;
@@ -74,9 +187,16 @@ export async function fetchTextFromUrl(
   url,
   { timeoutMs = 10000, headers, maxBytes = 1024 * 1024 } = {}
 ) {
-  const { protocol } = new URL(url);
+  const targetUrl = new URL(url);
+  const { protocol, hostname } = targetUrl;
   if (!ALLOWED_PROTOCOLS.has(protocol)) {
     throw new Error(`Unsupported protocol: ${protocol}`);
+  }
+  const displayHostname = hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname;
+  if (isForbiddenHostname(hostname)) {
+    throw new Error(`Refusing to fetch private address: ${displayHostname}`);
   }
 
   // Normalize timeout: fallback to 10000ms if invalid

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -284,6 +284,86 @@ describe('fetchTextFromUrl', () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it('rejects localhost hostnames', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('secret'),
+    });
+    await expect(fetchTextFromUrl('http://localhost/admin'))
+      .rejects.toThrow('Refusing to fetch private address: localhost');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects loopback IPv4 addresses', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('secret'),
+    });
+    await expect(fetchTextFromUrl('http://127.0.0.1/hidden'))
+      .rejects.toThrow('Refusing to fetch private address: 127.0.0.1');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects IPv6 loopback addresses', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('secret'),
+    });
+    await expect(fetchTextFromUrl('http://[::1]/hidden'))
+      .rejects.toThrow('Refusing to fetch private address: ::1');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects alternative IPv6 loopback spellings', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('secret'),
+    });
+    await expect(fetchTextFromUrl('http://[0:0:0:0:0:0:0:1]/hidden'))
+      .rejects.toThrow('Refusing to fetch private address: ::1');
+    await expect(fetchTextFromUrl('http://[::01]/hidden'))
+      .rejects.toThrow('Refusing to fetch private address: ::1');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects IPv6 link-local addresses beyond fe80 prefix', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('secret'),
+    });
+    await expect(fetchTextFromUrl('http://[fe90::1]/hidden'))
+      .rejects.toThrow('Refusing to fetch private address: fe90::1');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects IPv4-mapped IPv6 private addresses', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('secret'),
+    });
+    await expect(fetchTextFromUrl('http://[::ffff:192.168.0.1]/hidden'))
+      .rejects.toThrow('Refusing to fetch private address: ::ffff:c0a8:1');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it('allows uppercase HTTP protocol', async () => {
     fetch.mockResolvedValue({
       ok: true,

--- a/test/flash_and_report.test.js
+++ b/test/flash_and_report.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const scriptsDir = path.resolve(__dirname, '..', 'scripts');
+
+describe('flash_and_report helpers', () => {
+  it('exposes system_id in device metadata for eject support', () => {
+    const program = `
+import json
+import os
+import sys
+sys.path.insert(0, os.getcwd())
+from flash_and_report import _describe_device
+
+class Device:
+    def __init__(self):
+        self.path = '/dev/disk1'
+        self.description = 'USB Disk'
+        self.is_removable = True
+        self.human_size = '16 GB'
+        self.bus = 'USB'
+        self.mountpoints = ['/Volumes/PI']
+        self.system_id = 4242
+
+devices = [Device()]
+print(json.dumps(_describe_device(devices, '/dev/disk1')))
+`;
+
+    const result = spawnSync('python3', ['-c', program], {
+      cwd: scriptsDir,
+      encoding: 'utf8',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+
+    const metadata = JSON.parse(result.stdout.trim());
+    expect(metadata).toMatchObject({
+      path: '/dev/disk1',
+      description: 'USB Disk',
+      is_removable: true,
+      human_size: '16 GB',
+      bus: 'USB',
+      mountpoints: ['/Volumes/PI'],
+      system_id: 4242,
+    });
+  });
+});


### PR DESCRIPTION
what: ensure flash_and_report metadata carries system_id and add regression test verifying it; harden fetchTextFromUrl IPv6 private host detection and extend SSRF regression coverage
why: Windows auto-eject requires system_id to offline devices after hashing; SSRF protections must reject all loopback, link-local, and IPv4-mapped IPv6 spellings
how to test: npm run lint && npm run test:ci && npm audit
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68ca4c1983e4832f99c76bfeb6a6118f