### PR TITLE
Add Workable job board ingestion support

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -286,7 +286,6 @@ jobbot track add <job_id> --status applied --note "emailed hiring manager"
 - Docs, quickstart, sample data.
 
 **Stretch / nice-to-have**
-- Workable module.
 - Pandoc .docx export.
 - System-design rehearsal outlines.
 - Scheduler for periodic ingestion/matching.

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ so snapshots stay alongside other candidate data when the directory is moved.
 
 ## Job board ingestion
 
-Fetch public boards directly with Greenhouse, Lever, Ashby, or SmartRecruiters pipelines:
+Fetch public boards directly with Greenhouse, Lever, Ashby, SmartRecruiters, or Workable pipelines:
 
 ~~~bash
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest greenhouse --company example
@@ -278,15 +278,20 @@ JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest ashby --company example
 
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest smartrecruiters --company example
 # Imported 5 jobs from example
+
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest workable --company example
+# Imported 4 jobs from example
 ~~~
 
 Each listing in the response is normalised to plain text, parsed for title,
 location, and requirements, and written to `data/jobs/{job_id}.json` with a
-`source.type` reflecting the provider (`greenhouse`, `lever`, `ashby`, or `smartrecruiters`). Updates reuse
-the same job identifier so downstream tooling can diff revisions over time.
-Tests in [`test/greenhouse.test.js`](test/greenhouse.test.js),
-[`test/lever.test.js`](test/lever.test.js), [`test/ashby.test.js`](test/ashby.test.js), and
-[`test/smartrecruiters.test.js`](test/smartrecruiters.test.js) verify the ingest
+`source.type` reflecting the provider (`greenhouse`, `lever`, `ashby`,
+`smartrecruiters`, or `workable`). Updates reuse the same job identifier so
+downstream tooling can diff revisions over time. Tests in
+[`test/greenhouse.test.js`](test/greenhouse.test.js),
+[`test/lever.test.js`](test/lever.test.js), [`test/ashby.test.js`](test/ashby.test.js),
+[`test/smartrecruiters.test.js`](test/smartrecruiters.test.js), and
+[`test/workable.test.js`](test/workable.test.js) verify the ingest
 pipelines fetch board content, persist structured snapshots, surface fetch
 errors, and retain the `User-Agent: jobbot3000` request header alongside each
 capture so fetches are reproducible.

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -24,6 +24,7 @@ import { ingestGreenhouseBoard } from '../src/greenhouse.js';
 import { ingestLeverBoard } from '../src/lever.js';
 import { ingestSmartRecruitersBoard } from '../src/smartrecruiters.js';
 import { ingestAshbyBoard } from '../src/ashby.js';
+import { ingestWorkableBoard } from '../src/workable.js';
 
 function isHttpUrl(s) {
   return /^https?:\/\//i.test(s);
@@ -290,13 +291,28 @@ async function cmdIngestSmartRecruiters(args) {
   console.log(`Imported ${saved} ${noun} from ${company}`);
 }
 
+async function cmdIngestWorkable(args) {
+  const account = getFlag(args, '--company') || getFlag(args, '--account');
+  if (!account) {
+    console.error('Usage: jobbot ingest workable --company <slug>');
+    process.exit(2);
+  }
+
+  const { saved } = await ingestWorkableBoard({ account });
+  const noun = saved === 1 ? 'job' : 'jobs';
+  console.log(`Imported ${saved} ${noun} from ${account}`);
+}
+
 async function cmdIngest(args) {
   const sub = args[0];
   if (sub === 'greenhouse') return cmdIngestGreenhouse(args.slice(1));
   if (sub === 'lever') return cmdIngestLever(args.slice(1));
   if (sub === 'ashby') return cmdIngestAshby(args.slice(1));
   if (sub === 'smartrecruiters') return cmdIngestSmartRecruiters(args.slice(1));
-  console.error('Usage: jobbot ingest <greenhouse|lever|ashby|smartrecruiters> --company <slug>');
+  if (sub === 'workable') return cmdIngestWorkable(args.slice(1));
+  console.error(
+    'Usage: jobbot ingest <greenhouse|lever|ashby|smartrecruiters|workable> --company <slug>',
+  );
   process.exit(2);
 }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -43,7 +43,7 @@ revisit them later without blocking the workflow.
 **Goal:** Build a living shortlist of job opportunities pulled from the web or supplied manually.
 
 1. The user searches company boards via supported fetchers (Greenhouse, Lever, SmartRecruiters,
-   Ashby, with Workable on the roadmap) or pastes individual URLs into the CLI/UI. For example,
+   Ashby, Workable) or pastes individual URLs into the CLI/UI. For example,
    `jobbot ingest greenhouse --company acme` pulls the latest public postings into the local
    data directory, and `jobbot ingest lever --company acme` performs the same for Lever-hosted
    listings.

--- a/src/workable.js
+++ b/src/workable.js
@@ -1,0 +1,206 @@
+import fetch from 'node-fetch';
+import { extractTextFromHtml } from './fetch.js';
+import { jobIdFromSource, saveJobSnapshot } from './jobs.js';
+import { parseJobText } from './parser.js';
+
+const WORKABLE_BASE = 'https://www.workable.com/api/accounts';
+const WORKABLE_HEADERS = {
+  'User-Agent': 'jobbot3000',
+  Accept: 'application/json',
+};
+
+function sanitizeString(value) {
+  if (value == null) return '';
+  const trimmed = String(value).trim();
+  return trimmed;
+}
+
+function normalizeAccountSlug(account) {
+  const slug = sanitizeString(account);
+  if (!slug) {
+    throw new Error('Workable account slug is required');
+  }
+  return slug;
+}
+
+function buildJobsUrl(slug) {
+  return `${WORKABLE_BASE}/${encodeURIComponent(slug)}/jobs`;
+}
+
+function resolveShortcode(job) {
+  const direct = sanitizeString(job?.shortcode);
+  if (direct) return direct;
+  const id = sanitizeString(job?.id);
+  if (id) return id;
+  throw new Error('Workable job shortcode is required');
+}
+
+function buildJobDetailUrl(slug, shortcode) {
+  return `${WORKABLE_BASE}/${encodeURIComponent(slug)}/jobs/${encodeURIComponent(shortcode)}`;
+}
+
+function toPlainText(value) {
+  const str = sanitizeString(value);
+  if (!str) return '';
+  return extractTextFromHtml(str);
+}
+
+function appendPlain(parts, value) {
+  const text = toPlainText(value);
+  if (text) parts.push(text);
+}
+
+function collectSectionText(sections) {
+  if (!sections) return [];
+  const parts = [];
+  const entries = Array.isArray(sections)
+    ? sections
+    : typeof sections === 'object'
+      ? Object.values(sections)
+      : [];
+  for (const section of entries) {
+    if (!section || typeof section !== 'object') continue;
+    const title = sanitizeString(section.title);
+    if (title) parts.push(title);
+    appendPlain(parts, section.content ?? section.description ?? section.body);
+  }
+  return parts;
+}
+
+function gatherDetailText(detail, job) {
+  const parts = [];
+  const fields = [
+    detail?.full_description,
+    detail?.description,
+    detail?.description_html,
+    detail?.descriptionRaw,
+    detail?.requirements,
+    detail?.benefits,
+    job?.full_description,
+    job?.description,
+    job?.description_html,
+  ];
+  for (const field of fields) {
+    appendPlain(parts, field);
+  }
+  parts.push(...collectSectionText(detail?.sections));
+  parts.push(...collectSectionText(detail?.content?.sections));
+  if (!parts.length) {
+    appendPlain(parts, detail?.summary);
+    appendPlain(parts, job?.summary);
+  }
+  return parts.filter(Boolean).join('\n\n');
+}
+
+function extractLocation(detail, job) {
+  const attempt = (candidate) => {
+    if (!candidate) return '';
+    if (typeof candidate === 'string') return sanitizeString(candidate);
+    if (typeof candidate.location_str === 'string') return sanitizeString(candidate.location_str);
+    const fields = [candidate.city, candidate.state, candidate.region, candidate.country]
+      .map(sanitizeString)
+      .filter(Boolean);
+    return fields.join(', ').trim();
+  };
+  return (
+    attempt(detail?.location) ||
+    attempt(detail?.locations?.[0]) ||
+    attempt(job?.location) ||
+    attempt(job?.locations?.[0]) ||
+    ''
+  );
+}
+
+function mergeParsedJob(parsed, job, detail) {
+  const merged = { ...parsed };
+  const title =
+    sanitizeString(detail?.title) ||
+    sanitizeString(detail?.full_title) ||
+    sanitizeString(job?.title) ||
+    sanitizeString(job?.full_title);
+  if (!merged.title && title) merged.title = title;
+  const location = extractLocation(detail, job);
+  if (!merged.location && location) merged.location = location;
+  const employmentType = sanitizeString(detail?.employment_type || job?.employment_type);
+  if (employmentType) merged.employmentType = employmentType;
+  const department = sanitizeString(detail?.department || job?.department);
+  if (department) merged.department = department;
+  return merged;
+}
+
+function resolveCanonicalUrl({ job, detail, account, shortcode }) {
+  const urlCandidates = [
+    detail?.application_url,
+    detail?.url,
+    detail?.shortlink,
+    job?.application_url,
+    job?.url,
+    job?.shortlink,
+  ];
+  for (const candidate of urlCandidates) {
+    const normalized = sanitizeString(candidate);
+    if (normalized) return normalized;
+  }
+  const encodedAccount = encodeURIComponent(account);
+  const encodedShortcode = encodeURIComponent(shortcode);
+  return `https://apply.workable.com/${encodedAccount}/j/${encodedShortcode}/`;
+}
+
+function selectFetchedAt(detail, job) {
+  const candidates = [detail?.updated_at, detail?.published_at, job?.updated_at, job?.published_at];
+  for (const candidate of candidates) {
+    const normalized = sanitizeString(candidate);
+    if (normalized) return normalized;
+  }
+  return undefined;
+}
+
+export async function fetchWorkableJobs(account, { fetchImpl = fetch } = {}) {
+  const slug = normalizeAccountSlug(account);
+  const url = buildJobsUrl(slug);
+  const response = await fetchImpl(url, { headers: WORKABLE_HEADERS });
+  if (!response.ok) {
+    const statusLabel = `${response.status} ${response.statusText}`;
+    throw new Error(`Failed to fetch Workable account ${slug}: ${statusLabel}`);
+  }
+  const payload = await response.json();
+  const jobsArray = Array.isArray(payload?.jobs)
+    ? payload.jobs
+    : Array.isArray(payload)
+      ? payload
+      : Array.isArray(payload?.results)
+        ? payload.results
+        : [];
+  return { account: slug, jobs: jobsArray };
+}
+
+export async function ingestWorkableBoard({ account, fetchImpl = fetch } = {}) {
+  const { account: slug, jobs } = await fetchWorkableJobs(account, { fetchImpl });
+  const jobIds = [];
+
+  for (const job of jobs) {
+    const shortcode = resolveShortcode(job);
+    const detailUrl = buildJobDetailUrl(slug, shortcode);
+    const detailResponse = await fetchImpl(detailUrl, { headers: WORKABLE_HEADERS });
+    if (!detailResponse.ok) {
+      const statusLabel = `${detailResponse.status} ${detailResponse.statusText}`;
+      throw new Error(`Failed to fetch Workable job ${shortcode}: ${statusLabel}`);
+    }
+    const detail = await detailResponse.json();
+    const raw = gatherDetailText(detail, job);
+    const parsed = mergeParsedJob(parseJobText(raw), job, detail);
+    const canonicalUrl = resolveCanonicalUrl({ job, detail, account: slug, shortcode });
+    const id = jobIdFromSource({ provider: 'workable', url: canonicalUrl });
+    await saveJobSnapshot({
+      id,
+      raw,
+      parsed,
+      source: { type: 'workable', value: canonicalUrl },
+      requestHeaders: WORKABLE_HEADERS,
+      fetchedAt: selectFetchedAt(detail, job),
+    });
+    jobIds.push(id);
+  }
+
+  return { account: slug, saved: jobIds.length, jobIds };
+}

--- a/test/workable.test.js
+++ b/test/workable.test.js
@@ -1,0 +1,166 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('node-fetch', () => ({ default: vi.fn() }));
+
+import fetch from 'node-fetch';
+
+const JOBS_DIR = 'jobs';
+
+describe('Workable ingest', () => {
+  let dataDir;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-workable-'));
+    process.env.JOBBOT_DATA_DIR = dataDir;
+    fetch.mockReset();
+  });
+
+  afterEach(async () => {
+    if (dataDir) {
+      await fs.rm(dataDir, { recursive: true, force: true });
+      dataDir = undefined;
+    }
+    delete process.env.JOBBOT_DATA_DIR;
+  });
+
+  it('fetches Workable jobs and writes snapshots', async () => {
+    const listPayload = {
+      jobs: [
+        {
+          shortcode: 'abc123',
+          title: 'Senior Platform Engineer',
+          location: { location_str: 'Remote' },
+          url: 'https://apply.workable.com/example/j/abc123/',
+          updated_at: '2025-01-02T03:04:05Z',
+        },
+      ],
+    };
+
+    const detailPayload = {
+      shortcode: 'abc123',
+      title: 'Senior Platform Engineer',
+      location: { location_str: 'Remote' },
+      description: `
+        <h1>Senior Platform Engineer</h1>
+        <p>Build durable infrastructure.</p>
+        <h3>Requirements</h3>
+        <ul>
+          <li>Go</li>
+        </ul>
+      `,
+      updated_at: '2025-01-02T03:04:05Z',
+    };
+
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => listPayload,
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => detailPayload,
+      });
+
+    const { ingestWorkableBoard } = await import('../src/workable.js');
+
+    const result = await ingestWorkableBoard({ account: 'example' });
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      1,
+      'https://www.workable.com/api/accounts/example/jobs',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'User-Agent': 'jobbot3000',
+          Accept: 'application/json',
+        }),
+      }),
+    );
+
+    expect(fetch).toHaveBeenNthCalledWith(
+      2,
+      'https://www.workable.com/api/accounts/example/jobs/abc123',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'User-Agent': 'jobbot3000',
+          Accept: 'application/json',
+        }),
+      }),
+    );
+
+    expect(result).toMatchObject({ account: 'example', saved: 1 });
+    expect(result.jobIds).toHaveLength(1);
+
+    const jobsDir = path.join(dataDir, JOBS_DIR);
+    const files = await fs.readdir(jobsDir);
+    expect(files).toHaveLength(1);
+
+    const saved = JSON.parse(await fs.readFile(path.join(jobsDir, files[0]), 'utf8'));
+    expect(saved.source).toMatchObject({
+      type: 'workable',
+      value: 'https://apply.workable.com/example/j/abc123/',
+    });
+    expect(saved.source.headers).toEqual({
+      Accept: 'application/json',
+      'User-Agent': 'jobbot3000',
+    });
+    expect(saved.parsed.title).toBe('Senior Platform Engineer');
+    expect(saved.parsed.location).toBe('Remote');
+    const hasRequirement = saved.parsed.requirements.some((req) => req.includes('Go'));
+    expect(hasRequirement).toBe(true);
+    expect(saved.fetched_at).toBe('2025-01-02T03:04:05.000Z');
+  });
+
+  it('throws when the account fetch fails', async () => {
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      json: async () => ({}),
+    });
+
+    const { ingestWorkableBoard } = await import('../src/workable.js');
+
+    await expect(ingestWorkableBoard({ account: 'missing' })).rejects.toThrow(
+      /Failed to fetch Workable account/,
+    );
+  });
+
+  it('throws when a job detail fetch fails', async () => {
+    const listPayload = {
+      jobs: [
+        {
+          shortcode: 'abc123',
+          title: 'Senior Platform Engineer',
+          url: 'https://apply.workable.com/example/j/abc123/',
+        },
+      ],
+    };
+
+    fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => listPayload,
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: 'Internal Server Error',
+        json: async () => ({}),
+      });
+
+    const { ingestWorkableBoard } = await import('../src/workable.js');
+
+    await expect(ingestWorkableBoard({ account: 'example' })).rejects.toThrow(
+      /Failed to fetch Workable job/,
+    );
+  });
+});


### PR DESCRIPTION
what: add Workable board ingest module, CLI command, and coverage.
why: deliver the documented Workable integration so boards are feature-complete.
how to test: npm run lint && npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68cf3bd02028832f8d5dc48a2270491a