### PR TITLE
Add shortlist tag filtering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist tag job-123 dream remote
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist discard job-123 --reason "Not remote" --tags "Remote,onsite"
 # Discarded job-123: Not remote
 
-JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist sync job-123 --location Remote --level Senior --compensation "$185k"
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist sync job-123 --location Remote --level Senior --compensation "$185k" --synced-at 2025-03-06T08:00:00Z
 # Synced job-123 metadata
 
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --location remote
@@ -374,6 +374,18 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --location remote
 #   Location: Remote
 #   Level: Senior
 #   Compensation: $185k
+#   Synced At: 2025-03-06T08:00:00.000Z
+#   Tags: dream, remote
+#   Last Discard: Not remote (2025-03-05T12:00:00.000Z)
+
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --tag dream --tag remote
+# job-123
+#   Location: Remote
+#   Level: Senior
+#   Compensation: $185k
+#   Synced At: 2025-03-06T08:00:00.000Z
+#   Tags: dream, remote
+#   Last Discard: Not remote (2025-03-05T12:00:00.000Z)
 
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --json
 # {
@@ -382,7 +394,8 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --json
 #       "metadata": {
 #         "location": "Remote",
 #         "level": "Senior",
-#         "compensation": "$185k"
+#         "compensation": "$185k",
+#         "synced_at": "2025-03-06T08:00:00.000Z"
 #       },
 #       "tags": ["dream", "remote"],
 #       "discarded": [
@@ -406,10 +419,11 @@ The CLI stores shortlist labels, discard history, and sync metadata in `data/sho
 reasons, timestamps, optional tags, and location/level/compensation fields so recommendations can
 surface patterns later. Review past decisions with `jobbot shortlist archive [job_id]` (add `--json`
 to inspect all records at once), which reads from `data/discarded_jobs.json` so archive lookups and
-shortlist history stay in sync. Add `--json` to the shortlist list command when piping entries
-into other tools. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for refresh schedulers.
-Unit tests in [`test/shortlist.test.js`](test/shortlist.test.js) and the CLI suite in
-[`test/cli.test.js`](test/cli.test.js) exercise metadata updates, filters, discard tags, archive
+shortlist history stay in sync. Add `--json` to the shortlist list command when piping entries into
+other tools, and filter by metadata or tags (`--location`, `--level`, `--compensation`, or repeated
+`--tag` flags) when triaging opportunities. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for
+refresh schedulers. Unit tests in [`test/shortlist.test.js`](test/shortlist.test.js) and the CLI suite in
+[`test/cli.test.js`](test/cli.test.js) exercise metadata updates, tag filters, discard tags, archive
 exports, and the persisted format.
 
 ## Intake responses

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -368,6 +368,27 @@ function parseTagsFlag(args) {
     .filter(Boolean);
 }
 
+function collectTagFilters(args) {
+  const tags = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] !== '--tag') continue;
+    const value = args[i + 1];
+    if (!value || value.startsWith('--')) {
+      console.error(
+        'Usage: jobbot shortlist list [--location <value>] [--level <value>] ' +
+          '[--compensation <value>] [--tag <value>] [--json]'
+      );
+      process.exit(2);
+    }
+    for (const entry of String(value).split(',')) {
+      const trimmed = entry.trim();
+      if (trimmed) tags.push(trimmed);
+    }
+    i++;
+  }
+  return tags.length > 0 ? tags : undefined;
+}
+
 function formatIntakeList(entries) {
   if (!Array.isArray(entries) || entries.length === 0) {
     return 'No intake responses found';
@@ -704,6 +725,8 @@ async function cmdShortlistList(args) {
     level: getFlag(filteredArgs, '--level'),
     compensation: getFlag(filteredArgs, '--compensation'),
   };
+  const tagFilters = collectTagFilters(filteredArgs);
+  if (tagFilters) filters.tags = tagFilters;
 
   const store = await filterShortlist(filters);
   if (asJson) {

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -61,10 +61,11 @@ revisit them later without blocking the workflow.
    `data/discarded_jobs.json` so future recommendations can reference prior decisions. Review those
    decisions with `jobbot shortlist archive <job_id>` (or `--json` to inspect the full archive) before
    revisiting a role.
-4. The shortlist view exposes filters (location, level, compensation) via
-   `jobbot shortlist list --location <value>` and records sync metadata with
-   `jobbot shortlist sync` so future refreshes know when entries were last updated.
-   Add `--json` when exporting the filtered shortlist to other tools.
+4. The shortlist view exposes filters (location, level, compensation, tags) via
+   `jobbot shortlist list --location <value>` (and repeated `--tag <value>` flags)
+   and records sync metadata with `jobbot shortlist sync` so future refreshes know
+   when entries were last updated. Add `--json` when exporting the filtered shortlist
+   to other tools.
 
 **Unhappy paths:** fetch failures or ToS blocks surface actionable error messages and never retry
 aggressively to respect rate limits.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -712,6 +712,20 @@ describe('jobbot CLI', () => {
     expect(listOutput).toContain('Remote');
   });
 
+  it('filters shortlist entries by tag', () => {
+    runCli(['shortlist', 'tag', 'job-remote', 'Remote', 'Dream']);
+    runCli(['shortlist', 'tag', 'job-onsite', 'Onsite']);
+
+    const textOutput = runCli(['shortlist', 'list', '--tag', 'remote']);
+    expect(textOutput).toContain('job-remote');
+    expect(textOutput).not.toContain('job-onsite');
+
+    const jsonOutput = runCli(['shortlist', 'list', '--tag', 'remote', '--tag', 'dream', '--json']);
+    const payload = JSON.parse(jsonOutput);
+    expect(Object.keys(payload.jobs)).toEqual(['job-remote']);
+    expect(payload.jobs['job-remote'].tags).toEqual(['Remote', 'Dream']);
+  });
+
   it('lists shortlist entries as JSON with --json', () => {
     runCli([
       'shortlist',

--- a/test/shortlist.test.js
+++ b/test/shortlist.test.js
@@ -46,6 +46,22 @@ describe('shortlist metadata sync and filters', () => {
     expect(Object.keys(byFilters.jobs)).toEqual(['job-metadata']);
   });
 
+  it('filters shortlist entries by tag', async () => {
+    const { addJobTags, filterShortlist } = await import('../src/shortlist.js');
+
+    await addJobTags('job-tags', ['Remote', 'Dream']);
+    await addJobTags('job-other', ['Hold']);
+
+    const remote = await filterShortlist({ tags: ['remote'] });
+    expect(Object.keys(remote.jobs)).toEqual(['job-tags']);
+
+    const multi = await filterShortlist({ tags: ['remote', 'dream'] });
+    expect(Object.keys(multi.jobs)).toEqual(['job-tags']);
+
+    const none = await filterShortlist({ tags: ['onsite'] });
+    expect(Object.keys(none.jobs)).toEqual([]);
+  });
+
   it('records discard tags in shortlist and archive files', async () => {
     const { discardJob } = await import('../src/shortlist.js');
 


### PR DESCRIPTION
## Summary
- allow shortlist filters to match tags alongside location metadata
- expose a --tag flag in the CLI and cover it with unit + CLI tests
- document the tag filter usage and refreshed shortlist output samples

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68cfa34f60e0832f8831cc6d50456ba9