### PR TITLE
Add Lever job board ingestion support

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,21 +227,28 @@ The CLI respects `JOBBOT_DATA_DIR`, mirroring the application lifecycle store,
 so snapshots stay alongside other candidate data when the directory is moved.
 `test/jobs.test.js` covers this behaviour to keep the contract stable.
 
-## Greenhouse job board ingestion
+## Job board ingestion
 
-Fetch public boards directly with:
+Fetch public Greenhouse boards directly with:
 
 ~~~bash
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest greenhouse --company example
 # Imported 12 jobs from example
 ~~~
 
+Pull Lever postings with the same workflow:
+
+~~~bash
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest lever --org example
+# Imported 12 jobs from example
+~~~
+
 Each listing in the response is normalised to plain text, parsed for title,
 location, and requirements, and written to `data/jobs/{job_id}.json` with a
-`source.type` of `greenhouse`. Updates reuse the same job identifier so
-downstream tooling can diff revisions over time. `test/greenhouse.test.js`
-verifies the ingest pipeline fetches board content and persists structured
-snapshots.
+`source.type` describing the ATS (`greenhouse` or `lever`). Updates reuse the
+same job identifier so downstream tooling can diff revisions over time.
+`test/greenhouse.test.js` and `test/lever.test.js` verify the ingest pipeline
+fetches board content and persists structured snapshots for both providers.
 
 Job titles can be parsed from lines starting with `Title`, `Job Title`, `Position`, or `Role`.
 Headers can use colons or dash separators (for example, `Role - Staff Engineer`), and the same

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -14,6 +14,7 @@ import { recordJobDiscard } from '../src/discards.js';
 import { addJobTags, discardJob, filterShortlist, syncShortlistJob } from '../src/shortlist.js';
 import { initProfile } from '../src/profile.js';
 import { ingestGreenhouseBoard } from '../src/greenhouse.js';
+import { ingestLeverBoard } from '../src/lever.js';
 
 function isHttpUrl(s) {
   return /^https?:\/\//i.test(s);
@@ -210,10 +211,23 @@ async function cmdIngestGreenhouse(args) {
   console.log(`Imported ${saved} ${noun} from ${company}`);
 }
 
+async function cmdIngestLever(args) {
+  const org = getFlag(args, '--org') ?? getFlag(args, '--company');
+  if (!org) {
+    console.error('Usage: jobbot ingest lever --org <slug>');
+    process.exit(2);
+  }
+
+  const { saved } = await ingestLeverBoard({ org });
+  const noun = saved === 1 ? 'job' : 'jobs';
+  console.log(`Imported ${saved} ${noun} from ${org}`);
+}
+
 async function cmdIngest(args) {
   const sub = args[0];
   if (sub === 'greenhouse') return cmdIngestGreenhouse(args.slice(1));
-  console.error('Usage: jobbot ingest greenhouse --company <slug>');
+  if (sub === 'lever') return cmdIngestLever(args.slice(1));
+  console.error('Usage: jobbot ingest <greenhouse|lever> [options]');
   process.exit(2);
 }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -44,8 +44,8 @@ revisit them later without blocking the workflow.
 
 1. The user searches company boards via supported fetchers (Greenhouse, Lever, Ashby, Workable,
    SmartRecruiters) or pastes individual URLs into the CLI/UI. For example,
-   `jobbot ingest greenhouse --company acme` pulls the latest public postings into the local
-   data directory.
+   `jobbot ingest greenhouse --company acme` or `jobbot ingest lever --org acme` pull the latest
+   public postings into the local data directory.
 2. The fetch pipeline de-duplicates listings, normalizes HTML to text, and stores raw + parsed
    copies under `data/jobs/{job_id}.json` alongside fetch metadata (timestamp, source, request
    headers). Job identifiers are hashed from the source URL or file path so repeat fetches update

--- a/src/lever.js
+++ b/src/lever.js
@@ -1,0 +1,193 @@
+import fetch from 'node-fetch';
+import { extractTextFromHtml } from './fetch.js';
+import { jobIdFromSource, saveJobSnapshot } from './jobs.js';
+import { parseJobText } from './parser.js';
+
+const LEVER_BASE = 'https://api.lever.co/v0/postings';
+
+function normalizeOrgSlug(org) {
+  if (!org || typeof org !== 'string' || !org.trim()) {
+    throw new Error('Lever organization slug is required');
+  }
+  return org.trim();
+}
+
+function buildPostingsUrl(slug) {
+  return `${LEVER_BASE}/${encodeURIComponent(slug)}?mode=json`;
+}
+
+function resolveHostedUrl(job, slug) {
+  if (typeof job?.hostedUrl === 'string' && job.hostedUrl.trim()) {
+    return job.hostedUrl.trim();
+  }
+  return `https://jobs.lever.co/${slug}/${job.id}`;
+}
+
+function normalizeListEntry(entry) {
+  if (!entry || typeof entry !== 'object') return '';
+  const text =
+    typeof entry.text === 'string'
+      ? entry.text
+      : typeof entry.content === 'string'
+        ? entry.content
+        : '';
+  const trimmed = text.trim();
+  if (!trimmed) return '';
+  if (/^<li[\s>]/i.test(trimmed)) return trimmed;
+  return `<li>${trimmed}</li>`;
+}
+
+function humanizeListKey(key) {
+  if (!key) return 'Details';
+  return String(key)
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z\d])([A-Z])/g, '$1 $2')
+    .split(/\s+/)
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+const REQUIREMENT_SECTION_RE = /<h[1-6][^>]*>\s*Requirements\s*<\/h[1-6]>\s*<ul[\s\S]*?<\/ul>/gi;
+const LIST_ITEM_RE = /<li[\s\S]*?<\/li>/gi;
+
+function extractRequirementSectionDetails(html) {
+  if (typeof html !== 'string') {
+    return { cleaned: html, bullets: [] };
+  }
+
+  const bullets = [];
+  const cleaned = html.replace(REQUIREMENT_SECTION_RE, section => {
+    const items = section.match(LIST_ITEM_RE) || [];
+    for (const item of items) {
+      const text = extractTextFromHtml(item).trim();
+      if (text) bullets.push(text);
+    }
+    return '';
+  });
+
+  return { cleaned, bullets };
+}
+
+function collectLeverText(job) {
+  const lines = [];
+  let hasRequirementsHeader = false;
+
+  const pushRichText = value => {
+    if (typeof value !== 'string') return;
+    const text = extractTextFromHtml(value).trim();
+    if (!text) return;
+    lines.push(text);
+    if (/^requirements\b/i.test(text) || /\brequirements:/i.test(text)) {
+      hasRequirementsHeader = true;
+    }
+  };
+
+  const { cleaned: descriptionHtml, bullets: descriptionRequirementBullets } =
+    extractRequirementSectionDetails(job?.description);
+  pushRichText(descriptionHtml);
+
+  if (job?.lists && typeof job.lists === 'object') {
+    for (const [key, entries] of Object.entries(job.lists)) {
+      if (!Array.isArray(entries) || entries.length === 0) continue;
+      const bullets = entries
+        .map(normalizeListEntry)
+        .map(item => extractTextFromHtml(item).trim())
+        .filter(Boolean);
+      if (bullets.length === 0) continue;
+
+      const normalizedKey = String(key || '').trim().toLowerCase();
+      if (normalizedKey === 'requirements') {
+        const combined = descriptionRequirementBullets.splice(0).concat(bullets);
+        if (combined.length === 0) continue;
+        if (!hasRequirementsHeader) {
+          lines.push('Requirements:');
+          hasRequirementsHeader = true;
+        }
+        for (const bullet of combined) {
+          lines.push(`- ${bullet}`);
+        }
+        continue;
+      }
+
+      const header = humanizeListKey(key);
+      lines.push(`${header}:`);
+      if (/^requirements$/i.test(header)) hasRequirementsHeader = true;
+
+      for (const bullet of bullets) {
+        lines.push(`- ${bullet}`);
+      }
+    }
+  }
+
+  if (descriptionRequirementBullets.length > 0) {
+    if (!hasRequirementsHeader) {
+      lines.push('Requirements:');
+      hasRequirementsHeader = true;
+    }
+    for (const bullet of descriptionRequirementBullets) {
+      lines.push(`- ${bullet}`);
+    }
+  }
+
+  pushRichText(job?.additional);
+  pushRichText(job?.additionalPlain);
+  pushRichText(job?.descriptionPlain);
+
+  return lines.join('\n');
+}
+
+function mergeParsedJob(parsed, job) {
+  const merged = { ...parsed };
+  if ((!merged.title || !merged.title.trim()) && typeof job?.text === 'string') {
+    const title = job.text.trim();
+    if (title) merged.title = title;
+  }
+  const location =
+    typeof job?.categories?.location === 'string' ? job.categories.location.trim() : '';
+  if ((!merged.location || !merged.location.trim()) && location) {
+    merged.location = location;
+  }
+  return merged;
+}
+
+export async function fetchLeverPostings(org, { fetchImpl = fetch } = {}) {
+  const slug = normalizeOrgSlug(org);
+  const url = buildPostingsUrl(slug);
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch Lever postings ${slug}: ${response.status} ${response.statusText}`
+    );
+  }
+  const payload = await response.json();
+  const jobs = Array.isArray(payload)
+    ? payload
+    : Array.isArray(payload?.data)
+      ? payload.data
+      : [];
+  return { slug, jobs };
+}
+
+export async function ingestLeverBoard({ org, fetchImpl = fetch } = {}) {
+  const { slug, jobs } = await fetchLeverPostings(org, { fetchImpl });
+  const jobIds = [];
+
+  for (const job of jobs) {
+    if (!job || typeof job !== 'object') continue;
+    const text = collectLeverText(job);
+    const parsed = mergeParsedJob(parseJobText(text), job);
+    const absoluteUrl = resolveHostedUrl(job, slug);
+    const id = jobIdFromSource({ provider: 'lever', url: absoluteUrl });
+    await saveJobSnapshot({
+      id,
+      raw: text,
+      parsed,
+      source: { type: 'lever', value: absoluteUrl },
+      fetchedAt: job.updatedAt ?? job.createdAt,
+    });
+    jobIds.push(id);
+  }
+
+  return { org: slug, saved: jobIds.length, jobIds };
+}

--- a/test/lever.test.js
+++ b/test/lever.test.js
@@ -1,0 +1,101 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node-fetch', () => ({ default: vi.fn() }));
+
+import fetch from 'node-fetch';
+
+const JOBS_DIR = 'jobs';
+
+describe('Lever ingest', () => {
+  let dataDir;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-lever-'));
+    process.env.JOBBOT_DATA_DIR = dataDir;
+    fetch.mockReset();
+  });
+
+  afterEach(async () => {
+    if (dataDir) {
+      await fs.rm(dataDir, { recursive: true, force: true });
+      dataDir = undefined;
+    }
+    delete process.env.JOBBOT_DATA_DIR;
+  });
+
+  it('fetches Lever postings and writes snapshots', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => [
+        {
+          id: 'abc123',
+          text: 'Senior Backend Engineer',
+          hostedUrl: 'https://jobs.lever.co/example/abc123',
+          categories: { location: 'Remote', commitment: 'Full-time' },
+          description: `
+            <h2>About the role</h2>
+            <p>Help build reliable services.</p>
+            <h3>Requirements</h3>
+            <ul>
+              <li>Design distributed systems</li>
+            </ul>
+          `,
+          lists: {
+            requirements: [
+              { text: '<li>Own Node.js services</li>' },
+              { content: '<li>Coach teammates</li>' },
+            ],
+          },
+          updatedAt: 1751993411000,
+        },
+      ],
+    });
+
+    const { ingestLeverBoard } = await import('../src/lever.js');
+
+    const result = await ingestLeverBoard({ org: 'example' });
+
+    expect(fetch).toHaveBeenCalledWith('https://api.lever.co/v0/postings/example?mode=json');
+
+    expect(result).toMatchObject({ org: 'example', saved: 1 });
+    expect(result.jobIds).toHaveLength(1);
+
+    const jobsDir = path.join(dataDir, JOBS_DIR);
+    const files = await fs.readdir(jobsDir);
+    expect(files).toHaveLength(1);
+
+    const saved = JSON.parse(await fs.readFile(path.join(jobsDir, files[0]), 'utf8'));
+    expect(saved.source).toMatchObject({
+      type: 'lever',
+      value: 'https://jobs.lever.co/example/abc123',
+    });
+    expect(saved.parsed.title).toBe('Senior Backend Engineer');
+    expect(saved.parsed.location).toBe('Remote');
+    expect(saved.parsed.requirements).toEqual([
+      'Design distributed systems',
+      'Own Node.js services',
+      'Coach teammates',
+    ]);
+    expect(saved.fetched_at).toBe(new Date(1751993411000).toISOString());
+  });
+
+  it('throws when the postings fetch fails', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: async () => ({ error: 'Not Found' }),
+    });
+
+    const { ingestLeverBoard } = await import('../src/lever.js');
+
+    await expect(ingestLeverBoard({ org: 'missing' })).rejects.toThrow(
+      /Failed to fetch Lever postings/
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a Lever postings ingest module that normalizes description/list sections before saving snapshots
- expose `jobbot ingest lever` alongside docs that walk through fetching Lever boards from the CLI
- verify Lever ingest happy/error paths with new unit coverage and reference the test from the docs

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ce3c34e110832fac45c557e37ed8f5