### PR TITLE
Add skip tracking for intake prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,11 +493,28 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot intake list
 #   Asked At: 2025-02-01T12:34:56.000Z
 #   Recorded At: 2025-02-01T12:40:00.000Z
 #   ID: 123e4567-e89b-12d3-a456-426614174000
+
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot intake record \
+  --question "Which benefits matter most?" \
+  --skip \
+  --notes "Circle back after research"
+# Recorded intake response 987e6543-e21b-45d3-a456-426614174001
+
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot intake list --json | jq '.responses[1]'
+# {
+#   "question": "Which benefits matter most?",
+#   "answer": "",
+#   "status": "skipped",
+#   "notes": "Circle back after research",
+#   "asked_at": "2025-02-01T12:40:00.000Z",
+#   "recorded_at": "2025-02-01T12:40:00.000Z",
+#   "id": "987e6543-e21b-45d3-a456-426614174001"
+# }
 ```
 
-Entries are appended to `data/profile/intake.json` with normalized timestamps, optional tags, and
-notes so follow-up planning can reference prior answers. Recorded timestamps reflect when the
-command runs. Automated coverage in
+Entries are appended to `data/profile/intake.json` with normalized timestamps, optional tags, notes,
+and a `status` field so follow-up planning can reference prior answers and revisit skipped prompts.
+Recorded timestamps reflect when the command runs. Automated coverage in
 [`test/intake.test.js`](test/intake.test.js) and [`test/cli.test.js`](test/cli.test.js) verifies the
 stored shape and CLI workflows.
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -35,8 +35,9 @@ with retry options and explain how to manually fix the source file.
 2. The user answers via chat or a structured form. The assistant keeps asking follow-ups until it
    reaches a configured confidence threshold.
 3. Responses are appended to the profile as structured notes (`data/profile/intake.json`) via
-   `jobbot intake record`, and the model synthesizes updated bullet point options tagged by skill or
-   competency.
+   `jobbot intake record`. When a candidate postpones a prompt, `jobbot intake record --skip` marks
+   it for follow-up while preserving tags/notes so the model can circle back. The assistant
+   synthesizes updated bullet point options tagged by skill or competency.
 4. All interactions are stored locally with timestamps and provenance metadata for later review.
 
 **Unhappy paths:** the user can skip or postpone questions. Skips are marked so the assistant can

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -627,6 +627,40 @@ describe('jobbot CLI', () => {
       tags: ['growth', 'mission'],
       notes: 'Prefers collaborative teams',
       asked_at: '2025-02-01T12:34:56.000Z',
+      status: 'answered',
+    });
+  });
+
+  it('records skipped intake prompts for later follow-up', () => {
+    const output = runCli([
+      'intake',
+      'record',
+      '--question',
+      'Which benefits matter most?',
+      '--skip',
+      '--tags',
+      'benefits',
+      '--notes',
+      'Circle back after research',
+      '--asked-at',
+      '2025-02-02T08:00:00Z',
+    ]);
+    expect(output.trim()).toMatch(/^Recorded intake response /);
+
+    const list = runCli(['intake', 'list']);
+    expect(list).toContain('Which benefits matter most?');
+    expect(list).toContain('Status: Skipped');
+    expect(list).toContain('Answer: (skipped)');
+    expect(list).toContain('Tags: benefits');
+
+    const asJson = JSON.parse(runCli(['intake', 'list', '--json']));
+    expect(asJson.responses).toHaveLength(1);
+    expect(asJson.responses[0]).toMatchObject({
+      question: 'Which benefits matter most?',
+      status: 'skipped',
+      answer: '',
+      notes: 'Circle back after research',
+      tags: ['benefits'],
     });
   });
 

--- a/test/intake.test.js
+++ b/test/intake.test.js
@@ -46,6 +46,7 @@ describe('intake responses', () => {
       asked_at: '2025-02-01T12:00:00.000Z',
       tags: ['Growth', 'career'],
       notes: 'Prefers mission-driven teams',
+      status: 'answered',
     });
     expect(entry.recorded_at).toEqual(new Date(entry.recorded_at).toISOString());
     expect(typeof entry.id).toBe('string');
@@ -61,6 +62,7 @@ describe('intake responses', () => {
       asked_at: '2025-02-01T12:00:00.000Z',
       tags: ['Growth', 'career'],
       notes: 'Prefers mission-driven teams',
+      status: 'answered',
     });
   });
 
@@ -88,5 +90,33 @@ describe('intake responses', () => {
     entries[0].question = 'mutated';
     const reread = await getIntakeResponses();
     expect(reread[0].question).toBe('First');
+  });
+
+  it('records skipped prompts for future follow-up', async () => {
+    const { recordIntakeResponse, getIntakeResponses } = await import('../src/intake.js');
+
+    const entry = await recordIntakeResponse({
+      question: 'Which benefits matter most to you?',
+      skipped: true,
+      notes: 'Revisit after comparing offers',
+      tags: ['benefits'],
+      askedAt: '2025-02-02T08:00:00Z',
+    });
+
+    expect(entry.question).toBe('Which benefits matter most to you?');
+    expect(entry.status).toBe('skipped');
+    expect(entry.answer).toBe('');
+    expect(entry.notes).toBe('Revisit after comparing offers');
+    expect(entry.tags).toEqual(['benefits']);
+
+    const responses = await getIntakeResponses();
+    expect(responses).toHaveLength(1);
+    expect(responses[0]).toMatchObject({
+      question: 'Which benefits matter most to you?',
+      status: 'skipped',
+      answer: '',
+      notes: 'Revisit after comparing offers',
+      asked_at: '2025-02-02T08:00:00.000Z',
+    });
   });
 });


### PR DESCRIPTION
## Summary
- scanned docs for open work; Journey 2 Step 3 required `--skip`, which
  was ready to ship alongside existing intake storage
- persist intake status, allow skipped prompts without answers, and show
  "Status: Skipped" in CLI/list output and JSON
- document the skip flag plus status field so Journey 2 matches the CLI,
  and describe the new tests that gate the workflow

## Testing
- npm run lint
- npm run test:ci

## Test Matrix
- intake persistence: answered vs skipped status
- CLI intake record/list: text output, JSON output when skipping prompts


------
https://chatgpt.com/codex/tasks/task_e_68d0b3e46374832fa138eba87752e22f