### PR TITLE
✨ : – add Lever ingest support

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,21 +227,25 @@ The CLI respects `JOBBOT_DATA_DIR`, mirroring the application lifecycle store,
 so snapshots stay alongside other candidate data when the directory is moved.
 `test/jobs.test.js` covers this behaviour to keep the contract stable.
 
-## Greenhouse job board ingestion
+## Job board ingestion
 
-Fetch public boards directly with:
+Fetch public boards directly with Greenhouse or Lever pipelines:
 
 ~~~bash
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest greenhouse --company example
 # Imported 12 jobs from example
+
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest lever --company example
+# Imported 8 jobs from example
 ~~~
 
 Each listing in the response is normalised to plain text, parsed for title,
 location, and requirements, and written to `data/jobs/{job_id}.json` with a
-`source.type` of `greenhouse`. Updates reuse the same job identifier so
-downstream tooling can diff revisions over time. `test/greenhouse.test.js`
-verifies the ingest pipeline fetches board content and persists structured
-snapshots.
+`source.type` reflecting the provider (`greenhouse` or `lever`). Updates reuse
+the same job identifier so downstream tooling can diff revisions over time.
+Tests in [`test/greenhouse.test.js`](test/greenhouse.test.js) and
+[`test/lever.test.js`](test/lever.test.js) verify the ingest pipelines fetch
+board content, persist structured snapshots, and surface fetch errors.
 
 Job titles can be parsed from lines starting with `Title`, `Job Title`, `Position`, or `Role`.
 Headers can use colons or dash separators (for example, `Role - Staff Engineer`), and the same

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -14,6 +14,7 @@ import { recordJobDiscard } from '../src/discards.js';
 import { addJobTags, discardJob, filterShortlist, syncShortlistJob } from '../src/shortlist.js';
 import { initProfile } from '../src/profile.js';
 import { ingestGreenhouseBoard } from '../src/greenhouse.js';
+import { ingestLeverBoard } from '../src/lever.js';
 
 function isHttpUrl(s) {
   return /^https?:\/\//i.test(s);
@@ -210,10 +211,23 @@ async function cmdIngestGreenhouse(args) {
   console.log(`Imported ${saved} ${noun} from ${company}`);
 }
 
+async function cmdIngestLever(args) {
+  const company = getFlag(args, '--company') || getFlag(args, '--org');
+  if (!company) {
+    console.error('Usage: jobbot ingest lever --company <slug>');
+    process.exit(2);
+  }
+
+  const { saved } = await ingestLeverBoard({ org: company });
+  const noun = saved === 1 ? 'job' : 'jobs';
+  console.log(`Imported ${saved} ${noun} from ${company}`);
+}
+
 async function cmdIngest(args) {
   const sub = args[0];
   if (sub === 'greenhouse') return cmdIngestGreenhouse(args.slice(1));
-  console.error('Usage: jobbot ingest greenhouse --company <slug>');
+  if (sub === 'lever') return cmdIngestLever(args.slice(1));
+  console.error('Usage: jobbot ingest <greenhouse|lever> --company <slug>');
   process.exit(2);
 }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -45,7 +45,8 @@ revisit them later without blocking the workflow.
 1. The user searches company boards via supported fetchers (Greenhouse, Lever, Ashby, Workable,
    SmartRecruiters) or pastes individual URLs into the CLI/UI. For example,
    `jobbot ingest greenhouse --company acme` pulls the latest public postings into the local
-   data directory.
+   data directory, and `jobbot ingest lever --company acme` performs the same for Lever-hosted
+   listings.
 2. The fetch pipeline de-duplicates listings, normalizes HTML to text, and stores raw + parsed
    copies under `data/jobs/{job_id}.json` alongside fetch metadata (timestamp, source, request
    headers). Job identifiers are hashed from the source URL or file path so repeat fetches update

--- a/src/lever.js
+++ b/src/lever.js
@@ -1,0 +1,81 @@
+import fetch from 'node-fetch';
+import { extractTextFromHtml } from './fetch.js';
+import { jobIdFromSource, saveJobSnapshot } from './jobs.js';
+import { parseJobText } from './parser.js';
+
+const LEVER_BASE = 'https://api.lever.co/v0/postings';
+
+function normalizeOrgSlug(org) {
+  if (!org || typeof org !== 'string' || !org.trim()) {
+    throw new Error('Lever org slug is required');
+  }
+  return org.trim();
+}
+
+function buildOrgUrl(slug) {
+  return `${LEVER_BASE}/${encodeURIComponent(slug)}?mode=json`;
+}
+
+function resolveHostedUrl(job, slug) {
+  const fromJob = typeof job.hostedUrl === 'string' ? job.hostedUrl.trim() : '';
+  if (fromJob) return fromJob;
+  const jobId = typeof job.id === 'string' && job.id.trim() ? job.id.trim() : String(job.id ?? '');
+  if (jobId) return `https://jobs.lever.co/${slug}/${jobId}`;
+  return `https://jobs.lever.co/${slug}`;
+}
+
+function extractRawDescription(job) {
+  const plain = typeof job.descriptionPlain === 'string' ? job.descriptionPlain.trim() : '';
+  if (plain) return plain;
+  const html = typeof job.description === 'string' ? job.description : '';
+  if (html && html.trim()) return extractTextFromHtml(html);
+  const fallback = typeof job.text === 'string' ? job.text.trim() : '';
+  return fallback;
+}
+
+function extractLocation(job) {
+  const loc = job?.categories?.location;
+  return typeof loc === 'string' ? loc.trim() : '';
+}
+
+function mergeParsedJob(parsed, job) {
+  const merged = { ...parsed };
+  const title = typeof job.text === 'string' ? job.text.trim() : '';
+  if (!merged.title && title) merged.title = title;
+  const location = extractLocation(job);
+  if (!merged.location && location) merged.location = location;
+  return merged;
+}
+
+export async function fetchLeverJobs(org, { fetchImpl = fetch } = {}) {
+  const slug = normalizeOrgSlug(org);
+  const url = buildOrgUrl(slug);
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Lever org ${slug}: ${response.status} ${response.statusText}`);
+  }
+  const jobs = await response.json();
+  return { slug, jobs: Array.isArray(jobs) ? jobs : [] };
+}
+
+export async function ingestLeverBoard({ org, fetchImpl = fetch } = {}) {
+  const { slug, jobs } = await fetchLeverJobs(org, { fetchImpl });
+  const jobIds = [];
+
+  for (const job of jobs) {
+    const hostedUrl = resolveHostedUrl(job, slug);
+    const raw = extractRawDescription(job);
+    const parsed = mergeParsedJob(parseJobText(raw), job);
+    const id = jobIdFromSource({ provider: 'lever', url: hostedUrl });
+    await saveJobSnapshot({
+      id,
+      raw,
+      parsed,
+      source: { type: 'lever', value: hostedUrl },
+      fetchedAt: job.updatedAt ?? job.createdAt,
+    });
+    jobIds.push(id);
+  }
+
+  return { org: slug, saved: jobIds.length, jobIds };
+}

--- a/test/lever.test.js
+++ b/test/lever.test.js
@@ -1,0 +1,91 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node-fetch', () => ({ default: vi.fn() }));
+
+import fetch from 'node-fetch';
+
+const JOBS_DIR = 'jobs';
+
+describe('Lever ingest', () => {
+  let dataDir;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-lever-'));
+    process.env.JOBBOT_DATA_DIR = dataDir;
+    fetch.mockReset();
+  });
+
+  afterEach(async () => {
+    if (dataDir) {
+      await fs.rm(dataDir, { recursive: true, force: true });
+      dataDir = undefined;
+    }
+    delete process.env.JOBBOT_DATA_DIR;
+  });
+
+  it('fetches Lever jobs and writes snapshots', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => [
+        {
+          id: 'abc123',
+          text: 'Senior Platform Engineer',
+          hostedUrl: 'https://jobs.lever.co/example/abc123',
+          descriptionPlain: `
+Title: Senior Platform Engineer
+Company: Example Corp
+Location: Remote
+Requirements
+- Ship reliable systems
+`,
+          categories: { location: 'Remote' },
+          updatedAt: '2025-01-02T03:04:05Z',
+        },
+      ],
+    });
+
+    const { ingestLeverBoard } = await import('../src/lever.js');
+
+    const result = await ingestLeverBoard({ org: 'example' });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.lever.co/v0/postings/example?mode=json',
+    );
+
+    expect(result).toMatchObject({ org: 'example', saved: 1 });
+    expect(result.jobIds).toHaveLength(1);
+
+    const jobsDir = path.join(dataDir, JOBS_DIR);
+    const files = await fs.readdir(jobsDir);
+    expect(files).toHaveLength(1);
+
+    const saved = JSON.parse(await fs.readFile(path.join(jobsDir, files[0]), 'utf8'));
+    expect(saved.source).toMatchObject({
+      type: 'lever',
+      value: 'https://jobs.lever.co/example/abc123',
+    });
+    expect(saved.parsed.title).toBe('Senior Platform Engineer');
+    expect(saved.parsed.location).toBe('Remote');
+    expect(saved.fetched_at).toBe('2025-01-02T03:04:05.000Z');
+  });
+
+  it('throws when the org fetch fails', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: async () => ({}),
+    });
+
+    const { ingestLeverBoard } = await import('../src/lever.js');
+
+    await expect(ingestLeverBoard({ org: 'missing' })).rejects.toThrow(
+      /Failed to fetch Lever org/,
+    );
+  });
+});


### PR DESCRIPTION
what: add Lever ingest pipeline, CLI command, tests, docs
why: user journeys promised Lever fetcher parity with greenhouse
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ce3c34e110832fac45c557e37ed8f5