### PR TITLE
Align track discard CLI messaging with shortlist history

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,13 +619,15 @@ To capture discard reasons for shortlist triage:
 
 ```bash
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot track discard job-456 --reason "Salary too low"
-# Discarded job-456
+# Discarded job-456: Salary too low
 ```
 
 Discarded roles are archived in `data/discarded_jobs.json` with their reasons,
 timestamps, and optional tags so future recommendations can reference prior
-decisions. Unit tests in `test/discards.test.js` and the CLI suite cover the
-JSON format and command invocation.
+decisions. The same entry is recorded in `data/shortlist.json`, keeping the
+shortlist view's discard history aligned with the archive. Unit tests in
+`test/discards.test.js` and the CLI suite cover the JSON format and command
+invocation.
 
 ## Documentation
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -22,7 +22,7 @@ import {
   getApplicationReminders,
 } from '../src/application-events.js';
 import { recordApplication, STATUSES } from '../src/lifecycle.js';
-import { recordJobDiscard, getDiscardedJobs } from '../src/discards.js';
+import { getDiscardedJobs } from '../src/discards.js';
 import { addJobTags, discardJob, filterShortlist, syncShortlistJob } from '../src/shortlist.js';
 import { recordInterviewSession, getInterviewSession } from '../src/interviews.js';
 import { initProfile } from '../src/profile.js';
@@ -445,8 +445,8 @@ async function cmdTrackDiscard(args) {
   }
   const tags = parseTagsFlag(args);
   const date = getFlag(args, '--date');
-  await recordJobDiscard(jobId, { reason, tags, date });
-  console.log(`Discarded ${jobId}`);
+  const entry = await discardJob(jobId, reason, { tags, date });
+  console.log(`Discarded ${jobId}: ${entry.reason}`);
 }
 
 async function cmdTrack(args) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -261,6 +261,43 @@ describe('jobbot CLI', () => {
     ]);
   });
 
+  it('keeps shortlist discard history in sync when using track discard', () => {
+    const output = runCli([
+      'track',
+      'discard',
+      'job-track',
+      '--reason',
+      'Not a fit right now',
+      '--tags',
+      'Remote,onsite',
+      '--date',
+      '2025-04-05T12:00:00Z',
+    ]);
+
+    expect(output.trim()).toBe('Discarded job-track: Not a fit right now');
+
+    const shortlistPath = path.join(dataDir, 'shortlist.json');
+    const shortlist = JSON.parse(fs.readFileSync(shortlistPath, 'utf8'));
+    expect(shortlist.jobs['job-track']).toBeDefined();
+    expect(shortlist.jobs['job-track'].discarded).toEqual([
+      {
+        reason: 'Not a fit right now',
+        discarded_at: '2025-04-05T12:00:00.000Z',
+        tags: ['Remote', 'onsite'],
+      },
+    ]);
+
+    const archivePath = path.join(dataDir, 'discarded_jobs.json');
+    const archive = JSON.parse(fs.readFileSync(archivePath, 'utf8'));
+    expect(archive['job-track']).toEqual([
+      {
+        reason: 'Not a fit right now',
+        discarded_at: '2025-04-05T12:00:00.000Z',
+        tags: ['Remote', 'onsite'],
+      },
+    ]);
+  });
+
   it('shows application history with track history --json', () => {
     runCli([
       'track',
@@ -450,7 +487,7 @@ describe('jobbot CLI', () => {
       '--reason',
       'Below compensation range',
     ]);
-    expect(output.trim()).toBe('Discarded job-789');
+    expect(output.trim()).toBe('Discarded job-789: Below compensation range');
     const raw = JSON.parse(
       fs.readFileSync(path.join(dataDir, 'discarded_jobs.json'), 'utf8')
     );


### PR DESCRIPTION
## Summary
- log the discard reason from `jobbot track discard` now that the CLI reuses shortlist archival
- update the CLI coverage and README example to document the combined shortlist/archive flow

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68cf942b48b0832f83da1fe1007fc34f