### PR TITLE
Add CLI support for intake response logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,36 @@ schedulers. Unit tests in [`test/shortlist.test.js`](test/shortlist.test.js) and
 [`test/cli.test.js`](test/cli.test.js) exercise metadata updates, filters, discard tags, and the
 persisted format.
 
+## Intake responses
+
+Capture intake conversations and keep the answers alongside your profile:
+
+~~~bash
+DATA_DIR=$(mktemp -d)
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot intake record \
+  --question "What motivates you?" \
+  --answer "Building accessible tools" \
+  --tags "growth,mission" \
+  --notes "Prefers collaborative teams" \
+  --asked-at 2025-02-01T12:34:56Z
+# Recorded intake response 123e4567-e89b-12d3-a456-426614174000
+
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot intake list
+# What motivates you?
+#   Answer: Building accessible tools
+#   Tags: growth, mission
+#   Notes: Prefers collaborative teams
+#   Asked At: 2025-02-01T12:34:56.000Z
+#   Recorded At: 2025-02-01T12:40:00.000Z
+#   ID: 123e4567-e89b-12d3-a456-426614174000
+~~~
+
+Entries are appended to `data/profile/intake.json` with normalized timestamps, optional tags, and
+notes so follow-up planning can reference prior answers. Recorded timestamps reflect when the
+command runs. Automated coverage in
+[`test/intake.test.js`](test/intake.test.js) and [`test/cli.test.js`](test/cli.test.js) verifies the
+stored shape and CLI workflows.
+
 ## Conversion funnel analytics
 
 Build a quick snapshot of outreach ➜ screening ➜ onsite ➜ offer ➜ acceptance conversions:

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -31,8 +31,9 @@ with retry options and explain how to manually fix the source file.
    visa status, measurable outcomes, tools).
 2. The user answers via chat or a structured form. The assistant keeps asking follow-ups until it
    reaches a configured confidence threshold.
-3. Responses are appended to the profile as structured notes (`data/profile/intake.json`) and the
-   model synthesizes updated bullet point options tagged by skill or competency.
+3. Responses are appended to the profile as structured notes (`data/profile/intake.json`) via
+   `jobbot intake record`, and the model synthesizes updated bullet point options tagged by skill or
+   competency.
 4. All interactions are stored locally with timestamps and provenance metadata for later review.
 
 **Unhappy paths:** the user can skip or postpone questions. Skips are marked so the assistant can

--- a/src/intake.js
+++ b/src/intake.js
@@ -1,0 +1,164 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+let overrideDir;
+
+function resolveDataDir() {
+  return overrideDir || process.env.JOBBOT_DATA_DIR || path.resolve('data');
+}
+
+export function setIntakeDataDir(dir) {
+  overrideDir = dir || undefined;
+}
+
+function getPaths() {
+  const baseDir = resolveDataDir();
+  const profileDir = path.join(baseDir, 'profile');
+  return { profileDir, file: path.join(profileDir, 'intake.json') };
+}
+
+function sanitizeString(value) {
+  if (value == null) return undefined;
+  const str = typeof value === 'string' ? value : String(value);
+  const trimmed = str.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function requireString(value, label) {
+  const sanitized = sanitizeString(value);
+  if (!sanitized) {
+    throw new Error(`${label} is required`);
+  }
+  return sanitized;
+}
+
+function normalizeTimestamp(input, label) {
+  if (input == null) return undefined;
+  const date = input instanceof Date ? input : new Date(input);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`invalid ${label} timestamp: ${input}`);
+  }
+  return date.toISOString();
+}
+
+function normalizeTags(input) {
+  if (!input) return undefined;
+  const list = Array.isArray(input)
+    ? input
+    : String(input)
+        .split(',')
+        .map(entry => entry.trim());
+  const normalized = [];
+  const seen = new Set();
+  for (const item of list) {
+    const value = sanitizeString(item);
+    if (!value) continue;
+    const key = value.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    normalized.push(value);
+  }
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+async function readIntakeFile(file) {
+  try {
+    const raw = await fs.readFile(file, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const responses = Array.isArray(parsed.responses) ? parsed.responses : [];
+      return responses
+        .filter(entry => entry && typeof entry === 'object')
+        .map(entry => ({
+          id: typeof entry.id === 'string' ? entry.id : randomUUID(),
+          question: typeof entry.question === 'string' ? entry.question : '',
+          answer: typeof entry.answer === 'string' ? entry.answer : '',
+          asked_at: typeof entry.asked_at === 'string' ? entry.asked_at : undefined,
+          recorded_at: typeof entry.recorded_at === 'string' ? entry.recorded_at : undefined,
+          tags: Array.isArray(entry.tags)
+            ? entry.tags.filter(tag => typeof tag === 'string')
+            : undefined,
+          notes: typeof entry.notes === 'string' ? entry.notes : undefined,
+        }))
+        .filter(entry => entry.question && entry.answer);
+    }
+    return [];
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return [];
+    throw err;
+  }
+}
+
+async function writeIntakeFile(file, responses) {
+  const payload = {
+    responses: responses.map(entry => ({
+      ...entry,
+      tags: entry.tags ? entry.tags.slice() : undefined,
+    })),
+  };
+  const tmp = `${file}.tmp`;
+  await fs.writeFile(tmp, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  await fs.rename(tmp, file);
+}
+
+let writeLock = Promise.resolve();
+
+export function recordIntakeResponse(data = {}) {
+  let question;
+  let answer;
+  try {
+    question = requireString(data.question, 'question');
+    answer = requireString(data.answer, 'answer');
+  } catch (err) {
+    return Promise.reject(err);
+  }
+
+  let askedAt;
+  try {
+    askedAt = normalizeTimestamp(data.askedAt ?? data.asked_at, 'asked');
+  } catch (err) {
+    return Promise.reject(err);
+  }
+
+  const tags = normalizeTags(data.tags);
+  const notes = sanitizeString(data.notes);
+  const recordedAt = new Date().toISOString();
+  const effectiveAskedAt = askedAt || recordedAt;
+  const entry = {
+    id: randomUUID(),
+    question,
+    answer,
+    asked_at: effectiveAskedAt,
+    recorded_at: recordedAt,
+  };
+  if (tags) entry.tags = tags;
+  if (notes) entry.notes = notes;
+
+  const { profileDir, file } = getPaths();
+
+  const run = async () => {
+    await fs.mkdir(profileDir, { recursive: true });
+    const existing = await readIntakeFile(file);
+    existing.push(entry);
+    await writeIntakeFile(file, existing);
+    return {
+      ...entry,
+      tags: entry.tags ? entry.tags.slice() : undefined,
+      notes: entry.notes,
+    };
+  };
+
+  writeLock = writeLock.then(run, run);
+  return writeLock;
+}
+
+export async function getIntakeResponses() {
+  const { file } = getPaths();
+  const responses = await readIntakeFile(file);
+  return responses.map(entry => ({
+    ...entry,
+    tags: entry.tags ? entry.tags.slice() : undefined,
+    notes: entry.notes,
+  }));
+}

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -200,6 +200,41 @@ describe('jobbot CLI', () => {
     expect(entry.discarded_at).toEqual(new Date(entry.discarded_at).toISOString());
   });
 
+  it('records intake responses and lists them', () => {
+    const output = runCli([
+      'intake',
+      'record',
+      '--question',
+      'What motivates you?',
+      '--answer',
+      'Building accessible tools',
+      '--tags',
+      'growth,mission',
+      '--notes',
+      'Prefers collaborative teams',
+      '--asked-at',
+      '2025-02-01T12:34:56Z',
+    ]);
+    expect(output.trim()).toMatch(/^Recorded intake response /);
+
+    const list = runCli(['intake', 'list']);
+    expect(list).toContain('What motivates you?');
+    expect(list).toContain('Answer: Building accessible tools');
+    expect(list).toContain('Tags: growth, mission');
+
+    const raw = JSON.parse(
+      fs.readFileSync(path.join(dataDir, 'profile', 'intake.json'), 'utf8')
+    );
+    expect(raw.responses).toHaveLength(1);
+    expect(raw.responses[0]).toMatchObject({
+      question: 'What motivates you?',
+      answer: 'Building accessible tools',
+      tags: ['growth', 'mission'],
+      notes: 'Prefers collaborative teams',
+      asked_at: '2025-02-01T12:34:56.000Z',
+    });
+  });
+
   it('tags shortlist entries and persists labels', () => {
     const output = runCli(['shortlist', 'tag', 'job-abc', 'dream', 'remote']);
     expect(output.trim()).toBe('Tagged job-abc with dream, remote');


### PR DESCRIPTION
## Summary
- close the user-journey backlog entry for `data/profile/intake.json` by adding an intake persistence module
- extend the CLI with `jobbot intake record|list` to capture, normalize, and display structured intake notes
- document the workflow and cover it with new unit and CLI tests

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68cf4409a330832f8465c14b2144904c