### PR TITLE
✨ : – normalize summarize count fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ Pass `0` to `summarize` to return an empty string.
 
 Requesting more sentences than exist returns the entire text.
 
+Invalid or non-numeric `count` values default to a single sentence.
+
 The example below demonstrates this behavior:
 
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,11 @@ const isAlpha = (c) => (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
 const abbreviations = new Set(['mr', 'mrs', 'ms', 'dr', 'prof', 'sr', 'jr', 'st', 'vs']);
 
 export function summarize(text, count = 1) {
+  if (!Number.isFinite(count)) {
+    const parsed = Number(count);
+    count = Number.isFinite(parsed) ? parsed : 1;
+  }
+
   if (!text || count <= 0) return '';
 
   /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -33,6 +33,12 @@ describe('summarize', () => {
     expect(summarize('First.', -1)).toBe('');
   });
 
+  it('treats non-numeric count as one sentence', () => {
+    const text = 'First. Second.';
+    expect(summarize(text, 'nope')).toBe('First.');
+    expect(summarize(text, Number.NaN)).toBe('First.');
+  });
+
   it('returns empty string for empty input', () => {
     expect(summarize('', 2)).toBe('');
   });


### PR DESCRIPTION
what: default summarize() to one sentence when count is invalid
why: keep API in sync with CLI flag handling and avoid returning entire text
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ca4b9c3b34832f9be63610f6368603