### PR TITLE
Add reminders to application event logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ echo "First. Second. Third." | npx jobbot summarize - --sentences 2 --text
 # Track an application's status
 npx jobbot track add job-123 --status screening
 # => Recorded job-123 as screening
+
+# Schedule a follow-up reminder when logging outreach
+npx jobbot track log job-123 --channel follow_up --remind-at 2025-03-11T09:00:00Z --note "Check in"
+# => Logged job-123 event follow_up
 ```
 
 # Continuous integration
@@ -462,9 +466,9 @@ To capture outreach history:
 
 Use `jobbot track log <job_id> --channel <channel>` to record the outreach trail
 for each application. The command accepts optional metadata such as `--date`,
-`--contact`, `--documents` (comma-separated), and `--note`. Events are appended
-to `data/application_events.json`, grouped by job identifier, with timestamps
-normalized to ISO 8601.
+`--contact`, `--documents` (comma-separated), `--note`, and `--remind-at`.
+Events are appended to `data/application_events.json`, grouped by job
+identifier, with timestamps normalized to ISO 8601.
 
 Tests in `test/application-events.test.js` ensure that new log entries do not
 clobber history and that invalid channels or dates are rejected.

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -199,15 +199,17 @@ async function cmdTrackLog(args) {
   if (!jobId || !channel) {
     console.error(
       'Usage: jobbot track log <job_id> --channel <channel> [--date <date>] ' +
-        '[--contact <contact>] [--documents <file1,file2>] [--note <note>]'
+        '[--contact <contact>] [--documents <file1,file2>] [--note <note>] ' +
+        '[--remind-at <iso8601>]'
     );
     process.exit(2);
   }
   const date = getFlag(args, '--date');
   const contact = getFlag(args, '--contact');
   const note = getFlag(args, '--note');
+  const remindAt = getFlag(args, '--remind-at');
   const documents = parseDocumentsFlag(args);
-  await logApplicationEvent(jobId, { channel, date, contact, note, documents });
+  await logApplicationEvent(jobId, { channel, date, contact, note, documents, remindAt });
   console.log(`Logged ${jobId} event ${channel}`);
 }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -93,7 +93,8 @@ aggressively to respect rate limits.
    exposes `jobbot track add <job_id> --status <status>` so users can log updates inline with other
    workflows.
 3. Follow-up reminders and note-taking surfaces help the user prepare for upcoming steps while
-   consolidating feedback for future tailoring.
+   consolidating feedback for future tailoring. Use `jobbot track log --remind-at <iso8601>` to
+   capture the next follow-up timestamp with each note.
 
 **Unhappy paths:** conflicting updates (e.g., two devices editing simultaneously) trigger a merge
 flow that preserves both sets of notes.

--- a/src/application-events.js
+++ b/src/application-events.js
@@ -82,11 +82,21 @@ export function logApplicationEvent(jobId, event) {
   const contact = sanitizeString(event.contact);
   const note = sanitizeString(event.note);
   const documents = normalizeDocuments(event.documents);
+  const remindInput = event.remindAt ?? event.remind_at;
+  let remindAt;
+  if (remindInput !== undefined) {
+    try {
+      remindAt = normalizeDate(remindInput);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  }
 
   const entry = { channel, date };
   if (contact) entry.contact = contact;
   if (note) entry.note = note;
   if (documents) entry.documents = documents;
+  if (remindAt) entry.remind_at = remindAt;
 
   const { dir, file } = getPaths();
 

--- a/test/application-events.test.js
+++ b/test/application-events.test.js
@@ -32,6 +32,7 @@ describe('application events', () => {
       contact: 'Taylor Recruiter',
       documents: ['resume.pdf', 'cover-letter.pdf'],
       note: 'Referred by Alex',
+      remindAt: '2025-02-10T17:30:00Z',
     });
 
     const events = await getApplicationEvents('job-123');
@@ -42,6 +43,7 @@ describe('application events', () => {
       contact: 'Taylor Recruiter',
       documents: ['resume.pdf', 'cover-letter.pdf'],
       note: 'Referred by Alex',
+      remind_at: '2025-02-10T17:30:00.000Z',
     });
 
     const raw = await readEventsFile();
@@ -53,6 +55,7 @@ describe('application events', () => {
           contact: 'Taylor Recruiter',
           documents: ['resume.pdf', 'cover-letter.pdf'],
           note: 'Referred by Alex',
+          remind_at: '2025-02-10T17:30:00.000Z',
         },
       ],
     });

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -166,6 +166,8 @@ describe('jobbot CLI', () => {
       'resume.pdf,cover-letter.pdf',
       '--note',
       'Submitted via referral portal',
+      '--remind-at',
+      '2025-03-11T09:00:00Z',
     ]);
     expect(output.trim()).toBe('Logged job-xyz event applied');
     const raw = JSON.parse(
@@ -178,6 +180,7 @@ describe('jobbot CLI', () => {
         contact: 'Jordan Hiring Manager',
         documents: ['resume.pdf', 'cover-letter.pdf'],
         note: 'Submitted via referral portal',
+        remind_at: '2025-03-11T09:00:00.000Z',
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- allow jobbot track log to accept --remind-at for follow-up
- persist reminder timestamps in application events and docs/tests

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68cf4409a330832f8465c14b2144904c