### PR TITLE
Add SmartRecruiters job board ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ so snapshots stay alongside other candidate data when the directory is moved.
 
 ## Job board ingestion
 
-Fetch public boards directly with Greenhouse or Lever pipelines:
+Fetch public boards directly with Greenhouse, Lever, or SmartRecruiters pipelines:
 
 ~~~bash
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest greenhouse --company example
@@ -237,17 +237,21 @@ JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest greenhouse --company example
 
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest lever --company example
 # Imported 8 jobs from example
+
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest smartrecruiters --company example
+# Imported 5 jobs from example
 ~~~
 
 Each listing in the response is normalised to plain text, parsed for title,
 location, and requirements, and written to `data/jobs/{job_id}.json` with a
-`source.type` reflecting the provider (`greenhouse` or `lever`). Updates reuse
+`source.type` reflecting the provider (`greenhouse`, `lever`, or `smartrecruiters`). Updates reuse
 the same job identifier so downstream tooling can diff revisions over time.
-Tests in [`test/greenhouse.test.js`](test/greenhouse.test.js) and
-[`test/lever.test.js`](test/lever.test.js) verify the ingest pipelines fetch
-board content, persist structured snapshots, surface fetch errors, and retain
-the `User-Agent: jobbot3000` request header alongside each capture so fetches
-are reproducible.
+Tests in [`test/greenhouse.test.js`](test/greenhouse.test.js),
+[`test/lever.test.js`](test/lever.test.js), and
+[`test/smartrecruiters.test.js`](test/smartrecruiters.test.js) verify the ingest
+pipelines fetch board content, persist structured snapshots, surface fetch
+errors, and retain the `User-Agent: jobbot3000` request header alongside each
+capture so fetches are reproducible.
 
 Job titles can be parsed from lines starting with `Title`, `Job Title`, `Position`, or `Role`.
 Headers can use colons or dash separators (for example, `Role - Staff Engineer`), and the same

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -15,6 +15,7 @@ import { addJobTags, discardJob, filterShortlist, syncShortlistJob } from '../sr
 import { initProfile } from '../src/profile.js';
 import { ingestGreenhouseBoard } from '../src/greenhouse.js';
 import { ingestLeverBoard } from '../src/lever.js';
+import { ingestSmartRecruitersBoard } from '../src/smartrecruiters.js';
 
 function isHttpUrl(s) {
   return /^https?:\/\//i.test(s);
@@ -223,11 +224,24 @@ async function cmdIngestLever(args) {
   console.log(`Imported ${saved} ${noun} from ${company}`);
 }
 
+async function cmdIngestSmartRecruiters(args) {
+  const company = getFlag(args, '--company');
+  if (!company) {
+    console.error('Usage: jobbot ingest smartrecruiters --company <slug>');
+    process.exit(2);
+  }
+
+  const { saved } = await ingestSmartRecruitersBoard({ company });
+  const noun = saved === 1 ? 'job' : 'jobs';
+  console.log(`Imported ${saved} ${noun} from ${company}`);
+}
+
 async function cmdIngest(args) {
   const sub = args[0];
   if (sub === 'greenhouse') return cmdIngestGreenhouse(args.slice(1));
   if (sub === 'lever') return cmdIngestLever(args.slice(1));
-  console.error('Usage: jobbot ingest <greenhouse|lever> --company <slug>');
+  if (sub === 'smartrecruiters') return cmdIngestSmartRecruiters(args.slice(1));
+  console.error('Usage: jobbot ingest <greenhouse|lever|smartrecruiters> --company <slug>');
   process.exit(2);
 }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -42,8 +42,8 @@ revisit them later without blocking the workflow.
 
 **Goal:** Build a living shortlist of job opportunities pulled from the web or supplied manually.
 
-1. The user searches company boards via supported fetchers (Greenhouse, Lever, Ashby, Workable,
-   SmartRecruiters) or pastes individual URLs into the CLI/UI. For example,
+1. The user searches company boards via supported fetchers (Greenhouse, Lever, SmartRecruiters,
+   with Ashby and Workable on the roadmap) or pastes individual URLs into the CLI/UI. For example,
    `jobbot ingest greenhouse --company acme` pulls the latest public postings into the local
    data directory, and `jobbot ingest lever --company acme` performs the same for Lever-hosted
    listings.

--- a/src/smartrecruiters.js
+++ b/src/smartrecruiters.js
@@ -1,0 +1,133 @@
+import fetch from 'node-fetch';
+import { extractTextFromHtml } from './fetch.js';
+import { jobIdFromSource, saveJobSnapshot } from './jobs.js';
+import { parseJobText } from './parser.js';
+
+const SMARTRECRUITERS_BASE = 'https://api.smartrecruiters.com/v1/companies';
+const SMARTRECRUITERS_HEADERS = { 'User-Agent': 'jobbot3000' };
+const DEFAULT_LIMIT = 100;
+
+function normalizeCompanySlug(company) {
+  if (!company || typeof company !== 'string' || !company.trim()) {
+    throw new Error('SmartRecruiters company slug is required');
+  }
+  return company.trim();
+}
+
+function buildListUrl(slug, offset) {
+  const url = new URL(`${SMARTRECRUITERS_BASE}/${encodeURIComponent(slug)}/postings`);
+  url.searchParams.set('limit', String(DEFAULT_LIMIT));
+  url.searchParams.set('offset', String(offset));
+  return url.toString();
+}
+
+function resolveDetailUrl(slug, posting) {
+  const ref = typeof posting?.ref === 'string' && posting.ref.trim() ? posting.ref.trim() : '';
+  if (ref) return ref;
+  const id = typeof posting?.id === 'string' ? posting.id.trim() : String(posting?.id ?? '');
+  if (!id) {
+    throw new Error('SmartRecruiters posting id is required');
+  }
+  return `${SMARTRECRUITERS_BASE}/${encodeURIComponent(slug)}/postings/${encodeURIComponent(id)}`;
+}
+
+function toPlainText(html) {
+  if (!html) return '';
+  return extractTextFromHtml(html);
+}
+
+function extractSectionsText(detail) {
+  const sections = detail?.jobAd?.sections;
+  if (!sections || typeof sections !== 'object') return '';
+  const parts = [];
+  for (const section of Object.values(sections)) {
+    if (!section || typeof section !== 'object') continue;
+    const title = typeof section.title === 'string' ? section.title.trim() : '';
+    const text = typeof section.text === 'string' ? section.text : '';
+    const safeTitle = title ? toPlainText(title) : '';
+    const safeText = text ? toPlainText(text) : '';
+    if (safeTitle) parts.push(safeTitle);
+    if (safeText) parts.push(safeText);
+  }
+  return parts.filter(Boolean).join('\n\n');
+}
+
+function mergeParsedJob(parsed, posting, detail) {
+  const merged = { ...parsed };
+  const name =
+    (typeof detail?.name === 'string' && detail.name.trim()) ||
+    (typeof posting?.name === 'string' && posting.name.trim()) ||
+    '';
+  const location =
+    (typeof detail?.location?.fullLocation === 'string' && detail.location.fullLocation.trim()) ||
+    (typeof posting?.location?.fullLocation === 'string' && posting.location.fullLocation.trim()) ||
+    '';
+  if (!merged.title && name) merged.title = name;
+  if (!merged.location && location) merged.location = location;
+  return merged;
+}
+
+export async function fetchSmartRecruitersPostings(company, { fetchImpl = fetch } = {}) {
+  const slug = normalizeCompanySlug(company);
+  const postings = [];
+  let offset = 0;
+
+  while (true) {
+    const url = buildListUrl(slug, offset);
+    const response = await fetchImpl(url, { headers: SMARTRECRUITERS_HEADERS });
+    if (!response.ok) {
+      const statusLabel = `${response.status} ${response.statusText}`;
+      throw new Error(`Failed to fetch SmartRecruiters company ${slug}: ${statusLabel}`);
+    }
+    const payload = await response.json();
+    const items = Array.isArray(payload?.content) ? payload.content : [];
+    postings.push(...items);
+    const totalFound =
+      typeof payload?.totalFound === 'number' ? payload.totalFound : postings.length;
+    offset += items.length;
+    if (offset >= totalFound || items.length < DEFAULT_LIMIT) {
+      break;
+    }
+    if (items.length === 0) break;
+  }
+
+  return { slug, postings };
+}
+
+export async function ingestSmartRecruitersBoard({ company, fetchImpl = fetch } = {}) {
+  const { slug, postings } = await fetchSmartRecruitersPostings(company, { fetchImpl });
+  const jobIds = [];
+
+  for (const posting of postings) {
+    const detailUrl = resolveDetailUrl(slug, posting);
+    const detailResponse = await fetchImpl(detailUrl, { headers: SMARTRECRUITERS_HEADERS });
+    if (!detailResponse.ok) {
+      const statusLabel = `${detailResponse.status} ${detailResponse.statusText}`;
+      const postingId = posting?.id ?? '';
+      throw new Error(
+        `Failed to fetch SmartRecruiters posting ${postingId}: ${statusLabel}`,
+      );
+    }
+    const detail = await detailResponse.json();
+    const sectionsText = extractSectionsText(detail);
+    const raw = sectionsText || toPlainText(detail?.jobAd?.text) || '';
+    const parsed = mergeParsedJob(parseJobText(raw), posting, detail);
+    const postingUrl =
+      (typeof detail?.postingUrl === 'string' && detail.postingUrl.trim()) ||
+      (typeof posting?.postingUrl === 'string' && posting.postingUrl.trim()) ||
+      (typeof posting?.applyUrl === 'string' && posting.applyUrl.trim()) ||
+      detailUrl;
+    const id = jobIdFromSource({ provider: 'smartrecruiters', url: postingUrl });
+    await saveJobSnapshot({
+      id,
+      raw,
+      parsed,
+      source: { type: 'smartrecruiters', value: postingUrl },
+      requestHeaders: SMARTRECRUITERS_HEADERS,
+      fetchedAt: detail?.releasedDate ?? posting?.releasedDate,
+    });
+    jobIds.push(id);
+  }
+
+  return { company: slug, saved: jobIds.length, jobIds };
+}

--- a/test/smartrecruiters.test.js
+++ b/test/smartrecruiters.test.js
@@ -1,0 +1,134 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node-fetch', () => ({ default: vi.fn() }));
+
+import fetch from 'node-fetch';
+
+const JOBS_DIR = 'jobs';
+
+describe('SmartRecruiters ingest', () => {
+  let dataDir;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-smartrecruiters-'));
+    process.env.JOBBOT_DATA_DIR = dataDir;
+    fetch.mockReset();
+  });
+
+  afterEach(async () => {
+    if (dataDir) {
+      await fs.rm(dataDir, { recursive: true, force: true });
+      dataDir = undefined;
+    }
+    delete process.env.JOBBOT_DATA_DIR;
+  });
+
+  it('fetches SmartRecruiters jobs and writes snapshots', async () => {
+    const postingUrl =
+      'https://jobs.smartrecruiters.com/example/744000082406416-partner-development-manager';
+
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        offset: 0,
+        limit: 100,
+        totalFound: 1,
+        content: [
+          {
+            id: '744000082406416',
+            name: 'Partner Development Manager',
+            releasedDate: '2025-09-17T09:30:30.267Z',
+            ref: 'https://api.smartrecruiters.com/v1/companies/example/postings/744000082406416',
+            postingUrl,
+            location: { fullLocation: 'Remote, United Kingdom' },
+          },
+        ],
+      }),
+    });
+
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        name: 'Partner Development Manager',
+        postingUrl,
+        releasedDate: '2025-09-17T09:30:30.267Z',
+        location: { fullLocation: 'Remote, United Kingdom' },
+        jobAd: {
+          sections: {
+            jobDescription: {
+              title: 'Job Description',
+              text: '<p>Build scalable systems</p>',
+            },
+            qualifications: {
+              title: 'Qualifications',
+              text: '<ul><li>Experience shipping production systems</li></ul>',
+            },
+          },
+        },
+      }),
+    });
+
+    const { ingestSmartRecruitersBoard } = await import('../src/smartrecruiters.js');
+
+    const result = await ingestSmartRecruitersBoard({ company: 'example' });
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      'https://api.smartrecruiters.com/v1/companies/example/postings?limit=100&offset=0',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'User-Agent': 'jobbot3000' }),
+      }),
+    );
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://api.smartrecruiters.com/v1/companies/example/postings/744000082406416',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'User-Agent': 'jobbot3000' }),
+      }),
+    );
+
+    expect(result).toMatchObject({ company: 'example', saved: 1 });
+    expect(result.jobIds).toHaveLength(1);
+
+    const jobsDir = path.join(dataDir, JOBS_DIR);
+    const files = await fs.readdir(jobsDir);
+    expect(files).toHaveLength(1);
+
+    const saved = JSON.parse(await fs.readFile(path.join(jobsDir, files[0]), 'utf8'));
+    expect(saved.source).toMatchObject({
+      type: 'smartrecruiters',
+      value:
+        'https://jobs.smartrecruiters.com/example/744000082406416-partner-development-manager',
+    });
+    expect(saved.parsed.title).toBe('Partner Development Manager');
+    expect(saved.parsed.location).toBe('Remote, United Kingdom');
+    const hasRequirement = saved.parsed.requirements.some((req) =>
+      req.includes('Experience shipping production systems'),
+    );
+    expect(hasRequirement).toBe(true);
+    expect(saved.fetched_at).toBe('2025-09-17T09:30:30.267Z');
+  });
+
+  it('throws when the postings fetch fails', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: async () => ({}),
+    });
+
+    const { ingestSmartRecruitersBoard } = await import('../src/smartrecruiters.js');
+
+    await expect(ingestSmartRecruitersBoard({ company: 'example' })).rejects.toThrow(
+      /Failed to fetch SmartRecruiters company example/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Inventory: `docs/user-journeys.md` promised SmartRecruiters (plus Ashby/Workable) ingestion even though only Greenhouse and Lever shipped; SmartRecruiters fits in a single PR because its public API mirrors the existing pipelines.
- Add a SmartRecruiters ingest module and CLI subcommand that snapshots postings with normalized text and provider metadata.
- Document the new support in the README/user journey and cover it with unit tests for happy-path snapshots and failure handling.

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ce4e3854e8832fb82c76984eb15440