### PR TITLE
✨ : – Capture tracker metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ npm run test:ci
 echo "First. Second. Third." | npx jobbot summarize - --sentences 2 --text
 # => First. Second.
 # Non-numeric --sentences values fall back to 1 sentence
+
+# Track an application's status
+npx jobbot track add job-123 --status screening --channel referral --date 2025-09-18 \
+  --contact "Alex" --document resume.pdf --document cover-letter.pdf --notes "Sent follow-up"
+# => Recorded job-123 as screening
 ```
 
 # Continuous integration
@@ -199,6 +204,18 @@ Unit tests exercise punctuation with and without trailing whitespace so the
 summarizer keeps honoring these boundaries alongside abbreviations, decimals,
 and nested punctuation edge cases.
 
+## Job snapshots
+
+Fetching remote listings or matching local job descriptions writes snapshots to
+`data/jobs/{job_id}.json`. Snapshots include the raw body, parsed fields, the
+source descriptor (URL or file path), request headers, and a capture timestamp
+so the shortlist can be rebuilt later. Job identifiers are short SHA-256 hashes
+derived from the source, giving deterministic filenames without leaking PII.
+
+The CLI respects `JOBBOT_DATA_DIR`, mirroring the application lifecycle store,
+so snapshots stay alongside other candidate data when the directory is moved.
+`test/jobs.test.js` covers this behaviour to keep the contract stable.
+
 Job titles can be parsed from lines starting with `Title`, `Job Title`, `Position`, or `Role`.
 Headers can use colons or dash separators (for example, `Role - Staff Engineer`), and the same
 separators work for `Company` and `Location`. Parser unit tests cover both colon and dash cases so
@@ -229,13 +246,15 @@ font size immediately after logging in.
 ## Tracking Application Lifecycle
 
 Application statuses such as `no_response`, `screening`, `onsite`, `offer`, `rejected`, and
-`withdrawn` are saved to `data/applications.json`, a git-ignored file. Legacy entries using
-`next_round` still load for backward compatibility. Set `JOBBOT_DATA_DIR` to change the directory.
-These records power local Sankey diagrams so progress isn't lost between sessions.
-Writes are serialized to avoid dropping entries when recording multiple applications at once.
-If the file is missing it will be created, but other file errors or malformed JSON will throw.
-Unit tests cover each status, concurrent writes, missing files, invalid JSON, and rejection of
-unknown values.
+`withdrawn` are saved to `data/applications.json`, a git-ignored file. Each entry now stores the
+status alongside optional metadata captured via the CLI (`channel`, `date`, `contact`,
+`documents`, `notes`) and the timestamp of the latest update. Legacy entries using `next_round`
+still load for backward compatibility. Set `JOBBOT_DATA_DIR` to change the directory. These records
+power local Sankey diagrams so progress isn't lost between sessions. Writes are serialized to avoid
+dropping entries when recording multiple applications at once. If the file is missing it will be
+created, but other file errors or malformed JSON will throw. Unit tests cover each status,
+concurrent writes, metadata persistence, missing files, invalid JSON, and rejection of unknown
+values.
 
 ## Documentation
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -45,7 +45,8 @@ revisit them later without blocking the workflow.
    SmartRecruiters) or pastes individual URLs into the CLI/UI.
 2. The fetch pipeline de-duplicates listings, normalizes HTML to text, and stores raw + parsed
    copies under `data/jobs/{job_id}.json` alongside fetch metadata (timestamp, source, request
-   headers).
+   headers). Job identifiers are hashed from the source URL or file path so repeat fetches update
+   the same snapshot without leaking personally identifiable information.
 3. Users can tag or discard roles; discarded items stay archived with reasons to refine future
    recommendations.
 4. The shortlist view exposes filters (location, level, compensation) and sync metadata for future
@@ -78,7 +79,10 @@ aggressively to respect rate limits.
 1. When the user applies or sends outreach, they log the event (channel, date, documents shared,
    contact person) in the tracker.
 2. Application status transitions (no response, screening, onsite, offer, rejected, withdrawn) are
-   stored in `data/applications.json`, which is serialized safely to prevent data loss.
+   stored in `data/applications.json`, which is serialized safely to prevent data loss. The CLI
+   exposes `jobbot track add <job_id> --status <status>` with optional `--channel`, `--date`,
+   `--contact`, `--document`, and `--notes` flags so users can log updates inline with other
+   workflows.
 3. Follow-up reminders and note-taking surfaces help the user prepare for upcoming steps while
    consolidating feedback for future tailoring.
 

--- a/src/jobs.js
+++ b/src/jobs.js
@@ -1,0 +1,87 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+function resolveDataDir() {
+  return process.env.JOBBOT_DATA_DIR || path.resolve('data');
+}
+
+function normalizeHeaders(headers) {
+  if (!headers || typeof headers !== 'object') {
+    return {};
+  }
+  const normalized = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined || value === null) continue;
+    normalized[key] = String(value);
+  }
+  return normalized;
+}
+
+function toIsoTimestamp(timestamp) {
+  if (timestamp instanceof Date) return timestamp.toISOString();
+  if (typeof timestamp === 'number' || typeof timestamp === 'string') {
+    const date = new Date(timestamp);
+    if (!Number.isNaN(date.getTime())) return date.toISOString();
+  }
+  return new Date().toISOString();
+}
+
+/**
+ * Derive a stable job identifier from the provided source descriptor.
+ * Hashing keeps identifiers filesystem-safe while letting callers deduplicate entries.
+ *
+ * @param {string} source
+ * @returns {string}
+ */
+export function jobIdFromSource(source) {
+  const input = typeof source === 'string' ? source : JSON.stringify(source ?? '');
+  return crypto.createHash('sha256').update(input).digest('hex').slice(0, 16);
+}
+
+/**
+ * Persist the raw and parsed representation of a job posting alongside fetch metadata.
+ *
+ * @param {object} params
+ * @param {string} params.id Stable job identifier used as the filename.
+ * @param {string} params.raw Raw job content as fetched.
+ * @param {any} params.parsed Parsed job payload.
+ * @param {{ type?: string, value: string }} params.source Descriptor of where the job originated.
+ * @param {Record<string, any>} [params.requestHeaders] Headers used during the fetch, if any.
+ * @param {Date | string | number} [params.fetchedAt] Timestamp for when the snapshot was captured.
+ * @returns {Promise<string>} Absolute path to the written snapshot file.
+ */
+export async function saveJobSnapshot({
+  id,
+  raw,
+  parsed,
+  source,
+  requestHeaders,
+  fetchedAt,
+}) {
+  if (!id || typeof id !== 'string') {
+    throw new Error('job id is required');
+  }
+  if (!source || typeof source.value !== 'string') {
+    throw new Error('source value is required');
+  }
+
+  const jobsDir = path.join(resolveDataDir(), 'jobs');
+  await fs.mkdir(jobsDir, { recursive: true });
+
+  const payload = {
+    id,
+    fetched_at: toIsoTimestamp(fetchedAt),
+    raw: raw == null ? '' : String(raw),
+    parsed: parsed ?? null,
+    source: {
+      type: source.type || 'unknown',
+      value: source.value,
+      headers: normalizeHeaders(requestHeaders),
+    },
+  };
+
+  const file = path.join(jobsDir, `${id}.json`);
+  await fs.writeFile(file, JSON.stringify(payload, null, 2));
+  return file;
+}

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -44,6 +44,7 @@ async function readLifecycleFile(file) {
  */
 async function writeJsonFile(file, data) {
   const tmp = `${file}.tmp`;
+  await fs.mkdir(path.dirname(file), { recursive: true });
   await fs.writeFile(tmp, JSON.stringify(data, null, 2));
   await fs.rename(tmp, file);
 }
@@ -55,7 +56,39 @@ let writeLock = Promise.resolve();
  * Record an application's status. Throws if the lifecycle file cannot be read or contains
  * invalid JSON.
  */
-export function recordApplication(id, status) {
+function normalizeEntry(value) {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    if (typeof value.status === 'string') return { ...value };
+    return { status: undefined, ...value };
+  }
+  if (typeof value === 'string') return { status: value };
+  return {};
+}
+
+function normalizeLifecycle(data) {
+  if (!data || typeof data !== 'object') return {};
+  return Object.fromEntries(
+    Object.entries(data).map(([id, value]) => [id, normalizeEntry(value)]),
+  );
+}
+
+function sanitizeMetadata(metadata = {}) {
+  const result = {};
+  if (metadata.channel) result.channel = String(metadata.channel);
+  if (metadata.date) result.date = String(metadata.date);
+  if (metadata.contact) result.contact = String(metadata.contact);
+  if (metadata.notes) result.notes = String(metadata.notes);
+  if (metadata.documents !== undefined) {
+    const docs = Array.isArray(metadata.documents)
+      ? metadata.documents
+      : [metadata.documents];
+    const filtered = docs.map(doc => String(doc)).filter(Boolean);
+    if (filtered.length) result.documents = filtered;
+  }
+  return result;
+}
+
+export function recordApplication(id, status, metadata) {
   if (!STATUSES.includes(status)) {
     return Promise.reject(new Error(`unknown status: ${status}`));
   }
@@ -63,10 +96,15 @@ export function recordApplication(id, status) {
 
   const run = async () => {
     await fs.mkdir(dir, { recursive: true });
-    const data = await readLifecycleFile(file);
-    data[id] = status;
-    await writeJsonFile(file, data);
-    return data[id];
+    const existing = normalizeLifecycle(await readLifecycleFile(file));
+    const payload = {
+      status,
+      ...sanitizeMetadata(metadata),
+      updated_at: new Date().toISOString(),
+    };
+    existing[id] = payload;
+    await writeJsonFile(file, existing);
+    return payload;
   };
 
   writeLock = writeLock.then(run, run);
@@ -79,9 +117,10 @@ export function recordApplication(id, status) {
  */
 export async function getLifecycleCounts() {
   const { file } = getPaths();
-  const data = await readLifecycleFile(file);
+  const data = normalizeLifecycle(await readLifecycleFile(file));
   const counts = Object.fromEntries(STATUSES.map(s => [s, 0]));
-  for (const status of Object.values(data)) {
+  for (const entry of Object.values(data)) {
+    const status = entry && entry.status;
     if (counts[status] !== undefined) counts[status] += 1;
   }
   return counts;

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -97,9 +97,12 @@ export function recordApplication(id, status, metadata) {
   const run = async () => {
     await fs.mkdir(dir, { recursive: true });
     const existing = normalizeLifecycle(await readLifecycleFile(file));
+    const previous = existing[id] ? { ...existing[id] } : {};
     const payload = {
-      status,
+      ...previous,
+      ...sanitizeMetadata(previous),
       ...sanitizeMetadata(metadata),
+      status,
       updated_at: new Date().toISOString(),
     };
     existing[id] = payload;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,17 +1,35 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import os from 'node:os';
 import { summarize } from '../src/index.js';
+import { STATUSES } from '../src/lifecycle.js';
 
-function runCli(args, input) {
+const dataDir = path.resolve('test', 'tmp-cli-data');
+
+function runCli(args, input, envOverrides = {}) {
   const bin = path.resolve('bin', 'jobbot.js');
-  const opts = { encoding: 'utf8' };
+  const defaultEnv = envOverrides.JOBBOT_DATA_DIR
+    ? {}
+    : { JOBBOT_DATA_DIR: dataDir };
+  const opts = {
+    encoding: 'utf8',
+    env: { ...process.env, ...defaultEnv, ...envOverrides },
+  };
   if (input !== undefined) opts.input = input;
   return execFileSync('node', [bin, ...args], opts);
 }
 
 describe('jobbot CLI', () => {
+  beforeEach(() => {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(dataDir, { recursive: true, force: true });
+  });
+
   it('summarize from stdin', () => {
     const out = runCli(['summarize', '-'], 'First sentence. Second.');
     expect(out).toMatch(/First sentence\./);
@@ -51,6 +69,59 @@ describe('jobbot CLI', () => {
     const out = runCli(['match', '--resume', resumePath, '--job', jobPath, '--json']);
     const data = JSON.parse(out);
     expect(data.score).toBeGreaterThanOrEqual(50);
+  });
+
+  it('records application status with track add', () => {
+    const status = STATUSES.find(s => s !== 'next_round');
+    const output = runCli(['track', 'add', 'job-123', '--status', status]);
+    expect(output.trim()).toBe(`Recorded job-123 as ${status}`);
+    const raw = fs.readFileSync(path.join(dataDir, 'applications.json'), 'utf8');
+    const payload = JSON.parse(raw);
+    expect(payload['job-123']).toMatchObject({ status });
+    expect(typeof payload['job-123'].updated_at).toBe('string');
+  });
+
+  it('records application metadata with track add options', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'jobbot-track-'));
+    try {
+      const output = runCli(
+        [
+          'track',
+          'add',
+          'job-meta',
+          '--status',
+          'screening',
+          '--channel',
+          'referral',
+          '--date',
+          '2025-09-18',
+          '--contact',
+          'Alex',
+          '--document',
+          'resume.pdf',
+          '--document',
+          'cover-letter.pdf',
+          '--notes',
+          'Sent follow-up',
+        ],
+        undefined,
+        { JOBBOT_DATA_DIR: dir },
+      );
+      expect(output.trim()).toBe('Recorded job-meta as screening');
+      const raw = fs.readFileSync(path.join(dir, 'applications.json'), 'utf8');
+      const payload = JSON.parse(raw);
+      expect(payload['job-meta']).toMatchObject({
+        status: 'screening',
+        channel: 'referral',
+        date: '2025-09-18',
+        contact: 'Alex',
+        documents: ['resume.pdf', 'cover-letter.pdf'],
+        notes: 'Sent follow-up',
+      });
+      expect(typeof payload['job-meta'].updated_at).toBe('string');
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -1,0 +1,78 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+const dataDir = path.resolve('test', 'tmp-data');
+const jobsDir = path.join(dataDir, 'jobs');
+
+async function readSnapshot(id) {
+  const file = path.join(jobsDir, `${id}.json`);
+  const contents = await fs.readFile(file, 'utf8');
+  return JSON.parse(contents);
+}
+
+describe('job snapshots', () => {
+  beforeEach(async () => {
+    process.env.JOBBOT_DATA_DIR = dataDir;
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(dataDir, { recursive: true, force: true });
+    vi.useRealTimers();
+  });
+
+  it('persists raw and parsed listings with metadata under data/jobs', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-02T03:04:05Z'));
+    const { saveJobSnapshot, jobIdFromSource } = await import('../src/jobs.js');
+    const source = 'https://example.com/jobs/123';
+    const id = jobIdFromSource(source);
+    await saveJobSnapshot({
+      id,
+      raw: '<p>Hello</p>',
+      parsed: { title: 'Engineer', requirements: ['JS'] },
+      source: { type: 'url', value: source },
+      requestHeaders: { 'User-Agent': 'jobbot' },
+    });
+
+    const snapshot = await readSnapshot(id);
+    expect(snapshot).toEqual({
+      id,
+      fetched_at: '2025-01-02T03:04:05.000Z',
+      raw: '<p>Hello</p>',
+      parsed: { title: 'Engineer', requirements: ['JS'] },
+      source: {
+        type: 'url',
+        value: source,
+        headers: { 'User-Agent': 'jobbot' },
+      },
+    });
+  });
+
+  it('overwrites existing snapshots for the same job id', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-04-05T06:07:08Z'));
+    const { saveJobSnapshot, jobIdFromSource } = await import('../src/jobs.js');
+    const id = jobIdFromSource('https://example.com/jobs/456');
+    await saveJobSnapshot({
+      id,
+      raw: 'old',
+      parsed: { title: 'Old' },
+      source: { type: 'url', value: 'https://example.com/jobs/456' },
+    });
+
+    vi.setSystemTime(new Date('2025-04-05T07:08:09Z'));
+    await saveJobSnapshot({
+      id,
+      raw: 'new',
+      parsed: { title: 'New' },
+      source: { type: 'url', value: 'https://example.com/jobs/456' },
+    });
+
+    const snapshot = await readSnapshot(id);
+    expect(snapshot.raw).toBe('new');
+    expect(snapshot.parsed).toEqual({ title: 'New' });
+    expect(snapshot.fetched_at).toBe('2025-04-05T07:08:09.000Z');
+  });
+});


### PR DESCRIPTION
what: enrich the tracker so `jobbot track add` accepts metadata flags, persists structured lifecycle entries, and documents the workflow.
why: Journey 5 commits to logging outreach context (channel, date, docs, contacts) alongside statuses.
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ccd1479184832f818392dddaee6dda