### PR TITLE
♿ Normalize whitespace-only image labels in HTML extraction

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -24,7 +24,11 @@ function formatImageAlt(elem, walk, builder) {
   if (hidden === 'true' || hidden === '1') return;
   if (decorativeRole === 'presentation' || decorativeRole === 'none') return;
 
-  const label = alt || ariaLabel;
+  const normalizedAlt = typeof alt === 'string' ? alt.trim() : '';
+  const normalizedAriaLabel =
+    typeof ariaLabel === 'string' ? ariaLabel.trim() : '';
+
+  const label = normalizedAlt || normalizedAriaLabel;
   if (label) builder.addInline(label, { noWordTransform: true });
 }
 

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -160,6 +160,15 @@ describe('extractTextFromHtml', () => {
     expect(extractTextFromHtml(html)).toBe('Start Logo End');
   });
 
+  it('falls back to aria-label when alt text is whitespace', () => {
+    const html = `
+      <p>Start</p>
+      <img src="logo.png" alt="   " aria-label=" Logo " />
+      <p>End</p>
+    `;
+    expect(extractTextFromHtml(html)).toBe('Start Logo End');
+  });
+
   it('returns empty string for falsy input', () => {
     expect(extractTextFromHtml('')).toBe('');
     // @ts-expect-error testing null input


### PR DESCRIPTION
what: Trim img alt and aria-label attributes before text extraction.
why: Prevent whitespace-only alt text from hiding accessible labels.
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ca4b0c3d00832f856b14509167af28