### PR TITLE
✨ Align track history output with docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ Review the full history for a job with `jobbot track history <job_id>`. Pass
 
 ```bash
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track history job-1
+# job-1
 # 2025-03-01T08:00:00.000Z — follow_up
 #   Note: Send status update
 # 2025-03-05T09:00:00.000Z — call
@@ -554,7 +555,8 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track history job-1
 Tests in `test/application-events.test.js` ensure that new log entries do not
 clobber history and that invalid channels or dates are rejected.
 `test/cli.test.js` adds coverage for the history subcommand's text and JSON
-outputs so the note-taking surface stays reliable.
+outputs, including timestamp-first formatting, so the note-taking surface stays
+reliable.
 
 Surface follow-up work with `jobbot track reminders`. Pass `--now` to view from a
 given timestamp (defaults to the current time), `--upcoming-only` to suppress past-due

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -267,19 +267,22 @@ async function cmdTrackHistory(args) {
 
   const lines = [jobId];
   for (const event of events) {
-    const when = typeof event.date === 'string' && event.date ? ` (${event.date})` : '';
-    const channel = typeof event.channel === 'string' ? event.channel : 'unknown';
-    lines.push(`- ${channel}${when}`);
+    const timestamp =
+      typeof event.date === 'string' && event.date ? event.date : undefined;
+    const channel =
+      typeof event.channel === 'string' && event.channel
+        ? event.channel
+        : 'unknown';
+    const header = timestamp ? `${timestamp} — ${channel}` : channel;
+    lines.push(header);
     if (event.contact) lines.push(`  Contact: ${event.contact}`);
     if (Array.isArray(event.documents) && event.documents.length > 0) {
       lines.push(`  Documents: ${event.documents.join(', ')}`);
     }
     if (event.note) lines.push(`  Note: ${event.note}`);
     if (event.remind_at) lines.push(`  Remind At: ${event.remind_at}`);
-    lines.push('');
   }
 
-  if (lines[lines.length - 1] === '') lines.pop();
   console.log(lines.join('\n'));
 }
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -246,12 +246,12 @@ describe('jobbot CLI', () => {
 
     const textHistory = runCli(['track', 'history', 'job-xyz']);
     expect(textHistory).toContain('job-xyz');
-    expect(textHistory).toContain('applied (2025-03-04T00:00:00.000Z)');
+    expect(textHistory).toContain('2025-03-04T00:00:00.000Z — applied');
     expect(textHistory).toContain('Contact: Jordan Hiring Manager');
     expect(textHistory).toContain('Documents: resume.pdf, cover-letter.pdf');
     expect(textHistory).toContain('Note: Submitted via referral portal');
     expect(textHistory).toContain('Remind At: 2025-03-11T09:00:00.000Z');
-    expect(textHistory).toContain('follow_up (2025-03-12T09:15:00.000Z)');
+    expect(textHistory).toContain('2025-03-12T09:15:00.000Z — follow_up');
     expect(textHistory).toContain('Note: Sent thank-you follow-up');
 
     const jsonHistory = runCli(['track', 'history', 'job-xyz', '--json']);


### PR DESCRIPTION
## Summary
- Reviewed README.md and found the `jobbot track history` example promised timestamp-first output; implemented it because it fits in one PR and improves doc accuracy.
- Format CLI history events as `<timestamp> — <channel>` while preserving structured JSON output.
- Updated the CLI regression test and README commentary to describe the timestamp-first formatting.

## Testing
- ✅ `npm run lint`
- ✅ `npm run test:ci`
- ✅ `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68cf76150820832f97bbb196ec47f41e