### PR TITLE
Add resume metadata export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,25 @@ run();
 `loadResume` supports `.pdf`, `.md`, `.markdown`, and `.mdx` files; other
 extensions are read as plain text.
 
+Pass `{ withMetadata: true }` to capture basic file statistics alongside the
+cleaned text:
+
+```js
+const { text, metadata } = await loadResume('resume.md', { withMetadata: true });
+console.log(metadata);
+// {
+//   extension: '.md',
+//   format: 'markdown',
+//   bytes: 2312,
+//   characters: 1980,
+//   lineCount: 62,
+//   wordCount: 340
+// }
+```
+
+`test/resume.test.js` exercises the metadata branch so downstream callers can
+depend on the shape.
+
 Initialize a JSON Resume skeleton when you do not have an existing file:
 
 ```bash

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -13,6 +13,9 @@ jobbot3000.
    `resume.json`. When they start from scratch, `jobbot init` scaffolds
    `data/profile/resume.json` with empty JSON Resume sections ready for editing.
 2. The CLI or UI calls the resume loader to extract clean text and metadata.
+   Callers can request word/line counts, byte size, and the detected format via
+   `loadResume(<path>, { withMetadata: true })` so downstream steps can surface
+   parsing confidence or highlight missing sections.
 3. Parsed content is normalized into the JSON Resume schema and saved under `data/profile/`, a
    git-ignored directory so personal data never leaves the machine.
 4. The system surfaces parsing confidence scores, highlights ambiguities (dates, titles, metrics),

--- a/test/resume.test.js
+++ b/test/resume.test.js
@@ -59,4 +59,23 @@ describe('loadResume', () => {
     const result = await withTempFile('.PDF', 'dummy', loadResume);
     expect(result).toBe('PDF content');
   });
+
+  it('returns text and metadata when requested', async () => {
+    const content = '# Title\n\n**bold** text\n';
+    const result = await withTempFile('.md', content, file =>
+      loadResume(file, { withMetadata: true })
+    );
+
+    expect(result).toEqual({
+      text: 'Title\n\nbold text',
+      metadata: expect.objectContaining({
+        extension: '.md',
+        format: 'markdown',
+        bytes: Buffer.byteLength(content),
+        characters: 16,
+        lineCount: 3,
+        wordCount: 3,
+      }),
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add an optional metadata path to `loadResume` so callers can inspect format and content statistics
- document how to request metadata in the README and Journey 1 narrative
- extend the resume loader tests to cover the metadata branch

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68cf942b48b0832f83da1fe1007fc34f