### PR TITLE
Refactor parser requirement helpers

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -58,11 +58,54 @@ function findHeader(lines, primary, fallback) {
   return findFirstPatternIndex(lines, fallback);
 }
 
-function findFirstMatch(lines, patterns) {
+// Map of structured field names to their accepted header patterns.
+const FIELD_PATTERNS = {
+  title: TITLE_PATTERNS,
+  company: COMPANY_PATTERNS,
+  location: LOCATION_PATTERNS
+};
+
+/** Capture the first matching field value for the provided patterns. */
+function extractFieldValue(lines, patterns) {
   const { index, pattern } = findFirstPatternIndex(lines, patterns);
   if (index === -1 || !pattern) return '';
   const match = lines[index].match(pattern);
   return match ? match[1].trim() : '';
+}
+
+/** Extract the first match for each structured field. */
+function extractFields(lines) {
+  return Object.fromEntries(
+    Object.entries(FIELD_PATTERNS).map(([field, patterns]) => [
+      field,
+      extractFieldValue(lines, patterns)
+    ])
+  );
+}
+
+/** Pull requirement text that shares the same line as the matched header. */
+function extractInlineRequirement(headerLine, pattern) {
+  const rest = headerLine.replace(pattern, '').trim().replace(/^[:\s]+/, '');
+  if (!rest) return '';
+  return stripBullet(rest);
+}
+
+/** Determine whether a trimmed line looks like the start of a new section. */
+function isSectionHeader(line) {
+  return /^[A-Za-z].+:$/.test(line);
+}
+
+/** Collect requirement bullet lines until the next section header appears. */
+function collectRequirementLines(lines, startIndex) {
+  const collected = [];
+  for (let i = startIndex; i < lines.length; i += 1) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    if (isSectionHeader(line)) break;
+    const bullet = stripBullet(line);
+    if (bullet) collected.push(bullet);
+  }
+  return collected;
 }
 
 /**
@@ -77,26 +120,11 @@ function extractRequirements(lines) {
   );
   if (headerIndex === -1) return [];
 
-  const requirements = [];
-  const headerLine = lines[headerIndex];
-  let rest = headerLine.replace(headerPattern, '').trim();
-  rest = rest.replace(/^[:\s]+/, '');
+  const inlineRequirement = extractInlineRequirement(lines[headerIndex], headerPattern);
+  const subsequentLines = collectRequirementLines(lines, headerIndex + 1);
 
-  if (rest) {
-    // Strip bullet characters when the first requirement follows the header.
-    const first = stripBullet(rest);
-    if (first) requirements.push(first);
-  }
-
-  for (let i = headerIndex + 1; i < lines.length; i += 1) {
-    const line = lines[i].trim();
-    if (!line) continue;
-    if (/^[A-Za-z].+:$/.test(line)) break; // next section header
-    const bullet = stripBullet(line);
-    if (bullet) requirements.push(bullet);
-  }
-
-  return requirements;
+  if (!inlineRequirement) return subsequentLines;
+  return [inlineRequirement, ...subsequentLines];
 }
 
 /** Parse raw job posting text into structured fields. */
@@ -107,9 +135,7 @@ export function parseJobText(rawText) {
   const text = rawText.replace(/\r/g, '').trim();
   const lines = text.split(/\n+/);
 
-  const title = findFirstMatch(lines, TITLE_PATTERNS);
-  const company = findFirstMatch(lines, COMPANY_PATTERNS);
-  const location = findFirstMatch(lines, LOCATION_PATTERNS);
+  const { title, company, location } = extractFields(lines);
   const requirements = extractRequirements(lines);
 
   return { title, company, location, requirements, body: text };

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -138,6 +138,19 @@ Requirements:
     expect(parsed.requirements).toEqual(['Must do things']);
   });
 
+  it('stops capturing requirements at the next section header', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+Requirements:
+- Build features
+Benefits:
+- Health insurance
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual(['Build features']);
+  });
+
   it('captures requirement text on header line and strips other bullet types', () => {
     const text = `
 Title: Developer


### PR DESCRIPTION
what: restructure parser field extraction and requirement helpers
why: improve readability and reuse while preserving behavior
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ca4c0fa790832fb94057659159f52b