### PR TITLE
✨ : – add ashby ingestion pipeline

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -254,9 +254,9 @@ jobbot track add <job_id> --status applied --note "emailed hiring manager"
 - Minimal UI (profile editor, file upload).
 
 **Phase 1 — Job ingestion (1 week)**
-- Greenhouse Job Board fetcher + normalizer.
-- Lever Postings fetcher + normalizer.
-- Ashby Jobs fetcher + normalizer.
+- Greenhouse Job Board fetcher + normalizer. (shipped)
+- Lever Postings fetcher + normalizer. (shipped)
+- Ashby Jobs fetcher + normalizer. (shipped)
 - Caching, retries, per-domain politeness.
 - UI: source connections, search & filters.
 
@@ -286,7 +286,7 @@ jobbot track add <job_id> --status applied --note "emailed hiring manager"
 - Docs, quickstart, sample data.
 
 **Stretch / nice-to-have**
-- Workable + SmartRecruiters modules.
+- Workable module.
 - Pandoc .docx export.
 - System-design rehearsal outlines.
 - Scheduler for periodic ingestion/matching.

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ so snapshots stay alongside other candidate data when the directory is moved.
 
 ## Job board ingestion
 
-Fetch public boards directly with Greenhouse, Lever, or SmartRecruiters pipelines:
+Fetch public boards directly with Greenhouse, Lever, Ashby, or SmartRecruiters pipelines:
 
 ~~~bash
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest greenhouse --company example
@@ -240,16 +240,19 @@ JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest greenhouse --company example
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest lever --company example
 # Imported 8 jobs from example
 
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest ashby --company example
+# Imported 6 jobs from example
+
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest smartrecruiters --company example
 # Imported 5 jobs from example
 ~~~
 
 Each listing in the response is normalised to plain text, parsed for title,
 location, and requirements, and written to `data/jobs/{job_id}.json` with a
-`source.type` reflecting the provider (`greenhouse`, `lever`, or `smartrecruiters`). Updates reuse
+`source.type` reflecting the provider (`greenhouse`, `lever`, `ashby`, or `smartrecruiters`). Updates reuse
 the same job identifier so downstream tooling can diff revisions over time.
 Tests in [`test/greenhouse.test.js`](test/greenhouse.test.js),
-[`test/lever.test.js`](test/lever.test.js), and
+[`test/lever.test.js`](test/lever.test.js), [`test/ashby.test.js`](test/ashby.test.js), and
 [`test/smartrecruiters.test.js`](test/smartrecruiters.test.js) verify the ingest
 pipelines fetch board content, persist structured snapshots, surface fetch
 errors, and retain the `User-Agent: jobbot3000` request header alongside each

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -17,6 +17,7 @@ import { initProfile } from '../src/profile.js';
 import { ingestGreenhouseBoard } from '../src/greenhouse.js';
 import { ingestLeverBoard } from '../src/lever.js';
 import { ingestSmartRecruitersBoard } from '../src/smartrecruiters.js';
+import { ingestAshbyBoard } from '../src/ashby.js';
 
 function isHttpUrl(s) {
   return /^https?:\/\//i.test(s);
@@ -246,6 +247,18 @@ async function cmdIngestLever(args) {
   console.log(`Imported ${saved} ${noun} from ${company}`);
 }
 
+async function cmdIngestAshby(args) {
+  const company = getFlag(args, '--company') || getFlag(args, '--org');
+  if (!company) {
+    console.error('Usage: jobbot ingest ashby --company <slug>');
+    process.exit(2);
+  }
+
+  const { saved } = await ingestAshbyBoard({ org: company });
+  const noun = saved === 1 ? 'job' : 'jobs';
+  console.log(`Imported ${saved} ${noun} from ${company}`);
+}
+
 async function cmdIngestSmartRecruiters(args) {
   const company = getFlag(args, '--company');
   if (!company) {
@@ -262,8 +275,9 @@ async function cmdIngest(args) {
   const sub = args[0];
   if (sub === 'greenhouse') return cmdIngestGreenhouse(args.slice(1));
   if (sub === 'lever') return cmdIngestLever(args.slice(1));
+  if (sub === 'ashby') return cmdIngestAshby(args.slice(1));
   if (sub === 'smartrecruiters') return cmdIngestSmartRecruiters(args.slice(1));
-  console.error('Usage: jobbot ingest <greenhouse|lever|smartrecruiters> --company <slug>');
+  console.error('Usage: jobbot ingest <greenhouse|lever|ashby|smartrecruiters> --company <slug>');
   process.exit(2);
 }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -43,7 +43,7 @@ revisit them later without blocking the workflow.
 **Goal:** Build a living shortlist of job opportunities pulled from the web or supplied manually.
 
 1. The user searches company boards via supported fetchers (Greenhouse, Lever, SmartRecruiters,
-   with Ashby and Workable on the roadmap) or pastes individual URLs into the CLI/UI. For example,
+   Ashby, with Workable on the roadmap) or pastes individual URLs into the CLI/UI. For example,
    `jobbot ingest greenhouse --company acme` pulls the latest public postings into the local
    data directory, and `jobbot ingest lever --company acme` performs the same for Lever-hosted
    listings.

--- a/src/ashby.js
+++ b/src/ashby.js
@@ -1,0 +1,106 @@
+import fetch from 'node-fetch';
+import { extractTextFromHtml } from './fetch.js';
+import { jobIdFromSource, saveJobSnapshot } from './jobs.js';
+import { parseJobText } from './parser.js';
+
+const ASHBY_BASE = 'https://jobs.ashbyhq.com/api/postings';
+
+const ASHBY_HEADERS = {
+  'User-Agent': 'jobbot3000',
+  Accept: 'application/json',
+};
+
+function normalizeOrgSlug(org) {
+  if (!org || typeof org !== 'string' || !org.trim()) {
+    throw new Error('Ashby org slug is required');
+  }
+  return org.trim();
+}
+
+function buildOrgUrl(slug) {
+  const params = new URLSearchParams({
+    organizationSlug: slug,
+    includeCompensation: 'true',
+    includeUnlisted: 'false',
+  });
+  return `${ASHBY_BASE}?${params.toString()}`;
+}
+
+function deriveJobUrl(job, slug) {
+  const fromJob = typeof job.jobPostingUrl === 'string' ? job.jobPostingUrl.trim() : '';
+  if (fromJob) return fromJob;
+  const jobId = typeof job.id === 'string' && job.id.trim() ? job.id.trim() : '';
+  if (jobId) return `https://jobs.ashbyhq.com/${slug}/job/${jobId}`;
+  return `https://jobs.ashbyhq.com/${slug}`;
+}
+
+function selectRawDescription(job) {
+  const text = typeof job.descriptionText === 'string' ? job.descriptionText.trim() : '';
+  if (text) return text;
+  const html = typeof job.descriptionHtml === 'string' ? job.descriptionHtml : '';
+  if (html && html.trim()) return extractTextFromHtml(html);
+  const summary = typeof job.summary === 'string' ? job.summary.trim() : '';
+  return summary;
+}
+
+function extractLocation(job) {
+  const location = typeof job.locationName === 'string' ? job.locationName.trim() : '';
+  if (location) return location;
+  const secondary = Array.isArray(job?.secondaryLocations) ? job.secondaryLocations : [];
+  for (const entry of secondary) {
+    if (entry && typeof entry.name === 'string' && entry.name.trim()) {
+      return entry.name.trim();
+    }
+  }
+  return '';
+}
+
+function mergeParsedJob(parsed, job) {
+  const merged = { ...parsed };
+  const title = typeof job.title === 'string' ? job.title.trim() : '';
+  if (!merged.title && title) merged.title = title;
+  const location = extractLocation(job);
+  if (!merged.location && location) merged.location = location;
+  const employmentType = typeof job.employmentType === 'string' ? job.employmentType.trim() : '';
+  if (employmentType) merged.employmentType = employmentType;
+  const workplaceType = typeof job.workplaceType === 'string' ? job.workplaceType.trim() : '';
+  if (workplaceType) merged.workplaceType = workplaceType;
+  return merged;
+}
+
+export async function fetchAshbyJobs(org, { fetchImpl = fetch } = {}) {
+  const slug = normalizeOrgSlug(org);
+  const url = buildOrgUrl(slug);
+  const response = await fetchImpl(url, { headers: ASHBY_HEADERS });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch Ashby org ${slug}: ${response.status} ${response.statusText}`,
+    );
+  }
+  const payload = await response.json();
+  const jobPostings = Array.isArray(payload?.jobPostings) ? payload.jobPostings : [];
+  return { slug, jobPostings };
+}
+
+export async function ingestAshbyBoard({ org, fetchImpl = fetch } = {}) {
+  const { slug, jobPostings } = await fetchAshbyJobs(org, { fetchImpl });
+  const jobIds = [];
+
+  for (const job of jobPostings) {
+    const jobUrl = deriveJobUrl(job, slug);
+    const raw = selectRawDescription(job);
+    const parsed = mergeParsedJob(parseJobText(raw), job);
+    const id = jobIdFromSource({ provider: 'ashby', url: jobUrl });
+    await saveJobSnapshot({
+      id,
+      raw,
+      parsed,
+      source: { type: 'ashby', value: jobUrl },
+      requestHeaders: ASHBY_HEADERS,
+      fetchedAt: job.updatedAt ?? job.publishedDate,
+    });
+    jobIds.push(id);
+  }
+
+  return { org: slug, saved: jobIds.length, jobIds };
+}

--- a/test/ashby.test.js
+++ b/test/ashby.test.js
@@ -1,0 +1,111 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node-fetch', () => ({ default: vi.fn() }));
+
+import fetch from 'node-fetch';
+
+const JOBS_DIR = 'jobs';
+
+describe('Ashby ingest', () => {
+  let dataDir;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-ashby-'));
+    process.env.JOBBOT_DATA_DIR = dataDir;
+    fetch.mockReset();
+  });
+
+  afterEach(async () => {
+    if (dataDir) {
+      await fs.rm(dataDir, { recursive: true, force: true });
+      dataDir = undefined;
+    }
+    delete process.env.JOBBOT_DATA_DIR;
+  });
+
+  it('fetches Ashby jobs and writes snapshots', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        jobPostings: [
+          {
+            id: 'senior-platform-engineer',
+            title: 'Senior Platform Engineer',
+            locationName: 'Remote - US',
+            workplaceType: 'Remote',
+            employmentType: 'FullTime',
+            jobPostingUrl: 'https://jobs.ashbyhq.com/example/job/senior-platform-engineer',
+            descriptionHtml: `
+              <h1>Senior Platform Engineer</h1>
+              <p>Build durable infrastructure.</p>
+              <h3>Requirements</h3>
+              <ul>
+                <li>Go</li>
+              </ul>
+            `,
+            descriptionText: `Senior Platform Engineer\nRequirements\n- Go`,
+            updatedAt: '2025-03-04T05:06:07Z',
+          },
+        ],
+      }),
+    });
+
+    const { ingestAshbyBoard } = await import('../src/ashby.js');
+
+    const result = await ingestAshbyBoard({ org: 'example' });
+
+    const expectedUrl =
+      'https://jobs.ashbyhq.com/api/postings?organizationSlug=example' +
+      '&includeCompensation=true&includeUnlisted=false';
+
+    expect(fetch).toHaveBeenCalledWith(
+      expectedUrl,
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'User-Agent': 'jobbot3000',
+          Accept: 'application/json',
+        }),
+      }),
+    );
+
+    expect(result).toMatchObject({ org: 'example', saved: 1 });
+    expect(result.jobIds).toHaveLength(1);
+
+    const jobsDir = path.join(dataDir, JOBS_DIR);
+    const files = await fs.readdir(jobsDir);
+    expect(files).toHaveLength(1);
+
+    const saved = JSON.parse(await fs.readFile(path.join(jobsDir, files[0]), 'utf8'));
+    expect(saved.source).toMatchObject({
+      type: 'ashby',
+      value: 'https://jobs.ashbyhq.com/example/job/senior-platform-engineer',
+    });
+    expect(saved.source.headers).toEqual({
+      Accept: 'application/json',
+      'User-Agent': 'jobbot3000',
+    });
+    expect(saved.parsed.title).toBe('Senior Platform Engineer');
+    expect(saved.parsed.location).toBe('Remote - US');
+    const hasRequirement = saved.parsed.requirements.some((req) => req.includes('Go'));
+    expect(hasRequirement).toBe(true);
+    expect(saved.fetched_at).toBe('2025-03-04T05:06:07.000Z');
+  });
+
+  it('throws when the org fetch fails', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: async () => ({}),
+    });
+
+    const { ingestAshbyBoard } = await import('../src/ashby.js');
+
+    await expect(ingestAshbyBoard({ org: 'missing' })).rejects.toThrow(/Failed to fetch Ashby org/);
+  });
+});


### PR DESCRIPTION
## Summary
- add an Ashby job board ingest module, CLI command, and snapshot tests to cover success and error flows
- update roadmap docs to reflect the shipped Ashby pipeline and document the new CLI usage alongside existing ingest options

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ce57223f9c832fac5e26fca4d041d2