### PR TITLE
Preserve iterable headers when defaulting User-Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,9 @@ run();
 and noscript content, preserves image alt text or `aria-label` values (while
 ignoring `aria-hidden` images or those with `role="presentation"`/`"none"`), and
 collapses whitespace to single spaces. Pass `timeoutMs` (milliseconds) to
-override the 10s default, and `headers` to send custom HTTP headers. Responses
+override the 10s default, and `headers` to send custom HTTP headers. Requests
+default to sending `User-Agent: jobbot3000`; provide a `User-Agent` header to
+override it. Responses
 over 1 MB are rejected; override with `maxBytes` to adjust. Only `http` and
 `https` URLs are supported; other protocols throw an error. Requests to
 loopback, link-local, carrier-grade NAT, or other private network addresses

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -8,6 +8,12 @@ const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
 
 const LOOPBACK_HOSTNAMES = new Set(['localhost', 'localhost.']);
 
+const DEFAULT_USER_AGENT = 'jobbot3000';
+
+export const DEFAULT_FETCH_HEADERS = Object.freeze({
+  'User-Agent': DEFAULT_USER_AGENT,
+});
+
 function isPrivateIPv4(octets) {
   const [a, b] = octets;
   if (a === 10) return true;
@@ -72,6 +78,43 @@ function isForbiddenHostname(hostname) {
   }
 
   return false;
+}
+
+function buildRequestHeaders(headers) {
+  const merged = {};
+  let hasUserAgent = false;
+
+  const appendHeader = (key, value) => {
+    if (value === undefined || value === null) return;
+    const headerName = typeof key === 'string' ? key : String(key);
+    merged[headerName] = String(value);
+    if (headerName.toLowerCase() === 'user-agent') {
+      hasUserAgent = true;
+    }
+  };
+
+  if (headers) {
+    const iterable = typeof headers.entries === 'function' ? headers.entries() : null;
+    if (iterable) {
+      for (const [key, value] of iterable) {
+        appendHeader(key, value);
+      }
+    } else if (typeof headers[Symbol.iterator] === 'function') {
+      for (const [key, value] of headers) {
+        appendHeader(key, value);
+      }
+    } else if (typeof headers === 'object') {
+      for (const [key, value] of Object.entries(headers)) {
+        appendHeader(key, value);
+      }
+    }
+  }
+
+  if (!hasUserAgent) {
+    appendHeader('User-Agent', DEFAULT_USER_AGENT);
+  }
+
+  return merged;
 }
 
 const DNS_IGNORE_ERROR_CODES = new Set([
@@ -272,7 +315,7 @@ export async function fetchTextFromUrl(
     const response = await fetch(url, {
       redirect: 'follow',
       signal: controller.signal,
-      headers: headers || {},
+      headers: buildRequestHeaders(headers),
       size: maxBytes,
     });
     if (!response.ok) {

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -285,6 +285,55 @@ describe('fetchTextFromUrl', () => {
     );
   });
 
+  it('sends a default User-Agent header when none provided', async () => {
+    fetch.mockClear();
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('ok'),
+    });
+
+    await fetchTextFromUrl('http://example.com');
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://example.com',
+      expect.objectContaining({
+        headers: expect.objectContaining({ 'User-Agent': 'jobbot3000' }),
+      })
+    );
+  });
+
+  it('preserves iterable headers when adding the default User-Agent', async () => {
+    fetch.mockClear();
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers: { get: () => 'text/plain' },
+      text: () => Promise.resolve('ok'),
+    });
+
+    const iterableHeaders = new Map([
+      ['Authorization', 'Bearer token'],
+      ['X-Trace-Id', 42],
+    ]);
+
+    await fetchTextFromUrl('http://example.com', { headers: iterableHeaders });
+
+    expect(fetch).toHaveBeenCalledWith(
+      'http://example.com',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer token',
+          'X-Trace-Id': '42',
+          'User-Agent': 'jobbot3000',
+        }),
+      })
+    );
+  });
+
   it('rejects non-http/https URLs', async () => {
     fetch.mockClear();
     fetch.mockResolvedValue({


### PR DESCRIPTION
## Summary
- allow fetch header merging to iterate through Headers instances, Maps, and other iterables so custom entries survive
- add regression coverage ensuring iterable headers are retained alongside the default User-Agent

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68cf5d9c776c832fa46885cf7725cd9b