### PR TITLE
Add CLI support for listing application reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,21 @@ identifier, with timestamps normalized to ISO 8601.
 Tests in `test/application-events.test.js` ensure that new log entries do not
 clobber history and that invalid channels or dates are rejected.
 
+Surface follow-up work with `jobbot track reminders`. Pass `--now` to view from a
+given timestamp (defaults to the current time) and `--json` for structured output:
+
+~~~bash
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track reminders --now 2025-03-06T00:00:00Z
+# job-1 — 2025-03-05T09:00:00.000Z (follow_up, past due)
+#   Note: Send status update
+# job-2 — 2025-03-07T15:00:00.000Z (call, upcoming)
+#   Contact: Avery Hiring Manager
+~~~
+
+Unit tests in [`test/application-events.test.js`](test/application-events.test.js)
+cover reminder extraction, including past-due filtering. The CLI suite in
+[`test/cli.test.js`](test/cli.test.js) verifies the `--json` output.
+
 To capture discard reasons for shortlist triage:
 
 ~~~bash

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -14,7 +14,7 @@ import {
   toMarkdownMatchExplanation,
 } from '../src/exporters.js';
 import { saveJobSnapshot, jobIdFromSource } from '../src/jobs.js';
-import { logApplicationEvent } from '../src/application-events.js';
+import { logApplicationEvent, getApplicationReminders } from '../src/application-events.js';
 import { recordApplication, STATUSES } from '../src/lifecycle.js';
 import { recordJobDiscard } from '../src/discards.js';
 import { addJobTags, discardJob, filterShortlist, syncShortlistJob } from '../src/shortlist.js';
@@ -216,6 +216,45 @@ async function cmdTrackLog(args) {
   console.log(`Logged ${jobId} event ${channel}`);
 }
 
+async function cmdTrackReminders(args) {
+  const asJson = args.includes('--json');
+  const nowValue = getFlag(args, '--now');
+  const upcomingOnly = args.includes('--upcoming-only');
+
+  let reminders;
+  try {
+    reminders = await getApplicationReminders({
+      now: nowValue,
+      includePastDue: !upcomingOnly,
+    });
+  } catch (err) {
+    console.error(err.message || String(err));
+    process.exit(1);
+  }
+
+  if (asJson) {
+    console.log(JSON.stringify({ reminders }, null, 2));
+    return;
+  }
+
+  if (reminders.length === 0) {
+    console.log('No reminders scheduled');
+    return;
+  }
+
+  const lines = [];
+  for (const reminder of reminders) {
+    const descriptors = [];
+    if (reminder.channel) descriptors.push(reminder.channel);
+    descriptors.push(reminder.past_due ? 'past due' : 'upcoming');
+    lines.push(`${reminder.job_id} — ${reminder.remind_at} (${descriptors.join(', ')})`);
+    if (reminder.note) lines.push(`  Note: ${reminder.note}`);
+    if (reminder.contact) lines.push(`  Contact: ${reminder.contact}`);
+  }
+
+  console.log(lines.join('\n'));
+}
+
 function parseTagsFlag(args) {
   const raw = getFlag(args, '--tags');
   if (!raw) return undefined;
@@ -311,7 +350,8 @@ async function cmdTrack(args) {
   if (sub === 'add') return cmdTrackAdd(args.slice(1));
   if (sub === 'log') return cmdTrackLog(args.slice(1));
   if (sub === 'discard') return cmdTrackDiscard(args.slice(1));
-  console.error('Usage: jobbot track <add|log|discard> ...');
+  if (sub === 'reminders') return cmdTrackReminders(args.slice(1));
+  console.error('Usage: jobbot track <add|log|discard|reminders> ...');
   process.exit(2);
 }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -95,7 +95,8 @@ aggressively to respect rate limits.
    workflows.
 3. Follow-up reminders and note-taking surfaces help the user prepare for upcoming steps while
    consolidating feedback for future tailoring. Use `jobbot track log --remind-at <iso8601>` to
-   capture the next follow-up timestamp with each note.
+   capture the next follow-up timestamp with each note, and review upcoming outreach with
+   `jobbot track reminders` (add `--json` when piping into other tools).
 
 **Unhappy paths:** conflicting updates (e.g., two devices editing simultaneously) trigger a merge
 flow that preserves both sets of notes.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -185,6 +185,63 @@ describe('jobbot CLI', () => {
     ]);
   });
 
+  it('lists reminders with track reminders --json', () => {
+    runCli([
+      'track',
+      'log',
+      'job-1',
+      '--channel',
+      'follow_up',
+      '--date',
+      '2025-03-01T08:00:00Z',
+      '--note',
+      'Send status update',
+      '--remind-at',
+      '2025-03-05T09:00:00Z',
+    ]);
+    runCli([
+      'track',
+      'log',
+      'job-2',
+      '--channel',
+      'call',
+      '--date',
+      '2025-03-02T10:00:00Z',
+      '--contact',
+      'Avery Hiring Manager',
+      '--remind-at',
+      '2025-03-07T15:00:00Z',
+    ]);
+
+    const output = runCli([
+      'track',
+      'reminders',
+      '--json',
+      '--now',
+      '2025-03-06T00:00:00Z',
+    ]);
+
+    const payload = JSON.parse(output);
+    expect(payload).toEqual({
+      reminders: [
+        {
+          job_id: 'job-1',
+          remind_at: '2025-03-05T09:00:00.000Z',
+          channel: 'follow_up',
+          note: 'Send status update',
+          past_due: true,
+        },
+        {
+          job_id: 'job-2',
+          remind_at: '2025-03-07T15:00:00.000Z',
+          channel: 'call',
+          contact: 'Avery Hiring Manager',
+          past_due: false,
+        },
+      ],
+    });
+  });
+
   it('archives discarded jobs with reasons', () => {
     const output = runCli([
       'track',


### PR DESCRIPTION
## Summary
- surface logged follow-up reminders via `jobbot track reminders`
- expose reminder collection helper and cover it with targeted unit tests
- document the new workflow and cite the CLI coverage in README and journeys

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68cf683118cc832fb7cca57cfd763d79