### PR TITLE
Add Lever ingest header persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,9 @@ downstream tooling can diff revisions over time. Tests in
 pipelines fetch board content, persist structured snapshots, surface fetch
 errors, and retain the `User-Agent: jobbot3000` request header alongside each
 capture so fetches are reproducible.
+[`test/lever.test.js`](test/lever.test.js) now explicitly asserts the Lever
+client forwards that header to the API and persists it in saved snapshots so
+metadata stays consistent across providers.
 
 Job titles can be parsed from lines starting with `Title`, `Job Title`, `Position`, or `Role`.
 Headers can use colons or dash separators (for example, `Role - Staff Engineer`), and the same

--- a/src/lever.js
+++ b/src/lever.js
@@ -4,6 +4,7 @@ import { jobIdFromSource, saveJobSnapshot } from './jobs.js';
 import { parseJobText } from './parser.js';
 
 const LEVER_BASE = 'https://api.lever.co/v0/postings';
+const LEVER_HEADERS = { 'User-Agent': 'jobbot3000' };
 
 function normalizeOrgSlug(org) {
   if (!org || typeof org !== 'string' || !org.trim()) {
@@ -50,7 +51,7 @@ function mergeParsedJob(parsed, job) {
 export async function fetchLeverJobs(org, { fetchImpl = fetch } = {}) {
   const slug = normalizeOrgSlug(org);
   const url = buildOrgUrl(slug);
-  const response = await fetchImpl(url);
+  const response = await fetchImpl(url, { headers: LEVER_HEADERS });
   if (!response.ok) {
     throw new Error(`Failed to fetch Lever org ${slug}: ${response.status} ${response.statusText}`);
   }
@@ -72,6 +73,7 @@ export async function ingestLeverBoard({ org, fetchImpl = fetch } = {}) {
       raw,
       parsed,
       source: { type: 'lever', value: hostedUrl },
+      requestHeaders: LEVER_HEADERS,
       fetchedAt: job.updatedAt ?? job.createdAt,
     });
     jobIds.push(id);

--- a/test/lever.test.js
+++ b/test/lever.test.js
@@ -55,6 +55,7 @@ Requirements
 
     expect(fetch).toHaveBeenCalledWith(
       'https://api.lever.co/v0/postings/example?mode=json',
+      { headers: { 'User-Agent': 'jobbot3000' } },
     );
 
     expect(result).toMatchObject({ org: 'example', saved: 1 });
@@ -68,6 +69,7 @@ Requirements
     expect(saved.source).toMatchObject({
       type: 'lever',
       value: 'https://jobs.lever.co/example/abc123',
+      headers: { 'User-Agent': 'jobbot3000' },
     });
     expect(saved.parsed.title).toBe('Senior Platform Engineer');
     expect(saved.parsed.location).toBe('Remote');


### PR DESCRIPTION
what:
- send the jobbot3000 User-Agent with Lever ingest requests
- persist that header in snapshots and document the new coverage

why:
- README promised each ingest pipeline retained the User-Agent header

how to test:
- npm run lint
- npm run test:ci

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68cf5d9c776c832fa46885cf7725cd9b