### PR TITLE
Surface job application history in the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,8 +516,42 @@ for each application. The command accepts optional metadata such as `--date`,
 Events are appended to `data/application_events.json`, grouped by job
 identifier, with timestamps normalized to ISO 8601.
 
+Review timelines with `jobbot track history <job_id>` (add `--json` to pipe a
+structured payload). Each event includes the recorded channel, ISO8601
+timestamp, and any attached metadata:
+
+~~~bash
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track history job-123
+# job-123
+#   2025-03-04T00:00:00.000Z — applied
+#     Contact: Taylor Recruiter
+#     Documents: resume.pdf, cover-letter.pdf
+#     Note: Referred by Alex
+#     Reminder: 2025-03-11T09:00:00.000Z
+#   2025-03-15T16:00:00.000Z — interview
+#     Note: Panel with hiring team
+~~~
+
 Tests in `test/application-events.test.js` ensure that new log entries do not
 clobber history and that invalid channels or dates are rejected.
+CLI tests in `test/cli.test.js` exercise both the human-readable and JSON
+variants of `jobbot track history`.
+
+Surface follow-up work with `jobbot track reminders`. Pass `--now` to view from a
+given timestamp (defaults to the current time), `--upcoming-only` to suppress past-due
+entries, and `--json` for structured output:
+
+~~~bash
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track reminders --now 2025-03-06T00:00:00Z
+# job-1 — 2025-03-05T09:00:00.000Z (follow_up, past due)
+#   Note: Send status update
+# job-2 — 2025-03-07T15:00:00.000Z (call, upcoming)
+#   Contact: Avery Hiring Manager
+~~~
+
+Unit tests in [`test/application-events.test.js`](test/application-events.test.js)
+cover reminder extraction, including past-due filtering. The CLI suite in
+[`test/cli.test.js`](test/cli.test.js) verifies the `--json` output.
 
 To capture discard reasons for shortlist triage:
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -88,14 +88,17 @@ aggressively to respect rate limits.
 
 1. When the user applies or sends outreach, they log the event (channel, date, documents shared,
    contact person) with `jobbot track log <job_id> --channel <channel> [...]`, which appends the
-   metadata to `data/application_events.json` so the full history stays local.
+   metadata to `data/application_events.json` so the full history stays local. They can replay the
+   thread with `jobbot track history <job_id>` (or `--json` when scripting follow-ups).
 2. Application status transitions (no response, screening, onsite, offer, rejected, withdrawn) are
    stored in `data/applications.json`, which is serialized safely to prevent data loss. The CLI
    exposes `jobbot track add <job_id> --status <status>` so users can log updates inline with other
    workflows.
 3. Follow-up reminders and note-taking surfaces help the user prepare for upcoming steps while
    consolidating feedback for future tailoring. Use `jobbot track log --remind-at <iso8601>` to
-   capture the next follow-up timestamp with each note.
+   capture the next follow-up timestamp with each note, and review upcoming outreach with
+   `jobbot track reminders` (add `--upcoming-only` to hide past-due entries and `--json` when piping
+   into other tools).
 
 **Unhappy paths:** conflicting updates (e.g., two devices editing simultaneously) trigger a merge
 flow that preserves both sets of notes.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -185,6 +185,203 @@ describe('jobbot CLI', () => {
     ]);
   });
 
+  it('lists reminders with track reminders --json', () => {
+    runCli([
+      'track',
+      'log',
+      'job-1',
+      '--channel',
+      'follow_up',
+      '--date',
+      '2025-03-01T08:00:00Z',
+      '--note',
+      'Send status update',
+      '--remind-at',
+      '2025-03-05T09:00:00Z',
+    ]);
+    runCli([
+      'track',
+      'log',
+      'job-2',
+      '--channel',
+      'call',
+      '--date',
+      '2025-03-02T10:00:00Z',
+      '--contact',
+      'Avery Hiring Manager',
+      '--remind-at',
+      '2025-03-07T15:00:00Z',
+    ]);
+
+    const output = runCli([
+      'track',
+      'reminders',
+      '--json',
+      '--now',
+      '2025-03-06T00:00:00Z',
+    ]);
+
+    const payload = JSON.parse(output);
+    expect(payload).toEqual({
+      reminders: [
+        {
+          job_id: 'job-1',
+          remind_at: '2025-03-05T09:00:00.000Z',
+          channel: 'follow_up',
+          note: 'Send status update',
+          past_due: true,
+        },
+        {
+          job_id: 'job-2',
+          remind_at: '2025-03-07T15:00:00.000Z',
+          channel: 'call',
+          contact: 'Avery Hiring Manager',
+          past_due: false,
+        },
+      ],
+    });
+  });
+
+  it('formats reminder summaries and respects --upcoming-only', () => {
+    runCli([
+      'track',
+      'log',
+      'job-1',
+      '--channel',
+      'follow_up',
+      '--date',
+      '2025-03-01T08:00:00Z',
+      '--note',
+      'Send status update',
+      '--remind-at',
+      '2025-03-05T09:00:00Z',
+    ]);
+    runCli([
+      'track',
+      'log',
+      'job-2',
+      '--channel',
+      'call',
+      '--date',
+      '2025-03-02T10:00:00Z',
+      '--contact',
+      'Avery Hiring Manager',
+      '--remind-at',
+      '2025-03-07T15:00:00Z',
+    ]);
+
+    const fullOutput = runCli([
+      'track',
+      'reminders',
+      '--now',
+      '2025-03-06T00:00:00Z',
+    ]);
+
+    expect(fullOutput).toContain(
+      'job-1 — 2025-03-05T09:00:00.000Z (follow_up, past due)'
+    );
+    expect(fullOutput).toContain('  Note: Send status update');
+    expect(fullOutput).toContain(
+      'job-2 — 2025-03-07T15:00:00.000Z (call, upcoming)'
+    );
+    expect(fullOutput).toContain('  Contact: Avery Hiring Manager');
+
+    const upcomingOnly = runCli([
+      'track',
+      'reminders',
+      '--now',
+      '2025-03-06T00:00:00Z',
+      '--upcoming-only',
+    ]);
+
+    expect(upcomingOnly).not.toContain('job-1');
+    expect(upcomingOnly).toContain(
+      'job-2 — 2025-03-07T15:00:00.000Z (call, upcoming)'
+    );
+  });
+
+  it('shows application history for specific jobs and supports --json', () => {
+    runCli([
+      'track',
+      'log',
+      'job-xyz',
+      '--channel',
+      'applied',
+      '--date',
+      '2025-03-04',
+      '--contact',
+      'Taylor Recruiter',
+      '--documents',
+      'resume.pdf,cover-letter.pdf',
+      '--note',
+      'Referred by Alex',
+      '--remind-at',
+      '2025-03-11T09:00:00Z',
+    ]);
+    runCli([
+      'track',
+      'log',
+      'job-xyz',
+      '--channel',
+      'interview',
+      '--date',
+      '2025-03-15T16:00:00Z',
+      '--note',
+      'Panel with hiring team',
+    ]);
+    runCli([
+      'track',
+      'log',
+      'job-other',
+      '--channel',
+      'applied',
+      '--date',
+      '2025-03-05T12:00:00Z',
+    ]);
+
+    const output = runCli(['track', 'history', 'job-xyz']);
+
+    expect(output).toContain('job-xyz');
+    expect(output).toContain('2025-03-04T00:00:00.000Z — applied');
+    expect(output).toContain('  Contact: Taylor Recruiter');
+    expect(output).toContain('  Documents: resume.pdf, cover-letter.pdf');
+    expect(output).toContain('  Note: Referred by Alex');
+    expect(output).toContain('  Reminder: 2025-03-11T09:00:00.000Z');
+    expect(output).toContain('2025-03-15T16:00:00.000Z — interview');
+    expect(output).toContain('  Note: Panel with hiring team');
+
+    const jobJson = JSON.parse(runCli(['track', 'history', 'job-xyz', '--json']));
+    expect(jobJson).toEqual({
+      job_id: 'job-xyz',
+      events: [
+        {
+          channel: 'applied',
+          contact: 'Taylor Recruiter',
+          date: '2025-03-04T00:00:00.000Z',
+          documents: ['resume.pdf', 'cover-letter.pdf'],
+          note: 'Referred by Alex',
+          remind_at: '2025-03-11T09:00:00.000Z',
+        },
+        {
+          channel: 'interview',
+          date: '2025-03-15T16:00:00.000Z',
+          note: 'Panel with hiring team',
+        },
+      ],
+    });
+
+    const allJson = JSON.parse(runCli(['track', 'history', '--json']));
+    expect(allJson).toEqual({
+      'job-other': [
+        {
+          channel: 'applied',
+          date: '2025-03-05T12:00:00.000Z',
+        },
+      ],
+      'job-xyz': jobJson.events,
+    });
+  });
+
   it('archives discarded jobs with reasons', () => {
     const output = runCli([
       'track',


### PR DESCRIPTION
## Summary
- close Journey 5's backlog item by exposing `jobbot track history` so logged outreach is reviewable
- render chronological event timelines with both human-readable and JSON output that includes stored metadata
- document the history review flow in the README and journeys while adding CLI coverage for the new command

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68cf683118cc832fb7cca57cfd763d79