### PR TITLE
Add CLI discard archive for job shortlist

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,18 @@ normalized to ISO 8601.
 Tests in `test/application-events.test.js` ensure that new log entries do not
 clobber history and that invalid channels or dates are rejected.
 
+To capture discard reasons for shortlist triage:
+
+~~~bash
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot track discard job-456 --reason "Salary too low"
+# Discarded job-456
+~~~
+
+Discarded roles are archived in `data/discarded_jobs.json` with their reasons,
+timestamps, and optional tags so future recommendations can reference prior
+decisions. Unit tests in `test/discards.test.js` and the CLI suite cover the
+JSON format and command invocation.
+
 ## Documentation
 
 - [DESIGN.md](DESIGN.md) – architecture details and roadmap

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -47,8 +47,8 @@ revisit them later without blocking the workflow.
    copies under `data/jobs/{job_id}.json` alongside fetch metadata (timestamp, source, request
    headers). Job identifiers are hashed from the source URL or file path so repeat fetches update
    the same snapshot without leaking personally identifiable information.
-3. Users can tag or discard roles; discarded items stay archived with reasons to refine future
-   recommendations.
+3. Users can tag or discard roles; `jobbot track discard` archives reasons (and optional tags) in
+   `data/discarded_jobs.json` so future recommendations can reference prior decisions.
 4. The shortlist view exposes filters (location, level, compensation) and sync metadata for future
    refreshes.
 

--- a/src/discards.js
+++ b/src/discards.js
@@ -1,0 +1,117 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+function resolveDataDir() {
+  return process.env.JOBBOT_DATA_DIR || path.resolve('data');
+}
+
+function getDiscardFilePath() {
+  const dir = resolveDataDir();
+  return { dir, file: path.join(dir, 'discarded_jobs.json') };
+}
+
+async function readDiscardFile(file) {
+  try {
+    const contents = await fs.readFile(file, 'utf8');
+    const data = JSON.parse(contents);
+    if (data && typeof data === 'object') {
+      return data;
+    }
+    return {};
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return {};
+    throw err;
+  }
+}
+
+async function writeJsonFile(file, data) {
+  const tmp = `${file}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify(data, null, 2));
+  await fs.rename(tmp, file);
+}
+
+function normalizeJobId(jobId) {
+  if (!jobId || typeof jobId !== 'string' || !jobId.trim()) {
+    throw new Error('job id is required');
+  }
+  return jobId.trim();
+}
+
+function normalizeReason(reason) {
+  const value = typeof reason === 'string' ? reason.trim() : '';
+  if (!value) throw new Error('reason is required');
+  return value;
+}
+
+function normalizeTimestamp(input) {
+  const value = input ? new Date(input) : new Date();
+  if (Number.isNaN(value.getTime())) {
+    throw new Error(`invalid date: ${input}`);
+  }
+  return value.toISOString();
+}
+
+function normalizeTags(tags) {
+  if (!tags) return undefined;
+  const list = Array.isArray(tags)
+    ? tags
+    : String(tags)
+        .split(',')
+        .map(entry => entry.trim());
+  const normalized = [];
+  const seen = new Set();
+  for (const item of list) {
+    if (!item) continue;
+    const key = item.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    normalized.push(item);
+  }
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+let writeLock = Promise.resolve();
+
+export function recordJobDiscard(jobId, { reason, date, tags } = {}) {
+  let normalizedId;
+  let normalizedReason;
+  try {
+    normalizedId = normalizeJobId(jobId);
+    normalizedReason = normalizeReason(reason);
+  } catch (err) {
+    return Promise.reject(err);
+  }
+
+  let timestamp;
+  try {
+    timestamp = normalizeTimestamp(date);
+  } catch (err) {
+    return Promise.reject(err);
+  }
+
+  const normalizedTags = normalizeTags(tags);
+  const { dir, file } = getDiscardFilePath();
+
+  const run = async () => {
+    await fs.mkdir(dir, { recursive: true });
+    const data = await readDiscardFile(file);
+    const history = Array.isArray(data[normalizedId]) ? data[normalizedId] : [];
+    const entry = { reason: normalizedReason, discarded_at: timestamp };
+    if (normalizedTags) entry.tags = normalizedTags;
+    history.push(entry);
+    data[normalizedId] = history;
+    await writeJsonFile(file, data);
+    return entry;
+  };
+
+  writeLock = writeLock.then(run, run);
+  return writeLock;
+}
+
+export async function getDiscardedJobs(jobId) {
+  const { file } = getDiscardFilePath();
+  const data = await readDiscardFile(file);
+  if (jobId === undefined) return data;
+  const history = data[jobId];
+  return Array.isArray(history) ? history : [];
+}

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -111,4 +111,22 @@ describe('jobbot CLI', () => {
       },
     ]);
   });
+
+  it('archives discarded jobs with reasons', () => {
+    const output = runCli([
+      'track',
+      'discard',
+      'job-789',
+      '--reason',
+      'Below compensation range',
+    ]);
+    expect(output.trim()).toBe('Discarded job-789');
+    const raw = JSON.parse(
+      fs.readFileSync(path.join(dataDir, 'discarded_jobs.json'), 'utf8')
+    );
+    expect(raw['job-789']).toHaveLength(1);
+    const entry = raw['job-789'][0];
+    expect(entry.reason).toBe('Below compensation range');
+    expect(entry.discarded_at).toEqual(new Date(entry.discarded_at).toISOString());
+  });
 });

--- a/test/discards.test.js
+++ b/test/discards.test.js
@@ -1,0 +1,61 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const discardFileName = 'discarded_jobs.json';
+
+let dataDir;
+
+async function readDiscards() {
+  const file = path.join(dataDir, discardFileName);
+  const contents = await fs.readFile(file, 'utf8');
+  return JSON.parse(contents);
+}
+
+describe('discarded job archive', () => {
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-discards-'));
+    process.env.JOBBOT_DATA_DIR = dataDir;
+  });
+
+  afterEach(async () => {
+    if (dataDir) {
+      await fs.rm(dataDir, { recursive: true, force: true });
+      dataDir = undefined;
+    }
+    delete process.env.JOBBOT_DATA_DIR;
+  });
+
+  it('records discard reasons with ISO timestamps', async () => {
+    const { recordJobDiscard, getDiscardedJobs } = await import('../src/discards.js');
+    await recordJobDiscard('job-123', { reason: 'Not remote', date: '2025-01-02T03:04:05Z' });
+
+    const archive = await readDiscards();
+    expect(archive['job-123']).toEqual([
+      {
+        reason: 'Not remote',
+        discarded_at: '2025-01-02T03:04:05.000Z',
+      },
+    ]);
+
+    const byId = await getDiscardedJobs('job-123');
+    expect(byId).toEqual(archive['job-123']);
+  });
+
+  it('rejects missing job ids or reasons', async () => {
+    const { recordJobDiscard } = await import('../src/discards.js');
+    await expect(recordJobDiscard('', { reason: 'Missing' })).rejects.toThrow('job id is required');
+    await expect(recordJobDiscard('job-456', { reason: '' })).rejects.toThrow('reason is required');
+  });
+
+  it('stores optional tags without duplicates', async () => {
+    const { recordJobDiscard, getDiscardedJobs } = await import('../src/discards.js');
+    await recordJobDiscard('job-tags', {
+      reason: 'Not aligned',
+      tags: ['Remote', 'remote', ''],
+    });
+    const entries = await getDiscardedJobs('job-tags');
+    expect(entries[0].tags).toEqual(['Remote']);
+  });
+});


### PR DESCRIPTION
what:
- add discard archive store and CLI support
- document shortlist discard workflow

why:
- fulfill Journey 3 promise to archive discard reasons

how to test:
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ccf924181c832fa542c6fcaf3b72e0