### PR TITLE
Add CLI track command to record application statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,15 @@ If the file is missing it will be created, but other file errors or malformed JS
 Unit tests cover each status, concurrent writes, missing files, invalid JSON, and rejection of
 unknown values.
 
+Record statuses from the CLI so you never edit JSON by hand:
+
+```bash
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot track add job-123 --status screening
+# Recorded job-123 as screening
+```
+
+CLI tests assert that `jobbot track add` persists entries to `applications.json`.
+
 ## Documentation
 
 - [DESIGN.md](DESIGN.md) – architecture details and roadmap

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -7,6 +7,7 @@ import { parseJobText } from '../src/parser.js';
 import { loadResume } from '../src/resume.js';
 import { computeFitScore } from '../src/scoring.js';
 import { toJson, toMarkdownSummary, toMarkdownMatch } from '../src/exporters.js';
+import { recordApplication, STATUSES } from '../src/lifecycle.js';
 
 function isHttpUrl(s) {
   return /^https?:\/\//i.test(s);
@@ -85,10 +86,29 @@ async function cmdMatch(args) {
   else console.log(toMarkdownMatch(payload));
 }
 
+function trackUsage() {
+  console.error(
+    `Usage: jobbot track add <job_id> --status <status>\n` +
+      `Valid statuses: ${STATUSES.join(', ')}`
+  );
+  process.exit(2);
+}
+
+async function cmdTrack(args) {
+  const [action, id] = args;
+  if (action !== 'add') trackUsage();
+  if (!id) trackUsage();
+  const status = getFlag(args, '--status');
+  if (!status || typeof status !== 'string' || !status.trim()) trackUsage();
+  const recorded = await recordApplication(id, status.trim());
+  console.log(`Recorded ${id} as ${recorded}`);
+}
+
 async function main() {
   const [, , cmd, ...args] = process.argv;
   if (cmd === 'summarize') return cmdSummarize(args);
   if (cmd === 'match') return cmdMatch(args);
+  if (cmd === 'track') return cmdTrack(args);
   console.error('Usage: jobbot <summarize|match> [options]');
   process.exit(2);
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { summarize } from '../src/index.js';
 
@@ -51,6 +52,22 @@ describe('jobbot CLI', () => {
     const out = runCli(['match', '--resume', resumePath, '--job', jobPath, '--json']);
     const data = JSON.parse(out);
     expect(data.score).toBeGreaterThanOrEqual(50);
+  });
+
+  it('records application status with track add', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'jobbot-track-'));
+    const originalDataDir = process.env.JOBBOT_DATA_DIR;
+    process.env.JOBBOT_DATA_DIR = dir;
+    try {
+      const output = runCli(['track', 'add', 'job-123', '--status', 'screening']);
+      expect(output.trim()).toBe('Recorded job-123 as screening');
+      const raw = fs.readFileSync(path.join(dir, 'applications.json'), 'utf8');
+      expect(JSON.parse(raw)).toEqual({ 'job-123': 'screening' });
+    } finally {
+      if (originalDataDir === undefined) delete process.env.JOBBOT_DATA_DIR;
+      else process.env.JOBBOT_DATA_DIR = originalDataDir;
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- scanned DESIGN.md for actionable backlog items and found the documented `jobbot track add` flow missing from the CLI
- add a `track` command that records application statuses via the existing lifecycle module and reports success to the user
- extend the CLI test suite and README to cover the new command and document the regression test

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68ccd1479184832f818392dddaee6dda