### PR TITLE
Improve Lever ingest fragment handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,22 @@ downstream tooling can diff revisions over time. `test/greenhouse.test.js`
 verifies the ingest pipeline fetches board content and persists structured
 snapshots.
 
+## Lever job board ingestion
+
+Ingest Lever-hosted postings with:
+
+~~~bash
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest lever --org example
+# Imported 8 jobs from example
+~~~
+
+Lever responses expose HTML `content` blocks and optional section `lists`.
+Fragments can arrive as strings, arrays, or nested objects, and the ingest
+pipeline flattens them before normalising to text. Title and location metadata
+are merged back into the parsed snapshot, which is persisted to
+`data/jobs/{job_id}.json` with a `source.type` of `lever`. The contract and
+error handling are covered by `test/lever.test.js`.
+
 Job titles can be parsed from lines starting with `Title`, `Job Title`, `Position`, or `Role`.
 Headers can use colons or dash separators (for example, `Role - Staff Engineer`), and the same
 separators work for `Company` and `Location`. Parser unit tests cover both colon and dash cases so

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -14,6 +14,7 @@ import { recordJobDiscard } from '../src/discards.js';
 import { addJobTags, discardJob, filterShortlist, syncShortlistJob } from '../src/shortlist.js';
 import { initProfile } from '../src/profile.js';
 import { ingestGreenhouseBoard } from '../src/greenhouse.js';
+import { ingestLeverBoard } from '../src/lever.js';
 
 function isHttpUrl(s) {
   return /^https?:\/\//i.test(s);
@@ -213,8 +214,21 @@ async function cmdIngestGreenhouse(args) {
 async function cmdIngest(args) {
   const sub = args[0];
   if (sub === 'greenhouse') return cmdIngestGreenhouse(args.slice(1));
-  console.error('Usage: jobbot ingest greenhouse --company <slug>');
+  if (sub === 'lever') return cmdIngestLever(args.slice(1));
+  console.error('Usage: jobbot ingest <greenhouse|lever> [options]');
   process.exit(2);
+}
+
+async function cmdIngestLever(args) {
+  const org = getFlag(args, '--org');
+  if (!org) {
+    console.error('Usage: jobbot ingest lever --org <slug>');
+    process.exit(2);
+  }
+
+  const { saved } = await ingestLeverBoard({ org });
+  const noun = saved === 1 ? 'job' : 'jobs';
+  console.log(`Imported ${saved} ${noun} from ${org}`);
 }
 
 async function cmdShortlistTag(args) {

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -42,8 +42,8 @@ revisit them later without blocking the workflow.
 
 **Goal:** Build a living shortlist of job opportunities pulled from the web or supplied manually.
 
-1. The user searches company boards via supported fetchers (Greenhouse, Lever, Ashby, Workable,
-   SmartRecruiters) or pastes individual URLs into the CLI/UI. For example,
+1. The user searches company boards via supported fetchers (Greenhouse and Lever today; Ashby,
+   Workable, and SmartRecruiters are on the roadmap) or pastes individual URLs into the CLI/UI. For example,
    `jobbot ingest greenhouse --company acme` pulls the latest public postings into the local
    data directory.
 2. The fetch pipeline de-duplicates listings, normalizes HTML to text, and stores raw + parsed

--- a/src/lever.js
+++ b/src/lever.js
@@ -1,0 +1,163 @@
+import fetch from 'node-fetch';
+import { extractTextFromHtml } from './fetch.js';
+import { jobIdFromSource, saveJobSnapshot } from './jobs.js';
+import { parseJobText } from './parser.js';
+
+const LEVER_BASE = 'https://api.lever.co/v0/postings';
+
+function normalizeOrgSlug(org) {
+  if (!org || typeof org !== 'string' || !org.trim()) {
+    throw new Error('Lever org slug is required');
+  }
+  return org.trim();
+}
+
+function buildOrgUrl(slug) {
+  return `${LEVER_BASE}/${encodeURIComponent(slug)}?mode=json`;
+}
+
+function resolveAbsoluteUrl(job, slug) {
+  const hosted = typeof job?.hostedUrl === 'string' ? job.hostedUrl.trim() : '';
+  if (hosted) return hosted;
+  const identifier =
+    typeof job?.id === 'string' && job.id.trim()
+      ? job.id.trim()
+      : typeof job?.id === 'number'
+        ? String(job.id)
+        : '';
+  const fallback = identifier || 'unknown';
+  const encodedSlug = encodeURIComponent(slug);
+  const encodedId = encodeURIComponent(fallback);
+  return `https://jobs.lever.co/${encodedSlug}/${encodedId}`;
+}
+
+function extractLocation(job) {
+  const categories = job?.categories;
+  const byCategory =
+    categories && typeof categories.location === 'string' ? categories.location.trim() : '';
+  if (byCategory) return byCategory;
+  if (typeof job?.location === 'string' && job.location.trim()) return job.location.trim();
+  if (typeof job?.workplaceType === 'string' && job.workplaceType.trim()) {
+    return job.workplaceType.trim();
+  }
+  return '';
+}
+
+function normalizeHtmlFragments(fragment) {
+  if (!fragment) return [];
+  if (typeof fragment === 'string') {
+    const trimmed = fragment.trim();
+    return trimmed ? [trimmed] : [];
+  }
+  if (Array.isArray(fragment)) {
+    const collected = [];
+    for (const entry of fragment) {
+      collected.push(...normalizeHtmlFragments(entry));
+    }
+    return collected;
+  }
+  if (typeof fragment === 'object') {
+    const collected = [];
+    if (typeof fragment.text === 'string') {
+      const text = fragment.text.trim();
+      if (text) collected.push(text);
+    }
+    if (fragment.content !== undefined) {
+      collected.push(...normalizeHtmlFragments(fragment.content));
+    }
+    return collected;
+  }
+  return [];
+}
+
+function normalizePlainText(value) {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  return trimmed ? trimmed : '';
+}
+
+function buildJobHtml(job) {
+  const sections = [];
+  const title = typeof job?.text === 'string' ? job.text.trim() : '';
+  if (title) sections.push(`<h1>${title}</h1>`);
+
+  const mainContent = normalizeHtmlFragments(job?.content).join('\n');
+  if (mainContent) sections.push(mainContent);
+
+  if (Array.isArray(job?.lists)) {
+    for (const entry of job.lists) {
+      const heading = typeof entry?.text === 'string' ? entry.text.trim() : '';
+      const listHtml = normalizeHtmlFragments(entry?.content).join('\n');
+      if (heading || listHtml) {
+        const headingHtml = heading ? `<h2>${heading}</h2>` : '';
+        sections.push(`${headingHtml}${listHtml}`);
+      }
+    }
+  }
+
+  const descriptionHtml = normalizeHtmlFragments(job?.description).join('\n');
+  if (descriptionHtml) {
+    sections.push(descriptionHtml);
+  } else {
+    const descriptionPlain = normalizePlainText(job?.descriptionPlain);
+    if (descriptionPlain) sections.push(`<p>${descriptionPlain}</p>`);
+  }
+
+  const additionalHtml = normalizeHtmlFragments(job?.additional).join('\n');
+  if (additionalHtml) sections.push(additionalHtml);
+
+  const additionalPlain = normalizePlainText(job?.additionalPlain);
+  if (additionalPlain) sections.push(`<p>${additionalPlain}</p>`);
+
+  return sections.join('\n');
+}
+
+function mergeParsedJob(parsed, job) {
+  const merged = { ...parsed };
+  if (!merged.title) {
+    const title = typeof job?.text === 'string' ? job.text.trim() : '';
+    if (title) merged.title = title;
+  }
+  if (!merged.location) {
+    const location = extractLocation(job);
+    if (location) merged.location = location;
+  }
+  return merged;
+}
+
+export async function fetchLeverJobs(org, { fetchImpl = fetch } = {}) {
+  const slug = normalizeOrgSlug(org);
+  const url = buildOrgUrl(slug);
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Lever org ${slug}: ${response.status} ${response.statusText}`);
+  }
+  const payload = await response.json();
+  const jobs = Array.isArray(payload)
+    ? payload
+    : Array.isArray(payload?.data)
+      ? payload.data
+      : [];
+  return { slug, jobs };
+}
+
+export async function ingestLeverBoard({ org, fetchImpl = fetch } = {}) {
+  const { slug, jobs } = await fetchLeverJobs(org, { fetchImpl });
+  const jobIds = [];
+  for (const job of jobs) {
+    const absoluteUrl = resolveAbsoluteUrl(job, slug);
+    const html = buildJobHtml(job);
+    const text = extractTextFromHtml(html);
+    const parsed = mergeParsedJob(parseJobText(text), job);
+    const id = jobIdFromSource({ provider: 'lever', url: absoluteUrl });
+    await saveJobSnapshot({
+      id,
+      raw: text,
+      parsed,
+      source: { type: 'lever', value: absoluteUrl },
+      fetchedAt: job?.updatedAt ?? job?.createdAt,
+    });
+    jobIds.push(id);
+  }
+  return { org: slug, saved: jobIds.length, jobIds };
+}

--- a/test/lever.test.js
+++ b/test/lever.test.js
@@ -1,0 +1,159 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node-fetch', () => ({ default: vi.fn() }));
+
+import fetch from 'node-fetch';
+
+const JOBS_DIR = 'jobs';
+
+describe('Lever ingest', () => {
+  let dataDir;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-lever-'));
+    process.env.JOBBOT_DATA_DIR = dataDir;
+    fetch.mockReset();
+  });
+
+  afterEach(async () => {
+    if (dataDir) {
+      await fs.rm(dataDir, { recursive: true, force: true });
+      dataDir = undefined;
+    }
+    delete process.env.JOBBOT_DATA_DIR;
+  });
+
+  it('fetches Lever postings, normalizes HTML fragments, and writes snapshots', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => [
+        {
+          id: '123abc',
+          text: 'Backend Engineer',
+          categories: { location: 'Remote' },
+          content: [
+            '<p>Build APIs</p>',
+            { text: '<p>Ship features fast</p>' },
+          ],
+          lists: [
+            {
+              text: 'Responsibilities',
+              content: [
+                '<ul><li>Scale services</li></ul>',
+                { text: '<p>Maintain reliability</p>' },
+              ],
+            },
+            {
+              text: 'Qualifications',
+              content: [{ content: '<ul><li>TypeScript experience</li></ul>' }],
+            },
+          ],
+          descriptionPlain: 'More details about the role.',
+          hostedUrl: 'https://jobs.lever.co/example/123abc',
+          updatedAt: 1730419200000,
+        },
+      ],
+    });
+
+    const { ingestLeverBoard } = await import('../src/lever.js');
+
+    const result = await ingestLeverBoard({ org: 'example' });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.lever.co/v0/postings/example?mode=json',
+    );
+
+    expect(result).toMatchObject({ org: 'example', saved: 1 });
+    expect(result.jobIds).toHaveLength(1);
+
+    const jobsDir = path.join(dataDir, JOBS_DIR);
+    const files = await fs.readdir(jobsDir);
+    expect(files).toHaveLength(1);
+
+    const saved = JSON.parse(await fs.readFile(path.join(jobsDir, files[0]), 'utf8'));
+    expect(saved.source).toMatchObject({
+      type: 'lever',
+      value: 'https://jobs.lever.co/example/123abc',
+    });
+    expect(saved.parsed.title).toBe('Backend Engineer');
+    expect(saved.parsed.location).toBe('Remote');
+    expect(saved.raw).toContain('More details about the role.');
+    expect(saved.raw).toContain('Maintain reliability');
+    const requirements = saved.parsed.requirements.join(' ');
+    expect(requirements).toContain('Scale services');
+    expect(requirements).toContain('TypeScript experience');
+    expect(saved.fetched_at).toBe('2024-11-01T00:00:00.000Z');
+  });
+
+  it('throws when the org fetch fails', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: async () => ({}),
+    });
+
+    const { ingestLeverBoard } = await import('../src/lever.js');
+
+    await expect(ingestLeverBoard({ org: 'missing' })).rejects.toThrow(
+      /Failed to fetch Lever org/,
+    );
+  });
+
+  it('falls back to derived hosted URLs and merges metadata from plain fields', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => [
+        {
+          id: 42,
+          text: 'Data Engineer',
+          lists: [
+            {
+              text: 'Responsibilities',
+              content: ['<ul><li>Maintain pipelines</li></ul>'],
+            },
+          ],
+          descriptionPlain: 'Data team focused role.',
+          additional: ['<p>Bonus info</p>'],
+          additionalPlain: 'Apply soon.',
+          workplaceType: 'Hybrid - NYC',
+          hostedUrl: '  ',
+          createdAt: '2024-09-01T12:00:00Z',
+        },
+      ],
+    });
+
+    const { ingestLeverBoard } = await import('../src/lever.js');
+
+    const result = await ingestLeverBoard({ org: ' Example Corp ' });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.lever.co/v0/postings/Example%20Corp?mode=json',
+    );
+
+    expect(result).toMatchObject({ org: 'Example Corp', saved: 1 });
+    const [jobId] = result.jobIds;
+    expect(jobId).toBeTruthy();
+
+    const jobsDir = path.join(dataDir, JOBS_DIR);
+    const files = await fs.readdir(jobsDir);
+    expect(files).toHaveLength(1);
+
+    const saved = JSON.parse(await fs.readFile(path.join(jobsDir, files[0]), 'utf8'));
+    expect(saved.source).toMatchObject({
+      type: 'lever',
+      value: 'https://jobs.lever.co/Example%20Corp/42',
+    });
+    expect(saved.parsed.location).toBe('Hybrid - NYC');
+    expect(saved.raw).toContain('Data team focused role.');
+    expect(saved.raw).toContain('Bonus info');
+    expect(saved.raw).toContain('Apply soon.');
+  });
+});


### PR DESCRIPTION
## Summary
- flatten Lever HTML fragments before normalization and encode derived hosted URLs for missing links
- extend Lever ingest tests to cover nested content arrays and plain-text metadata fallbacks
- document the fragment flattening behaviour in the Lever ingestion README section

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ce3c34e110832fac45c557e37ed8f5