### PR TITLE
feat: add anonymized analytics export snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,12 +379,23 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot analytics funnel --json | jq '.stages[0]'
 #   "dropOff": 0,
 #   "conversionRate": 1
 # }
+
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot analytics export --out analytics.json
+# Saved analytics snapshot to /tmp/jobbot-cli-XXXX/analytics.json
+# jq '.channels' analytics.json
+# {
+#   "email": 1,
+#   "offer_accepted": 1,
+#   "referral": 1
+# }
 ~~~
 
 The analytics command reads `applications.json` and `application_events.json`, summarising stage
 counts, drop-offs, and conversion percentages. A dedicated unit test in
 [`test/analytics.test.js`](test/analytics.test.js) and a CLI flow in [`test/cli.test.js`](test/cli.test.js)
-cover outreach counts, acceptance detection, JSON formatting, and the largest drop-off highlight.
+cover outreach counts, acceptance detection, JSON formatting, the largest drop-off highlight, and the
+anonymized snapshot export. The `analytics export` subcommand captures aggregate status counts and
+event channels without embedding raw job identifiers so personal records stay scrubbed.
 
 ## Interview session logs
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -24,7 +24,7 @@ import { ingestGreenhouseBoard } from '../src/greenhouse.js';
 import { ingestLeverBoard } from '../src/lever.js';
 import { ingestSmartRecruitersBoard } from '../src/smartrecruiters.js';
 import { ingestAshbyBoard } from '../src/ashby.js';
-import { computeFunnel, formatFunnelReport } from '../src/analytics.js';
+import { computeFunnel, exportAnalyticsSnapshot, formatFunnelReport } from '../src/analytics.js';
 import { ingestWorkableBoard } from '../src/workable.js';
 
 function isHttpUrl(s) {
@@ -429,10 +429,25 @@ async function cmdAnalyticsFunnel(args) {
   console.log(formatFunnelReport(funnel));
 }
 
+async function cmdAnalyticsExport(args) {
+  const output = getFlag(args, '--out');
+  const snapshot = await exportAnalyticsSnapshot();
+  const payload = `${JSON.stringify(snapshot, null, 2)}\n`;
+  if (output) {
+    const resolved = path.resolve(process.cwd(), output);
+    await fs.promises.mkdir(path.dirname(resolved), { recursive: true });
+    await fs.promises.writeFile(resolved, payload, 'utf8');
+    console.log(`Saved analytics snapshot to ${resolved}`);
+    return;
+  }
+  console.log(payload.trimEnd());
+}
+
 async function cmdAnalytics(args) {
   const sub = args[0];
   if (sub === 'funnel') return cmdAnalyticsFunnel(args.slice(1));
-  console.error('Usage: jobbot analytics funnel [--json]');
+  if (sub === 'export') return cmdAnalyticsExport(args.slice(1));
+  console.error('Usage: jobbot analytics <funnel|export> [options]');
   process.exit(2);
 }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -124,7 +124,8 @@ suggestions to prevent burnout.
    ➜ acceptance) and highlight the largest drop-off.
 2. Metadata from tailoring and rehearsal sessions feeds back into the recommender so it can surface
    what worked (e.g., bullet variants correlated with interviews) while staying privacy-first.
-3. Users can export anonymized aggregates for personal record keeping without exposing raw PII.
+3. Users can export anonymized aggregates with `jobbot analytics export --out <file>` for personal
+   record keeping without exposing raw PII.
 
 **Unhappy paths:** missing data (e.g., unlogged rejections) is highlighted so the user can backfill
    later.


### PR DESCRIPTION
## Summary
- ship the Journey 7 promise from docs/user-journeys.md by adding a `jobbot analytics export` command that writes anonymized aggregates
- collect status totals, funnel data, and channel counts via the new `exportAnalyticsSnapshot` helper without leaking job identifiers
- document the workflow in README.md and docs/user-journeys.md and extend test/analytics.test.js plus test/cli.test.js to cover the export flow

## Test Plan
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68cf4409a330832f8465c14b2144904c