### PR TITLE
Escape Lever plain text before HTML interpolation

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -254,9 +254,9 @@ jobbot track add <job_id> --status applied --note "emailed hiring manager"
 - Minimal UI (profile editor, file upload).
 
 **Phase 1 — Job ingestion (1 week)**
-- Greenhouse Job Board fetcher + normalizer.
-- Lever Postings fetcher + normalizer.
-- Ashby Jobs fetcher + normalizer.
+- Greenhouse Job Board fetcher + normalizer (shipped via `jobbot ingest greenhouse`).
+- Lever Postings fetcher + normalizer (shipped via `jobbot ingest lever`).
+- Ashby Jobs fetcher + normalizer (shipped via `jobbot ingest ashby`).
 - Caching, retries, per-domain politeness.
 - UI: source connections, search & filters.
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -14,6 +14,8 @@ import { recordJobDiscard } from '../src/discards.js';
 import { addJobTags, discardJob, filterShortlist, syncShortlistJob } from '../src/shortlist.js';
 import { initProfile } from '../src/profile.js';
 import { ingestGreenhouseBoard } from '../src/greenhouse.js';
+import { ingestLeverBoard } from '../src/lever.js';
+import { ingestAshbyBoard } from '../src/ashby.js';
 
 function isHttpUrl(s) {
   return /^https?:\/\//i.test(s);
@@ -213,8 +215,34 @@ async function cmdIngestGreenhouse(args) {
 async function cmdIngest(args) {
   const sub = args[0];
   if (sub === 'greenhouse') return cmdIngestGreenhouse(args.slice(1));
-  console.error('Usage: jobbot ingest greenhouse --company <slug>');
+  if (sub === 'lever') return cmdIngestLever(args.slice(1));
+  if (sub === 'ashby') return cmdIngestAshby(args.slice(1));
+  console.error('Usage: jobbot ingest <greenhouse|lever|ashby> [options]');
   process.exit(2);
+}
+
+async function cmdIngestLever(args) {
+  const org = getFlag(args, '--org');
+  if (!org) {
+    console.error('Usage: jobbot ingest lever --org <slug>');
+    process.exit(2);
+  }
+
+  const { saved } = await ingestLeverBoard({ org });
+  const noun = saved === 1 ? 'job' : 'jobs';
+  console.log(`Imported ${saved} ${noun} from ${org}`);
+}
+
+async function cmdIngestAshby(args) {
+  const org = getFlag(args, '--org');
+  if (!org) {
+    console.error('Usage: jobbot ingest ashby --org <slug>');
+    process.exit(2);
+  }
+
+  const { saved } = await ingestAshbyBoard({ org });
+  const noun = saved === 1 ? 'job' : 'jobs';
+  console.log(`Imported ${saved} ${noun} from ${org}`);
 }
 
 async function cmdShortlistTag(args) {

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -42,8 +42,8 @@ revisit them later without blocking the workflow.
 
 **Goal:** Build a living shortlist of job opportunities pulled from the web or supplied manually.
 
-1. The user searches company boards via supported fetchers (Greenhouse, Lever, Ashby, Workable,
-   SmartRecruiters) or pastes individual URLs into the CLI/UI. For example,
+1. The user searches company boards via supported fetchers (Greenhouse, Lever, and Ashby today;
+   Workable and SmartRecruiters are on the roadmap) or pastes individual URLs into the CLI/UI. For example,
    `jobbot ingest greenhouse --company acme` pulls the latest public postings into the local
    data directory.
 2. The fetch pipeline de-duplicates listings, normalizes HTML to text, and stores raw + parsed

--- a/src/ashby.js
+++ b/src/ashby.js
@@ -1,0 +1,290 @@
+import fetch from 'node-fetch';
+import { extractTextFromHtml } from './fetch.js';
+import { jobIdFromSource, saveJobSnapshot } from './jobs.js';
+import { parseJobText } from './parser.js';
+
+const ASHBY_BASE = 'https://jobs.ashbyhq.com/api/non-embed/company';
+
+function normalizeOrgSlug(org) {
+  if (!org || typeof org !== 'string' || !org.trim()) {
+    throw new Error('Ashby org slug is required');
+  }
+  return org.trim();
+}
+
+function buildOrgUrl(slug) {
+  return `${ASHBY_BASE}/${encodeURIComponent(slug)}?includeCompensation=true`;
+}
+
+function escapeHtml(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function wrapParagraph(text) {
+  if (!text) return '';
+  return `<p>${escapeHtml(text)}</p>`;
+}
+
+function stripParagraph(html) {
+  const trimmed = html.trim();
+  if (trimmed.startsWith('<p>') && trimmed.endsWith('</p>')) {
+    return trimmed.slice(3, -4).trim();
+  }
+  return trimmed;
+}
+
+function toListItemHtml(html) {
+  const trimmed = html.trim();
+  if (!trimmed) return '';
+  if (trimmed.startsWith('<li')) return trimmed;
+  const body = stripParagraph(trimmed);
+  return `<li>${body}</li>`;
+}
+
+function flattenRichContent(fragment) {
+  if (!fragment) return [];
+  if (typeof fragment === 'string') {
+    const trimmed = fragment.trim();
+    return trimmed ? [trimmed] : [];
+  }
+  if (Array.isArray(fragment)) {
+    const collected = [];
+    for (const entry of fragment) {
+      collected.push(...flattenRichContent(entry));
+    }
+    return collected;
+  }
+  if (typeof fragment === 'object') {
+    const collected = [];
+    const htmlFields = ['html', 'value', 'richText', 'bodyHtml', 'contentHtml'];
+    for (const field of htmlFields) {
+      if (typeof fragment[field] === 'string') {
+        const html = fragment[field].trim();
+        if (html) collected.push(html);
+      }
+    }
+    const textFields = ['text', 'plainText', 'bodyText', 'descriptionText'];
+    for (const field of textFields) {
+      if (typeof fragment[field] === 'string') {
+        const text = fragment[field].trim();
+        if (text) collected.push(wrapParagraph(text));
+      }
+    }
+    const arrayFields = ['content', 'items', 'children', 'sections', 'blocks', 'elements'];
+    for (const field of arrayFields) {
+      if (Array.isArray(fragment[field])) {
+        collected.push(...flattenRichContent(fragment[field]));
+      }
+    }
+    return collected;
+  }
+  return [];
+}
+
+function flattenSections(sections) {
+  if (!Array.isArray(sections)) return [];
+  const fragments = [];
+  for (const section of sections) {
+    if (!section || typeof section !== 'object') continue;
+    const heading =
+      typeof section.title === 'string'
+        ? section.title.trim()
+        : typeof section.heading === 'string'
+          ? section.heading.trim()
+          : typeof section.name === 'string'
+            ? section.name.trim()
+            : '';
+    const baseContent = flattenRichContent(
+      section.content ?? section.blocks ?? section.elements ?? section.richText ?? section.body,
+    );
+    if (Array.isArray(section.items)) {
+      const items = flattenRichContent(section.items)
+        .map(toListItemHtml)
+        .filter(Boolean)
+        .join('');
+      if (items) baseContent.push(`<ul>${items}</ul>`);
+    }
+    if (heading) fragments.push(`<h2>${escapeHtml(heading)}</h2>`);
+    if (baseContent.length) fragments.push(baseContent.join('\n'));
+    const nested = flattenSections(
+      section.sections ?? section.children ?? section.subsections ?? section.groups,
+    );
+    if (nested.length) fragments.push(nested.join('\n'));
+  }
+  return fragments;
+}
+
+function buildJobHtml(job) {
+  const fragments = [];
+  const title = typeof job?.title === 'string' ? job.title.trim() : '';
+  if (title) fragments.push(`<h1>${escapeHtml(title)}</h1>`);
+
+  const primaryHtml = flattenRichContent(job?.descriptionHtml ?? job?.description);
+  if (primaryHtml.length) fragments.push(primaryHtml.join('\n'));
+
+  if (typeof job?.descriptionText === 'string') {
+    const text = job.descriptionText.trim();
+    if (text) fragments.push(wrapParagraph(text));
+  }
+
+  const sectionFragments = flattenSections(
+    job?.sections ?? job?.contentSections ?? job?.richTextSections,
+  );
+  if (sectionFragments.length) fragments.push(sectionFragments.join('\n'));
+
+  const additionalHtml = flattenRichContent(job?.additionalHtml ?? job?.additional);
+  if (additionalHtml.length) fragments.push(additionalHtml.join('\n'));
+
+  if (typeof job?.additionalText === 'string') {
+    const text = job.additionalText.trim();
+    if (text) fragments.push(wrapParagraph(text));
+  }
+
+  return fragments.join('\n');
+}
+
+function toLocationString(value) {
+  if (!value) return '';
+  if (typeof value === 'string') return value.trim();
+  if (typeof value === 'object') {
+    const candidates = [value.name, value.text, value.displayName, value.location];
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string' && candidate.trim()) return candidate.trim();
+    }
+  }
+  return '';
+}
+
+function extractLocation(job) {
+  const direct = toLocationString(job?.location);
+  if (direct) return direct;
+  const primary = toLocationString(job?.primaryLocation);
+  if (primary) return primary;
+  const jobLocation = toLocationString(job?.jobLocation);
+  if (jobLocation) return jobLocation;
+  if (Array.isArray(job?.locations)) {
+    const names = Array.from(new Set(job.locations.map(toLocationString).filter(Boolean)));
+    if (names.length) return names.join(' / ');
+  }
+  if (typeof job?.locationText === 'string' && job.locationText.trim()) {
+    return job.locationText.trim();
+  }
+  return '';
+}
+
+function mergeParsedJob(parsed, job) {
+  const merged = { ...parsed };
+  if (!merged.title) {
+    const title = typeof job?.title === 'string' ? job.title.trim() : '';
+    if (title) merged.title = title;
+  }
+  if (!merged.location) {
+    const location = extractLocation(job);
+    if (location) merged.location = location;
+  }
+  return merged;
+}
+
+function resolveAbsoluteUrl(job, slug) {
+  const candidates = [job?.jobUrl, job?.url, job?.applyUrl, job?.applicationUrl, job?.hostedUrl];
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate.trim();
+  }
+  const identifier =
+    typeof job?.id === 'string' && job.id.trim()
+      ? job.id.trim()
+      : typeof job?.postingId === 'string' && job.postingId.trim()
+        ? job.postingId.trim()
+        : typeof job?.id === 'number'
+          ? String(job.id)
+          : typeof job?.postingId === 'number'
+            ? String(job.postingId)
+            : typeof job?.slug === 'string' && job.slug.trim()
+              ? job.slug.trim()
+              : 'unknown';
+  const encodedSlug = encodeURIComponent(slug);
+  const encodedId = encodeURIComponent(identifier);
+  return `https://jobs.ashbyhq.com/${encodedSlug}/job/${encodedId}`;
+}
+
+function pickTimestamp(job) {
+  const fields = ['updatedAt', 'postedAt', 'publishedAt', 'refreshedAt', 'createdAt'];
+  for (const field of fields) {
+    const value = job?.[field];
+    if (value !== undefined && value !== null && value !== '') return value;
+  }
+  return undefined;
+}
+
+function collectSectionJobs(section) {
+  if (!section || typeof section !== 'object') return [];
+  const entries = [];
+  if (Array.isArray(section.jobs)) entries.push(...section.jobs);
+  if (Array.isArray(section.postings)) entries.push(...section.postings);
+  if (Array.isArray(section.items)) entries.push(...section.items);
+  if (Array.isArray(section.openings)) entries.push(...section.openings);
+  const jobs = entries.filter(entry => entry && typeof entry === 'object');
+  const nestedSections =
+    section.sections ?? section.children ?? section.subsections ?? section.groups ?? [];
+  if (Array.isArray(nestedSections)) {
+    for (const child of nestedSections) {
+      jobs.push(...collectSectionJobs(child));
+    }
+  }
+  return jobs;
+}
+
+function collectJobs(payload) {
+  const jobs = [];
+  const board = payload?.jobBoard ?? payload;
+  if (Array.isArray(board?.jobs)) {
+    jobs.push(...board.jobs.filter(job => job && typeof job === 'object'));
+  }
+  if (Array.isArray(board?.postings)) {
+    jobs.push(...board.postings.filter(job => job && typeof job === 'object'));
+  }
+  if (Array.isArray(board?.sections)) {
+    for (const section of board.sections) {
+      jobs.push(...collectSectionJobs(section));
+    }
+  }
+  return jobs;
+}
+
+export async function fetchAshbyJobs(org, { fetchImpl = fetch } = {}) {
+  const slug = normalizeOrgSlug(org);
+  const url = buildOrgUrl(slug);
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Ashby org ${slug}: ${response.status} ${response.statusText}`);
+  }
+  const payload = await response.json();
+  const jobs = collectJobs(payload);
+  return { slug, jobs };
+}
+
+export async function ingestAshbyBoard({ org, fetchImpl = fetch } = {}) {
+  const { slug, jobs } = await fetchAshbyJobs(org, { fetchImpl });
+  const jobIds = [];
+  for (const job of jobs) {
+    const absoluteUrl = resolveAbsoluteUrl(job, slug);
+    const html = buildJobHtml(job);
+    const text = extractTextFromHtml(html);
+    const parsed = mergeParsedJob(parseJobText(text), job);
+    const id = jobIdFromSource({ provider: 'ashby', url: absoluteUrl });
+    await saveJobSnapshot({
+      id,
+      raw: text,
+      parsed,
+      source: { type: 'ashby', value: absoluteUrl },
+      fetchedAt: pickTimestamp(job),
+    });
+    jobIds.push(id);
+  }
+  return { org: slug, saved: jobIds.length, jobIds };
+}

--- a/src/lever.js
+++ b/src/lever.js
@@ -1,0 +1,172 @@
+import fetch from 'node-fetch';
+import { extractTextFromHtml } from './fetch.js';
+import { jobIdFromSource, saveJobSnapshot } from './jobs.js';
+import { parseJobText } from './parser.js';
+
+const LEVER_BASE = 'https://api.lever.co/v0/postings';
+
+function normalizeOrgSlug(org) {
+  if (!org || typeof org !== 'string' || !org.trim()) {
+    throw new Error('Lever org slug is required');
+  }
+  return org.trim();
+}
+
+function buildOrgUrl(slug) {
+  return `${LEVER_BASE}/${encodeURIComponent(slug)}?mode=json`;
+}
+
+function resolveAbsoluteUrl(job, slug) {
+  const hosted = typeof job?.hostedUrl === 'string' ? job.hostedUrl.trim() : '';
+  if (hosted) return hosted;
+  const identifier =
+    typeof job?.id === 'string' && job.id.trim()
+      ? job.id.trim()
+      : typeof job?.id === 'number'
+        ? String(job.id)
+        : '';
+  const fallback = identifier || 'unknown';
+  const encodedSlug = encodeURIComponent(slug);
+  const encodedId = encodeURIComponent(fallback);
+  return `https://jobs.lever.co/${encodedSlug}/${encodedId}`;
+}
+
+function extractLocation(job) {
+  const categories = job?.categories;
+  const byCategory =
+    categories && typeof categories.location === 'string' ? categories.location.trim() : '';
+  if (byCategory) return byCategory;
+  if (typeof job?.location === 'string' && job.location.trim()) return job.location.trim();
+  if (typeof job?.workplaceType === 'string' && job.workplaceType.trim()) {
+    return job.workplaceType.trim();
+  }
+  return '';
+}
+
+function normalizeHtmlFragments(fragment) {
+  if (!fragment) return [];
+  if (typeof fragment === 'string') {
+    const trimmed = fragment.trim();
+    return trimmed ? [trimmed] : [];
+  }
+  if (Array.isArray(fragment)) {
+    const collected = [];
+    for (const entry of fragment) {
+      collected.push(...normalizeHtmlFragments(entry));
+    }
+    return collected;
+  }
+  if (typeof fragment === 'object') {
+    const collected = [];
+    if (typeof fragment.text === 'string') {
+      const text = fragment.text.trim();
+      if (text) collected.push(text);
+    }
+    if (fragment.content !== undefined) {
+      collected.push(...normalizeHtmlFragments(fragment.content));
+    }
+    return collected;
+  }
+  return [];
+}
+
+function normalizePlainText(value) {
+  if (typeof value !== 'string') return '';
+  const trimmed = value.trim();
+  return trimmed ? trimmed : '';
+}
+
+function escapeHtml(value) {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function buildJobHtml(job) {
+  const sections = [];
+  const title = typeof job?.text === 'string' ? job.text.trim() : '';
+  if (title) sections.push(`<h1>${escapeHtml(title)}</h1>`);
+
+  const mainContent = normalizeHtmlFragments(job?.content).join('\n');
+  if (mainContent) sections.push(mainContent);
+
+  if (Array.isArray(job?.lists)) {
+    for (const entry of job.lists) {
+      const heading = typeof entry?.text === 'string' ? entry.text.trim() : '';
+      const listHtml = normalizeHtmlFragments(entry?.content).join('\n');
+      if (heading || listHtml) {
+        const headingHtml = heading ? `<h2>${escapeHtml(heading)}</h2>` : '';
+        sections.push(`${headingHtml}${listHtml}`);
+      }
+    }
+  }
+
+  const descriptionHtml = normalizeHtmlFragments(job?.description).join('\n');
+  if (descriptionHtml) {
+    sections.push(descriptionHtml);
+  } else {
+    const descriptionPlain = normalizePlainText(job?.descriptionPlain);
+    if (descriptionPlain) sections.push(`<p>${escapeHtml(descriptionPlain)}</p>`);
+  }
+
+  const additionalHtml = normalizeHtmlFragments(job?.additional).join('\n');
+  if (additionalHtml) sections.push(additionalHtml);
+
+  const additionalPlain = normalizePlainText(job?.additionalPlain);
+  if (additionalPlain) sections.push(`<p>${escapeHtml(additionalPlain)}</p>`);
+
+  return sections.join('\n');
+}
+
+function mergeParsedJob(parsed, job) {
+  const merged = { ...parsed };
+  if (!merged.title) {
+    const title = typeof job?.text === 'string' ? job.text.trim() : '';
+    if (title) merged.title = title;
+  }
+  if (!merged.location) {
+    const location = extractLocation(job);
+    if (location) merged.location = location;
+  }
+  return merged;
+}
+
+export async function fetchLeverJobs(org, { fetchImpl = fetch } = {}) {
+  const slug = normalizeOrgSlug(org);
+  const url = buildOrgUrl(slug);
+  const response = await fetchImpl(url);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Lever org ${slug}: ${response.status} ${response.statusText}`);
+  }
+  const payload = await response.json();
+  const jobs = Array.isArray(payload)
+    ? payload
+    : Array.isArray(payload?.data)
+      ? payload.data
+      : [];
+  return { slug, jobs };
+}
+
+export async function ingestLeverBoard({ org, fetchImpl = fetch } = {}) {
+  const { slug, jobs } = await fetchLeverJobs(org, { fetchImpl });
+  const jobIds = [];
+  for (const job of jobs) {
+    const absoluteUrl = resolveAbsoluteUrl(job, slug);
+    const html = buildJobHtml(job);
+    const text = extractTextFromHtml(html);
+    const parsed = mergeParsedJob(parseJobText(text), job);
+    const id = jobIdFromSource({ provider: 'lever', url: absoluteUrl });
+    await saveJobSnapshot({
+      id,
+      raw: text,
+      parsed,
+      source: { type: 'lever', value: absoluteUrl },
+      fetchedAt: job?.updatedAt ?? job?.createdAt,
+    });
+    jobIds.push(id);
+  }
+  return { org: slug, saved: jobIds.length, jobIds };
+}

--- a/test/ashby.test.js
+++ b/test/ashby.test.js
@@ -1,0 +1,168 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node-fetch', () => ({ default: vi.fn() }));
+
+import fetch from 'node-fetch';
+
+const JOBS_DIR = 'jobs';
+
+describe('Ashby ingest', () => {
+  let dataDir;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-ashby-'));
+    process.env.JOBBOT_DATA_DIR = dataDir;
+    fetch.mockReset();
+  });
+
+  afterEach(async () => {
+    if (dataDir) {
+      await fs.rm(dataDir, { recursive: true, force: true });
+      dataDir = undefined;
+    }
+    delete process.env.JOBBOT_DATA_DIR;
+  });
+
+  it('fetches Ashby postings, flattens nested sections, and writes snapshots', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        jobBoard: {
+          sections: [
+            {
+              title: 'Engineering',
+              jobs: [
+                {
+                  id: 'job-1',
+                  title: 'Senior Backend Engineer',
+                  primaryLocation: { name: 'Remote - US' },
+                  descriptionHtml: '<p>Build APIs</p>',
+                  sections: [
+                    {
+                      heading: 'Responsibilities',
+                      content: [
+                        '<ul><li>Scale services</li></ul>',
+                        { html: '<p>Own incidents</p>' },
+                        { text: 'Collaborate cross-functionally' },
+                        { items: ['<li>Pair program weekly</li>', { text: 'Mentor teammates' }] },
+                      ],
+                    },
+                    {
+                      title: 'Qualifications',
+                      content: [
+                        { html: '<ul><li>5+ years Node.js</li></ul>' },
+                        { text: 'Experience with GraphQL' },
+                      ],
+                    },
+                  ],
+                  additionalText: 'Nice to have: distributed systems.',
+                  jobUrl: 'https://jobs.ashbyhq.com/example/job/job-1',
+                  updatedAt: '2024-11-05T10:00:00Z',
+                },
+                {
+                  id: 'job 3',
+                  title: 'Data Analyst',
+                  locationText: 'Toronto, Canada',
+                  descriptionHtml: '<p>Analyze data.</p>',
+                  sections: [],
+                  postedAt: 1730419200000,
+                },
+              ],
+              sections: [
+                {
+                  title: 'Support',
+                  postings: [
+                    {
+                      id: 'job-2',
+                      title: 'Support Specialist',
+                      location: { text: 'Austin, TX' },
+                      descriptionText: 'Assist customers.',
+                      contentSections: [
+                        {
+                          name: 'Responsibilities',
+                          items: ['<p>Handle tickets</p>', { text: 'Document feedback' }],
+                        },
+                      ],
+                      applyUrl: 'https://jobs.ashbyhq.com/example/job/job-2',
+                      postedAt: '2024-10-01T08:00:00Z',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    });
+
+    const { ingestAshbyBoard } = await import('../src/ashby.js');
+
+    const result = await ingestAshbyBoard({ org: ' Example Org ' });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://jobs.ashbyhq.com/api/non-embed/company/Example%20Org?includeCompensation=true',
+    );
+
+    expect(result).toMatchObject({ org: 'Example Org', saved: 3 });
+    expect(result.jobIds).toHaveLength(3);
+
+    const jobsDir = path.join(dataDir, JOBS_DIR);
+    const files = await fs.readdir(jobsDir);
+    expect(files).toHaveLength(3);
+
+    const savedByTitle = {};
+    for (const file of files) {
+      const saved = JSON.parse(await fs.readFile(path.join(jobsDir, file), 'utf8'));
+      savedByTitle[saved.parsed.title] = saved;
+    }
+
+    const backend = savedByTitle['Senior Backend Engineer'];
+    expect(backend).toBeTruthy();
+    expect(backend.source).toMatchObject({
+      type: 'ashby',
+      value: 'https://jobs.ashbyhq.com/example/job/job-1',
+    });
+    expect(backend.parsed.location).toBe('Remote - US');
+    expect(backend.raw).toContain('Scale services');
+    expect(backend.raw).toContain('Mentor teammates');
+    expect(backend.raw).toContain('Nice to have: distributed systems.');
+    expect(backend.fetched_at).toBe('2024-11-05T10:00:00.000Z');
+
+    const support = savedByTitle['Support Specialist'];
+    expect(support).toBeTruthy();
+    expect(support.source.value).toBe('https://jobs.ashbyhq.com/example/job/job-2');
+    expect(support.parsed.location).toBe('Austin, TX');
+    expect(support.raw).toContain('Handle tickets');
+    expect(support.raw).toContain('Document feedback');
+    expect(support.fetched_at).toBe('2024-10-01T08:00:00.000Z');
+
+    const analyst = savedByTitle['Data Analyst'];
+    expect(analyst).toBeTruthy();
+    expect(analyst.source.value).toBe(
+      'https://jobs.ashbyhq.com/Example%20Org/job/job%203',
+    );
+    expect(analyst.parsed.location).toBe('Toronto, Canada');
+    expect(analyst.raw).toContain('Analyze data.');
+    expect(analyst.fetched_at).toBe('2024-11-01T00:00:00.000Z');
+  });
+
+  it('throws when the org fetch fails', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: async () => ({}),
+    });
+
+    const { ingestAshbyBoard } = await import('../src/ashby.js');
+
+    await expect(ingestAshbyBoard({ org: 'missing' })).rejects.toThrow(
+      /Failed to fetch Ashby org/,
+    );
+  });
+});

--- a/test/lever.test.js
+++ b/test/lever.test.js
@@ -1,0 +1,190 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node-fetch', () => ({ default: vi.fn() }));
+
+import fetch from 'node-fetch';
+
+const JOBS_DIR = 'jobs';
+
+describe('Lever ingest', () => {
+  let dataDir;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-lever-'));
+    process.env.JOBBOT_DATA_DIR = dataDir;
+    fetch.mockReset();
+  });
+
+  afterEach(async () => {
+    if (dataDir) {
+      await fs.rm(dataDir, { recursive: true, force: true });
+      dataDir = undefined;
+    }
+    delete process.env.JOBBOT_DATA_DIR;
+  });
+
+  it('fetches Lever postings, normalizes HTML fragments, and writes snapshots', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => [
+        {
+          id: '123abc',
+          text: 'Backend Engineer',
+          categories: { location: 'Remote' },
+          content: [
+            '<p>Build APIs</p>',
+            { text: '<p>Ship features fast</p>' },
+          ],
+          lists: [
+            {
+              text: 'Responsibilities',
+              content: [
+                '<ul><li>Scale services</li></ul>',
+                { text: '<p>Maintain reliability</p>' },
+              ],
+            },
+            {
+              text: 'Qualifications',
+              content: [{ content: '<ul><li>TypeScript experience</li></ul>' }],
+            },
+          ],
+          descriptionPlain: 'More details about the role.',
+          hostedUrl: 'https://jobs.lever.co/example/123abc',
+          updatedAt: 1730419200000,
+        },
+      ],
+    });
+
+    const { ingestLeverBoard } = await import('../src/lever.js');
+
+    const result = await ingestLeverBoard({ org: 'example' });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.lever.co/v0/postings/example?mode=json',
+    );
+
+    expect(result).toMatchObject({ org: 'example', saved: 1 });
+    expect(result.jobIds).toHaveLength(1);
+
+    const jobsDir = path.join(dataDir, JOBS_DIR);
+    const files = await fs.readdir(jobsDir);
+    expect(files).toHaveLength(1);
+
+    const saved = JSON.parse(await fs.readFile(path.join(jobsDir, files[0]), 'utf8'));
+    expect(saved.source).toMatchObject({
+      type: 'lever',
+      value: 'https://jobs.lever.co/example/123abc',
+    });
+    expect(saved.parsed.title).toBe('Backend Engineer');
+    expect(saved.parsed.location).toBe('Remote');
+    expect(saved.raw).toContain('More details about the role.');
+    expect(saved.raw).toContain('Maintain reliability');
+    const requirements = saved.parsed.requirements.join(' ');
+    expect(requirements).toContain('Scale services');
+    expect(requirements).toContain('TypeScript experience');
+    expect(saved.fetched_at).toBe('2024-11-01T00:00:00.000Z');
+  });
+
+  it('throws when the org fetch fails', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: async () => ({}),
+    });
+
+    const { ingestLeverBoard } = await import('../src/lever.js');
+
+    await expect(ingestLeverBoard({ org: 'missing' })).rejects.toThrow(
+      /Failed to fetch Lever org/,
+    );
+  });
+
+  it('falls back to derived hosted URLs and merges metadata from plain fields', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => [
+        {
+          id: 42,
+          text: 'Data Engineer',
+          lists: [
+            {
+              text: 'Responsibilities',
+              content: ['<ul><li>Maintain pipelines</li></ul>'],
+            },
+          ],
+          descriptionPlain: 'Data team focused role.',
+          additional: ['<p>Bonus info</p>'],
+          additionalPlain: 'Apply soon.',
+          workplaceType: 'Hybrid - NYC',
+          hostedUrl: '  ',
+          createdAt: '2024-09-01T12:00:00Z',
+        },
+      ],
+    });
+
+    const { ingestLeverBoard } = await import('../src/lever.js');
+
+    const result = await ingestLeverBoard({ org: ' Example Corp ' });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.lever.co/v0/postings/Example%20Corp?mode=json',
+    );
+
+    expect(result).toMatchObject({ org: 'Example Corp', saved: 1 });
+    const [jobId] = result.jobIds;
+    expect(jobId).toBeTruthy();
+
+    const jobsDir = path.join(dataDir, JOBS_DIR);
+    const files = await fs.readdir(jobsDir);
+    expect(files).toHaveLength(1);
+
+    const saved = JSON.parse(await fs.readFile(path.join(jobsDir, files[0]), 'utf8'));
+    expect(saved.source).toMatchObject({
+      type: 'lever',
+      value: 'https://jobs.lever.co/Example%20Corp/42',
+    });
+    expect(saved.parsed.location).toBe('Hybrid - NYC');
+    expect(saved.raw).toContain('Data team focused role.');
+    expect(saved.raw).toContain('Bonus info');
+    expect(saved.raw).toContain('Apply soon.');
+  });
+
+  it('escapes plain text fields before wrapping them in HTML', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => [
+        {
+          id: 'escape-1',
+          text: 'Quality & Safety <Lead>',
+          descriptionPlain: 'Handle <edge> & "quoted" workflows.',
+          additionalPlain: "It's great & safe.",
+          createdAt: '2024-09-15T08:00:00Z',
+        },
+      ],
+    });
+
+    const { ingestLeverBoard } = await import('../src/lever.js');
+
+    const result = await ingestLeverBoard({ org: 'escape-co' });
+
+    expect(result).toMatchObject({ org: 'escape-co', saved: 1 });
+
+    const jobsDir = path.join(dataDir, JOBS_DIR);
+    const [file] = await fs.readdir(jobsDir);
+    const saved = JSON.parse(await fs.readFile(path.join(jobsDir, file), 'utf8'));
+
+    expect(saved.raw).toMatch(/Quality & Safety <Lead>/i);
+    expect(saved.raw).toMatch(/Handle <edge> & "quoted" workflows\./);
+    expect(saved.raw).toMatch(/It's great & safe\./);
+  });
+});


### PR DESCRIPTION
## Summary
- escape Lever job title and list headings before wrapping them in HTML to avoid dropping characters during text extraction
- encode plain-text description and additional fields to preserve literal special characters in saved snapshots
- add a regression test that exercises Lever ingests containing angle brackets and ampersands

## Testing
- npm run lint
- npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68ce3c34e110832fac45c557e37ed8f5