### PR TITLE
Add JSON output for shortlist list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,27 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --location remote
 #   Level: Senior
 #   Compensation: $185k
 
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --json
+# {
+#   "jobs": {
+#     "job-123": {
+#       "metadata": {
+#         "location": "Remote",
+#         "level": "Senior",
+#         "compensation": "$185k"
+#       },
+#       "tags": ["dream", "remote"],
+#       "discarded": [
+#         {
+#           "reason": "Not remote",
+#           "discarded_at": "2025-03-05T12:00:00.000Z",
+#           "tags": ["Remote", "onsite"]
+#         }
+#       ]
+#     }
+#   }
+# }
+
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist archive job-123
 # job-123
 # - 2025-03-05T12:00:00.000Z — Not remote
@@ -366,8 +387,9 @@ The CLI stores shortlist labels, discard history, and sync metadata in `data/sho
 reasons, timestamps, optional tags, and location/level/compensation fields so recommendations can
 surface patterns later. Review past decisions with `jobbot shortlist archive [job_id]` (add `--json`
 to inspect all records at once), which reads from `data/discarded_jobs.json` so archive lookups and
-shortlist history stay in sync. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for refresh
-schedulers. Unit tests in [`test/shortlist.test.js`](test/shortlist.test.js) and the CLI suite in
+shortlist history stay in sync. Add `--json` to the shortlist list command when piping entries
+into other tools. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for refresh schedulers.
+Unit tests in [`test/shortlist.test.js`](test/shortlist.test.js) and the CLI suite in
 [`test/cli.test.js`](test/cli.test.js) exercise metadata updates, filters, discard tags, archive
 exports, and the persisted format.
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -697,13 +697,19 @@ function formatDiscardArchive(archive) {
 }
 
 async function cmdShortlistList(args) {
+  const asJson = args.includes('--json');
+  const filteredArgs = asJson ? args.filter(arg => arg !== '--json') : args;
   const filters = {
-    location: getFlag(args, '--location'),
-    level: getFlag(args, '--level'),
-    compensation: getFlag(args, '--compensation'),
+    location: getFlag(filteredArgs, '--location'),
+    level: getFlag(filteredArgs, '--level'),
+    compensation: getFlag(filteredArgs, '--compensation'),
   };
 
   const store = await filterShortlist(filters);
+  if (asJson) {
+    console.log(JSON.stringify({ jobs: store.jobs }, null, 2));
+    return;
+  }
   console.log(formatShortlistList(store.jobs));
 }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -61,6 +61,7 @@ revisit them later without blocking the workflow.
 4. The shortlist view exposes filters (location, level, compensation) via
    `jobbot shortlist list --location <value>` and records sync metadata with
    `jobbot shortlist sync` so future refreshes know when entries were last updated.
+   Add `--json` when exporting the filtered shortlist to other tools.
 
 **Unhappy paths:** fetch failures or ToS blocks surface actionable error messages and never retry
 aggressively to respect rate limits.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -652,6 +652,58 @@ describe('jobbot CLI', () => {
     expect(listOutput).toContain('Remote');
   });
 
+  it('lists shortlist entries as JSON with --json', () => {
+    runCli([
+      'shortlist',
+      'sync',
+      'job-json',
+      '--location',
+      'Remote',
+      '--level',
+      'Senior',
+      '--compensation',
+      '$200k',
+      '--synced-at',
+      '2025-06-01T10:00:00Z',
+    ]);
+    runCli(['shortlist', 'tag', 'job-json', 'Remote']);
+    runCli([
+      'shortlist',
+      'discard',
+      'job-json',
+      '--reason',
+      'Paused search',
+      '--tags',
+      'Paused,paused',
+      '--date',
+      '2025-06-02T09:30:00Z',
+    ]);
+
+    const output = runCli(['shortlist', 'list', '--json']);
+    const payload = JSON.parse(output);
+
+    expect(payload).toEqual({
+      jobs: {
+        'job-json': {
+          tags: ['Remote'],
+          metadata: {
+            location: 'Remote',
+            level: 'Senior',
+            compensation: '$200k',
+            synced_at: '2025-06-01T10:00:00.000Z',
+          },
+          discarded: [
+            {
+              reason: 'Paused search',
+              discarded_at: '2025-06-02T09:30:00.000Z',
+              tags: ['Paused'],
+            },
+          ],
+        },
+      },
+    });
+  });
+
   it('summarizes conversion funnel analytics', () => {
     runCli(['track', 'log', 'job-1', '--channel', 'email', '--date', '2025-01-02']);
     runCli(['track', 'add', 'job-1', '--status', 'screening']);


### PR DESCRIPTION
## Summary
- add `--json` handling to `jobbot shortlist list` so filters can export structured data
- document the machine-readable shortlist output in the README and user journeys
- cover the new behavior with a CLI integration test exercising tags, metadata, and discards

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68cf8893f84c832fbcb95549ecb8adef