### PR TITLE
Fix analytics conversion rate for zero baseline stages

### DIFF
--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -24,6 +24,7 @@ import { ingestGreenhouseBoard } from '../src/greenhouse.js';
 import { ingestLeverBoard } from '../src/lever.js';
 import { ingestSmartRecruitersBoard } from '../src/smartrecruiters.js';
 import { ingestAshbyBoard } from '../src/ashby.js';
+import { computeFunnel, formatFunnelReport } from '../src/analytics.js';
 
 function isHttpUrl(s) {
   return /^https?:\/\//i.test(s);
@@ -402,6 +403,23 @@ async function cmdShortlist(args) {
   process.exit(2);
 }
 
+async function cmdAnalyticsFunnel(args) {
+  const format = args.includes('--json') ? 'json' : 'text';
+  const funnel = await computeFunnel();
+  if (format === 'json') {
+    console.log(JSON.stringify(funnel, null, 2));
+    return;
+  }
+  console.log(formatFunnelReport(funnel));
+}
+
+async function cmdAnalytics(args) {
+  const sub = args[0];
+  if (sub === 'funnel') return cmdAnalyticsFunnel(args.slice(1));
+  console.error('Usage: jobbot analytics funnel [--json]');
+  process.exit(2);
+}
+
 async function cmdInterviewsRecord(args) {
   const jobId = args[0];
   const sessionId = args[1];
@@ -484,9 +502,12 @@ async function main() {
   if (cmd === 'match') return cmdMatch(args);
   if (cmd === 'track') return cmdTrack(args);
   if (cmd === 'shortlist') return cmdShortlist(args);
+  if (cmd === 'analytics') return cmdAnalytics(args);
   if (cmd === 'ingest') return cmdIngest(args);
   if (cmd === 'interviews') return cmdInterviews(args);
-  console.error('Usage: jobbot <init|summarize|match|track|shortlist|interviews|ingest> [options]');
+  console.error(
+    'Usage: jobbot <init|summarize|match|track|shortlist|analytics|interviews|ingest> [options]'
+  );
   process.exit(2);
 }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -119,9 +119,9 @@ suggestions to prevent burnout.
 
 **Goal:** Maintain visibility into success rates and continuously improve recommendations.
 
-1. The analytics process reads application and interaction logs to update a local Sankey diagram
-   showing conversions (outreach ➜ screening ➜ onsite ➜ offer ➜ acceptance) and major drop-off
-   points.
+1. The analytics process reads application and interaction logs via `jobbot analytics funnel`
+   to update a local Sankey-style view showing conversions (outreach ➜ screening ➜ onsite ➜ offer
+   ➜ acceptance) and highlight the largest drop-off.
 2. Metadata from tailoring and rehearsal sessions feeds back into the recommender so it can surface
    what worked (e.g., bullet variants correlated with interviews) while staying privacy-first.
 3. Users can export anonymized aggregates for personal record keeping without exposing raw PII.

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -1,0 +1,204 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+let overrideDir;
+
+function resolveDataDir() {
+  return overrideDir || process.env.JOBBOT_DATA_DIR || path.resolve('data');
+}
+
+export function setAnalyticsDataDir(dir) {
+  overrideDir = dir || undefined;
+}
+
+async function readJsonFile(file) {
+  try {
+    const raw = await fs.readFile(file, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') {
+      return parsed;
+    }
+    return {};
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return {};
+    throw err;
+  }
+}
+
+function getPaths() {
+  const dir = resolveDataDir();
+  return {
+    applications: path.join(dir, 'applications.json'),
+    events: path.join(dir, 'application_events.json'),
+  };
+}
+
+function countJobsWithEvents(events) {
+  let count = 0;
+  for (const history of Object.values(events)) {
+    if (Array.isArray(history) && history.length > 0) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function getStatusCounts(statuses) {
+  const counts = new Map();
+  for (const value of Object.values(statuses)) {
+    if (typeof value !== 'string') continue;
+    const key = value.trim();
+    if (!key) continue;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return counts;
+}
+
+const ACCEPTANCE_STATUS = new Set(['accepted', 'acceptance', 'hired']);
+const ACCEPTANCE_CHANNELS = new Set([
+  'offer_accepted',
+  'offer accepted',
+  'accepted_offer',
+  'accept offer',
+  'acceptance',
+  'offeraccept',
+  'offer-accepted',
+]);
+
+function collectAcceptanceJobs(statuses, events) {
+  const accepted = new Set();
+  for (const [jobId, rawStatus] of Object.entries(statuses)) {
+    if (typeof rawStatus !== 'string') continue;
+    const status = rawStatus.trim().toLowerCase();
+    if (!status) continue;
+    if (ACCEPTANCE_STATUS.has(status)) {
+      accepted.add(jobId);
+    }
+  }
+  for (const [jobId, history] of Object.entries(events)) {
+    if (!Array.isArray(history)) continue;
+    for (const entry of history) {
+      const channel = typeof entry?.channel === 'string' ? entry.channel.trim().toLowerCase() : '';
+      if (channel && ACCEPTANCE_CHANNELS.has(channel)) {
+        accepted.add(jobId);
+        break;
+      }
+    }
+  }
+  return accepted;
+}
+
+function unionJobIds(statuses, events) {
+  const ids = new Set();
+  for (const key of Object.keys(statuses)) ids.add(key);
+  for (const key of Object.keys(events)) ids.add(key);
+  return ids;
+}
+
+const STAGE_SEQUENCE = [
+  { key: 'outreach', label: 'Outreach', type: 'outreach' },
+  { key: 'screening', label: 'Screening', type: 'status', status: 'screening' },
+  { key: 'onsite', label: 'Onsite', type: 'status', status: 'onsite' },
+  { key: 'offer', label: 'Offer', type: 'status', status: 'offer' },
+  { key: 'acceptance', label: 'Acceptance', type: 'acceptance' },
+];
+
+function roundPercent(value) {
+  if (!Number.isFinite(value)) return undefined;
+  return Math.round(value * 100);
+}
+
+export async function computeFunnel() {
+  const { applications, events } = getPaths();
+  const [statuses, interactions] = await Promise.all([
+    readJsonFile(applications),
+    readJsonFile(events),
+  ]);
+
+  const statusCounts = getStatusCounts(statuses);
+  const withEvents = countJobsWithEvents(interactions);
+  const acceptedJobs = collectAcceptanceJobs(statuses, interactions);
+  const trackedJobs = unionJobIds(statuses, interactions).size;
+
+  const stages = [];
+  let previousCount;
+  for (const stage of STAGE_SEQUENCE) {
+    let count = 0;
+    if (stage.type === 'outreach') {
+      count = withEvents;
+    } else if (stage.type === 'status') {
+      count = statusCounts.get(stage.status) ?? 0;
+    } else if (stage.type === 'acceptance') {
+      count = acceptedJobs.size;
+    }
+
+    const dropOff = previousCount != null && previousCount > count ? previousCount - count : 0;
+    let conversionRate;
+    if (previousCount == null) {
+      conversionRate = 1;
+    } else if (previousCount === 0) {
+      conversionRate = null;
+    } else {
+      conversionRate = count / previousCount;
+    }
+    stages.push({
+      key: stage.key,
+      label: stage.label,
+      count,
+      dropOff,
+      conversionRate,
+    });
+    previousCount = count;
+  }
+
+  let largestDropOff = null;
+  for (let i = 1; i < stages.length; i += 1) {
+    const stage = stages[i];
+    if (!largestDropOff || stage.dropOff > largestDropOff.dropOff) {
+      largestDropOff = {
+        from: stages[i - 1].key,
+        fromLabel: stages[i - 1].label,
+        to: stage.key,
+        toLabel: stage.label,
+        dropOff: stage.dropOff,
+      };
+    }
+  }
+
+  return {
+    totals: {
+      trackedJobs,
+      withEvents,
+    },
+    stages,
+    largestDropOff,
+  };
+}
+
+function formatStageLine(stage, index) {
+  const base = `${stage.label}: ${stage.count}`;
+  if (index === 0) return base;
+  const percent = roundPercent(stage.conversionRate);
+  const percentLabel = percent === undefined ? 'n/a' : `${percent}%`;
+  const dropSuffix = stage.dropOff > 0 ? `, ${stage.dropOff} drop-off` : '';
+  return `${base} (${percentLabel} conversion${dropSuffix})`;
+}
+
+export function formatFunnelReport(funnel) {
+  if (!funnel || !Array.isArray(funnel.stages) || funnel.stages.length === 0) {
+    return 'No analytics data available';
+  }
+  const lines = funnel.stages.map((stage, index) => formatStageLine(stage, index));
+  if (funnel.largestDropOff && funnel.largestDropOff.dropOff > 0) {
+    lines.push(
+      `Largest drop-off: ${funnel.largestDropOff.fromLabel} → ${funnel.largestDropOff.toLabel} (` +
+        `${funnel.largestDropOff.dropOff} lost)`
+    );
+  } else {
+    lines.push('Largest drop-off: none');
+  }
+  const tracked = funnel.totals?.trackedJobs ?? 0;
+  const withEvents = funnel.totals?.withEvents ?? 0;
+  lines.push(`Tracked jobs: ${tracked} total; ${withEvents} with outreach events`);
+  return lines.join('\n');
+}

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -1,0 +1,128 @@
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let dataDir;
+let restoreAnalyticsDir;
+
+describe('analytics conversion funnel', () => {
+  beforeEach(async () => {
+    const fs = await import('node:fs/promises');
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-analytics-'));
+    process.env.JOBBOT_DATA_DIR = dataDir;
+    restoreAnalyticsDir = undefined;
+  });
+
+  afterEach(async () => {
+    if (restoreAnalyticsDir) {
+      await restoreAnalyticsDir();
+      restoreAnalyticsDir = undefined;
+    }
+    if (dataDir) {
+      const fs = await import('node:fs/promises');
+      await fs.rm(dataDir, { recursive: true, force: true });
+      dataDir = undefined;
+    }
+    delete process.env.JOBBOT_DATA_DIR;
+  });
+
+  it('summarizes lifecycle and event data into drop-off stages', async () => {
+    const fs = await import('node:fs/promises');
+    await fs.writeFile(
+      path.join(dataDir, 'applications.json'),
+      JSON.stringify(
+        {
+          'job-1': 'screening',
+          'job-2': 'onsite',
+          'job-3': 'offer',
+          'job-4': 'rejected',
+          'job-5': 'withdrawn',
+        },
+        null,
+        2,
+      ),
+    );
+    await fs.writeFile(
+      path.join(dataDir, 'application_events.json'),
+      JSON.stringify(
+        {
+          'job-1': [
+            { channel: 'email', date: '2025-01-02T10:00:00.000Z' },
+            { channel: 'follow_up', date: '2025-01-05T15:30:00.000Z' },
+          ],
+          'job-2': [{ channel: 'referral', date: '2025-01-03T12:00:00.000Z' }],
+          'job-3': [
+            { channel: 'email', date: '2025-01-04T09:00:00.000Z' },
+            { channel: 'offer_accepted', date: '2025-02-01T18:00:00.000Z' },
+          ],
+          'job-4': [{ channel: 'application', date: '2025-01-06T08:00:00.000Z' }],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const { computeFunnel, formatFunnelReport, setAnalyticsDataDir } = await import(
+      '../src/analytics.js'
+    );
+    setAnalyticsDataDir(dataDir);
+    restoreAnalyticsDir = async () => setAnalyticsDataDir(undefined);
+
+    const funnel = await computeFunnel();
+    expect(funnel).toMatchObject({
+      totals: { trackedJobs: 5, withEvents: 4 },
+      largestDropOff: { from: 'outreach', to: 'screening', dropOff: 3 },
+      stages: [
+        { key: 'outreach', count: 4, conversionRate: 1 },
+        { key: 'screening', count: 1, conversionRate: 0.25, dropOff: 3 },
+        { key: 'onsite', count: 1, conversionRate: 1, dropOff: 0 },
+        { key: 'offer', count: 1, conversionRate: 1, dropOff: 0 },
+        { key: 'acceptance', count: 1, conversionRate: 1, dropOff: 0 },
+      ],
+    });
+
+    const report = formatFunnelReport(funnel);
+    expect(report).toContain('Outreach: 4');
+    expect(report).toContain('Screening: 1 (25% conversion, 3 drop-off)');
+    expect(report).toContain('Largest drop-off: Outreach → Screening (3 lost)');
+    expect(report).toContain('Tracked jobs: 5 total; 4 with outreach events');
+  });
+
+  it('marks conversion as unavailable when the previous stage has no jobs', async () => {
+    const fs = await import('node:fs/promises');
+    await fs.writeFile(
+      path.join(dataDir, 'applications.json'),
+      JSON.stringify(
+        {
+          'job-onsite': 'onsite',
+        },
+        null,
+        2,
+      ),
+    );
+    await fs.writeFile(
+      path.join(dataDir, 'application_events.json'),
+      JSON.stringify({}, null, 2),
+    );
+
+    const { computeFunnel, formatFunnelReport, setAnalyticsDataDir } = await import(
+      '../src/analytics.js'
+    );
+    setAnalyticsDataDir(dataDir);
+    restoreAnalyticsDir = async () => setAnalyticsDataDir(undefined);
+
+    const funnel = await computeFunnel();
+    const stageMap = Object.fromEntries(funnel.stages.map(stage => [stage.key, stage]));
+
+    expect(stageMap.outreach.count).toBe(0);
+    expect(stageMap.screening.count).toBe(0);
+    expect(stageMap.onsite.count).toBe(1);
+    expect(stageMap.onsite.conversionRate).toBeNull();
+    expect(stageMap.offer.conversionRate).toBe(0);
+    expect(stageMap.acceptance.conversionRate).toBeNull();
+
+    const report = formatFunnelReport(funnel);
+    expect(report).toContain('Onsite: 1 (n/a conversion');
+    expect(report).toContain('Offer: 0 (0% conversion, 1 drop-off)');
+  });
+});


### PR DESCRIPTION
what: add analytics funnel module and CLI surface with text/json output; mark zero-baseline conversions as n/a
why: close the documented analytics journey with shipped functionality and avoid misleading 100% conversions when outreach data is missing
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68cf3bd02028832f8d5dc48a2270491a