### PR TITLE
Add CLI reminders listing for follow-up planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,25 @@ identifier, with timestamps normalized to ISO 8601.
 Tests in `test/application-events.test.js` ensure that new log entries do not
 clobber history and that invalid channels or dates are rejected.
 
+Surface upcoming follow-ups with `jobbot track reminders`:
+
+~~~bash
+DATA_DIR=$(mktemp -d)
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track log job-789 --channel follow_up \
+  --date 2025-03-10 --note "Prep onsite agenda" --remind-at 2025-03-17T09:00:00Z
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track reminders
+# job-789
+#   Remind At: 2025-03-17T09:00:00.000Z
+#   Channel: follow_up
+#   Note: Prep onsite agenda
+~~~
+
+The reminders view scans `application_events.json`, sorts entries by
+`remind_at`, highlights overdue timestamps, and supports `--json` for downstream
+automation. Each reminder carries the logged channel, note, contact (if
+provided), and original log timestamp so preparation details stay attached to
+the schedule.
+
 To capture discard reasons for shortlist triage:
 
 ~~~bash

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -95,7 +95,8 @@ aggressively to respect rate limits.
    workflows.
 3. Follow-up reminders and note-taking surfaces help the user prepare for upcoming steps while
    consolidating feedback for future tailoring. Use `jobbot track log --remind-at <iso8601>` to
-   capture the next follow-up timestamp with each note.
+   capture the next follow-up timestamp with each note, and review upcoming or overdue entries with
+   `jobbot track reminders`.
 
 **Unhappy paths:** conflicting updates (e.g., two devices editing simultaneously) trigger a merge
 flow that preserves both sets of notes.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -185,6 +185,47 @@ describe('jobbot CLI', () => {
     ]);
   });
 
+  it('lists reminders with track reminders', () => {
+    const now = new Date();
+    const upcoming = new Date(now.getTime() + 24 * 60 * 60 * 1000).toISOString();
+    const overdue = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+
+    runCli([
+      'track',
+      'log',
+      'job-upcoming',
+      '--channel',
+      'follow_up',
+      '--date',
+      now.toISOString(),
+      '--note',
+      'Prep for onsite',
+      '--remind-at',
+      upcoming,
+    ]);
+
+    runCli([
+      'track',
+      'log',
+      'job-overdue',
+      '--channel',
+      'thank_you',
+      '--date',
+      now.toISOString(),
+      '--note',
+      'Send thank-you email',
+      '--remind-at',
+      overdue,
+    ]);
+
+    const output = runCli(['track', 'reminders']);
+
+    expect(output).toContain('job-overdue');
+    expect(output).toContain('OVERDUE');
+    expect(output).toContain('job-upcoming');
+    expect(output.indexOf('job-overdue')).toBeLessThan(output.indexOf('job-upcoming'));
+  });
+
   it('archives discarded jobs with reasons', () => {
     const output = runCli([
       'track',


### PR DESCRIPTION
## Summary
- add `getReminders` helper and a `jobbot track reminders` subcommand so logged follow-ups are easy to review
- cover reminder collection in unit and CLI tests and surface overdue markers in formatted output
- document the reminders workflow in the README and journey backlog

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68cf683118cc832fb7cca57cfd763d79