### PR TITLE
Skip CI for docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,15 @@ name: CI
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.mdx'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '**/*.mdx'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ echo "First. Second. Third." | npx jobbot summarize - --sentences 2 --text
 ```
 
 # Continuous integration
-GitHub Actions runs lint and test checks on each push and pull request. To keep builds fast and reliable,
-in-progress runs for the same branch are canceled when new commits arrive.
+GitHub Actions runs lint and test checks on each push and pull request that includes code changes.
+Markdown-only updates skip CI to keep the pipeline fast, and in-progress runs for the same branch are
+canceled when new commits arrive.
 
 In code, import the `summarize` function and pass the number of sentences to keep:
 


### PR DESCRIPTION
## Summary
- skip CI workflow runs for markdown-only pushes and pull requests
- document the markdown-only exclusion in the Continuous Integration section of the README

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ca4b5f289c832f952d29469d19b120