### PR TITLE
✨ : add match explanations

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -265,7 +265,7 @@ jobbot track add <job_id> --status applied --note "emailed hiring manager"
 - Keyword/BM25 baseline + cosine combo scoring.
 - O*NET/ESCO synonym expansion.
 - Explanations UI (hits/gaps/evidence).
-- CLI: `jobbot match --explain`.
+- CLI: `jobbot match --explain` (shipped).
 
 **Phase 3 — Tailoring & rendering (1 week)**
 - Templating (choose Typst or LaTeX first; Tectonic/Typst CLI).

--- a/README.md
+++ b/README.md
@@ -198,6 +198,39 @@ console.log(md);
 When only the matched or missing lists are present, the Markdown output starts with the
 corresponding section heading instead of an extra leading blank line.
 
+The CLI surfaces the same explanation with `jobbot match --explain`, appending a narrative summary
+of hits and gaps after the standard Markdown report. JSON output gains an `explanation` field when
+the flag is supplied.
+
+```bash
+cat <<'EOF' > resume.txt
+Designed large-scale services and mentored senior engineers.
+EOF
+
+cat <<'EOF' > job.txt
+Title: Staff Engineer
+Requirements
+- Distributed systems experience
+- Certified Kubernetes administrator
+- Mentors senior engineers
+EOF
+
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot match --resume resume.txt --job job.txt --explain
+# # Staff Engineer
+# ## Matched
+# - Distributed systems experience
+# - Mentors senior engineers
+#
+# ## Missing
+# - Certified Kubernetes administrator
+#
+# ## Explanation
+#
+# Matched 2 of 3 requirements (67%).
+# Hits: Distributed systems experience; Mentors senior engineers
+# Gaps: Certified Kubernetes administrator
+```
+
 The summarizer extracts the first sentence, handling `.`, `!`, `?`, and consecutive terminal
 punctuation like `?!`, including when followed by closing quotes or parentheses. Terminators apply
 only when followed by whitespace or the end of text, so decimals like `1.99` remain intact.

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -67,7 +67,8 @@ aggressively to respect rate limits.
 **Goal:** Produce truthful, role-specific collateral that maximizes the candidate's odds.
 
 1. For a selected job, the matcher scores fit using semantic + lexical signals and explains hits,
-   gaps, and blockers.
+   gaps, and blockers. CLI users can run `jobbot match --explain` to append the narrative summary to
+   the Markdown report or add an `explanation` string to JSON payloads.
 2. The resume renderer clones the base profile, selects the most relevant bullets, and prepares a
    tailored resume (PDF, text preview) plus optional cover letter. All outputs cite the source
    fields they originate from so the user can audit changes.

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -7,5 +7,11 @@ export default {
   fitScore: 'Fit Score',
   matched: 'Matched',
   missing: 'Missing',
+  explanation: 'Explanation',
+  hits: 'Hits',
+  gaps: 'Gaps',
+  noHits: 'No direct hits from the resume.',
+  noGaps: 'No missing requirements detected.',
+  coverageSummary: 'Matched {matched} of {total} requirements ({score}%).',
   greeting: 'Hello, {name}!'
 };

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -7,5 +7,11 @@ export default {
   fitScore: 'Puntaje de Ajuste',
   matched: 'Coincidencias',
   missing: 'Faltantes',
+  explanation: 'Explicación',
+  hits: 'Aciertos',
+  gaps: 'Vacíos',
+  noHits: 'Sin coincidencias directas desde el currículum.',
+  noGaps: 'No se detectaron requisitos faltantes.',
+  coverageSummary: 'Coincidió con {matched} de {total} requisitos ({score}%).',
   greeting: '¡Hola, {name}!'
 };

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -7,5 +7,11 @@ export default {
   fitScore: "Score d'adéquation",
   matched: 'Correspondances',
   missing: 'Manquants',
+  explanation: 'Explication',
+  hits: 'Points forts',
+  gaps: 'Lacunes',
+  noHits: 'Aucune correspondance directe depuis le CV.',
+  noGaps: 'Aucune exigence manquante détectée.',
+  coverageSummary: 'Correspond {matched} sur {total} exigences ({score} %).',
   greeting: 'Bonjour, {name}!'
 };

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -110,6 +110,39 @@ describe('jobbot CLI', () => {
     expect(data.score).toBeGreaterThanOrEqual(50);
   });
 
+  it('explains hits and gaps with match --explain', () => {
+    const job = [
+      'Title: Staff Engineer',
+      'Company: ExampleCorp',
+      'Requirements',
+      '- Distributed systems experience',
+      '- Certified Kubernetes administrator',
+      '- Mentors senior engineers',
+    ].join('\n');
+    const resume = [
+      'Led distributed systems design and migrations to cloud-native stacks.',
+      'Managed mentoring programs for staff engineers.',
+    ].join('\n');
+    const jobPath = path.resolve('test', 'fixtures', 'job-explain.txt');
+    const resumePath = path.resolve('test', 'fixtures', 'resume-explain.txt');
+    fs.mkdirSync(path.dirname(jobPath), { recursive: true });
+    fs.writeFileSync(jobPath, job);
+    fs.writeFileSync(resumePath, resume);
+
+    const out = runCli([
+      'match',
+      '--resume',
+      resumePath,
+      '--job',
+      jobPath,
+      '--explain',
+    ]);
+
+    expect(out).toContain('## Explanation');
+    expect(out).toMatch(/Matched 2 of 3 requirements/);
+    expect(out).toMatch(/Gaps: Certified Kubernetes administrator/);
+  });
+
   it('records application status with track add', () => {
     const status = STATUSES[0]; // pick a valid status
     const output = runCli(['track', 'add', 'job-123', '--status', status]);

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { toJson, toMarkdownSummary, toMarkdownMatch } from '../src/exporters.js';
+import {
+  toJson,
+  toMarkdownSummary,
+  toMarkdownMatch,
+  formatMatchExplanation,
+  toMarkdownMatchExplanation,
+} from '../src/exporters.js';
 
 describe('exporters', () => {
   it('converts objects to pretty JSON', () => {
@@ -197,5 +203,35 @@ describe('exporters', () => {
       '- Rust',
     ].join('\n');
     expect(output).toBe(expected);
+  });
+
+  it('summarizes match explanations with top hits and gaps', () => {
+    const text = formatMatchExplanation({
+      matched: ['JavaScript expertise', 'Mentored seniors'],
+      missing: ['Public cloud expertise'],
+      score: 67,
+    });
+    expect(text).toContain('Matched 2 of 3 requirements (67%)');
+    expect(text).toContain('Hits: JavaScript expertise; Mentored seniors');
+    expect(text).toContain('Gaps: Public cloud expertise');
+  });
+
+  it('falls back when no hits or gaps are present', () => {
+    const text = formatMatchExplanation({ matched: [], missing: [] });
+    expect(text).toContain('Matched 0 of 0 requirements (0%)');
+    expect(text).toContain('No direct hits from the resume.');
+    expect(text).toContain('No missing requirements detected.');
+  });
+
+  it('renders markdown explanation with escaped content', () => {
+    const md = toMarkdownMatchExplanation({
+      matched: ['Node.js (services)'],
+      missing: ['Go & Rust'],
+      score: 50,
+    });
+    expect(md).toContain('## Explanation');
+    expect(md).toContain('Matched 1 of 2 requirements \\(50%\\)');
+    expect(md).toContain('Hits: Node.js \\(services\\)');
+    expect(md).toContain('Gaps: Go & Rust');
   });
 });


### PR DESCRIPTION
what: implement jobbot match --explain output and translations
why: deliver roadmap-explained hits/gaps summaries in CLI and JSON
how: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68ce57223f9c832fac5e26fca4d041d2