### PR TITLE
Add CLI history view for application events

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,14 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track log job-3 --channel offer_accepted --
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track log job-4 --channel email --date 2025-01-05
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track add job-4 --status rejected
 
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track history job-3
+# job-3
+# - email (2025-01-04T00:00:00.000Z)
+#   Documents: resume.pdf
+#   Note: Submitted via referral portal
+# - offer_accepted (2025-02-01T00:00:00.000Z)
+#   Reminder: 2025-02-10T09:00:00.000Z
+
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot analytics funnel
 # Outreach: 4
 # Screening: 1 (25% conversion, 3 drop-off)
@@ -516,8 +524,14 @@ for each application. The command accepts optional metadata such as `--date`,
 Events are appended to `data/application_events.json`, grouped by job
 identifier, with timestamps normalized to ISO 8601.
 
+Review the timeline with `jobbot track history <job_id>`, which renders each
+event alongside contacts, documents, notes, and reminders. Pass `--json`
+to export the structured payload for automation.
+
 Tests in `test/application-events.test.js` ensure that new log entries do not
 clobber history and that invalid channels or dates are rejected.
+`test/cli.test.js` adds coverage for the history subcommand's text and JSON
+outputs so the note-taking surface stays reliable.
 
 To capture discard reasons for shortlist triage:
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -95,7 +95,8 @@ aggressively to respect rate limits.
    workflows.
 3. Follow-up reminders and note-taking surfaces help the user prepare for upcoming steps while
    consolidating feedback for future tailoring. Use `jobbot track log --remind-at <iso8601>` to
-   capture the next follow-up timestamp with each note.
+   capture the next follow-up timestamp with each note. Review the timeline with
+   `jobbot track history <job_id>` (pass `--json` for automation) when planning the next actions.
 
 **Unhappy paths:** conflicting updates (e.g., two devices editing simultaneously) trigger a merge
 flow that preserves both sets of notes.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -185,6 +185,67 @@ describe('jobbot CLI', () => {
     ]);
   });
 
+  it('shows application history with track history', () => {
+    runCli([
+      'track',
+      'log',
+      'job-xyz',
+      '--channel',
+      'applied',
+      '--date',
+      '2025-03-04',
+      '--contact',
+      'Jordan Hiring Manager',
+      '--documents',
+      'resume.pdf,cover-letter.pdf',
+      '--note',
+      'Submitted via referral portal',
+      '--remind-at',
+      '2025-03-11T09:00:00Z',
+    ]);
+
+    runCli([
+      'track',
+      'log',
+      'job-xyz',
+      '--channel',
+      'follow_up',
+      '--date',
+      '2025-03-12T09:15:00Z',
+      '--note',
+      'Sent thank-you follow-up',
+    ]);
+
+    const textHistory = runCli(['track', 'history', 'job-xyz']);
+    expect(textHistory).toContain('job-xyz');
+    expect(textHistory).toContain('applied (2025-03-04T00:00:00.000Z)');
+    expect(textHistory).toContain('Contact: Jordan Hiring Manager');
+    expect(textHistory).toContain('Documents: resume.pdf, cover-letter.pdf');
+    expect(textHistory).toContain('Note: Submitted via referral portal');
+    expect(textHistory).toContain('Reminder: 2025-03-11T09:00:00.000Z');
+    expect(textHistory).toContain('follow_up (2025-03-12T09:15:00.000Z)');
+    expect(textHistory).toContain('Note: Sent thank-you follow-up');
+
+    const jsonHistory = runCli(['track', 'history', 'job-xyz', '--json']);
+    const parsed = JSON.parse(jsonHistory);
+    expect(parsed.job).toBe('job-xyz');
+    expect(parsed.events).toEqual([
+      {
+        channel: 'applied',
+        date: '2025-03-04T00:00:00.000Z',
+        contact: 'Jordan Hiring Manager',
+        documents: ['resume.pdf', 'cover-letter.pdf'],
+        note: 'Submitted via referral portal',
+        remind_at: '2025-03-11T09:00:00.000Z',
+      },
+      {
+        channel: 'follow_up',
+        date: '2025-03-12T09:15:00.000Z',
+        note: 'Sent thank-you follow-up',
+      },
+    ]);
+  });
+
   it('archives discarded jobs with reasons', () => {
     const output = runCli([
       'track',


### PR DESCRIPTION
## Summary
- add a `jobbot track history` subcommand that formats application timelines or exports JSON
- document the history surface in the README and user journey for tracking outreach and reminders
- cover the new command with CLI tests for both human-readable and JSON output

## Test Matrix
| Scenario | Coverage |
| --- | --- |
| Timeline rendered with contacts, documents, notes, and reminders | `test/cli.test.js` "shows application history with track history" |
| JSON export of application history | `test/cli.test.js` "shows application history with track history" |

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68cf683118cc832fb7cca57cfd763d79