### PR TITLE
Sync track discard with shortlist history

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,13 +619,15 @@ To capture discard reasons for shortlist triage:
 
 ```bash
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot track discard job-456 --reason "Salary too low"
-# Discarded job-456
+# Discarded job-456: Salary too low
 ```
 
 Discarded roles are archived in `data/discarded_jobs.json` with their reasons,
 timestamps, and optional tags so future recommendations can reference prior
-decisions. Unit tests in `test/discards.test.js` and the CLI suite cover the
-JSON format and command invocation.
+decisions. The `track discard` command shares the shortlist writer so history in
+`data/shortlist.json` stays aligned even when discards originate from the track
+workflow. Unit tests in `test/discards.test.js` and the CLI suite cover the JSON
+format and command invocation.
 
 ## Documentation
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -22,7 +22,7 @@ import {
   getApplicationReminders,
 } from '../src/application-events.js';
 import { recordApplication, STATUSES } from '../src/lifecycle.js';
-import { recordJobDiscard, getDiscardedJobs } from '../src/discards.js';
+import { getDiscardedJobs } from '../src/discards.js';
 import { addJobTags, discardJob, filterShortlist, syncShortlistJob } from '../src/shortlist.js';
 import { recordInterviewSession, getInterviewSession } from '../src/interviews.js';
 import { initProfile } from '../src/profile.js';
@@ -445,8 +445,8 @@ async function cmdTrackDiscard(args) {
   }
   const tags = parseTagsFlag(args);
   const date = getFlag(args, '--date');
-  await recordJobDiscard(jobId, { reason, tags, date });
-  console.log(`Discarded ${jobId}`);
+  const entry = await discardJob(jobId, reason, { tags, date });
+  console.log(`Discarded ${jobId}: ${entry.reason}`);
 }
 
 async function cmdTrack(args) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -450,7 +450,7 @@ describe('jobbot CLI', () => {
       '--reason',
       'Below compensation range',
     ]);
-    expect(output.trim()).toBe('Discarded job-789');
+    expect(output.trim()).toBe('Discarded job-789: Below compensation range');
     const raw = JSON.parse(
       fs.readFileSync(path.join(dataDir, 'discarded_jobs.json'), 'utf8')
     );
@@ -458,6 +458,29 @@ describe('jobbot CLI', () => {
     const entry = raw['job-789'][0];
     expect(entry.reason).toBe('Below compensation range');
     expect(entry.discarded_at).toEqual(new Date(entry.discarded_at).toISOString());
+  });
+
+  it('updates shortlist history when discarding via track command', () => {
+    runCli([
+      'track',
+      'discard',
+      'job-shortlist-sync',
+      '--reason',
+      'Not aligned with goals',
+      '--tags',
+      'remote,onsite',
+    ]);
+
+    const shortlistPath = path.join(dataDir, 'shortlist.json');
+    expect(fs.existsSync(shortlistPath)).toBe(true);
+    const shortlist = JSON.parse(fs.readFileSync(shortlistPath, 'utf8'));
+    expect(shortlist.jobs['job-shortlist-sync']).toBeDefined();
+    const [entry] = shortlist.jobs['job-shortlist-sync'].discarded;
+    expect(entry).toMatchObject({
+      reason: 'Not aligned with goals',
+      tags: ['remote', 'onsite'],
+    });
+    expect(typeof entry.discarded_at).toBe('string');
   });
 
   it('surfaces discard archive snapshots with shortlist archive', () => {


### PR DESCRIPTION
## Summary
- update the `track discard` subcommand to reuse the shortlist writer so discard reasons propagate to `shortlist.json`
- extend the CLI tests to cover the shared path and document the combined archive behavior

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68cf942b48b0832f83da1fe1007fc34f