### PR TITLE
Refine parser field extraction helper

### DIFF
--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -138,6 +138,19 @@ Requirements:
     expect(parsed.requirements).toEqual(['Must do things']);
   });
 
+  it('stops capturing requirements at the next section header', () => {
+    const text = `
+Title: Developer
+Company: Example Corp
+Requirements:
+- Build features
+Benefits:
+- Health insurance
+`;
+    const parsed = parseJobText(text);
+    expect(parsed.requirements).toEqual(['Build features']);
+  });
+
   it('captures requirement text on header line and strips other bullet types', () => {
     const text = `
 Title: Developer


### PR DESCRIPTION
what: inline structured field extraction to remove unused helper
why: satisfy eslint no-unused-vars regression from previous refactor
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ca4c0fa790832fb94057659159f52b