### PR TITLE
Capture Greenhouse request headers in snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,8 +240,9 @@ Each listing in the response is normalised to plain text, parsed for title,
 location, and requirements, and written to `data/jobs/{job_id}.json` with a
 `source.type` of `greenhouse`. Updates reuse the same job identifier so
 downstream tooling can diff revisions over time. `test/greenhouse.test.js`
-verifies the ingest pipeline fetches board content and persists structured
-snapshots.
+verifies the ingest pipeline fetches board content, persists structured
+snapshots, and retains the `User-Agent: jobbot3000` request header alongside
+each capture so fetches are reproducible.
 
 Job titles can be parsed from lines starting with `Title`, `Job Title`, `Position`, or `Role`.
 Headers can use colons or dash separators (for example, `Role - Staff Engineer`), and the same

--- a/src/greenhouse.js
+++ b/src/greenhouse.js
@@ -5,6 +5,8 @@ import { parseJobText } from './parser.js';
 
 const GREENHOUSE_BASE = 'https://boards.greenhouse.io/v1/boards';
 
+const GREENHOUSE_HEADERS = { 'User-Agent': 'jobbot3000' };
+
 function normalizeBoardSlug(board) {
   if (!board || typeof board !== 'string' || !board.trim()) {
     throw new Error('Greenhouse board slug is required');
@@ -39,7 +41,7 @@ function mergeParsedJob(parsed, job) {
 export async function fetchGreenhouseJobs(board, { fetchImpl = fetch } = {}) {
   const slug = normalizeBoardSlug(board);
   const url = buildBoardUrl(slug);
-  const response = await fetchImpl(url);
+  const response = await fetchImpl(url, { headers: GREENHOUSE_HEADERS });
   if (!response.ok) {
     throw new Error(
       `Failed to fetch Greenhouse board ${slug}: ${response.status} ${response.statusText}`,
@@ -65,6 +67,7 @@ export async function ingestGreenhouseBoard({ board, fetchImpl = fetch } = {}) {
       raw: text,
       parsed,
       source: { type: 'greenhouse', value: absoluteUrl },
+      requestHeaders: GREENHOUSE_HEADERS,
       fetchedAt: job.updated_at,
     });
     jobIds.push(id);

--- a/test/greenhouse.test.js
+++ b/test/greenhouse.test.js
@@ -60,6 +60,9 @@ describe('Greenhouse ingest', () => {
 
     expect(fetch).toHaveBeenCalledWith(
       'https://boards.greenhouse.io/v1/boards/example/jobs?content=true',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'User-Agent': 'jobbot3000' }),
+      }),
     );
 
     expect(result).toMatchObject({ board: 'example', saved: 1 });
@@ -74,6 +77,7 @@ describe('Greenhouse ingest', () => {
       type: 'greenhouse',
       value: 'https://boards.greenhouse.io/example/jobs/123',
     });
+    expect(saved.source.headers).toEqual({ 'User-Agent': 'jobbot3000' });
     expect(saved.parsed.title).toBe('Staff Engineer');
     expect(saved.parsed.location).toBe('Remote');
     const hasRequirement = saved.parsed.requirements.some((req) =>


### PR DESCRIPTION
## Summary
- include a User-Agent header when fetching Greenhouse boards and persist it with each job snapshot
- document the preserved header so the job snapshots section reflects shipped behaviour

## Future work inventory
- README.md job snapshots section promised request headers in captures; threading the headers from ingest delivers that behaviour in a single PR

## Test coverage
- test/greenhouse.test.js verifies saved snapshots retain the User-Agent header

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ce3c34e110832fac45c557e37ed8f5