### PR TITLE
Align track history output with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,18 +564,18 @@ Review the full history for a job with `jobbot track history <job_id>`. Pass
 ```bash
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track history job-1
 # job-1
-# 2025-03-01T08:00:00.000Z — follow_up
+# - follow_up (2025-03-01T08:00:00.000Z)
 #   Note: Send status update
-# 2025-03-05T09:00:00.000Z — call
+# - call (2025-03-05T09:00:00.000Z)
 #   Contact: Avery Hiring Manager
-#   Remind At: 2025-03-07T12:00:00.000Z
+#   Reminder: 2025-03-07T12:00:00.000Z
 ```
 
 Tests in `test/application-events.test.js` ensure that new log entries do not
 clobber history and that invalid channels or dates are rejected.
 `test/cli.test.js` adds coverage for the history subcommand's text and JSON
-outputs, including timestamp-first formatting, so the note-taking surface stays
-reliable.
+outputs, including channel-first bullet formatting and reminder labels, so the
+note-taking surface stays reliable.
 
 Surface follow-up work with `jobbot track reminders`. Pass `--now` to view from a
 given timestamp (defaults to the current time), `--upcoming-only` to suppress past-due

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -304,17 +304,17 @@ async function cmdTrackHistory(args) {
     const timestamp =
       typeof event.date === 'string' && event.date ? event.date : undefined;
     const channel =
-      typeof event.channel === 'string' && event.channel
-        ? event.channel
+      typeof event.channel === 'string' && event.channel && event.channel.trim()
+        ? event.channel.trim()
         : 'unknown';
-    const header = timestamp ? `${timestamp} — ${channel}` : channel;
-    lines.push(header);
+    const header = timestamp ? `${channel} (${timestamp})` : channel;
+    lines.push(`- ${header}`);
     if (event.contact) lines.push(`  Contact: ${event.contact}`);
     if (Array.isArray(event.documents) && event.documents.length > 0) {
       lines.push(`  Documents: ${event.documents.join(', ')}`);
     }
     if (event.note) lines.push(`  Note: ${event.note}`);
-    if (event.remind_at) lines.push(`  Remind At: ${event.remind_at}`);
+    if (event.remind_at) lines.push(`  Reminder: ${event.remind_at}`);
   }
 
   console.log(lines.join('\n'));

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -294,12 +294,12 @@ describe('jobbot CLI', () => {
 
     const textHistory = runCli(['track', 'history', 'job-xyz']);
     expect(textHistory).toContain('job-xyz');
-    expect(textHistory).toContain('2025-03-04T00:00:00.000Z — applied');
+    expect(textHistory).toContain('- applied (2025-03-04T00:00:00.000Z)');
     expect(textHistory).toContain('Contact: Jordan Hiring Manager');
     expect(textHistory).toContain('Documents: resume.pdf, cover-letter.pdf');
     expect(textHistory).toContain('Note: Submitted via referral portal');
-    expect(textHistory).toContain('Remind At: 2025-03-11T09:00:00.000Z');
-    expect(textHistory).toContain('2025-03-12T09:15:00.000Z — follow_up');
+    expect(textHistory).toContain('Reminder: 2025-03-11T09:00:00.000Z');
+    expect(textHistory).toContain('- follow_up (2025-03-12T09:15:00.000Z)');
     expect(textHistory).toContain('Note: Sent thank-you follow-up');
 
     const jsonHistory = runCli(['track', 'history', 'job-xyz', '--json']);


### PR DESCRIPTION
## Summary
- align `jobbot track history` output with the documented channel-first, bulleted format and `Reminder` label
- expand the CLI test to assert the new formatting so the history surface stays locked in
- refresh the README to describe the updated formatting and note the supporting coverage

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68cf8893f84c832fbcb95549ecb8adef