### PR TITLE
✨ : – Capture shortlist discard tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ DATA_DIR=$(mktemp -d)
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist tag job-123 dream remote
 # Tagged job-123 with dream, remote
 
-JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist discard job-123 --reason "Not remote"
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist discard job-123 --reason "Not remote" --tags "Remote,onsite"
 # Discarded job-123: Not remote
 
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist sync job-123 --location Remote --level Senior --compensation "$185k"
@@ -267,10 +267,12 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --location remote
 ~~~
 
 The CLI stores shortlist labels, discard history, and sync metadata in `data/shortlist.json`, keeping
-reasons, timestamps, and location/level/compensation fields so recommendations can surface patterns
-later. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for refresh schedulers. Unit tests in
-[`test/shortlist.test.js`](test/shortlist.test.js) and the CLI suite in
-[`test/cli.test.js`](test/cli.test.js) exercise metadata updates, filters, and the persisted format.
+reasons, timestamps, optional tags, and location/level/compensation fields so recommendations can
+surface patterns later. Discard actions also append to `data/discarded_jobs.json` so archive lookups
+and shortlist history stay in sync. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for refresh
+schedulers. Unit tests in [`test/shortlist.test.js`](test/shortlist.test.js) and the CLI suite in
+[`test/cli.test.js`](test/cli.test.js) exercise metadata updates, filters, discard tags, and the
+persisted format.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -210,12 +210,18 @@ async function cmdShortlistTag(args) {
 
 async function cmdShortlistDiscard(args) {
   const jobId = args[0];
-  const reason = getFlag(args.slice(1), '--reason');
+  const rest = args.slice(1);
+  const reason = getFlag(rest, '--reason');
   if (!jobId || !reason) {
-    console.error('Usage: jobbot shortlist discard <job_id> --reason <reason>');
+    console.error(
+      'Usage: jobbot shortlist discard <job_id> --reason <reason> [--tags <tag1,tag2>] ' +
+        '[--date <date>]'
+    );
     process.exit(2);
   }
-  const entry = await discardJob(jobId, reason);
+  const tags = parseTagsFlag(rest);
+  const date = getFlag(rest, '--date');
+  const entry = await discardJob(jobId, reason, { tags, date });
   console.log(`Discarded ${jobId}: ${entry.reason}`);
 }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -48,7 +48,8 @@ revisit them later without blocking the workflow.
    copies under `data/jobs/{job_id}.json` alongside fetch metadata (timestamp, source, request
    headers). Job identifiers are hashed from the source URL or file path so repeat fetches update
    the same snapshot without leaking personally identifiable information.
-3. Users can tag or discard roles with `jobbot shortlist tag` / `jobbot shortlist discard`.
+3. Users can tag or discard roles with `jobbot shortlist tag` /
+   `jobbot shortlist discard --tags <tag1,tag2>`.
    Discarded roles are also archived with reasons (and optional tags) in
    `data/discarded_jobs.json` so future recommendations can reference prior decisions.
 4. The shortlist view exposes filters (location, level, compensation) via

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -195,6 +195,29 @@ describe('jobbot CLI', () => {
     expect(entry.discarded_at).toMatch(/T.*Z$/);
   });
 
+  it('captures optional tags when discarding shortlist entries', () => {
+    runCli([
+      'shortlist',
+      'discard',
+      'job-tags',
+      '--reason',
+      'Location mismatch',
+      '--tags',
+      'Remote,onsite,remote',
+    ]);
+
+    const shortlist = JSON.parse(
+      fs.readFileSync(path.join(dataDir, 'shortlist.json'), 'utf8')
+    );
+    const [entry] = shortlist.jobs['job-tags'].discarded;
+    expect(entry.tags).toEqual(['Remote', 'onsite']);
+
+    const archive = JSON.parse(
+      fs.readFileSync(path.join(dataDir, 'discarded_jobs.json'), 'utf8')
+    );
+    expect(archive['job-tags'][0].tags).toEqual(['Remote', 'onsite']);
+  });
+
   it('syncs shortlist metadata and filters entries by location', () => {
     const syncOutput = runCli([
       'shortlist',


### PR DESCRIPTION
✨ : – Capture shortlist discard tags

what
- allow shortlist discard to accept tags/date and sync archive
- document shortlist discard tags and archive coverage
- add CLI/unit coverage for shortlist discard tagging

why
- journey 3 promised optional tags for shortlist discards

how to test
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68ce370f5724832faec8fe2bb4ddad28