### PR TITLE
Add acceptance lifecycle statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,10 +536,11 @@ font size immediately after logging in.
 
 ## Tracking Application Lifecycle
 
-Application statuses such as `no_response`, `screening`, `onsite`, `offer`, `rejected`, and
-`withdrawn` are saved to `data/applications.json`, a git-ignored file. Legacy entries using
-`next_round` still load for backward compatibility. Set `JOBBOT_DATA_DIR` to change the directory.
-These records power local Sankey diagrams so progress isn't lost between sessions.
+Application statuses such as `no_response`, `screening`, `onsite`, `offer`, `rejected`,
+`withdrawn`, and acceptance outcomes (`accepted`, `acceptance`, `hired`) are saved to
+`data/applications.json`, a git-ignored file. Legacy entries using `next_round` still load for
+backward compatibility. Set `JOBBOT_DATA_DIR` to change the directory. These records power local
+Sankey diagrams so progress isn't lost between sessions.
 Writes are serialized to avoid dropping entries when recording multiple applications at once.
 If the file is missing it will be created, but other file errors or malformed JSON will throw.
 Unit tests cover each status, concurrent writes, missing files, invalid JSON, and rejection of

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -92,8 +92,9 @@ aggressively to respect rate limits.
 1. When the user applies or sends outreach, they log the event (channel, date, documents shared,
    contact person) with `jobbot track log <job_id> --channel <channel> [...]`, which appends the
    metadata to `data/application_events.json` so the full history stays local.
-2. Application status transitions (no response, screening, onsite, offer, rejected, withdrawn) are
-   stored in `data/applications.json`, which is serialized safely to prevent data loss. The CLI
+2. Application status transitions covering no response, screening, onsite, offer, rejected,
+   withdrawn, and acceptance outcomes (accepted/acceptance/hired) are stored in
+   `data/applications.json`, which is serialized safely to prevent data loss. The CLI
    exposes `jobbot track add <job_id> --status <status> [--note <note>]` so users can log updates and
    quick notes inline with other workflows.
 3. Follow-up reminders and note-taking surfaces help the user prepare for upcoming steps while

--- a/src/lifecycle.js
+++ b/src/lifecycle.js
@@ -4,6 +4,7 @@ import path from 'node:path';
 /**
  * Valid application status values.
  * `next_round` remains as a legacy alias for older logs.
+ * Acceptance synonyms (`accepted`, `acceptance`, `hired`) feed analytics rollups.
  */
 export const STATUSES = [
   'no_response',
@@ -13,6 +14,9 @@ export const STATUSES = [
   'rejected',
   'withdrawn',
   'next_round',
+  'accepted',
+  'acceptance',
+  'hired',
 ];
 
 function getPaths() {

--- a/test/lifecycle.test.js
+++ b/test/lifecycle.test.js
@@ -14,6 +14,9 @@ const ALL_STATUSES = [
   'rejected',
   'withdrawn',
   'next_round',
+  'accepted',
+  'acceptance',
+  'hired',
 ];
 
 const expectedCounts = (overrides = {}) => ({
@@ -70,19 +73,30 @@ test('stores optional notes alongside application statuses', async () => {
   });
 });
 
-test('tracks screening, onsite, offer, and withdrawn statuses', async () => {
+test('tracks core lifecycle and acceptance statuses', async () => {
   const entries = [
     ['job-screening', 'screening'],
     ['job-onsite', 'onsite'],
     ['job-offer', 'offer'],
     ['job-withdrawn', 'withdrawn'],
+    ['job-accepted', 'accepted'],
+    ['job-acceptance', 'acceptance'],
+    ['job-hired', 'hired'],
   ];
   for (const [id, status] of entries) {
     await recordApplication(id, status);
   }
   const counts = await getLifecycleCounts();
   expect(counts).toEqual(
-    expectedCounts({ screening: 1, onsite: 1, offer: 1, withdrawn: 1 })
+    expectedCounts({
+      screening: 1,
+      onsite: 1,
+      offer: 1,
+      withdrawn: 1,
+      accepted: 1,
+      acceptance: 1,
+      hired: 1,
+    })
   );
 });
 


### PR DESCRIPTION
## Summary
- allow tracking acceptance outcomes (`accepted`, `acceptance`, `hired`) alongside existing lifecycle statuses and document the support
- extend lifecycle tests to cover acceptance statuses so analytics can roll them into the acceptance stage

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68cf942b48b0832f83da1fe1007fc34f