### PR TITLE
Add ATS warnings to resume metadata

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -273,7 +273,7 @@ jobbot track add <job_id> --status applied --note "emailed hiring manager"
 **Phase 3 — Tailoring & rendering (1 week)**
 - Templating (choose Typst or LaTeX first; Tectonic/Typst CLI).
 - One-page constraint, dynamic bullet swapping.
-- ATS plain text preview + warnings (tables/images detection).
+- ATS plain text preview + warnings (tables/images detection). (shipped)
 - Cover letter template + slot-fill with job-specific context.
 
 **Phase 4 — Interview rehearsal (1 week)**

--- a/README.md
+++ b/README.md
@@ -150,12 +150,20 @@ console.log(metadata);
 //   bytes: 2312,
 //   characters: 1980,
 //   lineCount: 62,
-//   wordCount: 340
+//   wordCount: 340,
+//   warnings: [
+//     {
+//       type: 'tables',
+//       message: 'Detected table formatting; ATS parsers often ignore table content.'
+//     }
+//   ]
 // }
 ```
 
 `test/resume.test.js` exercises the metadata branch so downstream callers can
-depend on the shape.
+depend on the shape. When tables or images appear in the source material, the
+metadata includes `warnings` entries that flag ATS-hostile patterns; new tests
+assert tables and images trigger the warnings so resume imports surface risks.
 
 Initialize a JSON Resume skeleton when you do not have an existing file:
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -19,8 +19,8 @@ jobbot3000.
 3. Parsed content is normalized into the JSON Resume schema and saved under `data/profile/`, a
    git-ignored directory so personal data never leaves the machine.
 4. The system surfaces parsing confidence scores, highlights ambiguities (dates, titles, metrics),
-   and prompts the user to confirm or edit the imported fields before they become the source of
-   truth.
+   flags ATS warnings for tables or embedded images, and prompts the user to confirm or edit the
+   imported fields before they become the source of truth.
 
 **Unhappy paths:** unsupported format, unreadable PDF, or missing sections trigger inline guidance
 with retry options and explain how to manually fix the source file.

--- a/src/resume.js
+++ b/src/resume.js
@@ -2,46 +2,8 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import removeMarkdown from 'remove-markdown';
 
-/**
- * File-type specific loaders. Each handler reads and returns plain text content.
- * Handlers may perform additional parsing based on the extension.
- *
- * @type {Record<string, (filePath: string) => Promise<string>>}
- */
-async function loadMarkdown(filePath) {
-  const raw = await fs.readFile(filePath, 'utf-8');
-  return removeMarkdown(raw).trim();
-}
-
 const MARKDOWN_EXTENSIONS = ['.md', '.markdown', '.mdx'];
 
-const LOADERS = {
-  async '.pdf'(filePath) {
-    const buffer = await fs.readFile(filePath);
-    // Lazy import to reduce startup overhead and make optional
-    const { default: pdf } = await import('pdf-parse');
-    const data = await pdf(buffer);
-    return (data.text || '').trim();
-  },
-};
-
-for (const ext of MARKDOWN_EXTENSIONS) LOADERS[ext] = loadMarkdown;
-
-/**
- * Load a resume file and return its plain text content.
- * Supports `.pdf`, `.md`, `.markdown`, and `.mdx` formats; other files are read as plain text.
- *
- * @param {string} filePath
- * @param {{ withMetadata?: boolean }} [options]
- * @returns {Promise<string | { text: string, metadata: {
- *   extension: string,
- *   format: 'pdf' | 'markdown' | 'text',
- *   bytes: number,
- *   characters: number,
- *   lineCount: number,
- *   wordCount: number,
- * } }>}
- */
 function detectFormat(extension) {
   if (MARKDOWN_EXTENSIONS.includes(extension)) return 'markdown';
   if (extension === '.pdf') return 'pdf';
@@ -59,15 +21,124 @@ function countLines(text) {
   return text.split(/\r?\n/).length;
 }
 
+function containsMarkdownTable(raw) {
+  if (typeof raw !== 'string' || raw.indexOf('|') === -1) return false;
+  const lines = raw.split(/\r?\n/);
+  for (let i = 0; i < lines.length - 1; i += 1) {
+    const line = lines[i];
+    const next = lines[i + 1];
+    if (!line.includes('|') || !next.includes('|')) continue;
+    const cellCount = line.split('|').filter(part => part.trim() !== '').length;
+    if (cellCount < 2) continue;
+    if (/\|?\s*:?-{3,}:?\s*(?:\||$)/.test(next)) {
+      return true;
+    }
+    const nextCellCount = next.split('|').filter(part => part.trim() !== '').length;
+    if (nextCellCount >= 2 && /\s{2,}/.test(line) === false && /\s{2,}/.test(next) === false) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function containsPipeTable(raw) {
+  if (typeof raw !== 'string' || raw.indexOf('|') === -1) return false;
+  const lines = raw.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const cells = trimmed.split('|').filter(Boolean);
+    if (cells.length >= 3) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function containsHtmlTable(raw) {
+  if (typeof raw !== 'string') return false;
+  return /<\s*table\b/i.test(raw);
+}
+
+function containsMarkdownImage(raw) {
+  if (typeof raw !== 'string') return false;
+  return /!\[[^\]]*\]\([^)]+\)/.test(raw);
+}
+
+function containsHtmlImage(raw) {
+  if (typeof raw !== 'string') return false;
+  return /<\s*img\b/i.test(raw);
+}
+
+function detectAtsWarnings(raw, format) {
+  if (typeof raw !== 'string' || !raw.trim()) return [];
+  const warnings = [];
+
+  let tablesDetected = containsHtmlTable(raw);
+  if (!tablesDetected) {
+    if (format === 'markdown') tablesDetected = containsMarkdownTable(raw);
+    else tablesDetected = containsPipeTable(raw);
+  }
+
+  if (tablesDetected) {
+    warnings.push({
+      type: 'tables',
+      message: 'Detected table formatting; ATS parsers often ignore table content.',
+    });
+  }
+
+  let imagesDetected = containsHtmlImage(raw);
+  if (!imagesDetected && format === 'markdown') {
+    imagesDetected = containsMarkdownImage(raw);
+  }
+
+  if (imagesDetected) {
+    warnings.push({
+      type: 'images',
+      message: 'Detected embedded images; ATS scanners may drop graphics entirely.',
+    });
+  }
+
+  return warnings;
+}
+
+async function readRawContent(filePath, format) {
+  if (format === 'pdf') {
+    const buffer = await fs.readFile(filePath);
+    const { default: pdf } = await import('pdf-parse');
+    const data = await pdf(buffer);
+    return typeof data.text === 'string' ? data.text : '';
+  }
+  return fs.readFile(filePath, 'utf-8');
+}
+
+function toPlainText(raw, format) {
+  if (typeof raw !== 'string') return '';
+  const content = format === 'markdown' ? removeMarkdown(raw) : raw;
+  return content.trim();
+}
+
+/**
+ * Load a resume file and return its plain text content.
+ * Supports `.pdf`, `.md`, `.markdown`, and `.mdx` formats; other files are read as plain text.
+ *
+ * @param {string} filePath
+ * @param {{ withMetadata?: boolean }} [options]
+ * @returns {Promise<string | { text: string, metadata: {
+ *   extension: string,
+ *   format: 'pdf' | 'markdown' | 'text',
+ *   bytes: number,
+ *   characters: number,
+ *   lineCount: number,
+ *   wordCount: number,
+ *   warnings?: Array<{ type: string, message: string }>,
+ * } }>}
+ */
 export async function loadResume(filePath, options = {}) {
   const extension = path.extname(filePath).toLowerCase();
-  const loader = LOADERS[extension];
-  let text;
-  if (loader) text = await loader(filePath);
-  else {
-    const raw = await fs.readFile(filePath, 'utf-8');
-    text = raw.trim();
-  }
+  const format = detectFormat(extension);
+  const raw = await readRawContent(filePath, format);
+  const text = toPlainText(raw, format);
 
   if (!options.withMetadata) {
     return text;
@@ -76,12 +147,17 @@ export async function loadResume(filePath, options = {}) {
   const stats = await fs.stat(filePath);
   const metadata = {
     extension: extension || '',
-    format: detectFormat(extension),
+    format,
     bytes: stats.size,
     characters: text.length,
     lineCount: countLines(text),
     wordCount: countWords(text),
   };
+
+  const warnings = detectAtsWarnings(raw, format);
+  if (warnings.length > 0) {
+    metadata.warnings = warnings;
+  }
 
   return { text, metadata };
 }

--- a/test/resume.test.js
+++ b/test/resume.test.js
@@ -78,4 +78,33 @@ describe('loadResume', () => {
       }),
     });
   });
+
+  it('flags ATS warning signals when tables or images are present', async () => {
+    const content = [
+      '# Title',
+      '',
+      '| Skill | Years |',
+      '| ----- | ----- |',
+      '| JS    | 10    |',
+      '',
+      '![Diagram](diagram.png)',
+    ].join('\n');
+
+    const result = await withTempFile('.md', content, file =>
+      loadResume(file, { withMetadata: true })
+    );
+
+    expect(result.metadata.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'tables',
+          message: expect.stringContaining('table'),
+        }),
+        expect.objectContaining({
+          type: 'images',
+          message: expect.stringContaining('image'),
+        }),
+      ])
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- mark the Phase 3 ATS preview roadmap item as shipped and document the new resume warnings in the README and user journey
- enhance `loadResume` metadata to surface ATS table/image warnings and extend tests to cover the detection logic

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d0b3e46374832fa138eba87752e22f