### PR TITLE
Add shortlist JSON export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,6 +460,10 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --json
 #   }
 # }
 
+# Persist the filtered shortlist to disk for sharing
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --json --out shortlist.json
+# Saved shortlist snapshot to /tmp/jobbot-cli-XXXX/shortlist.json
+
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist archive job-123
 # job-123
 # - 2025-03-05T12:00:00.000Z — Not remote
@@ -472,9 +476,9 @@ surface patterns later. Review past decisions with `jobbot shortlist archive [jo
 to inspect all records at once), which reads from `data/discarded_jobs.json` so archive lookups and
 shortlist history stay in sync. JSON exports now include a `last_discard` summary so downstream tools
 can surface the most recent rationale without traversing the full history. Add `--json` to the
-shortlist list command when piping entries into other tools, and filter by metadata or tags
-(`--location`, `--level`, `--compensation`, or repeated `--tag` flags) when triaging opportunities.
-Text output also surfaces `Last Discard Tags` when tag
+shortlist list command when piping entries into other tools; include `--out <path>` to persist the
+snapshot on disk. Filter by metadata or tags (`--location`, `--level`, `--compensation`, or repeated
+`--tag` flags) when triaging opportunities. Text output also surfaces `Last Discard Tags` when tag
 history exists so the rationale stays visible without opening the archive. When older history entries
 lack timestamps, the CLI labels them as `(unknown time)` so legacy discards still surface their
 rationale. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -394,7 +394,7 @@ function collectTagFilters(args) {
     if (!value || value.startsWith('--')) {
       console.error(
         'Usage: jobbot shortlist list [--location <value>] [--level <value>] ' +
-          '[--compensation <value>] [--tag <value>] [--json]'
+          '[--compensation <value>] [--tag <value>] [--json] [--out <path>]'
       );
       process.exit(2);
     }
@@ -754,7 +754,23 @@ function formatDiscardArchive(archive) {
 
 async function cmdShortlistList(args) {
   const asJson = args.includes('--json');
-  const filteredArgs = asJson ? args.filter(arg => arg !== '--json') : args;
+  const outPath = getFlag(args, '--out');
+  const filteredArgs = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === '--json') continue;
+    if (arg === '--out') {
+      i += 1;
+      continue;
+    }
+    filteredArgs.push(arg);
+  }
+
+  if (outPath && !asJson) {
+    console.error('--out is only supported with --json');
+    process.exit(2);
+  }
+
   const filters = {
     location: getFlag(filteredArgs, '--location'),
     level: getFlag(filteredArgs, '--level'),
@@ -765,7 +781,15 @@ async function cmdShortlistList(args) {
 
   const store = await filterShortlist(filters);
   if (asJson) {
-    console.log(JSON.stringify({ jobs: store.jobs }, null, 2));
+    const payload = { jobs: store.jobs };
+    if (outPath) {
+      const resolved = path.resolve(process.cwd(), outPath);
+      await fs.promises.mkdir(path.dirname(resolved), { recursive: true });
+      await fs.promises.writeFile(resolved, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+      console.log(`Saved shortlist snapshot to ${resolved}`);
+    } else {
+      console.log(JSON.stringify(payload, null, 2));
+    }
     return;
   }
   console.log(formatShortlistList(store.jobs));

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -65,8 +65,8 @@ revisit them later without blocking the workflow.
 4. The shortlist view exposes filters (location, level, compensation, tags) via
    `jobbot shortlist list --location <value>` (and repeated `--tag <value>` flags)
    and records sync metadata with `jobbot shortlist sync` so future refreshes know
-   when entries were last updated. Add `--json` when exporting the filtered shortlist
-   to other tools.
+   when entries were last updated. Add `--json` (and optionally
+   `--out <path>`) when exporting the filtered shortlist to other tools.
 
 **Unhappy paths:** fetch failures or ToS blocks surface actionable error messages and never retry
 aggressively to respect rate limits.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -787,6 +787,52 @@ describe('jobbot CLI', () => {
     });
   });
 
+  it('writes shortlist JSON snapshots to disk with --out', () => {
+    runCli([
+      'shortlist',
+      'sync',
+      'job-export',
+      '--location',
+      'Remote',
+      '--level',
+      'Staff',
+    ]);
+
+    runCli([
+      'shortlist',
+      'discard',
+      'job-export',
+      '--reason',
+      'Deprioritized',
+      '--date',
+      '2025-03-05T12:00:00Z',
+    ]);
+
+    const outPath = path.join(dataDir, 'exports', 'shortlist.json');
+    const output = runCli([
+      'shortlist',
+      'list',
+      '--json',
+      '--out',
+      outPath,
+    ]);
+
+    expect(output.trim()).toBe(`Saved shortlist snapshot to ${outPath}`);
+
+    const snapshot = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+    expect(snapshot.jobs).toHaveProperty('job-export');
+    expect(snapshot.jobs['job-export']).toMatchObject({
+      metadata: {
+        location: 'Remote',
+        level: 'Staff',
+      },
+      last_discard: {
+        reason: 'Deprioritized',
+        discarded_at: '2025-03-05T12:00:00.000Z',
+      },
+    });
+  });
+
   it('syncs shortlist metadata and filters entries by location', () => {
     const syncOutput = runCli([
       'shortlist',


### PR DESCRIPTION
## Summary
- allow `jobbot shortlist list` to accept `--out <path>` when combined with `--json`
- write JSON snapshots to disk and surface a CLI confirmation message
- document the export workflow and cover it with a new CLI regression test

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d0bd51f74c832fa7066d75ea12b1f7