### PR TITLE
feat: throttle ATS fetchers per tenant

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -103,8 +103,9 @@ Integrations: Greenhouse/Lever/Ashby/Workable/SmartRecruiters job board APIs, O*
 **Pluggable fetchers**  
 Each ATS = a module returning a normalized `JobPosting`. Backoff flows through `fetchWithRetry`, and
 the Greenhouse fetcher now persists `ETag`/`If-Modified-Since` validators so repeat syncs issue
-conditional requests instead of re-downloading unchanged boards. Per-tenant rate limits remain on
-the backlog.
+conditional requests instead of re-downloading unchanged boards. Per-tenant throttles cap each
+board/org/account at roughly four requests per second by default so tenants stay within vendor rate
+limits.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -348,7 +348,10 @@ downstream tooling can diff revisions over time. Tests in
 [`test/workable.test.js`](test/workable.test.js) verify the ingest
 pipelines fetch board content, persist structured snapshots, surface fetch
 errors, and retain the `User-Agent: jobbot3000` request header alongside each
-capture so fetches are reproducible.
+capture so fetches are reproducible. A shared rate limiter throttles each board/org/account to
+roughly four requests per second, spacing list/detail fetches to respect vendor budgets;
+[`test/fetch.test.js`](test/fetch.test.js) verifies sequential calls wait for the throttle window
+before dispatching.
 [`test/lever.test.js`](test/lever.test.js) now explicitly asserts the Lever
 client forwards that header to the API and persists it in saved snapshots so
 metadata stays consistent across providers. Automated coverage in

--- a/test/ashby.test.js
+++ b/test/ashby.test.js
@@ -57,7 +57,7 @@ describe('Ashby ingest', () => {
 
     const { ingestAshbyBoard } = await import('../src/ashby.js');
 
-    const result = await ingestAshbyBoard({ org: 'example' });
+    const result = await ingestAshbyBoard({ org: 'example', rateLimitIntervalMs: 0 });
 
     const expectedUrl =
       'https://jobs.ashbyhq.com/api/postings?organizationSlug=example' +
@@ -106,6 +106,8 @@ describe('Ashby ingest', () => {
 
     const { ingestAshbyBoard } = await import('../src/ashby.js');
 
-    await expect(ingestAshbyBoard({ org: 'missing' })).rejects.toThrow(/Failed to fetch Ashby org/);
+    await expect(
+      ingestAshbyBoard({ org: 'missing', rateLimitIntervalMs: 0 })
+    ).rejects.toThrow(/Failed to fetch Ashby org/);
   });
 });

--- a/test/greenhouse.test.js
+++ b/test/greenhouse.test.js
@@ -56,7 +56,7 @@ describe('Greenhouse ingest', () => {
 
     const { ingestGreenhouseBoard } = await import('../src/greenhouse.js');
 
-    const result = await ingestGreenhouseBoard({ board: 'example' });
+    const result = await ingestGreenhouseBoard({ board: 'example', rateLimitIntervalMs: 0 });
 
     expect(fetch).toHaveBeenCalledWith(
       'https://boards.greenhouse.io/v1/boards/example/jobs?content=true',
@@ -97,7 +97,9 @@ describe('Greenhouse ingest', () => {
 
     const { ingestGreenhouseBoard } = await import('../src/greenhouse.js');
 
-    await expect(ingestGreenhouseBoard({ board: 'missing' })).rejects.toThrow(
+    await expect(
+      ingestGreenhouseBoard({ board: 'missing', rateLimitIntervalMs: 0 })
+    ).rejects.toThrow(
       /Failed to fetch Greenhouse board/,
     );
   });
@@ -139,6 +141,7 @@ describe('Greenhouse ingest', () => {
     const result = await ingestGreenhouseBoard({
       board: 'example',
       retry: { retries: 1, delayMs: 0 },
+      rateLimitIntervalMs: 0,
     });
 
     expect(fetch).toHaveBeenCalledTimes(2);
@@ -164,7 +167,10 @@ describe('Greenhouse ingest', () => {
 
     const { ingestGreenhouseBoard } = await import('../src/greenhouse.js');
 
-    const cachedResult = await ingestGreenhouseBoard({ board: 'example' });
+    const cachedResult = await ingestGreenhouseBoard({
+      board: 'example',
+      rateLimitIntervalMs: 0,
+    });
     expect(cachedResult.notModified).toBe(false);
 
     const cachePath = path.join(dataDir, 'cache', 'greenhouse', 'example.json');
@@ -206,7 +212,10 @@ describe('Greenhouse ingest', () => {
 
     const { ingestGreenhouseBoard } = await import('../src/greenhouse.js');
 
-    const result = await ingestGreenhouseBoard({ board: 'example' });
+    const result = await ingestGreenhouseBoard({
+      board: 'example',
+      rateLimitIntervalMs: 0,
+    });
 
     expect(result).toMatchObject({ board: 'example', saved: 0, jobIds: [], notModified: true });
     const jobsDir = path.join(dataDir, JOBS_DIR);

--- a/test/lever.test.js
+++ b/test/lever.test.js
@@ -51,7 +51,7 @@ Requirements
 
     const { ingestLeverBoard } = await import('../src/lever.js');
 
-    const result = await ingestLeverBoard({ org: 'example' });
+    const result = await ingestLeverBoard({ org: 'example', rateLimitIntervalMs: 0 });
 
     expect(fetch).toHaveBeenCalledWith(
       'https://api.lever.co/v0/postings/example?mode=json',
@@ -86,7 +86,9 @@ Requirements
 
     const { ingestLeverBoard } = await import('../src/lever.js');
 
-    await expect(ingestLeverBoard({ org: 'missing' })).rejects.toThrow(
+    await expect(
+      ingestLeverBoard({ org: 'missing', rateLimitIntervalMs: 0 })
+    ).rejects.toThrow(
       /Failed to fetch Lever org/,
     );
   });

--- a/test/smartrecruiters.test.js
+++ b/test/smartrecruiters.test.js
@@ -77,7 +77,10 @@ describe('SmartRecruiters ingest', () => {
 
     const { ingestSmartRecruitersBoard } = await import('../src/smartrecruiters.js');
 
-    const result = await ingestSmartRecruitersBoard({ company: 'example' });
+    const result = await ingestSmartRecruitersBoard({
+      company: 'example',
+      rateLimitIntervalMs: 0,
+    });
 
     expect(fetch).toHaveBeenNthCalledWith(
       1,
@@ -128,7 +131,11 @@ describe('SmartRecruiters ingest', () => {
     const { ingestSmartRecruitersBoard } = await import('../src/smartrecruiters.js');
 
     await expect(
-      ingestSmartRecruitersBoard({ company: 'example', retry: { delayMs: 0 } })
+      ingestSmartRecruitersBoard({
+        company: 'example',
+        retry: { delayMs: 0 },
+        rateLimitIntervalMs: 0,
+      })
     ).rejects.toThrow(
       /Failed to fetch SmartRecruiters company example/,
     );

--- a/test/workable.test.js
+++ b/test/workable.test.js
@@ -70,7 +70,7 @@ describe('Workable ingest', () => {
 
     const { ingestWorkableBoard } = await import('../src/workable.js');
 
-    const result = await ingestWorkableBoard({ account: 'example' });
+    const result = await ingestWorkableBoard({ account: 'example', rateLimitIntervalMs: 0 });
 
     expect(fetch).toHaveBeenNthCalledWith(
       1,
@@ -127,7 +127,9 @@ describe('Workable ingest', () => {
 
     const { ingestWorkableBoard } = await import('../src/workable.js');
 
-    await expect(ingestWorkableBoard({ account: 'missing' })).rejects.toThrow(
+    await expect(
+      ingestWorkableBoard({ account: 'missing', rateLimitIntervalMs: 0 })
+    ).rejects.toThrow(
       /Failed to fetch Workable account/,
     );
   });
@@ -159,7 +161,11 @@ describe('Workable ingest', () => {
     const { ingestWorkableBoard } = await import('../src/workable.js');
 
     await expect(
-      ingestWorkableBoard({ account: 'example', retry: { delayMs: 0 } })
+      ingestWorkableBoard({
+        account: 'example',
+        retry: { delayMs: 0 },
+        rateLimitIntervalMs: 0,
+      })
     ).rejects.toThrow(
       /Failed to fetch Workable job/,
     );


### PR DESCRIPTION
## Summary
- add a shared per-tenant rate limiter to `fetchWithRetry` with a test reset helper
- wire default throttles through the Greenhouse, Lever, Ashby, SmartRecruiters, and Workable ingestors and let tests opt out
- document the new throttle behaviour and cover it with unit updates

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d0aa86f918832fb7a7d2000923aec1