### PR TITLE
Add greenhouse job board ingestion command

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,22 @@ The CLI respects `JOBBOT_DATA_DIR`, mirroring the application lifecycle store,
 so snapshots stay alongside other candidate data when the directory is moved.
 `test/jobs.test.js` covers this behaviour to keep the contract stable.
 
+## Greenhouse job board ingestion
+
+Fetch public boards directly with:
+
+~~~bash
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest greenhouse --company example
+# Imported 12 jobs from example
+~~~
+
+Each listing in the response is normalised to plain text, parsed for title,
+location, and requirements, and written to `data/jobs/{job_id}.json` with a
+`source.type` of `greenhouse`. Updates reuse the same job identifier so
+downstream tooling can diff revisions over time. `test/greenhouse.test.js`
+verifies the ingest pipeline fetches board content and persists structured
+snapshots.
+
 Job titles can be parsed from lines starting with `Title`, `Job Title`, `Position`, or `Role`.
 Headers can use colons or dash separators (for example, `Role - Staff Engineer`), and the same
 separators work for `Company` and `Location`. Parser unit tests cover both colon and dash cases so

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -13,6 +13,7 @@ import { recordApplication, STATUSES } from '../src/lifecycle.js';
 import { recordJobDiscard } from '../src/discards.js';
 import { addJobTags, discardJob, filterShortlist, syncShortlistJob } from '../src/shortlist.js';
 import { initProfile } from '../src/profile.js';
+import { ingestGreenhouseBoard } from '../src/greenhouse.js';
 
 function isHttpUrl(s) {
   return /^https?:\/\//i.test(s);
@@ -197,6 +198,25 @@ async function cmdTrack(args) {
   process.exit(2);
 }
 
+async function cmdIngestGreenhouse(args) {
+  const company = getFlag(args, '--company');
+  if (!company) {
+    console.error('Usage: jobbot ingest greenhouse --company <slug>');
+    process.exit(2);
+  }
+
+  const { saved } = await ingestGreenhouseBoard({ board: company });
+  const noun = saved === 1 ? 'job' : 'jobs';
+  console.log(`Imported ${saved} ${noun} from ${company}`);
+}
+
+async function cmdIngest(args) {
+  const sub = args[0];
+  if (sub === 'greenhouse') return cmdIngestGreenhouse(args.slice(1));
+  console.error('Usage: jobbot ingest greenhouse --company <slug>');
+  process.exit(2);
+}
+
 async function cmdShortlistTag(args) {
   const [jobId, ...tagArgs] = args;
   if (!jobId || tagArgs.length === 0) {
@@ -307,7 +327,8 @@ async function main() {
   if (cmd === 'match') return cmdMatch(args);
   if (cmd === 'track') return cmdTrack(args);
   if (cmd === 'shortlist') return cmdShortlist(args);
-  console.error('Usage: jobbot <init|summarize|match|track|shortlist> [options]');
+  if (cmd === 'ingest') return cmdIngest(args);
+  console.error('Usage: jobbot <init|summarize|match|track|shortlist|ingest> [options]');
   process.exit(2);
 }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -43,7 +43,9 @@ revisit them later without blocking the workflow.
 **Goal:** Build a living shortlist of job opportunities pulled from the web or supplied manually.
 
 1. The user searches company boards via supported fetchers (Greenhouse, Lever, Ashby, Workable,
-   SmartRecruiters) or pastes individual URLs into the CLI/UI.
+   SmartRecruiters) or pastes individual URLs into the CLI/UI. For example,
+   `jobbot ingest greenhouse --company acme` pulls the latest public postings into the local
+   data directory.
 2. The fetch pipeline de-duplicates listings, normalizes HTML to text, and stores raw + parsed
    copies under `data/jobs/{job_id}.json` alongside fetch metadata (timestamp, source, request
    headers). Job identifiers are hashed from the source URL or file path so repeat fetches update

--- a/src/greenhouse.js
+++ b/src/greenhouse.js
@@ -1,0 +1,74 @@
+import fetch from 'node-fetch';
+import { extractTextFromHtml } from './fetch.js';
+import { jobIdFromSource, saveJobSnapshot } from './jobs.js';
+import { parseJobText } from './parser.js';
+
+const GREENHOUSE_BASE = 'https://boards.greenhouse.io/v1/boards';
+
+function normalizeBoardSlug(board) {
+  if (!board || typeof board !== 'string' || !board.trim()) {
+    throw new Error('Greenhouse board slug is required');
+  }
+  return board.trim();
+}
+
+function buildBoardUrl(slug) {
+  return `${GREENHOUSE_BASE}/${encodeURIComponent(slug)}/jobs?content=true`;
+}
+
+function resolveAbsoluteUrl(job, slug) {
+  const value = typeof job.absolute_url === 'string' && job.absolute_url.trim()
+    ? job.absolute_url.trim()
+    : `https://boards.greenhouse.io/${slug}/jobs/${job.id}`;
+  return value;
+}
+
+function extractLocation(job) {
+  const name = job?.location?.name;
+  return typeof name === 'string' ? name.trim() : '';
+}
+
+function mergeParsedJob(parsed, job) {
+  const merged = { ...parsed };
+  if (!merged.title && typeof job.title === 'string') merged.title = job.title;
+  const location = extractLocation(job);
+  if (!merged.location && location) merged.location = location;
+  return merged;
+}
+
+export async function fetchGreenhouseJobs(board, { fetchImpl = fetch } = {}) {
+  const slug = normalizeBoardSlug(board);
+  const url = buildBoardUrl(slug);
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch Greenhouse board ${slug}: ${response.status} ${response.statusText}`,
+    );
+  }
+  const payload = await response.json();
+  const jobs = Array.isArray(payload?.jobs) ? payload.jobs : [];
+  return { slug, jobs };
+}
+
+export async function ingestGreenhouseBoard({ board, fetchImpl = fetch } = {}) {
+  const { slug, jobs } = await fetchGreenhouseJobs(board, { fetchImpl });
+  const jobIds = [];
+
+  for (const job of jobs) {
+    const absoluteUrl = resolveAbsoluteUrl(job, slug);
+    const html = typeof job.content === 'string' ? job.content : '';
+    const text = html ? extractTextFromHtml(html) : '';
+    const parsed = mergeParsedJob(parseJobText(text), job);
+    const id = jobIdFromSource({ provider: 'greenhouse', url: absoluteUrl });
+    await saveJobSnapshot({
+      id,
+      raw: text,
+      parsed,
+      source: { type: 'greenhouse', value: absoluteUrl },
+      fetchedAt: job.updated_at,
+    });
+    jobIds.push(id);
+  }
+
+  return { board: slug, saved: jobIds.length, jobIds };
+}

--- a/test/greenhouse.test.js
+++ b/test/greenhouse.test.js
@@ -1,0 +1,100 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node-fetch', () => ({ default: vi.fn() }));
+
+import fetch from 'node-fetch';
+
+const JOBS_DIR = 'jobs';
+
+describe('Greenhouse ingest', () => {
+  let dataDir;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-greenhouse-'));
+    process.env.JOBBOT_DATA_DIR = dataDir;
+    fetch.mockReset();
+  });
+
+  afterEach(async () => {
+    if (dataDir) {
+      await fs.rm(dataDir, { recursive: true, force: true });
+      dataDir = undefined;
+    }
+    delete process.env.JOBBOT_DATA_DIR;
+  });
+
+  it('fetches Greenhouse jobs and writes snapshots', async () => {
+    const html = `
+      <h1>Staff Engineer</h1>
+      <p>Company: Example Corp</p>
+      <p>Location: Remote</p>
+      <h3>Requirements</h3>
+      <ul>
+        <li>Experience shipping production systems</li>
+      </ul>
+    `;
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        jobs: [
+          {
+            id: 123,
+            title: 'Staff Engineer',
+            location: { name: 'Remote' },
+            absolute_url: 'https://boards.greenhouse.io/example/jobs/123',
+            content: html,
+            updated_at: '2025-04-05T06:07:08Z',
+          },
+        ],
+      }),
+    });
+
+    const { ingestGreenhouseBoard } = await import('../src/greenhouse.js');
+
+    const result = await ingestGreenhouseBoard({ board: 'example' });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://boards.greenhouse.io/v1/boards/example/jobs?content=true',
+    );
+
+    expect(result).toMatchObject({ board: 'example', saved: 1 });
+    expect(result.jobIds).toHaveLength(1);
+
+    const jobsDir = path.join(dataDir, JOBS_DIR);
+    const files = await fs.readdir(jobsDir);
+    expect(files).toHaveLength(1);
+
+    const saved = JSON.parse(await fs.readFile(path.join(jobsDir, files[0]), 'utf8'));
+    expect(saved.source).toMatchObject({
+      type: 'greenhouse',
+      value: 'https://boards.greenhouse.io/example/jobs/123',
+    });
+    expect(saved.parsed.title).toBe('Staff Engineer');
+    expect(saved.parsed.location).toBe('Remote');
+    const hasRequirement = saved.parsed.requirements.some((req) =>
+      req.includes('Experience shipping production systems'),
+    );
+    expect(hasRequirement).toBe(true);
+    expect(saved.fetched_at).toBe('2025-04-05T06:07:08.000Z');
+  });
+
+  it('throws when the board fetch fails', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: async () => ({}),
+    });
+
+    const { ingestGreenhouseBoard } = await import('../src/greenhouse.js');
+
+    await expect(ingestGreenhouseBoard({ board: 'missing' })).rejects.toThrow(
+      /Failed to fetch Greenhouse board/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a Greenhouse board ingest command to the CLI and wire it into usage help
- persist fetched postings through a new greenhouse ingest module that normalises HTML before saving job snapshots
- cover the pipeline with a dedicated Vitest suite and document the workflow in the README and Journey 3 notes

## Future work triage
- DESIGN.md lists multiple backlog CLI surfaces (e.g. `jobbot ingest greenhouse --company foo`, Lever/Ashby/Workable/SmartRecruiters ingest, tailored matching commands). The Greenhouse ingest path was selected because it stands alone, reuses existing snapshot plumbing, and fits cleanly into a single PR. Remaining ingest targets can follow the same shape in future slices. 【F:DESIGN.md†L222-L233】

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68ce370f5724832faec8fe2bb4ddad28