### PR TITLE
Normalize discard archive reads and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,9 +475,9 @@ can surface the most recent rationale without traversing the full history. Add `
 shortlist list command when piping entries into other tools, and filter by metadata or tags
 (`--location`, `--level`, `--compensation`, or repeated `--tag` flags) when triaging opportunities.
 Text output also surfaces `Last Discard Tags` when tag
-history exists so the rationale stays visible without opening the archive. When older history entries
-lack timestamps, the CLI labels them as `(unknown time)` so legacy discards still surface their
-rationale. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for
+history exists so the rationale stays visible without opening the archive. The archive reader trims
+messy history entries, sorts them chronologically, and fills missing timestamps with `unknown time`
+so legacy discards still surface their rationale. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for
 refresh schedulers. Shells treat `$` as a variable prefix, so `--compensation "$185k"` expands to
 `85k`. The CLI re-attaches a default currency symbol so the stored value becomes `$85k`; escape the
 dollar sign (`--compensation "\$185k"`) when you need the digits preserved. Override the auto-attached

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -526,20 +526,20 @@ describe('jobbot CLI', () => {
       'discard',
       'job-1',
       '--reason',
-      'Not remote',
-      '--tags',
-      'remote,onsite',
+      'Changed priorities',
       '--date',
-      '2025-03-05T12:00:00Z',
+      '2025-03-08T09:30:00Z',
     ]);
     runCli([
       'shortlist',
       'discard',
       'job-1',
       '--reason',
-      'Changed priorities',
+      'Not remote',
+      '--tags',
+      'remote,onsite',
       '--date',
-      '2025-03-08T09:30:00Z',
+      '2025-03-05T12:00:00Z',
     ]);
     runCli([
       'shortlist',
@@ -559,15 +559,27 @@ describe('jobbot CLI', () => {
     expect(archiveText).toContain('Tags: remote, onsite');
     expect(archiveText).toContain('job-2');
     expect(archiveText).toContain('2025-04-01T14:45:00.000Z — Compensation mismatch');
+    expect(
+      archiveText.indexOf('2025-03-05T12:00:00.000Z — Not remote') <
+        archiveText.indexOf('2025-03-08T09:30:00.000Z — Changed priorities')
+    ).toBe(true);
 
     const singleJob = runCli(['shortlist', 'archive', 'job-1']);
     expect(singleJob).toContain('job-1');
     expect(singleJob).toContain('2025-03-08T09:30:00.000Z — Changed priorities');
     expect(singleJob).not.toContain('job-2');
+    expect(
+      singleJob.indexOf('2025-03-05T12:00:00.000Z — Not remote') <
+        singleJob.indexOf('2025-03-08T09:30:00.000Z — Changed priorities')
+    ).toBe(true);
 
     const asJson = JSON.parse(runCli(['shortlist', 'archive', '--json']));
     expect(Object.keys(asJson.discarded)).toContain('job-1');
     expect(asJson.discarded['job-1']).toHaveLength(2);
+    expect(asJson.discarded['job-1'][0]).toMatchObject({
+      reason: 'Not remote',
+      discarded_at: '2025-03-05T12:00:00.000Z',
+    });
     expect(asJson.discarded['job-2'][0]).toMatchObject({
       reason: 'Compensation mismatch',
       discarded_at: '2025-04-01T14:45:00.000Z',
@@ -584,6 +596,12 @@ describe('jobbot CLI', () => {
           tags: ['compensation'],
         },
       ],
+    });
+
+    const job1Json = JSON.parse(runCli(['shortlist', 'archive', 'job-1', '--json']));
+    expect(job1Json.history[0]).toMatchObject({
+      reason: 'Not remote',
+      discarded_at: '2025-03-05T12:00:00.000Z',
     });
   });
 


### PR DESCRIPTION
## Summary
- inventoried outstanding discard archive normalization TODOs and finished the actionable test/doc work
- ensured CLI archive output relies on shared normalization helpers with sorted history
- expanded discard unit and CLI coverage for messy archive data and documented the normalized behavior

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d0bd51f74c832fa7066d75ea12b1f7