### PR TITLE
Add resume ambiguity heuristics to metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ console.log(metadata);
 //   characters: 1980,
 //   lineCount: 62,
 //   wordCount: 340,
+//   confidence: 0.9,
+//   ambiguities: [
+//     {
+//       type: 'metrics',
+//       message: 'No numeric metrics detected; consider adding quantified achievements.'
+//     }
+//   ],
 //   warnings: [
 //     {
 //       type: 'tables',
@@ -164,6 +171,9 @@ console.log(metadata);
 depend on the shape. When tables or images appear in the source material, the
 metadata includes `warnings` entries that flag ATS-hostile patterns; new tests
 assert tables and images trigger the warnings so resume imports surface risks.
+Ambiguity heuristics now emit `ambiguities` entries when month ranges omit years,
+job titles are missing, or quantified metrics are absent, and the `confidence`
+score reflects those signals so review tools can triage follow-up work.
 
 Initialize a JSON Resume skeleton when you do not have an existing file:
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -20,7 +20,9 @@ jobbot3000.
    git-ignored directory so personal data never leaves the machine.
 4. The system surfaces parsing confidence scores, highlights ambiguities (dates, titles, metrics),
    flags ATS warnings for tables or embedded images, and prompts the user to confirm or edit the
-   imported fields before they become the source of truth.
+   imported fields before they become the source of truth. Ambiguity heuristics catch month ranges
+   without four-digit years, resumes lacking recognizable titles, and profiles with no numeric
+   metrics so candidates can fill the gaps.
 
 **Unhappy paths:** unsupported format, unreadable PDF, or missing sections trigger inline guidance
 with retry options and explain how to manually fix the source file.

--- a/src/resume.js
+++ b/src/resume.js
@@ -70,6 +70,85 @@ function containsHtmlImage(raw) {
   return /<\s*img\b/i.test(raw);
 }
 
+const MONTH_PATTERN_PARTS = [
+  'jan(?:uary)?',
+  'feb(?:ruary)?',
+  'mar(?:ch)?',
+  'apr(?:il)?',
+  'may',
+  'jun(?:e)?',
+  'jul(?:y)?',
+  'aug(?:ust)?',
+  'sep(?:tember)?',
+  'oct(?:ober)?',
+  'nov(?:ember)?',
+  'dec(?:ember)?',
+];
+const MONTH_NAME_RE = new RegExp(`\\b(?:${MONTH_PATTERN_PARTS.join('|')})\\b`, 'i');
+const YEAR_RE = /\b(19|20)\d{2}\b/;
+const DIGIT_RE = /\d/;
+const TITLE_KEYWORDS = [
+  'engineer',
+  'developer',
+  'manager',
+  'designer',
+  'consultant',
+  'analyst',
+  'director',
+  'specialist',
+  'architect',
+  'scientist',
+  'lead',
+];
+
+function detectAmbiguities(raw) {
+  if (typeof raw !== 'string' || !raw.trim()) return [];
+
+  const ambiguities = [];
+  const lines = raw.split(/\r?\n/);
+  for (const line of lines) {
+    if (!MONTH_NAME_RE.test(line)) continue;
+    if (YEAR_RE.test(line)) continue;
+    ambiguities.push({
+      type: 'dates',
+      message: 'Detected month references without four-digit years; confirm date ranges are clear.',
+    });
+    break;
+  }
+
+  if (!DIGIT_RE.test(raw)) {
+    ambiguities.push({
+      type: 'metrics',
+      message: 'No numeric metrics detected; consider adding quantified achievements.',
+    });
+  }
+
+  let hasTitleKeyword = false;
+  for (const keyword of TITLE_KEYWORDS) {
+    const pattern = new RegExp(`\\b${keyword}\\b`, 'i');
+    if (pattern.test(raw)) {
+      hasTitleKeyword = true;
+      break;
+    }
+  }
+  if (!hasTitleKeyword) {
+    ambiguities.push({
+      type: 'titles',
+      message: 'No common role titles detected; ensure positions are clearly labeled.',
+    });
+  }
+
+  return ambiguities;
+}
+
+function computeConfidenceScore(warnings, ambiguities) {
+  const warningCount = Array.isArray(warnings) ? warnings.length : 0;
+  const ambiguityCount = Array.isArray(ambiguities) ? ambiguities.length : 0;
+  const penalty = warningCount * 0.15 + ambiguityCount * 0.1;
+  const score = Math.max(0.3, Math.min(1, 1 - penalty));
+  return Math.round(score * 100) / 100;
+}
+
 function detectAtsWarnings(raw, format) {
   if (typeof raw !== 'string' || !raw.trim()) return [];
   const warnings = [];
@@ -155,9 +234,16 @@ export async function loadResume(filePath, options = {}) {
   };
 
   const warnings = detectAtsWarnings(raw, format);
+  const ambiguities = detectAmbiguities(raw);
+  const confidence = computeConfidenceScore(warnings, ambiguities);
+
   if (warnings.length > 0) {
     metadata.warnings = warnings;
   }
+  if (ambiguities.length > 0) {
+    metadata.ambiguities = ambiguities;
+  }
+  metadata.confidence = confidence;
 
   return { text, metadata };
 }

--- a/test/resume.test.js
+++ b/test/resume.test.js
@@ -107,4 +107,41 @@ describe('loadResume', () => {
       ])
     );
   });
+
+  it('annotates metadata with ambiguities and confidence heuristics', async () => {
+    const content = [
+      '# Summary',
+      '',
+      'Jan - Present',
+      'Leading strategic initiatives across teams.',
+      '',
+      '| Skill | Level |',
+      '| ----- | ----- |',
+      '| Collaboration | High |',
+      '',
+      '![Workflow](workflow.png)',
+    ].join('\n');
+
+    const result = await withTempFile('.md', content, file =>
+      loadResume(file, { withMetadata: true })
+    );
+
+    expect(result.metadata.ambiguities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'dates',
+          message: expect.stringContaining('date'),
+        }),
+        expect.objectContaining({
+          type: 'metrics',
+          message: expect.stringContaining('numeric'),
+        }),
+        expect.objectContaining({
+          type: 'titles',
+          message: expect.stringContaining('titles'),
+        }),
+      ])
+    );
+    expect(result.metadata.confidence).toBeCloseTo(0.4, 5);
+  });
 });


### PR DESCRIPTION
## Summary
- add resume ambiguity heuristics for dates, titles, and metrics alongside a confidence score
- extend resume metadata tests to cover ambiguity detection and confidence values
- document the new metadata fields and heuristics in the README and Journey 1 flow

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d0bd51f74c832fa7066d75ea12b1f7