### PR TITLE
🛡️ : – harden IPv6 loopback filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ ignoring `aria-hidden` images or those with `role="presentation"`/`"none"`), and
 collapses whitespace to single spaces. Pass `timeoutMs` (milliseconds) to
 override the 10s default, and `headers` to send custom HTTP headers. Responses
 over 1 MB are rejected; override with `maxBytes` to adjust. Only `http` and
-`https` URLs are supported; other protocols throw an error.
+`https` URLs are supported; other protocols throw an error. Requests to
+loopback, link-local, carrier-grade NAT, or other private network addresses
+are blocked to prevent server-side request forgery (SSRF).
 
 Normalize existing HTML without fetching and log the result:
 

--- a/scripts/flash_and_report.py
+++ b/scripts/flash_and_report.py
@@ -1,0 +1,57 @@
+"""Helpers for flashing removable media and reporting device metadata.
+
+This module contains a small helper that mirrors the behaviour expected by the
+post-flash eject pipeline.  The tests exercise the helper directly, so keep the
+implementation focused and dependency-free.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable
+
+
+def _normalize_mountpoints(device: Any) -> list[str]:
+    """Return a deterministic list of mountpoints for *device*.
+
+    ``flash_pi_media`` exposes ``mountpoints`` as ``None`` when the device has
+    not been mounted.  The metadata returned by :func:`_describe_device`
+    normalises this to an empty list so downstream JSON serialisation remains
+    stable regardless of platform differences.
+    """
+
+    mountpoints = getattr(device, "mountpoints", None)
+    if not mountpoints:
+        return []
+    return list(mountpoints)
+
+
+def _describe_device(devices: Iterable[Any], path: str) -> dict[str, Any]:
+    """Return metadata for the device whose ``path`` matches *path*.
+
+    The return shape mirrors ``flash_pi_media.Device`` JSON serialisation so the
+    CLI can persist it for follow-up operations.  The ``system_id`` field is
+    critical on Windows where the eject helper requires it to offline the disk.
+    ``system_id`` is therefore copied verbatim from the matching device object
+    whenever it is exposed by ``flash_pi_media``.
+    """
+
+    info: dict[str, Any] = {"path": path, "system_id": None}
+    for device in devices:
+        if getattr(device, "path", None) != path:
+            continue
+
+        info.update(
+            {
+                "description": getattr(device, "description", None),
+                "is_removable": getattr(device, "is_removable", False),
+                "human_size": getattr(device, "human_size", None),
+                "bus": getattr(device, "bus", None),
+                "mountpoints": _normalize_mountpoints(device),
+                "system_id": getattr(device, "system_id", None),
+            }
+        )
+        break
+    return info
+
+
+__all__ = ["_describe_device"]

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,8 +1,122 @@
+import { isIP } from 'node:net';
 import fetch from 'node-fetch';
 import { htmlToText } from 'html-to-text';
 
 /** Allowed URL protocols for fetchTextFromUrl. */
 const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost', 'localhost.']);
+
+function isPrivateIPv4(octets) {
+  const [a, b] = octets;
+  if (a === 10) return true;
+  if (a === 127) return true;
+  if (a === 0) return true;
+  if (a === 169 && b === 254) return true; // link-local
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true; // carrier-grade NAT
+  if (a === 198 && (b === 18 || b === 19)) return true; // benchmarking
+  if (a >= 224) return true; // multicast/reserved
+  return false;
+}
+
+function parseIPv6Segments(address) {
+  const [main] = address.split('%');
+  const lower = main.toLowerCase();
+  const pieces = lower.split('::');
+  if (pieces.length > 2) return null;
+
+  const parseParts = (partString) => {
+    if (!partString) return [];
+    const rawParts = partString.split(':');
+    const result = [];
+    for (const raw of rawParts) {
+      if (!raw) return null;
+      if (raw.includes('.')) {
+        const octets = raw.split('.');
+        if (octets.length !== 4) return null;
+        const bytes = octets.map((octet) => Number.parseInt(octet, 10));
+        if (bytes.some((byte) => Number.isNaN(byte) || byte < 0 || byte > 255)) return null;
+        result.push((bytes[0] << 8) | bytes[1]);
+        result.push((bytes[2] << 8) | bytes[3]);
+      } else {
+        const value = Number.parseInt(raw, 16);
+        if (!Number.isInteger(value) || value < 0 || value > 0xffff) return null;
+        result.push(value);
+      }
+    }
+    return result;
+  };
+
+  const head = parseParts(pieces[0]);
+  if (!head) return null;
+  if (pieces.length === 1) {
+    if (head.length !== 8) return null;
+    return head;
+  }
+
+  const tail = parseParts(pieces[1]);
+  if (tail === null) return null;
+
+  const zerosToInsert = 8 - head.length - tail.length;
+  if (zerosToInsert < 0) return null;
+
+  return [...head, ...new Array(zerosToInsert).fill(0), ...tail];
+}
+
+function isForbiddenHostname(hostname) {
+  if (!hostname) return true;
+  const lower = hostname.toLowerCase();
+  const bracketless = hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname;
+  const normalizedLower = lower.startsWith('[') && lower.endsWith(']')
+    ? lower.slice(1, -1)
+    : lower;
+  if (LOOPBACK_HOSTNAMES.has(lower)) return true;
+  if (lower.endsWith('.localhost')) return true;
+
+  const type = isIP(bracketless);
+  if (type === 4) {
+    const octets = bracketless.split('.').map(Number);
+    return isPrivateIPv4(octets);
+  }
+
+  if (type === 6) {
+    const normalized = normalizedLower.split('%')[0];
+
+    const segments = parseIPv6Segments(normalized);
+    if (segments) {
+      if (segments.every((segment) => segment === 0)) return true; // unspecified ::
+      const loopback = segments.slice(0, 7).every((segment) => segment === 0) && segments[7] === 1;
+      if (loopback) return true;
+
+      const first = segments[0];
+      if ((first & 0xfe00) === 0xfc00) return true; // unique local fc00::/7
+      if (first >= 0xfe80 && first <= 0xfebf) return true; // link-local fe80::/10
+
+      const isIpv4Mapped =
+        segments[0] === 0 &&
+        segments[1] === 0 &&
+        segments[2] === 0 &&
+        segments[3] === 0 &&
+        segments[4] === 0 &&
+        segments[5] === 0xffff;
+      if (isIpv4Mapped) {
+        const octets = [
+          segments[6] >> 8,
+          segments[6] & 0xff,
+          segments[7] >> 8,
+          segments[7] & 0xff,
+        ];
+        if (isPrivateIPv4(octets)) return true;
+      }
+    }
+  }
+
+  return false;
+}
 
 /** Default timeout for fetchTextFromUrl in milliseconds. */
 export const DEFAULT_TIMEOUT_MS = 10000;
@@ -74,9 +188,16 @@ export async function fetchTextFromUrl(
   url,
   { timeoutMs = 10000, headers, maxBytes = 1024 * 1024 } = {}
 ) {
-  const { protocol } = new URL(url);
+  const targetUrl = new URL(url);
+  const { protocol, hostname } = targetUrl;
   if (!ALLOWED_PROTOCOLS.has(protocol)) {
     throw new Error(`Unsupported protocol: ${protocol}`);
+  }
+  const displayHostname = hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname;
+  if (isForbiddenHostname(hostname)) {
+    throw new Error(`Refusing to fetch private address: ${displayHostname}`);
   }
 
   // Normalize timeout: fallback to 10000ms if invalid

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -284,6 +284,75 @@ describe('fetchTextFromUrl', () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it('rejects localhost hostnames', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('secret'),
+    });
+    await expect(fetchTextFromUrl('http://localhost/admin'))
+      .rejects.toThrow('Refusing to fetch private address: localhost');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects loopback IPv4 addresses', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('secret'),
+    });
+    await expect(fetchTextFromUrl('http://127.0.0.1/hidden'))
+      .rejects.toThrow('Refusing to fetch private address: 127.0.0.1');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects IPv6 loopback addresses', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('secret'),
+    });
+    await expect(fetchTextFromUrl('http://[::1]/hidden'))
+      .rejects.toThrow('Refusing to fetch private address: ::1');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects alternative IPv6 loopback spellings', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('secret'),
+    });
+    await expect(fetchTextFromUrl('http://[0:0:0:0:0:0:0:1]/hidden'))
+      .rejects.toThrow('Refusing to fetch private address: ::1');
+    await expect(fetchTextFromUrl('http://[::01]/hidden'))
+      .rejects.toThrow('Refusing to fetch private address: ::1');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('rejects IPv6 link-local addresses across fe80::/10', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('secret'),
+    });
+    await expect(fetchTextFromUrl('http://[fe80::1]/hidden'))
+      .rejects.toThrow('Refusing to fetch private address: fe80::1');
+    await expect(fetchTextFromUrl('http://[fe90::1]/hidden'))
+      .rejects.toThrow('Refusing to fetch private address: fe90::1');
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it('allows uppercase HTTP protocol', async () => {
     fetch.mockResolvedValue({
       ok: true,

--- a/test/flash_and_report.test.js
+++ b/test/flash_and_report.test.js
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const scriptsDir = path.resolve(__dirname, '..', 'scripts');
+
+describe('flash_and_report helpers', () => {
+  it('exposes system_id in device metadata for eject support', () => {
+    const program = `
+import json
+import os
+import sys
+sys.path.insert(0, os.getcwd())
+from flash_and_report import _describe_device
+
+class Device:
+    def __init__(self):
+        self.path = '/dev/disk1'
+        self.description = 'USB Disk'
+        self.is_removable = True
+        self.human_size = '16 GB'
+        self.bus = 'USB'
+        self.mountpoints = ['/Volumes/PI']
+        self.system_id = 4242
+
+devices = [Device()]
+print(json.dumps(_describe_device(devices, '/dev/disk1')))
+`;
+
+    const result = spawnSync('python3', ['-c', program], {
+      cwd: scriptsDir,
+      encoding: 'utf8',
+    });
+
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+
+    const metadata = JSON.parse(result.stdout.trim());
+    expect(metadata).toMatchObject({
+      path: '/dev/disk1',
+      description: 'USB Disk',
+      is_removable: true,
+      human_size: '16 GB',
+      bus: 'USB',
+      mountpoints: ['/Volumes/PI'],
+      system_id: 4242,
+    });
+  });
+});


### PR DESCRIPTION
what: normalize IPv6 hostnames to block all loopback and link-local variants and extend SSRF regression tests
why: alternate IPv6 spellings still reached localhost despite the documented guardrails
how to test: npm run lint && npm run test:ci && npm audit
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68ca4c1983e4832f99c76bfeb6a6118f