### PR TITLE
✨ : surface legacy shortlist discards without timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,12 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --json
 #           "discarded_at": "2025-03-05T12:00:00.000Z",
 #           "tags": ["Remote", "onsite"]
 #         }
-#       ]
+#       ],
+#       "last_discard": {
+#         "reason": "Not remote",
+#         "discarded_at": "2025-03-05T12:00:00.000Z",
+#         "tags": ["Remote", "onsite"]
+#       }
 #     }
 #   }
 # }
@@ -457,10 +462,14 @@ The CLI stores shortlist labels, discard history, and sync metadata in `data/sho
 reasons, timestamps, optional tags, and location/level/compensation fields so recommendations can
 surface patterns later. Review past decisions with `jobbot shortlist archive [job_id]` (add `--json`
 to inspect all records at once), which reads from `data/discarded_jobs.json` so archive lookups and
-shortlist history stay in sync. Add `--json` to the shortlist list command when piping entries into
-other tools, and filter by metadata or tags (`--location`, `--level`, `--compensation`, or repeated
-`--tag` flags) when triaging opportunities. Text output also surfaces `Last Discard Tags` when tag
-history exists so the rationale stays visible without opening the archive. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for
+shortlist history stay in sync. JSON exports now include a `last_discard` summary so downstream tools
+can surface the most recent rationale without traversing the full history. Add `--json` to the
+shortlist list command when piping entries into other tools, and filter by metadata or tags
+(`--location`, `--level`, `--compensation`, or repeated `--tag` flags) when triaging opportunities.
+Text output also surfaces `Last Discard Tags` when tag
+history exists so the rationale stays visible without opening the archive. When older history entries
+lack timestamps, the CLI labels them as `(unknown time)` so legacy discards still surface their
+rationale. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for
 refresh schedulers. Shells treat `$` as a variable prefix, so `--compensation "$185k"` expands to
 `85k`. The CLI re-attaches a default currency symbol so the stored value becomes `$85k`; escape the
 dollar sign (`--compensation "\$185k"`) when you need the digits preserved. Override the auto-attached

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -645,16 +645,14 @@ function formatShortlistList(jobs) {
     if (metadata.compensation) lines.push(`  Compensation: ${metadata.compensation}`);
     if (metadata.synced_at) lines.push(`  Synced At: ${metadata.synced_at}`);
     if (tags.length) lines.push(`  Tags: ${tags.join(', ')}`);
-    if (discarded.length) {
-      const latest = discarded[discarded.length - 1];
-      if (latest?.reason && latest?.discarded_at) {
-        lines.push(`  Last Discard: ${latest.reason} (${latest.discarded_at})`);
-        const lastTags = Array.isArray(latest.tags)
-          ? latest.tags.map(tag => String(tag).trim()).filter(Boolean)
-          : [];
-        if (lastTags.length > 0) {
-          lines.push(`  Last Discard Tags: ${lastTags.join(', ')}`);
-        }
+    const normalizedDiscard = normalizeDiscardEntries(discarded);
+    if (normalizedDiscard.length > 0) {
+      const latest = normalizedDiscard[normalizedDiscard.length - 1];
+      const reason = latest.reason || 'Unknown reason';
+      const timestamp = latest.discarded_at || 'unknown time';
+      lines.push(`  Last Discard: ${reason} (${timestamp})`);
+      if (latest.tags && latest.tags.length > 0) {
+        lines.push(`  Last Discard Tags: ${latest.tags.join(', ')}`);
       }
     }
     lines.push('');

--- a/test/shortlist.test.js
+++ b/test/shortlist.test.js
@@ -155,4 +155,32 @@ describe('shortlist metadata sync and filters', () => {
       delete process.env.JOBBOT_SHORTLIST_CURRENCY;
     }
   });
+
+  it('exposes the latest discard summary alongside shortlist entries', async () => {
+    const { discardJob, getShortlist, filterShortlist } = await import('../src/shortlist.js');
+
+    await discardJob('job-history', 'Not remote', {
+      tags: ['Remote', 'onsite'],
+      date: '2025-03-05T12:00:00Z',
+    });
+
+    await discardJob('job-history', 'Focus changed', {
+      tags: ['Focus', 'focus', ' remote '],
+      date: '2025-03-07T09:30:00Z',
+    });
+
+    const snapshot = await getShortlist('job-history');
+    expect(snapshot.last_discard).toEqual({
+      reason: 'Focus changed',
+      discarded_at: '2025-03-07T09:30:00.000Z',
+      tags: ['Focus', 'remote'],
+    });
+
+    const filtered = await filterShortlist();
+    expect(filtered.jobs['job-history'].last_discard).toEqual({
+      reason: 'Focus changed',
+      discarded_at: '2025-03-07T09:30:00.000Z',
+      tags: ['Focus', 'remote'],
+    });
+  });
 });


### PR DESCRIPTION
what: show shortlist last discard details when legacy entries omit timestamps and
      document the `(unknown time)` fallback.
why: README promises text output surfaces discard rationale even for history
     entries with tags, but missing timestamps hid that context.
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d0b3e46374832fa138eba87752e22f