### PR TITLE
Add retries to job board ingestion fetchers

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -257,7 +257,7 @@ jobbot track add <job_id> --status applied --note "emailed hiring manager"
 - Greenhouse Job Board fetcher + normalizer. (shipped)
 - Lever Postings fetcher + normalizer. (shipped)
 - Ashby Jobs fetcher + normalizer. (shipped)
-- Caching, retries, per-domain politeness.
+- Caching, retries (shipped), per-domain politeness.
 - UI: source connections, search & filters.
 
 **Phase 2 — Matching (1 week)**

--- a/README.md
+++ b/README.md
@@ -335,7 +335,9 @@ errors, and retain the `User-Agent: jobbot3000` request header alongside each
 capture so fetches are reproducible.
 [`test/lever.test.js`](test/lever.test.js) now explicitly asserts the Lever
 client forwards that header to the API and persists it in saved snapshots so
-metadata stays consistent across providers.
+metadata stays consistent across providers. Automated coverage in
+[`test/greenhouse.test.js`](test/greenhouse.test.js) also exercises the retry
+logic so transient 5xx responses are retried before surfacing to callers.
 
 Job titles can be parsed from lines starting with `Title`, `Job Title`, `Position`, or `Role`.
 Headers can use colons or dash separators (for example, `Role - Staff Engineer`), and the same

--- a/test/smartrecruiters.test.js
+++ b/test/smartrecruiters.test.js
@@ -118,7 +118,7 @@ describe('SmartRecruiters ingest', () => {
   });
 
   it('throws when the postings fetch fails', async () => {
-    fetch.mockResolvedValueOnce({
+    fetch.mockResolvedValue({
       ok: false,
       status: 500,
       statusText: 'Internal Server Error',
@@ -127,7 +127,9 @@ describe('SmartRecruiters ingest', () => {
 
     const { ingestSmartRecruitersBoard } = await import('../src/smartrecruiters.js');
 
-    await expect(ingestSmartRecruitersBoard({ company: 'example' })).rejects.toThrow(
+    await expect(
+      ingestSmartRecruitersBoard({ company: 'example', retry: { delayMs: 0 } })
+    ).rejects.toThrow(
       /Failed to fetch SmartRecruiters company example/,
     );
   });

--- a/test/workable.test.js
+++ b/test/workable.test.js
@@ -143,23 +143,24 @@ describe('Workable ingest', () => {
       ],
     };
 
-    fetch
-      .mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        json: async () => listPayload,
-      })
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        statusText: 'Internal Server Error',
-        json: async () => ({}),
-      });
+    fetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: async () => ({}),
+    });
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => listPayload,
+    });
 
     const { ingestWorkableBoard } = await import('../src/workable.js');
 
-    await expect(ingestWorkableBoard({ account: 'example' })).rejects.toThrow(
+    await expect(
+      ingestWorkableBoard({ account: 'example', retry: { delayMs: 0 } })
+    ).rejects.toThrow(
       /Failed to fetch Workable job/,
     );
   });


### PR DESCRIPTION
## Summary
- add a shared `fetchWithRetry` helper that retries transient fetch failures with exponential backoff
- wire the retry helper into each job board ingest module and expose a configurable retry option
- document the new behavior and extend the test suites to cover transient failure retries

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68cfa34f60e0832f8831cc6d50456ba9