### PR TITLE
✨ Surface shortlist discard tags in CLI output

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --location remote
 #   Synced At: 2025-03-06T08:00:00.000Z
 #   Tags: dream, remote
 #   Last Discard: Not remote (2025-03-05T12:00:00.000Z)
+#   Last Discard Tags: Remote, onsite
 
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --tag dream --tag remote
 # job-123
@@ -388,6 +389,7 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --tag dream --tag remote
 #   Synced At: 2025-03-06T08:00:00.000Z
 #   Tags: dream, remote
 #   Last Discard: Not remote (2025-03-05T12:00:00.000Z)
+#   Last Discard Tags: Remote, onsite
 
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --json
 # {
@@ -423,7 +425,8 @@ surface patterns later. Review past decisions with `jobbot shortlist archive [jo
 to inspect all records at once), which reads from `data/discarded_jobs.json` so archive lookups and
 shortlist history stay in sync. Add `--json` to the shortlist list command when piping entries into
 other tools, and filter by metadata or tags (`--location`, `--level`, `--compensation`, or repeated
-`--tag` flags) when triaging opportunities. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for
+`--tag` flags) when triaging opportunities. Text output also surfaces `Last Discard Tags` when tag
+history exists so the rationale stays visible without opening the archive. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for
 refresh schedulers. Shells treat `$` as a variable prefix, so `--compensation "$185k"` expands to
 `85k`. The CLI re-attaches a default currency symbol so the stored value becomes `$85k`; escape the
 dollar sign (`--compensation "\$185k"`) when you need the digits preserved. Override the auto-attached

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -645,6 +645,12 @@ function formatShortlistList(jobs) {
       const latest = discarded[discarded.length - 1];
       if (latest?.reason && latest?.discarded_at) {
         lines.push(`  Last Discard: ${latest.reason} (${latest.discarded_at})`);
+        const lastTags = Array.isArray(latest.tags)
+          ? latest.tags.map(tag => String(tag).trim()).filter(Boolean)
+          : [];
+        if (lastTags.length > 0) {
+          lines.push(`  Last Discard Tags: ${lastTags.join(', ')}`);
+        }
       }
     }
     lines.push('');

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -681,6 +681,24 @@ describe('jobbot CLI', () => {
     expect(archive['job-tags'][0].tags).toEqual(['Remote', 'onsite']);
   });
 
+  it('surfaces discard tags in shortlist list output', () => {
+    runCli([
+      'shortlist',
+      'discard',
+      'job-with-discard-tags',
+      '--reason',
+      'Changed focus',
+      '--tags',
+      'Remote,onsite',
+      '--date',
+      '2025-03-05T12:00:00Z',
+    ]);
+
+    const output = runCli(['shortlist', 'list']);
+    expect(output).toContain('job-with-discard-tags');
+    expect(output).toContain('Last Discard Tags: Remote, onsite');
+  });
+
   it('syncs shortlist metadata and filters entries by location', () => {
     const syncOutput = runCli([
       'shortlist',


### PR DESCRIPTION
✨ : – Surface shortlist discard tags in CLI output

what: show last discard tags in shortlist list text output and README.
why: README documents discard tags guiding triage; CLI hid them.
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d09237cd80832fb2dff80511b198b3