### PR TITLE
Add blockers to match explanations

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,16 +263,29 @@ JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot match --resume resume.txt --job job.txt 
 # Matched 2 of 3 requirements (67%).
 # Hits: Distributed systems experience; Mentors senior engineers
 # Gaps: Certified Kubernetes administrator
+# Blockers: Certified Kubernetes administrator
 
 # Persist a DOCX match report while keeping machine-readable output
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot match --resume resume.txt --job job.txt --json --docx match.docx
 # => JSON match report prints to stdout; match.docx contains the formatted document
 ```
 
+Fit scoring recognizes common abbreviations so lexical-only resumes still match spelled-out
+requirements. `AWS` on a resume matches `Amazon Web Services`, `ML` pairs with `Machine learning`,
+`AI` aligns with `Artificial intelligence`, and `Postgres` maps to `PostgreSQL`. Automated coverage
+in [`test/scoring.test.js`](test/scoring.test.js) exercises these semantic aliases.
+
+The explanation helper also highlights blockers when missing requirements look like must-haves.
+Entries containing phrases such as “must”, “required”, “security clearance”, “visa”, “sponsorship”,
+“certification”, “license”, “authorization”, or “citizenship” are surfaced in a dedicated line so
+reviewers can distinguish urgent gaps from nice-to-have skills. Tests in
+[`test/exporters.test.js`](test/exporters.test.js) cover blocker detection and the fallback message
+when no mandatory requirements are found.
+
 The summarizer extracts the first sentence, handling `.`, `!`, `?`, and consecutive terminal
 punctuation like `?!`, including when followed by closing quotes or parentheses. Terminators apply
 only when followed by whitespace or the end of text, so decimals like `1.99` remain intact.
-It ignores bare newlines.  
+It ignores bare newlines.
 It scans text character-by-character to avoid large intermediate arrays and regex performance
 pitfalls, falling back to the trimmed input when no sentence punctuation is found.
 Trailing quotes or parentheses are included when they immediately follow punctuation, and all

--- a/src/exporters.js
+++ b/src/exporters.js
@@ -224,6 +224,31 @@ export function toMarkdownMatch({
 
 const EXPLANATION_LIMIT = 5;
 
+const BLOCKER_PATTERNS = [
+  /\bmust\b/i,
+  /\brequir(?:e|es|ed|ement)s?\b/i,
+  /\bmandatory\b/i,
+  /\bclearance\b/i,
+  /\bvisa\b/i,
+  /\bsponsorship\b/i,
+  /\bcertif(?:ied|ication)s?\b/i,
+  /\blicen[cs]e\b/i,
+  /\bauthorization\b/i,
+  /\bcitizen(?:ship)?\b/i,
+  /\bwork permit\b/i,
+];
+
+function collectBlockers(requirements) {
+  const blockers = [];
+  for (const requirement of requirements) {
+    const normalized = requirement.toLowerCase();
+    if (BLOCKER_PATTERNS.some(pattern => pattern.test(normalized))) {
+      blockers.push(requirement);
+    }
+  }
+  return blockers;
+}
+
 export function formatMatchExplanation({
   matched,
   missing,
@@ -250,7 +275,12 @@ export function formatMatchExplanation({
     ? `${t('gaps', locale)}: ${gaps.slice(0, capped).join('; ')}`
     : t('noGaps', locale);
 
-  return [summary, hitsLine, gapsLine].join('\n');
+  const blockers = collectBlockers(gaps);
+  const blockersLine = blockers.length
+    ? `${t('blockers', locale)}: ${blockers.slice(0, capped).join('; ')}`
+    : t('noBlockers', locale);
+
+  return [summary, hitsLine, gapsLine, blockersLine].join('\n');
 }
 
 export function toMarkdownMatchExplanation(options) {

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -12,6 +12,8 @@ export default {
   gaps: 'Gaps',
   noHits: 'No direct hits from the resume.',
   noGaps: 'No missing requirements detected.',
+  blockers: 'Blockers',
+  noBlockers: 'No blockers flagged.',
   coverageSummary: 'Matched {matched} of {total} requirements ({score}%).',
   greeting: 'Hello, {name}!'
 };

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -12,6 +12,8 @@ export default {
   gaps: 'Vacíos',
   noHits: 'Sin coincidencias directas desde el currículum.',
   noGaps: 'No se detectaron requisitos faltantes.',
+  blockers: 'Obstáculos',
+  noBlockers: 'No se identificaron obstáculos.',
   coverageSummary: 'Coincidió con {matched} de {total} requisitos ({score}%).',
   greeting: '¡Hola, {name}!'
 };

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -208,15 +208,16 @@ describe('exporters', () => {
     expect(output).toBe(expected);
   });
 
-  it('summarizes match explanations with top hits and gaps', () => {
+  it('summarizes match explanations with top hits, gaps, and blockers', () => {
     const text = formatMatchExplanation({
       matched: ['JavaScript expertise', 'Mentored seniors'],
-      missing: ['Public cloud expertise'],
+      missing: ['Must have public cloud expertise'],
       score: 67,
     });
     expect(text).toContain('Matched 2 of 3 requirements (67%)');
     expect(text).toContain('Hits: JavaScript expertise; Mentored seniors');
-    expect(text).toContain('Gaps: Public cloud expertise');
+    expect(text).toContain('Gaps: Must have public cloud expertise');
+    expect(text).toContain('Blockers: Must have public cloud expertise');
   });
 
   it('falls back when no hits or gaps are present', () => {
@@ -224,6 +225,24 @@ describe('exporters', () => {
     expect(text).toContain('Matched 0 of 0 requirements (0%)');
     expect(text).toContain('No direct hits from the resume.');
     expect(text).toContain('No missing requirements detected.');
+    expect(text).toContain('No blockers flagged.');
+  });
+
+  it('surfaces blockers based on must-have keywords', () => {
+    const text = formatMatchExplanation({
+      matched: [],
+      missing: [
+        'Security clearance required',
+        'AWS certification preferred',
+        'Strong communication skills',
+      ],
+    });
+    const blockersLine =
+      'Blockers: Security clearance required; AWS certification preferred';
+    const gapsLine =
+      'Gaps: Security clearance required; AWS certification preferred; Strong communication skills';
+    expect(text).toContain(blockersLine);
+    expect(text).toContain(gapsLine);
   });
 
   it('renders markdown explanation with escaped content', () => {
@@ -236,6 +255,7 @@ describe('exporters', () => {
     expect(md).toContain('Matched 1 of 2 requirements \\(50%\\)');
     expect(md).toContain('Hits: Node.js \\(services\\)');
     expect(md).toContain('Gaps: Go & Rust');
+    expect(md).toContain('No blockers flagged.');
   });
 
   it('generates DOCX summaries with localized labels', async () => {


### PR DESCRIPTION
## Summary
- surface blocker requirements in match explanations with new heuristics and translations
- document blocker highlighting in README so the CLI output matches the described behavior
- extend exporter tests to cover blocker detection, fallback messaging, and markdown escaping

## Testing
- npm run lint
- npm run test:ci *(fails: job snapshots overwrite, shortlist tag filter, application-events reminders timed out in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d09237cd80832fb2dff80511b198b3