### PR TITLE
Normalize shortlist compensation filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,10 @@ surface patterns later. Review past decisions with `jobbot shortlist archive [jo
 to inspect all records at once), which reads from `data/discarded_jobs.json` so archive lookups and
 shortlist history stay in sync. Add `--json` to the shortlist list command when piping entries
 into other tools. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for refresh schedulers.
+Shells treat `$` as a variable prefix, so `--compensation "$185k"` expands to `85k`. The CLI
+re-attaches a default currency symbol so the stored value becomes `$85k`; escape the dollar sign
+(`--compensation "\$185k"`) when you need the digits preserved. Override the auto-attached symbol by
+setting `JOBBOT_SHORTLIST_CURRENCY` (for example, `JOBBOT_SHORTLIST_CURRENCY='€'`).
 Unit tests in [`test/shortlist.test.js`](test/shortlist.test.js) and the CLI suite in
 [`test/cli.test.js`](test/cli.test.js) exercise metadata updates, filters, discard tags, archive
 exports, and the persisted format.

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -62,6 +62,23 @@ function getNumberFlag(args, name, fallback) {
   return Number.isFinite(n) ? n : fallback;
 }
 
+const CURRENCY_SYMBOL_RE = /^\p{Sc}/u;
+const DEFAULT_SHORTLIST_CURRENCY = process.env.JOBBOT_SHORTLIST_CURRENCY
+  ? process.env.JOBBOT_SHORTLIST_CURRENCY.trim()
+  : '$';
+
+function normalizeCompensation(value) {
+  if (value == null) return undefined;
+  const trimmed = String(value).trim();
+  if (!trimmed) return undefined;
+  if (CURRENCY_SYMBOL_RE.test(trimmed)) return trimmed;
+  if (!/^\d/.test(trimmed)) return trimmed;
+  const simpleNumeric = /^\d[\d.,]*(?:\s?(?:k|m|b))?$/i;
+  if (!simpleNumeric.test(trimmed)) return trimmed;
+  const symbol = DEFAULT_SHORTLIST_CURRENCY || '$';
+  return `${symbol}${trimmed}`;
+}
+
 function parseMultilineList(value) {
   if (value == null) return undefined;
   const str = typeof value === 'string' ? value : String(value);
@@ -573,7 +590,7 @@ async function cmdShortlistSync(args) {
   if (location) metadata.location = location;
   const level = getFlag(rest, '--level');
   if (level) metadata.level = level;
-  const compensation = getFlag(rest, '--compensation');
+  const compensation = normalizeCompensation(getFlag(rest, '--compensation'));
   if (compensation) metadata.compensation = compensation;
   const syncedAt = getFlag(rest, '--synced-at');
   if (syncedAt) metadata.syncedAt = syncedAt;
@@ -702,7 +719,7 @@ async function cmdShortlistList(args) {
   const filters = {
     location: getFlag(filteredArgs, '--location'),
     level: getFlag(filteredArgs, '--level'),
-    compensation: getFlag(filteredArgs, '--compensation'),
+    compensation: normalizeCompensation(getFlag(filteredArgs, '--compensation')),
   };
 
   const store = await filterShortlist(filters);

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -764,6 +764,70 @@ describe('jobbot CLI', () => {
     });
   });
 
+  it('restores currency symbols when sync invoked via shell quoting', () => {
+    const bin = path.resolve('bin', 'jobbot.js');
+    const command = [
+      `${process.execPath} ${bin} shortlist sync job-shell`,
+      '--location Remote',
+      '--level Senior',
+      '--compensation "$185k"',
+    ].join(' ');
+    execFileSync('bash', ['-lc', command], {
+      encoding: 'utf8',
+      env: { ...process.env, JOBBOT_DATA_DIR: dataDir },
+    });
+
+    const shortlist = JSON.parse(
+      fs.readFileSync(path.join(dataDir, 'shortlist.json'), 'utf8')
+    );
+    expect(shortlist.jobs['job-shell'].metadata.compensation).toBe('$85k');
+  });
+
+  it('filters shortlist entries using normalized compensation values', () => {
+    const bin = path.resolve('bin', 'jobbot.js');
+    const command = [
+      `${process.execPath} ${bin} shortlist sync job-shell-filter`,
+      '--location Remote',
+      '--level Senior',
+      '--compensation "$185k"',
+    ].join(' ');
+    execFileSync('bash', ['-lc', command], {
+      encoding: 'utf8',
+      env: { ...process.env, JOBBOT_DATA_DIR: dataDir },
+    });
+
+    const listOutput = runCli(['shortlist', 'list', '--compensation', '85k']);
+    expect(listOutput).toContain('job-shell-filter');
+    expect(listOutput).toContain('Compensation: $85k');
+  });
+
+  it('uses JOBBOT_SHORTLIST_CURRENCY when restoring compensation', () => {
+    const bin = path.resolve('bin', 'jobbot.js');
+    const command = [
+      `${process.execPath} ${bin} shortlist sync job-euro`,
+      '--location Remote',
+      '--level Mid',
+      '--compensation "120k"',
+    ].join(' ');
+    execFileSync('bash', ['-lc', command], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        JOBBOT_DATA_DIR: dataDir,
+        JOBBOT_SHORTLIST_CURRENCY: '€',
+      },
+    });
+
+    const shortlist = JSON.parse(
+      fs.readFileSync(path.join(dataDir, 'shortlist.json'), 'utf8')
+    );
+    expect(shortlist.jobs['job-euro'].metadata).toMatchObject({
+      compensation: '€120k',
+      level: 'Mid',
+      location: 'Remote',
+    });
+  });
+
   it('summarizes conversion funnel analytics', () => {
     runCli(['track', 'log', 'job-1', '--channel', 'email', '--date', '2025-01-02']);
     runCli(['track', 'add', 'job-1', '--status', 'screening']);


### PR DESCRIPTION
## Summary
- normalize the shortlist list compensation filter to apply the same currency prefixing as sync
- add a CLI regression test covering shortlist list compensation filters after shell quoting

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68cfa34f60e0832f8831cc6d50456ba9