### PR TITLE
✅ : – Stabilize resume placeholder detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ console.log(metadata);
 //       type: 'tables',
 //       message: 'Detected table formatting; ATS parsers often ignore table content.'
 //     }
+//   ],
+//   confidence: {
+//     score: 0.82,
+//     signals: [
+//       'Detected common resume headings: experience, education',
+//       'Detected bullet formatting in experience sections'
+//     ]
+//   },
+//   ambiguities: [
+//     {
+//       type: 'date',
+//       value: '20XX',
+//       message: 'Potential placeholder date detected'
+//     }
 //   ]
 // }
 ```
@@ -164,6 +178,10 @@ console.log(metadata);
 depend on the shape. When tables or images appear in the source material, the
 metadata includes `warnings` entries that flag ATS-hostile patterns; new tests
 assert tables and images trigger the warnings so resume imports surface risks.
+Confidence heuristics and placeholder detection keep resume imports trustworthy.
+The suite also asserts the presence of parsing confidence signals and ambiguity
+highlights (for example, placeholder dates like `20XX` or metrics such as `XX%`)
+alongside ATS warnings so regressions surface quickly.
 
 Initialize a JSON Resume skeleton when you do not have an existing file:
 

--- a/src/resume.js
+++ b/src/resume.js
@@ -3,6 +3,156 @@ import path from 'node:path';
 import removeMarkdown from 'remove-markdown';
 
 const MARKDOWN_EXTENSIONS = ['.md', '.markdown', '.mdx'];
+const COMMON_HEADING_TERMS = ['experience', 'education', 'skills', 'projects', 'summary'];
+const TITLE_PLACEHOLDERS = [
+  'Your Title Here',
+  'Insert Title',
+  'Title Here',
+  'Position Title',
+  'Role Title',
+  'Your Role',
+  'Job Title Here',
+];
+const TITLE_PLACEHOLDER_PATTERN = new RegExp(
+  `\\b(?:${TITLE_PLACEHOLDERS.join('|')})\\b`,
+  'gi',
+);
+const DATE_PLACEHOLDER_PATTERNS = [
+  /\b(?:19|20)[X?]{2}\b/gi,
+  /\b(?:XX|\?\?)\/\d{2,4}\b/gi,
+  /\b\d{1,2}\/(?:XX|\?\?)\b/gi,
+  /\bTBD\b/gi,
+];
+const METRIC_PLACEHOLDER_PATTERNS = [
+  /\b(?:XX|\?\?)\s*(?:%|percent|percentage)(?!\w)/gi,
+  /\b(?:XX|\?\?)\s*(?:k|m|mm|bn|billion|million)(?!\w)/gi,
+];
+
+function detectResumeHeadings(text) {
+  if (!text) return [];
+  const found = new Set();
+  for (const term of COMMON_HEADING_TERMS) {
+    const pattern = new RegExp(`\\b${term}\\b`, 'i');
+    if (pattern.test(text)) {
+      found.add(term);
+    }
+  }
+  return Array.from(found);
+}
+
+function hasBulletFormatting(text) {
+  if (!text) return false;
+  return /^\s*[-*•–—]/m.test(text);
+}
+
+function estimateParsingConfidence(text, warnings = []) {
+  const trimmed = typeof text === 'string' ? text.trim() : '';
+  if (!trimmed) {
+    return { score: 0, signals: ['No resume content detected'] };
+  }
+
+  let score = 0.35;
+  const signals = [];
+  const length = trimmed.length;
+
+  if (length >= 800) {
+    score += 0.3;
+    signals.push('Detected substantial resume length (>= 800 characters)');
+  } else if (length >= 400) {
+    score += 0.25;
+    signals.push('Detected sufficient resume length (>= 400 characters)');
+  } else if (length >= 200) {
+    score += 0.2;
+    signals.push('Resume content is brief but present (< 400 characters)');
+  } else {
+    score -= 0.1;
+    signals.push('Resume content is very short (< 200 characters)');
+  }
+
+  const headings = detectResumeHeadings(trimmed);
+  if (headings.length >= 2) {
+    score += 0.2;
+    signals.push(`Detected common resume headings: ${headings.join(', ')}`);
+  } else if (headings.length === 1) {
+    score += 0.1;
+    signals.push(`Detected resume heading: ${headings[0]}`);
+  } else {
+    score -= 0.1;
+    signals.push('No common resume headings detected');
+  }
+
+  if (hasBulletFormatting(trimmed)) {
+    score += 0.15;
+    signals.push('Detected bullet formatting in experience sections');
+  } else {
+    score -= 0.05;
+    signals.push('No bullet formatting detected');
+  }
+
+  if (Array.isArray(warnings)) {
+    if (warnings.some(warning => warning && warning.type === 'tables')) {
+      score -= 0.1;
+      signals.push('Table formatting may affect ATS parsing');
+    }
+    if (warnings.some(warning => warning && warning.type === 'images')) {
+      score -= 0.05;
+      signals.push('Embedded images may be ignored by ATS scanners');
+    }
+  }
+
+  const bounded = Math.max(0, Math.min(1, score));
+  return { score: Number(bounded.toFixed(2)), signals };
+}
+
+function ensureGlobalFlag(flags) {
+  return flags.includes('g') ? flags : `${flags}g`;
+}
+
+function collectMatches(patterns, text) {
+  const matches = [];
+  for (const pattern of patterns) {
+    const regExp = new RegExp(pattern.source, ensureGlobalFlag(pattern.flags));
+    let match;
+    while ((match = regExp.exec(text)) !== null) {
+      if (match[0]) {
+        matches.push(match[0]);
+      }
+    }
+  }
+  return matches;
+}
+
+function detectAmbiguities(text) {
+  if (!text) return [];
+  const ambiguities = [];
+  const seen = new Set();
+
+  const addFinding = (type, value, message) => {
+    const key = `${type}:${value.toLowerCase()}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    ambiguities.push({ type, value, message });
+  };
+
+  for (const match of collectMatches(DATE_PLACEHOLDER_PATTERNS, text)) {
+    addFinding('date', match.trim(), 'Potential placeholder date detected');
+  }
+
+  const titleMatches = text.match(TITLE_PLACEHOLDER_PATTERN);
+  if (titleMatches) {
+    for (const match of titleMatches) {
+      addFinding('title', match.trim(), 'Potential placeholder title detected');
+    }
+  }
+
+  for (const match of collectMatches(METRIC_PLACEHOLDER_PATTERNS, text)) {
+    const value = match.trim();
+    if (!value || /^\+?$/.test(value)) continue;
+    addFinding('metric', value, 'Potential placeholder metric detected');
+  }
+
+  return ambiguities;
+}
 
 function detectFormat(extension) {
   if (MARKDOWN_EXTENSIONS.includes(extension)) return 'markdown';
@@ -157,6 +307,16 @@ export async function loadResume(filePath, options = {}) {
   const warnings = detectAtsWarnings(raw, format);
   if (warnings.length > 0) {
     metadata.warnings = warnings;
+  }
+
+  const confidence = estimateParsingConfidence(text, warnings);
+  if (confidence) {
+    metadata.confidence = confidence;
+  }
+
+  const ambiguities = detectAmbiguities(text);
+  if (ambiguities.length > 0) {
+    metadata.ambiguities = ambiguities;
   }
 
   return { text, metadata };

--- a/test/resume.test.js
+++ b/test/resume.test.js
@@ -107,4 +107,54 @@ describe('loadResume', () => {
       ])
     );
   });
+
+  it('annotates parsing confidence and highlights ambiguous placeholders', async () => {
+    const content = [
+      '## Experience',
+      'Senior Developer at Acme Corp',
+      '- Increased revenue by XX% year over year while leading a distributed team ' +
+        'of seven engineers.',
+      '- Shipped analytics dashboards adopted by 12 partner teams across the organization.',
+      '',
+      '## Education',
+      'Your Title Here',
+      'Bachelor of Science — Jan 20XX - Present',
+    ].join('\n');
+
+    const result = await withTempFile('.md', content, file =>
+      loadResume(file, { withMetadata: true })
+    );
+
+    expect(result.metadata.confidence).toMatchObject({
+      score: expect.any(Number),
+      signals: expect.arrayContaining([
+        expect.stringContaining('resume heading'),
+        expect.stringContaining('bullet'),
+      ]),
+    });
+    expect(result.metadata.confidence.score).toBeGreaterThanOrEqual(0.5);
+    expect(result.metadata.confidence.score).toBeLessThanOrEqual(1);
+
+    expect(result.metadata.ambiguities).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'metric', value: 'XX%' }),
+        expect.objectContaining({ type: 'date', value: '20XX' }),
+        expect.objectContaining({ type: 'title', value: 'Your Title Here' }),
+      ])
+    );
+  });
+
+  it('detects ambiguities consistently across repeated loads', async () => {
+    const content = [
+      'Your Title Here',
+      'Led projects that delivered XX% efficiency gains by 20XX.',
+    ].join('\n');
+
+    await withTempFile('.txt', content, async file => {
+      const first = await loadResume(file, { withMetadata: true });
+      const second = await loadResume(file, { withMetadata: true });
+
+      expect(first.metadata.ambiguities).toEqual(second.metadata.ambiguities);
+    });
+  });
 });


### PR DESCRIPTION
what: clone placeholder regexes before scanning and add regression
why: avoid stale lastIndex state and keep ambiguity hints consistent
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d0bd51f74c832fa7066d75ea12b1f7