### PR TITLE
Handle unchanged Greenhouse board responses

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -101,7 +101,10 @@ Integrations: Greenhouse/Lever/Ashby/Workable/SmartRecruiters job board APIs, O*
 - Do **not** automate LinkedIn profile scraping or login-gated sites. Respect robots.txt and site ToS.
 
 **Pluggable fetchers**  
-Each ATS = a module returning a normalized `JobPosting`. Add basic backoff, ETag/If-Modified-Since caching, and per-tenant rate limits.
+Each ATS = a module returning a normalized `JobPosting`. Backoff flows through `fetchWithRetry`, and
+the Greenhouse fetcher now persists `ETag`/`If-Modified-Since` validators so repeat syncs issue
+conditional requests instead of re-downloading unchanged boards. Per-tenant rate limits remain on
+the backlog.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -337,7 +337,13 @@ capture so fetches are reproducible.
 client forwards that header to the API and persists it in saved snapshots so
 metadata stays consistent across providers. Automated coverage in
 [`test/greenhouse.test.js`](test/greenhouse.test.js) also exercises the retry
-logic so transient 5xx responses are retried before surfacing to callers.
+logic so transient 5xx responses are retried before surfacing to callers. The
+Greenhouse ingest client now caches `ETag`/`Last-Modified` validators and
+replays them on the next fetch, skipping snapshot work when the board returns a
+`304 Not Modified`. The command exits with `Greenhouse board <slug> unchanged`
+so repeated syncs are noiseless, and the Greenhouse test suite verifies the
+cache is written and that conditional requests short-circuit without touching
+the filesystem when nothing has changed.
 
 Job titles can be parsed from lines starting with `Title`, `Job Title`, `Position`, or `Role`.
 Headers can use colons or dash separators (for example, `Role - Staff Engineer`), and the same

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -506,7 +506,11 @@ async function cmdIngestGreenhouse(args) {
     process.exit(2);
   }
 
-  const { saved } = await ingestGreenhouseBoard({ board: company });
+  const { saved, notModified } = await ingestGreenhouseBoard({ board: company });
+  if (notModified) {
+    console.log(`Greenhouse board ${company} unchanged since last sync`);
+    return;
+  }
   const noun = saved === 1 ? 'job' : 'jobs';
   console.log(`Imported ${saved} ${noun} from ${company}`);
 }

--- a/src/greenhouse.js
+++ b/src/greenhouse.js
@@ -1,3 +1,5 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
 import fetch from 'node-fetch';
 import { extractTextFromHtml, fetchWithRetry } from './fetch.js';
 import { jobIdFromSource, saveJobSnapshot } from './jobs.js';
@@ -6,6 +8,68 @@ import { parseJobText } from './parser.js';
 const GREENHOUSE_BASE = 'https://boards.greenhouse.io/v1/boards';
 
 const GREENHOUSE_HEADERS = { 'User-Agent': 'jobbot3000' };
+
+function resolveDataDir() {
+  return process.env.JOBBOT_DATA_DIR || path.resolve('data');
+}
+
+function getCachePaths(slug) {
+  const dir = path.join(resolveDataDir(), 'cache', 'greenhouse');
+  return { dir, file: path.join(dir, `${slug}.json`) };
+}
+
+async function readCacheMetadata(slug) {
+  const { file } = getCachePaths(slug);
+  try {
+    const raw = await fs.readFile(file, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object') {
+      const metadata = {};
+      if (typeof parsed.etag === 'string' && parsed.etag.trim()) {
+        metadata.etag = parsed.etag.trim();
+      }
+      if (typeof parsed.lastModified === 'string' && parsed.lastModified.trim()) {
+        metadata.lastModified = parsed.lastModified.trim();
+      }
+      return metadata;
+    }
+  } catch (err) {
+    if (!err || err.code !== 'ENOENT') throw err;
+  }
+  return {};
+}
+
+async function writeCacheMetadata(slug, metadata) {
+  const entries = {};
+  if (metadata.etag) entries.etag = metadata.etag;
+  if (metadata.lastModified) entries.lastModified = metadata.lastModified;
+
+  const { dir, file } = getCachePaths(slug);
+  if (Object.keys(entries).length === 0) {
+    await fs.rm(file, { force: true });
+    return;
+  }
+
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(file, `${JSON.stringify(entries, null, 2)}\n`, 'utf8');
+}
+
+function getResponseHeader(response, name) {
+  if (!response || !response.headers) return undefined;
+  const headers = response.headers;
+  if (typeof headers.get === 'function') {
+    const direct = headers.get(name);
+    if (direct) return direct;
+    const lower = headers.get(name.toLowerCase());
+    if (lower) return lower;
+    return undefined;
+  }
+  const direct = headers[name];
+  if (typeof direct === 'string' && direct) return direct;
+  const lower = headers[name.toLowerCase()];
+  if (typeof lower === 'string' && lower) return lower;
+  return undefined;
+}
 
 function normalizeBoardSlug(board) {
   if (!board || typeof board !== 'string' || !board.trim()) {
@@ -41,11 +105,35 @@ function mergeParsedJob(parsed, job) {
 export async function fetchGreenhouseJobs(board, { fetchImpl = fetch, retry } = {}) {
   const slug = normalizeBoardSlug(board);
   const url = buildBoardUrl(slug);
+  const cacheMetadata = await readCacheMetadata(slug);
+  const headers = { ...GREENHOUSE_HEADERS };
+  if (cacheMetadata.etag) headers['If-None-Match'] = cacheMetadata.etag;
+  if (cacheMetadata.lastModified) headers['If-Modified-Since'] = cacheMetadata.lastModified;
+
   const response = await fetchWithRetry(url, {
     fetchImpl,
-    headers: GREENHOUSE_HEADERS,
+    headers,
     retry,
   });
+
+  const notModified = response.status === 304;
+  const etag = getResponseHeader(response, 'etag');
+  const lastModified = getResponseHeader(response, 'last-modified');
+  const metadataToPersist = {};
+  if (etag) metadataToPersist.etag = etag;
+  else if (notModified && cacheMetadata.etag) {
+    metadataToPersist.etag = cacheMetadata.etag;
+  }
+  if (lastModified) metadataToPersist.lastModified = lastModified;
+  else if (notModified && cacheMetadata.lastModified) {
+    metadataToPersist.lastModified = cacheMetadata.lastModified;
+  }
+  await writeCacheMetadata(slug, metadataToPersist);
+
+  if (notModified) {
+    return { slug, jobs: [], notModified: true };
+  }
+
   if (!response.ok) {
     throw new Error(
       `Failed to fetch Greenhouse board ${slug}: ${response.status} ${response.statusText}`,
@@ -53,11 +141,11 @@ export async function fetchGreenhouseJobs(board, { fetchImpl = fetch, retry } = 
   }
   const payload = await response.json();
   const jobs = Array.isArray(payload?.jobs) ? payload.jobs : [];
-  return { slug, jobs };
+  return { slug, jobs, notModified: false };
 }
 
 export async function ingestGreenhouseBoard({ board, fetchImpl = fetch, retry } = {}) {
-  const { slug, jobs } = await fetchGreenhouseJobs(board, { fetchImpl, retry });
+  const { slug, jobs, notModified } = await fetchGreenhouseJobs(board, { fetchImpl, retry });
   const jobIds = [];
 
   for (const job of jobs) {
@@ -77,5 +165,5 @@ export async function ingestGreenhouseBoard({ board, fetchImpl = fetch, retry } 
     jobIds.push(id);
   }
 
-  return { board: slug, saved: jobIds.length, jobIds };
+  return { board: slug, saved: jobIds.length, jobIds, notModified: Boolean(notModified) };
 }

--- a/test/greenhouse.test.js
+++ b/test/greenhouse.test.js
@@ -65,7 +65,7 @@ describe('Greenhouse ingest', () => {
       }),
     );
 
-    expect(result).toMatchObject({ board: 'example', saved: 1 });
+    expect(result).toMatchObject({ board: 'example', saved: 1, notModified: false });
     expect(result.jobIds).toHaveLength(1);
 
     const jobsDir = path.join(dataDir, JOBS_DIR);
@@ -143,5 +143,79 @@ describe('Greenhouse ingest', () => {
 
     expect(fetch).toHaveBeenCalledTimes(2);
     expect(result.saved).toBe(1);
+  });
+
+  it('persists caching headers for subsequent Greenhouse requests', async () => {
+    const headers = {
+      get: (name) => {
+        const lower = name.toLowerCase();
+        if (lower === 'etag') return '"etag-123"';
+        if (lower === 'last-modified') return 'Wed, 01 Jan 2025 00:00:00 GMT';
+        return null;
+      },
+    };
+    fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      headers,
+      json: async () => ({ jobs: [] }),
+    });
+
+    const { ingestGreenhouseBoard } = await import('../src/greenhouse.js');
+
+    const cachedResult = await ingestGreenhouseBoard({ board: 'example' });
+    expect(cachedResult.notModified).toBe(false);
+
+    const cachePath = path.join(dataDir, 'cache', 'greenhouse', 'example.json');
+    const cached = JSON.parse(await fs.readFile(cachePath, 'utf8'));
+    expect(cached).toEqual({
+      etag: '"etag-123"',
+      lastModified: 'Wed, 01 Jan 2025 00:00:00 GMT',
+    });
+  });
+
+  it('sends conditional headers and skips work when the board is unchanged', async () => {
+    const cacheDir = path.join(dataDir, 'cache', 'greenhouse');
+    await fs.mkdir(cacheDir, { recursive: true });
+    const cachePath = path.join(cacheDir, 'example.json');
+    await fs.writeFile(
+      cachePath,
+      JSON.stringify({
+        etag: '"etag-123"',
+        lastModified: 'Wed, 01 Jan 2025 00:00:00 GMT',
+      }),
+    );
+
+    fetch.mockImplementation(async (url, init) => {
+      expect(init.headers).toMatchObject({
+        'User-Agent': 'jobbot3000',
+        'If-None-Match': '"etag-123"',
+        'If-Modified-Since': 'Wed, 01 Jan 2025 00:00:00 GMT',
+      });
+      return {
+        ok: false,
+        status: 304,
+        statusText: 'Not Modified',
+        headers: { get: () => null },
+        json: async () => {
+          throw new Error('body should not be read for 304 responses');
+        },
+      };
+    });
+
+    const { ingestGreenhouseBoard } = await import('../src/greenhouse.js');
+
+    const result = await ingestGreenhouseBoard({ board: 'example' });
+
+    expect(result).toMatchObject({ board: 'example', saved: 0, jobIds: [], notModified: true });
+    const jobsDir = path.join(dataDir, JOBS_DIR);
+    await expect(fs.readdir(jobsDir)).rejects.toMatchObject({ code: 'ENOENT' });
+
+    const cached = JSON.parse(await fs.readFile(cachePath, 'utf8'));
+    expect(cached).toEqual({
+      etag: '"etag-123"',
+      lastModified: 'Wed, 01 Jan 2025 00:00:00 GMT',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- propagate the Greenhouse fetcher notModified flag so ingest results expose unchanged boards
- teach the CLI to print an "unchanged" status and document the quieter sync behavior
- extend the Greenhouse ingest suite to assert the flag for both 200 and 304 responses

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d09237cd80832fb2dff80511b198b3