### PR TITLE
✨ shortlist tagging + discard CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,23 @@ exercise this path with 120k-line resumes to ensure the tokenizer stays under 20
 are scanned without regex or temporary arrays, improving large input performance. Blank or
 non-string requirement entries are skipped so invalid bullets don't affect scoring.
 
+## Shortlist tags and discards
+
+Tag incoming roles with keywords or archive them with a rationale to guide future matches:
+
+~~~bash
+DATA_DIR=$(mktemp -d)
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist tag job-123 dream remote
+# Tagged job-123 with dream, remote
+
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist discard job-123 --reason "Not remote"
+# Discarded job-123: Not remote
+~~~
+
+The CLI stores shortlist labels and discard history in `data/shortlist.json`, keeping reasons and
+timestamps so recommendations can surface patterns later. CLI tests in
+[`test/cli.test.js`](test/cli.test.js) cover both commands to lock in the persisted format.
+
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -10,6 +10,7 @@ import { toJson, toMarkdownSummary, toMarkdownMatch } from '../src/exporters.js'
 import { saveJobSnapshot, jobIdFromSource } from '../src/jobs.js';
 import { logApplicationEvent } from '../src/application-events.js';
 import { recordApplication, STATUSES } from '../src/lifecycle.js';
+import { addJobTags, discardJob } from '../src/shortlist.js';
 
 function isHttpUrl(s) {
   return /^https?:\/\//i.test(s);
@@ -169,11 +170,42 @@ async function cmdTrack(args) {
   process.exit(2);
 }
 
+async function cmdShortlistTag(args) {
+  const [jobId, ...tagArgs] = args;
+  if (!jobId || tagArgs.length === 0) {
+    console.error('Usage: jobbot shortlist tag <job_id> <tag> [tag ...]');
+    process.exit(2);
+  }
+  const tags = tagArgs.map(tag => String(tag));
+  const allTags = await addJobTags(jobId, tags);
+  console.log(`Tagged ${jobId} with ${allTags.join(', ')}`);
+}
+
+async function cmdShortlistDiscard(args) {
+  const jobId = args[0];
+  const reason = getFlag(args.slice(1), '--reason');
+  if (!jobId || !reason) {
+    console.error('Usage: jobbot shortlist discard <job_id> --reason <reason>');
+    process.exit(2);
+  }
+  const entry = await discardJob(jobId, reason);
+  console.log(`Discarded ${jobId}: ${entry.reason}`);
+}
+
+async function cmdShortlist(args) {
+  const sub = args[0];
+  if (sub === 'tag') return cmdShortlistTag(args.slice(1));
+  if (sub === 'discard') return cmdShortlistDiscard(args.slice(1));
+  console.error('Usage: jobbot shortlist <tag|discard> ...');
+  process.exit(2);
+}
+
 async function main() {
   const [, , cmd, ...args] = process.argv;
   if (cmd === 'summarize') return cmdSummarize(args);
   if (cmd === 'match') return cmdMatch(args);
   if (cmd === 'track') return cmdTrack(args);
+  if (cmd === 'shortlist') return cmdShortlist(args);
   console.error('Usage: jobbot <summarize|match|track> [options]');
   process.exit(2);
 }

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -47,8 +47,9 @@ revisit them later without blocking the workflow.
    copies under `data/jobs/{job_id}.json` alongside fetch metadata (timestamp, source, request
    headers). Job identifiers are hashed from the source URL or file path so repeat fetches update
    the same snapshot without leaking personally identifiable information.
-3. Users can tag or discard roles; discarded items stay archived with reasons to refine future
-   recommendations.
+3. Users can tag or discard roles with `jobbot shortlist tag` / `jobbot shortlist discard`.
+   Discarded items stay archived with reasons in `data/shortlist.json`
+   to refine future recommendations.
 4. The shortlist view exposes filters (location, level, compensation) and sync metadata for future
    refreshes.
 
@@ -69,8 +70,9 @@ aggressively to respect rate limits.
 4. Generated files, diffs, and build logs live in `data/deliverables/{job_id}/` and are versioned by
    timestamp.
 
-**Unhappy paths:** low fit scores or missing must-haves trigger guidance (e.g., suggest skill prep or
-   highlight transferable experience) and let the user decline tailoring for that role.
+**Unhappy paths:** low fit scores or missing must-haves trigger guidance
+  (e.g., suggest skill prep or highlight transferable experience) and let the user decline
+  tailoring for that role.
 
 ## Journey 5: Apply and Track Outcomes
 

--- a/src/shortlist.js
+++ b/src/shortlist.js
@@ -1,0 +1,136 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+let overrideDir;
+
+function resolveDataDir() {
+  return overrideDir || process.env.JOBBOT_DATA_DIR || path.resolve('data');
+}
+
+export function setShortlistDataDir(dir) {
+  overrideDir = dir || undefined;
+}
+
+function getPaths() {
+  const dir = resolveDataDir();
+  return { dir, file: path.join(dir, 'shortlist.json') };
+}
+
+async function readShortlistFile(file) {
+  try {
+    const contents = await fs.readFile(file, 'utf8');
+    const parsed = JSON.parse(contents);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return { jobs: {} };
+    }
+    if (!parsed.jobs || typeof parsed.jobs !== 'object' || Array.isArray(parsed.jobs)) {
+      return { jobs: {} };
+    }
+    return { jobs: { ...parsed.jobs } };
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return { jobs: {} };
+    throw err;
+  }
+}
+
+async function writeJsonFile(file, data) {
+  const tmp = `${file}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(data, null, 2));
+  await fs.rename(tmp, file);
+}
+
+function normalizeTag(tag) {
+  if (tag == null) return undefined;
+  const trimmed = String(tag).trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function ensureJobRecord(store, jobId) {
+  if (!store.jobs[jobId] || typeof store.jobs[jobId] !== 'object') {
+    store.jobs[jobId] = { tags: [], discarded: [] };
+  } else {
+    const record = store.jobs[jobId];
+    if (!Array.isArray(record.tags)) record.tags = [];
+    if (!Array.isArray(record.discarded)) record.discarded = [];
+  }
+  return store.jobs[jobId];
+}
+
+let writeLock = Promise.resolve();
+
+export function addJobTags(jobId, tags) {
+  if (!jobId || typeof jobId !== 'string' || !jobId.trim()) {
+    return Promise.reject(new Error('job id is required'));
+  }
+  const normalizedTags = [];
+  for (const tag of tags) {
+    const clean = normalizeTag(tag);
+    if (clean) normalizedTags.push(clean);
+  }
+  if (normalizedTags.length === 0) {
+    return Promise.reject(new Error('at least one tag is required'));
+  }
+
+  const jobKey = jobId.trim();
+  const { dir, file } = getPaths();
+
+  const run = async () => {
+    await fs.mkdir(dir, { recursive: true });
+    const store = await readShortlistFile(file);
+    const record = ensureJobRecord(store, jobKey);
+    for (const tag of normalizedTags) {
+      if (!record.tags.includes(tag)) {
+        record.tags.push(tag);
+      }
+    }
+    await writeJsonFile(file, store);
+    return record.tags.slice();
+  };
+
+  writeLock = writeLock.then(run, run);
+  return writeLock;
+}
+
+export function discardJob(jobId, reason) {
+  if (!jobId || typeof jobId !== 'string' || !jobId.trim()) {
+    return Promise.reject(new Error('job id is required'));
+  }
+  const normalizedReason = reason == null ? '' : String(reason).trim();
+  if (!normalizedReason) {
+    return Promise.reject(new Error('reason is required'));
+  }
+
+  const jobKey = jobId.trim();
+  const { dir, file } = getPaths();
+
+  const run = async () => {
+    await fs.mkdir(dir, { recursive: true });
+    const store = await readShortlistFile(file);
+    const record = ensureJobRecord(store, jobKey);
+    const entry = {
+      reason: normalizedReason,
+      discarded_at: new Date().toISOString(),
+    };
+    record.discarded.push(entry);
+    await writeJsonFile(file, store);
+    return entry;
+  };
+
+  writeLock = writeLock.then(run, run);
+  return writeLock;
+}
+
+export async function getShortlist(jobId) {
+  const { file } = getPaths();
+  const store = await readShortlistFile(file);
+  if (jobId === undefined) {
+    return store;
+  }
+  const record = store.jobs[jobId];
+  if (!record) {
+    return { tags: [], discarded: [] };
+  }
+  const tags = Array.isArray(record.tags) ? record.tags.slice() : [];
+  const discarded = Array.isArray(record.discarded) ? record.discarded.slice() : [];
+  return { tags, discarded };
+}

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -111,4 +111,32 @@ describe('jobbot CLI', () => {
       },
     ]);
   });
+
+  it('tags shortlist entries and persists labels', () => {
+    const output = runCli(['shortlist', 'tag', 'job-abc', 'dream', 'remote']);
+    expect(output.trim()).toBe('Tagged job-abc with dream, remote');
+    const raw = JSON.parse(
+      fs.readFileSync(path.join(dataDir, 'shortlist.json'), 'utf8')
+    );
+    expect(raw.jobs['job-abc'].tags).toEqual(['dream', 'remote']);
+  });
+
+  it('archives discard reasons for shortlist entries', () => {
+    runCli(['shortlist', 'tag', 'job-def', 'onsite']);
+    const output = runCli([
+      'shortlist',
+      'discard',
+      'job-def',
+      '--reason',
+      'Not remote friendly',
+    ]);
+    expect(output.trim()).toBe('Discarded job-def: Not remote friendly');
+    const raw = JSON.parse(
+      fs.readFileSync(path.join(dataDir, 'shortlist.json'), 'utf8')
+    );
+    expect(raw.jobs['job-def'].discarded).toHaveLength(1);
+    const [entry] = raw.jobs['job-def'].discarded;
+    expect(entry.reason).toBe('Not remote friendly');
+    expect(entry.discarded_at).toMatch(/T.*Z$/);
+  });
 });


### PR DESCRIPTION
## Summary
- inventory revealed docs/user-journeys.md promised shortlist tagging/discard archiving; this change ships the CLI support and storage to close that gap
- add shortlist persistence module that records tags and discard reasons in data/shortlist.json with atomic writes and timestamped history
- extend jobbot CLI with `shortlist tag` / `shortlist discard`, update README/docs, and cover the flow with new Vitest CLI cases

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68ccf924181c832fa542c6fcaf3b72e0