### PR TITLE
Add per-tenant rate limiting to job board fetchers

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -103,8 +103,8 @@ Integrations: Greenhouse/Lever/Ashby/Workable/SmartRecruiters job board APIs, O*
 **Pluggable fetchers**  
 Each ATS = a module returning a normalized `JobPosting`. Backoff flows through `fetchWithRetry`, and
 the Greenhouse fetcher now persists `ETag`/`If-Modified-Since` validators so repeat syncs issue
-conditional requests instead of re-downloading unchanged boards. Per-tenant rate limits remain on
-the backlog.
+conditional requests instead of re-downloading unchanged boards. Per-tenant rate limits throttle
+board fetches via configurable intervals so individual tenants stay within API policies.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,11 @@ run();
 
 `fetchTextFromUrl` strips scripts, styles, navigation, header, footer, aside,
 and noscript content, preserves image alt text or `aria-label` values (while
-ignoring `aria-hidden` images or those with `role="presentation"`/`"none"`), and
-collapses whitespace to single spaces. Pass `timeoutMs` (milliseconds) to
+ignoring `aria-hidden` images—including boolean attributes without a value—or
+those with `role="presentation"`/`"none"`), and collapses whitespace to single
+spaces. Tests in [`test/fetch.test.js`](test/fetch.test.js) cover uppercase,
+numeric, and valueless `aria-hidden` attributes alongside role variants so
+regressions are caught early. Pass `timeoutMs` (milliseconds) to
 override the 10s default, and `headers` to send custom HTTP headers. Requests
 default to sending `User-Agent: jobbot3000`; provide a `User-Agent` header to
 override it. Responses
@@ -349,6 +352,15 @@ downstream tooling can diff revisions over time. Tests in
 pipelines fetch board content, persist structured snapshots, surface fetch
 errors, and retain the `User-Agent: jobbot3000` request header alongside each
 capture so fetches are reproducible.
+Per-tenant rate limits prevent hammering board APIs: set
+`JOBBOT_GREENHOUSE_RATE_LIMIT_MS`, `JOBBOT_LEVER_RATE_LIMIT_MS`,
+`JOBBOT_ASHBY_RATE_LIMIT_MS`, `JOBBOT_SMARTRECRUITERS_RATE_LIMIT_MS`, or
+`JOBBOT_WORKABLE_RATE_LIMIT_MS` to throttle repeat requests. Greenhouse caches
+the last fetch timestamp per board and seeds the limiter across CLI runs so
+back-to-back syncs stay compliant. New coverage in
+[`test/fetch.test.js`](test/fetch.test.js) exercises the limiter queue, and
+[`test/greenhouse.test.js`](test/greenhouse.test.js) verifies consecutive syncs
+defer the second fetch until the configured window elapses.
 [`test/lever.test.js`](test/lever.test.js) now explicitly asserts the Lever
 client forwards that header to the API and persists it in saved snapshots so
 metadata stays consistent across providers. Automated coverage in


### PR DESCRIPTION
## Summary
- add a reusable fetch queue rate limiter and expose helpers to configure per-host keys
- throttle each job board tenant via environment-configurable intervals and persist last fetch timestamps for greenhouse
- document the new knobs and extend the test suite for limiter behavior and greenhouse caching

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d0aa86f918832fb7a7d2000923aec1