### PR TITLE
Add support for notes when tracking application statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,12 +501,27 @@ Record and track your applications directly from the CLI—never edit JSON by ha
 To capture statuses:
 
 ~~~bash
-JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot track add job-123 --status screening
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot track add job-123 --status screening \
+  --note "Emailed hiring manager"
 # Recorded job-123 as screening
 ~~~
 
-This persists entries to `applications.json`. CLI tests assert that
-`jobbot track add` correctly appends and updates statuses.
+This persists entries to `applications.json` as objects that record the status,
+an `updated_at` ISO 8601 timestamp, and optional notes:
+
+```json
+{
+  "job-123": {
+    "status": "screening",
+    "note": "Emailed hiring manager",
+    "updated_at": "2025-02-01T10:00:00.000Z"
+  }
+}
+```
+
+Unit coverage in [`test/lifecycle.test.js`](test/lifecycle.test.js) and CLI
+automation in [`test/cli.test.js`](test/cli.test.js) verify note persistence and
+timestamp normalization alongside the existing status checks.
 
 To capture outreach history:
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -176,15 +176,35 @@ async function cmdMatch(args) {
 async function cmdTrackAdd(args) {
   const jobId = args[0];
   const status = getFlag(args, '--status');
+  const usage =
+    `Usage: jobbot track add <job_id> --status <status>\n` +
+    `Valid statuses: ${STATUSES.join(', ')}\n` +
+    'Optional: --note <note>';
   if (!jobId || !status) {
-    console.error(
-      `Usage: jobbot track add <job_id> --status <status>\n` +
-        `Valid statuses: ${STATUSES.join(', ')}`
-    );
+    console.error(usage);
     process.exit(2);
   }
-  const recorded = await recordApplication(jobId, status.trim());
-  console.log(`Recorded ${jobId} as ${recorded}`);
+
+  const noteFlagIndex = args.indexOf('--note');
+  if (noteFlagIndex !== -1) {
+    const next = args[noteFlagIndex + 1];
+    if (!next || next.startsWith('--')) {
+      console.error(usage);
+      process.exit(2);
+    }
+  }
+
+  const note = getFlag(args, '--note');
+  try {
+    const recorded = await recordApplication(jobId, status.trim(), { note });
+    console.log(`Recorded ${jobId} as ${recorded}`);
+  } catch (err) {
+    if (err && /note cannot be empty/i.test(String(err.message))) {
+      console.error('Note cannot be empty');
+      process.exit(2);
+    }
+    throw err;
+  }
 }
 
 function parseDocumentsFlag(args) {

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -91,8 +91,8 @@ aggressively to respect rate limits.
    metadata to `data/application_events.json` so the full history stays local.
 2. Application status transitions (no response, screening, onsite, offer, rejected, withdrawn) are
    stored in `data/applications.json`, which is serialized safely to prevent data loss. The CLI
-   exposes `jobbot track add <job_id> --status <status>` so users can log updates inline with other
-   workflows.
+   exposes `jobbot track add <job_id> --status <status> [--note <note>]` so users can log updates and
+   quick notes inline with other workflows.
 3. Follow-up reminders and note-taking surfaces help the user prepare for upcoming steps while
    consolidating feedback for future tailoring. Use `jobbot track log --remind-at <iso8601>` to
    capture the next follow-up timestamp with each note.

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -45,11 +45,18 @@ function countJobsWithEvents(events) {
   return count;
 }
 
+function extractStatusValue(value) {
+  if (typeof value === 'string') return value.trim();
+  if (value && typeof value === 'object' && typeof value.status === 'string') {
+    return value.status.trim();
+  }
+  return '';
+}
+
 function getStatusCounts(statuses) {
   const counts = new Map();
   for (const value of Object.values(statuses)) {
-    if (typeof value !== 'string') continue;
-    const key = value.trim();
+    const key = extractStatusValue(value);
     if (!key) continue;
     counts.set(key, (counts.get(key) ?? 0) + 1);
   }
@@ -70,8 +77,9 @@ const ACCEPTANCE_CHANNELS = new Set([
 function collectAcceptanceJobs(statuses, events) {
   const accepted = new Set();
   for (const [jobId, rawStatus] of Object.entries(statuses)) {
-    if (typeof rawStatus !== 'string') continue;
-    const status = rawStatus.trim().toLowerCase();
+    const extracted = extractStatusValue(rawStatus);
+    if (!extracted) continue;
+    const status = extracted.toLowerCase();
     if (!status) continue;
     if (ACCEPTANCE_STATUS.has(status)) {
       accepted.add(jobId);

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -148,7 +148,35 @@ describe('jobbot CLI', () => {
     const output = runCli(['track', 'add', 'job-123', '--status', status]);
     expect(output.trim()).toBe(`Recorded job-123 as ${status}`);
     const raw = fs.readFileSync(path.join(dataDir, 'applications.json'), 'utf8');
-    expect(JSON.parse(raw)).toEqual({ 'job-123': status });
+    const parsed = JSON.parse(raw);
+    expect(parsed['job-123'].status).toBe(status);
+    expect(parsed['job-123'].note).toBeUndefined();
+    expect(parsed['job-123'].updated_at).toEqual(
+      new Date(parsed['job-123'].updated_at).toISOString()
+    );
+  });
+
+  it('records application status notes with track add --note', () => {
+    const output = runCli([
+      'track',
+      'add',
+      'job-456',
+      '--status',
+      'screening',
+      '--note',
+      'Emailed hiring manager',
+    ]);
+    expect(output.trim()).toBe('Recorded job-456 as screening');
+    const raw = JSON.parse(
+      fs.readFileSync(path.join(dataDir, 'applications.json'), 'utf8')
+    );
+    expect(raw['job-456']).toMatchObject({
+      status: 'screening',
+      note: 'Emailed hiring manager',
+    });
+    expect(raw['job-456'].updated_at).toEqual(
+      new Date(raw['job-456'].updated_at).toISOString()
+    );
   });
 
   it('logs application events with track log', () => {


### PR DESCRIPTION
## Summary
- extend `jobbot track add` to accept an optional `--note` flag and persist status metadata with timestamps
- normalize lifecycle storage to keep `status`, `updated_at`, and optional `note`, updating analytics readers for backwards compatibility
- document the new format and add unit + CLI coverage for status notes alongside existing lifecycle tests

## Future Work Review
- DESIGN.md documents `jobbot track add <job_id> --status <status> --note "emailed hiring manager"`; this PR implements that documented CLI behavior
- Larger roadmap items in DESIGN.md (e.g., `jobbot tailor`, `jobbot rehearse`) remain deferred for future work

## Test Matrix
- Lifecycle unit tests cover note persistence, timestamp normalization, and concurrent updates
- CLI integration tests exercise `track add --note` end-to-end alongside existing workflows

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68cf683118cc832fb7cca57cfd763d79