### PR TITLE
Add jobbot init profile scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,18 @@ run();
 `loadResume` supports `.pdf`, `.md`, `.markdown`, and `.mdx` files; other
 extensions are read as plain text.
 
+Initialize a JSON Resume skeleton when you do not have an existing file:
+
+```bash
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot init
+# Initialized profile at /tmp/jobbot-profile-XXXX/profile/resume.json
+```
+
+`jobbot init` writes `profile/resume.json` under the data directory with empty
+basics, work, education, skills, projects, certificates, and languages
+sections. The command is idempotent and preserves existing resumes; see
+`test/cli.test.js` and `test/profile.test.js` for coverage.
+
 Format parsed results as Markdown. The exporters escape Markdown control characters so job
 content cannot inject arbitrary links or formatting when rendered downstream:
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -10,6 +10,7 @@ import { toJson, toMarkdownSummary, toMarkdownMatch } from '../src/exporters.js'
 import { saveJobSnapshot, jobIdFromSource } from '../src/jobs.js';
 import { logApplicationEvent } from '../src/application-events.js';
 import { recordApplication, STATUSES } from '../src/lifecycle.js';
+import { initProfile } from '../src/profile.js';
 
 function isHttpUrl(s) {
   return /^https?:\/\//i.test(s);
@@ -169,12 +170,20 @@ async function cmdTrack(args) {
   process.exit(2);
 }
 
+async function cmdInit(args) {
+  const force = args.includes('--force');
+  const { created, path: resumePath } = await initProfile({ force });
+  if (created) console.log(`Initialized profile at ${resumePath}`);
+  else console.log(`Profile already exists at ${resumePath}`);
+}
+
 async function main() {
   const [, , cmd, ...args] = process.argv;
+  if (cmd === 'init') return cmdInit(args);
   if (cmd === 'summarize') return cmdSummarize(args);
   if (cmd === 'match') return cmdMatch(args);
   if (cmd === 'track') return cmdTrack(args);
-  console.error('Usage: jobbot <summarize|match|track> [options]');
+  console.error('Usage: jobbot <init|summarize|match|track> [options]');
   process.exit(2);
 }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -10,7 +10,8 @@ translate them into backlog items, prompts, and acceptance tests.
 jobbot3000.
 
 1. The user selects a local resume file (PDF, Markdown, MDX, or plain text) or points to an existing
-   `resume.json`.
+   `resume.json`. When they start from scratch, `jobbot init` scaffolds
+   `data/profile/resume.json` with empty JSON Resume sections ready for editing.
 2. The CLI or UI calls the resume loader to extract clean text and metadata.
 3. Parsed content is normalized into the JSON Resume schema and saved under `data/profile/`, a
    git-ignored directory so personal data never leaves the machine.

--- a/src/profile.js
+++ b/src/profile.js
@@ -1,0 +1,76 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+const JSON_RESUME_SCHEMA_URL =
+  'https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json';
+
+function resolveDataDir() {
+  return process.env.JOBBOT_DATA_DIR || path.resolve('data');
+}
+
+function createResumeSkeleton() {
+  const timestamp = new Date().toISOString();
+  return {
+    $schema: JSON_RESUME_SCHEMA_URL,
+    basics: {
+      name: '',
+      label: '',
+      email: '',
+      phone: '',
+      website: '',
+      summary: '',
+      location: {
+        city: '',
+        region: '',
+        country: '',
+      },
+    },
+    work: [],
+    volunteer: [],
+    education: [],
+    awards: [],
+    publications: [],
+    skills: [],
+    languages: [],
+    interests: [],
+    references: [],
+    projects: [],
+    certificates: [],
+    meta: {
+      generatedAt: timestamp,
+      generator: 'jobbot3000',
+      version: '1.0.0',
+    },
+  };
+}
+
+/**
+ * Initialise the profile workspace by creating a JSON Resume skeleton.
+ * When the resume already exists and `force` is false, the file is left untouched.
+ *
+ * @param {{ force?: boolean }} [options]
+ * @returns {Promise<{ created: boolean, path: string }>}
+ *   Result describing whether the file was created.
+ */
+export async function initProfile({ force = false } = {}) {
+  const dataDir = resolveDataDir();
+  const profileDir = path.join(dataDir, 'profile');
+  const resumePath = path.join(profileDir, 'resume.json');
+
+  await fs.mkdir(profileDir, { recursive: true });
+
+  if (!force) {
+    try {
+      await fs.access(resumePath);
+      return { created: false, path: resumePath };
+    } catch (err) {
+      if (err?.code !== 'ENOENT') throw err;
+    }
+  }
+
+  const skeleton = createResumeSkeleton();
+  await fs.writeFile(resumePath, `${JSON.stringify(skeleton, null, 2)}\n`, 'utf8');
+  return { created: true, path: resumePath };
+}
+
+export const PROFILE_SCHEMA_URL = JSON_RESUME_SCHEMA_URL;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -32,6 +32,43 @@ describe('jobbot CLI', () => {
     }
   });
 
+  it('initializes a resume skeleton with init command', () => {
+    const output = runCli(['init']);
+    expect(output.trim()).toMatch(/Initialized profile at/);
+
+    const profileDir = path.join(dataDir, 'profile');
+    const resumePath = path.join(profileDir, 'resume.json');
+    const raw = fs.readFileSync(resumePath, 'utf8');
+    const resume = JSON.parse(raw);
+
+    expect(resume).toMatchObject({
+      $schema:
+        'https://raw.githubusercontent.com/jsonresume/resume-schema/v1.0.0/schema.json',
+      basics: {
+        name: '',
+        label: '',
+        email: '',
+        phone: '',
+        website: '',
+        summary: '',
+        location: {
+          city: '',
+          region: '',
+          country: '',
+        },
+      },
+      work: [],
+      education: [],
+      projects: [],
+      skills: [],
+      certificates: [],
+      languages: [],
+    });
+
+    expect(typeof resume.meta?.generatedAt).toBe('string');
+    expect(resume.meta?.generator).toBe('jobbot3000');
+  });
+
   it('summarize from stdin', () => {
     const out = runCli(['summarize', '-'], 'First sentence. Second.');
     expect(out).toMatch(/First sentence\./);

--- a/test/profile.test.js
+++ b/test/profile.test.js
@@ -1,0 +1,48 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let dataDir;
+
+describe('profile init', () => {
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-profile-'));
+    process.env.JOBBOT_DATA_DIR = dataDir;
+  });
+
+  afterEach(async () => {
+    if (dataDir) {
+      await fs.rm(dataDir, { recursive: true, force: true });
+      dataDir = undefined;
+    }
+    delete process.env.JOBBOT_DATA_DIR;
+  });
+
+  it('creates a resume skeleton when none exists', async () => {
+    const { initProfile } = await import('../src/profile.js');
+    const result = await initProfile();
+    expect(result.created).toBe(true);
+    const resumePath = path.join(dataDir, 'profile', 'resume.json');
+    const raw = await fs.readFile(resumePath, 'utf8');
+    const resume = JSON.parse(raw);
+    expect(Array.isArray(resume.work)).toBe(true);
+    expect(resume.basics).toBeDefined();
+  });
+
+  it('does not overwrite an existing resume file', async () => {
+    const resumePath = path.join(dataDir, 'profile', 'resume.json');
+    await fs.mkdir(path.dirname(resumePath), { recursive: true });
+    await fs.writeFile(
+      resumePath,
+      JSON.stringify({ basics: { name: 'Existing' } }, null, 2),
+      'utf8'
+    );
+
+    const { initProfile } = await import('../src/profile.js');
+    const result = await initProfile();
+    expect(result.created).toBe(false);
+    const raw = await fs.readFile(resumePath, 'utf8');
+    expect(JSON.parse(raw)).toEqual({ basics: { name: 'Existing' } });
+  });
+});


### PR DESCRIPTION
## Summary
- add a profile initializer that writes a JSON Resume skeleton under `data/profile`
- wire the `jobbot init` CLI command so users can scaffold resumes without overwriting existing files
- document the initialization workflow in the README and Journey 1, and cover it in `test/cli.test.js` and `test/profile.test.js`

## Testing
- npm run lint
- npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68ccf924181c832fa542c6fcaf3b72e0