### PR TITLE
Add LinkedIn import command and importer coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,21 @@ basics, work, education, skills, projects, certificates, and languages
 sections. The command is idempotent and preserves existing resumes; see
 `test/cli.test.js` and `test/profile.test.js` for coverage.
 
+Import a LinkedIn profile export to seed the resume with verified contact,
+work history, education, and skills:
+
+```bash
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot import linkedin linkedin-profile.json
+# Imported LinkedIn profile to /tmp/jobbot-profile-XXXX/profile/resume.json (basics +5, work +1, education +1, skills +3)
+```
+
+The importer accepts LinkedIn JSON exports (downloadable from
+`https://www.linkedin.com/psettings/member-data`) and merges them into the
+existing resume without overwriting confirmed fields. Work history, education,
+and skill entries are deduplicated so repeated imports keep the profile tidy.
+See `test/profile-import.test.js` for normalization edge cases and
+`test/cli.test.js` for CLI wiring.
+
 Format parsed results as Markdown. The exporters escape Markdown control characters so job
 content cannot inject arbitrary links or formatting when rendered downstream:
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -12,6 +12,9 @@ jobbot3000.
 1. The user selects a local resume file (PDF, Markdown, MDX, or plain text) or points to an existing
    `resume.json`. When they start from scratch, `jobbot init` scaffolds
    `data/profile/resume.json` with empty JSON Resume sections ready for editing.
+   When a LinkedIn data export is available, `jobbot import linkedin <file>`
+   merges contact details, work history, education, and skills into the same
+   profile without overwriting confirmed fields.
 2. The CLI or UI calls the resume loader to extract clean text and metadata.
    Callers can request word/line counts, byte size, and the detected format via
    `loadResume(<path>, { withMetadata: true })` so downstream steps can surface

--- a/src/profile.js
+++ b/src/profile.js
@@ -44,14 +44,6 @@ function createResumeSkeleton() {
   };
 }
 
-/**
- * Initialise the profile workspace by creating a JSON Resume skeleton.
- * When the resume already exists and `force` is false, the file is left untouched.
- *
- * @param {{ force?: boolean }} [options]
- * @returns {Promise<{ created: boolean, path: string }>}
- *   Result describing whether the file was created.
- */
 export async function initProfile({ force = false } = {}) {
   const dataDir = resolveDataDir();
   const profileDir = path.join(dataDir, 'profile');
@@ -73,4 +65,422 @@ export async function initProfile({ force = false } = {}) {
   return { created: true, path: resumePath };
 }
 
+function sanitizeString(value) {
+  if (value == null) return undefined;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+  return undefined;
+}
+
+function sanitizeMultiline(value) {
+  const str = sanitizeString(value);
+  if (!str) return undefined;
+  return str.replace(/\r?\n+/g, '\n').trim();
+}
+
+function formatLinkedInDate(input) {
+  if (!input) return undefined;
+  if (typeof input === 'string') {
+    const trimmed = input.trim();
+    if (!trimmed) return undefined;
+    if (/^\d{4}$/.test(trimmed) || /^\d{4}-\d{2}$/.test(trimmed)) {
+      return trimmed;
+    }
+    const parsed = new Date(trimmed);
+    if (!Number.isNaN(parsed.getTime())) {
+      const year = parsed.getUTCFullYear();
+      const month = parsed.getUTCMonth() + 1;
+      return Number.isFinite(month)
+        ? `${year}-${String(month).padStart(2, '0')}`
+        : `${year}`;
+    }
+    return undefined;
+  }
+
+  if (typeof input === 'object') {
+    const year = Number(input.year);
+    if (!Number.isFinite(year)) return undefined;
+    const month = Number(input.month);
+    if (Number.isFinite(month) && month >= 1 && month <= 12) {
+      return `${year}-${String(month).padStart(2, '0')}`;
+    }
+    return `${year}`;
+  }
+
+  return undefined;
+}
+
+function extractLinkedInLocation(data) {
+  if (!data || typeof data !== 'object') return undefined;
+  const rawLocation =
+    sanitizeString(data.geoLocationName) ||
+    sanitizeString(data.locationName) ||
+    sanitizeString(data.location) ||
+    sanitizeString(data.profileLocation?.displayName) ||
+    sanitizeString(data.profileLocation?.defaultLocalizedNameWithoutCountryName);
+
+  if (!rawLocation) return undefined;
+
+  const parts = rawLocation
+    .split(',')
+    .map(part => part.trim())
+    .filter(Boolean);
+  if (parts.length === 0) return undefined;
+
+  const location = {};
+  if (parts.length === 1) {
+    location.city = parts[0];
+  } else if (parts.length === 2) {
+    [location.city, location.region] = parts;
+  } else {
+    location.city = parts[0];
+    location.region = parts[1];
+    location.country = parts[parts.length - 1];
+  }
+  return location;
+}
+
+function mapLinkedInPositions(positions) {
+  if (!Array.isArray(positions)) return [];
+  const mapped = [];
+
+  for (const position of positions) {
+    if (!position || typeof position !== 'object') continue;
+
+    const company =
+      sanitizeString(position.companyName) ||
+      sanitizeString(position.company?.name) ||
+      sanitizeString(position.company?.companyName);
+    const title = sanitizeString(position.title);
+    if (!company && !title) continue;
+
+    const entry = {};
+    if (company) entry.name = company;
+    if (title) entry.position = title;
+
+    const summary = sanitizeMultiline(position.description || position.summary);
+    if (summary) entry.summary = summary;
+
+    const location = sanitizeString(position.locationName);
+    if (location) entry.location = location;
+
+    const startDate = formatLinkedInDate(position.timePeriod?.startDate || position.startDate);
+    if (startDate) entry.startDate = startDate;
+    const endDate = formatLinkedInDate(position.timePeriod?.endDate || position.endDate);
+    if (endDate) entry.endDate = endDate;
+
+    const url =
+      sanitizeString(position.company?.companyPageUrl) ||
+      sanitizeString(position.company?.canonicalUrl) ||
+      sanitizeString(position.company?.websiteUrl) ||
+      sanitizeString(position.company?.url);
+    if (url) entry.url = url;
+
+    mapped.push(entry);
+  }
+
+  return mapped;
+}
+
+function mapLinkedInEducation(entries) {
+  if (!Array.isArray(entries)) return [];
+  const mapped = [];
+
+  for (const item of entries) {
+    if (!item || typeof item !== 'object') continue;
+
+    const institution = sanitizeString(item.schoolName || item.school);
+    const degree = sanitizeString(item.degreeName || item.degree);
+    const field = sanitizeString(item.fieldOfStudy || item.field);
+    if (!institution && !degree && !field) continue;
+
+    const entry = {};
+    if (institution) entry.institution = institution;
+    if (degree) entry.studyType = degree;
+    if (field) entry.area = field;
+
+    const startDate = formatLinkedInDate(item.timePeriod?.startDate || item.startDate);
+    if (startDate) entry.startDate = startDate;
+    const endDate = formatLinkedInDate(item.timePeriod?.endDate || item.endDate);
+    if (endDate) entry.endDate = endDate;
+
+    mapped.push(entry);
+  }
+
+  return mapped;
+}
+
+function mapLinkedInSkills(skills) {
+  if (!Array.isArray(skills)) return [];
+  const mapped = [];
+
+  for (const skill of skills) {
+    let name;
+    if (typeof skill === 'string') {
+      name = sanitizeString(skill);
+    } else if (skill && typeof skill === 'object') {
+      name = sanitizeString(skill.name || skill.skillName || skill.localizedName);
+    }
+    if (!name) continue;
+    mapped.push({ name });
+  }
+
+  return mapped;
+}
+
+function normalizeLinkedInProfile(data) {
+  if (!data || typeof data !== 'object') {
+    return { basics: {}, work: [], education: [], skills: [] };
+  }
+
+  const basics = {};
+  const firstName = sanitizeString(data.firstName || data.first_name);
+  const lastName = sanitizeString(data.lastName || data.last_name);
+  const nameParts = [firstName, lastName].filter(Boolean);
+  if (nameParts.length > 0) basics.name = nameParts.join(' ');
+
+  const headline = sanitizeString(data.headline);
+  if (headline) basics.label = headline;
+
+  const summary = sanitizeMultiline(data.summary || data.summaryText || data.about);
+  if (summary) basics.summary = summary;
+
+  const contact = data.contactInfo || data['contact-info'];
+  if (contact && typeof contact === 'object') {
+    const email = sanitizeString(contact.emailAddress || contact.email);
+    if (email) basics.email = email;
+
+    const websites = Array.isArray(contact.websites) ? contact.websites : [];
+    for (const site of websites) {
+      const url = sanitizeString(site?.url || site);
+      if (url) {
+        basics.website = url;
+        break;
+      }
+    }
+
+    const phones = Array.isArray(contact.phoneNumbers) ? contact.phoneNumbers : [];
+    for (const phone of phones) {
+      const number = sanitizeString(phone?.number || phone);
+      if (number) {
+        basics.phone = number;
+        break;
+      }
+    }
+  }
+
+  const location = extractLinkedInLocation(data);
+  if (location) basics.location = location;
+
+  return {
+    basics,
+    work: mapLinkedInPositions(data.positions || data.experiences || []),
+    education: mapLinkedInEducation(data.educations || data.education || []),
+    skills: mapLinkedInSkills(data.skills || data.skillItems || []),
+  };
+}
+
+function ensureBasicsStructure(resume) {
+  if (!resume.basics || typeof resume.basics !== 'object') {
+    resume.basics = {
+      name: '',
+      label: '',
+      email: '',
+      phone: '',
+      website: '',
+      summary: '',
+      location: { city: '', region: '', country: '' },
+    };
+  } else if (!resume.basics.location || typeof resume.basics.location !== 'object') {
+    resume.basics.location = { city: '', region: '', country: '' };
+  }
+}
+
+function applyField(target, key, value) {
+  const clean = sanitizeString(value);
+  if (!clean) return 0;
+  const current = target[key];
+  if (current && typeof current === 'string' && current.trim()) return 0;
+  if (current === clean) return 0;
+  target[key] = clean;
+  return 1;
+}
+
+function mergeWorkEntries(resume, entries) {
+  if (!Array.isArray(entries) || entries.length === 0) return 0;
+  if (!Array.isArray(resume.work)) resume.work = [];
+
+  const existingKeys = new Set(
+    resume.work.map(item =>
+      [
+        sanitizeString(item.name)?.toLowerCase() || '',
+        sanitizeString(item.position)?.toLowerCase() || '',
+        sanitizeString(item.startDate) || '',
+      ].join('|'),
+    ),
+  );
+
+  let added = 0;
+  for (const entry of entries) {
+    const key = [
+      sanitizeString(entry.name)?.toLowerCase() || '',
+      sanitizeString(entry.position)?.toLowerCase() || '',
+      sanitizeString(entry.startDate) || '',
+    ].join('|');
+    if (existingKeys.has(key)) continue;
+    resume.work.push({ ...entry });
+    existingKeys.add(key);
+    added += 1;
+  }
+  return added;
+}
+
+function mergeEducationEntries(resume, entries) {
+  if (!Array.isArray(entries) || entries.length === 0) return 0;
+  if (!Array.isArray(resume.education)) resume.education = [];
+
+  const existingKeys = new Set(
+    resume.education.map(item =>
+      [
+        sanitizeString(item.institution)?.toLowerCase() || '',
+        sanitizeString(item.studyType)?.toLowerCase() || '',
+        sanitizeString(item.startDate) || '',
+      ].join('|'),
+    ),
+  );
+
+  let added = 0;
+  for (const entry of entries) {
+    const key = [
+      sanitizeString(entry.institution)?.toLowerCase() || '',
+      sanitizeString(entry.studyType)?.toLowerCase() || '',
+      sanitizeString(entry.startDate) || '',
+    ].join('|');
+    if (existingKeys.has(key)) continue;
+    resume.education.push({ ...entry });
+    existingKeys.add(key);
+    added += 1;
+  }
+  return added;
+}
+
+function mergeSkillEntries(resume, entries) {
+  if (!Array.isArray(entries) || entries.length === 0) return 0;
+  if (!Array.isArray(resume.skills)) resume.skills = [];
+
+  const existing = new Set(
+    resume.skills
+      .map(skill => sanitizeString(skill?.name)?.toLowerCase())
+      .filter(Boolean),
+  );
+
+  let added = 0;
+  for (const entry of entries) {
+    const name = sanitizeString(entry?.name);
+    if (!name) continue;
+    const key = name.toLowerCase();
+    if (existing.has(key)) continue;
+    resume.skills.push({ name });
+    existing.add(key);
+    added += 1;
+  }
+  return added;
+}
+
+function mergeLinkedInIntoResume(resume, normalized) {
+  const { basics, work, education, skills } = normalized;
+  ensureBasicsStructure(resume);
+
+  let basicsUpdated = 0;
+  if (basics && typeof basics === 'object') {
+    const target = resume.basics;
+    basicsUpdated += applyField(target, 'name', basics.name);
+    basicsUpdated += applyField(target, 'label', basics.label);
+    basicsUpdated += applyField(target, 'email', basics.email);
+    basicsUpdated += applyField(target, 'phone', basics.phone);
+    basicsUpdated += applyField(target, 'website', basics.website);
+    basicsUpdated += applyField(target, 'summary', basics.summary);
+
+    if (basics.location && typeof basics.location === 'object') {
+      const locTarget =
+        target.location || (target.location = { city: '', region: '', country: '' });
+      basicsUpdated += applyField(locTarget, 'city', basics.location.city);
+      basicsUpdated += applyField(locTarget, 'region', basics.location.region);
+      basicsUpdated += applyField(locTarget, 'country', basics.location.country);
+    }
+  }
+
+  const workAdded = mergeWorkEntries(resume, work);
+  const educationAdded = mergeEducationEntries(resume, education);
+  const skillsAdded = mergeSkillEntries(resume, skills);
+
+  return { basicsUpdated, workAdded, educationAdded, skillsAdded };
+}
+
+export async function importLinkedInProfile(filePath) {
+  if (!filePath || typeof filePath !== 'string' || !filePath.trim()) {
+    throw new Error('LinkedIn profile path is required');
+  }
+
+  const resolved = path.resolve(process.cwd(), filePath);
+  let raw;
+  try {
+    raw = await fs.readFile(resolved, 'utf8');
+  } catch (err) {
+    if (err?.code === 'ENOENT') {
+      throw new Error(`LinkedIn profile not found: ${resolved}`);
+    }
+    throw err;
+  }
+
+  let data;
+  try {
+    data = JSON.parse(raw);
+  } catch {
+    throw new Error('Invalid LinkedIn profile JSON');
+  }
+
+  const { path: resumePath } = await initProfile();
+  let resumeRaw;
+  try {
+    resumeRaw = await fs.readFile(resumePath, 'utf8');
+  } catch (err) {
+    if (err?.code === 'ENOENT') {
+      resumeRaw = JSON.stringify(createResumeSkeleton());
+    } else {
+      throw err;
+    }
+  }
+
+  let resume;
+  try {
+    resume = JSON.parse(resumeRaw);
+  } catch {
+    throw new Error('Existing resume.json could not be parsed');
+  }
+
+  const normalized = normalizeLinkedInProfile(data);
+  const result = mergeLinkedInIntoResume(resume, normalized);
+
+  await fs.writeFile(resumePath, `${JSON.stringify(resume, null, 2)}\n`, 'utf8');
+  return { path: resumePath, ...result };
+}
+
 export const PROFILE_SCHEMA_URL = JSON_RESUME_SCHEMA_URL;
+
+export {
+  sanitizeString,
+  sanitizeMultiline,
+  formatLinkedInDate,
+  extractLinkedInLocation,
+  mapLinkedInPositions,
+  mapLinkedInEducation,
+  mapLinkedInSkills,
+  normalizeLinkedInProfile,
+  mergeLinkedInIntoResume,
+};

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -116,6 +116,24 @@ describe('jobbot CLI', () => {
     expect(out).not.toMatch(/#|\*\*/);
   });
 
+  it('imports LinkedIn profile exports with import linkedin', () => {
+    const fixture = path.resolve('test', 'fixtures', 'linkedin-profile.json');
+    const out = runCli(['import', 'linkedin', fixture]);
+    expect(out).toMatch(/Imported LinkedIn profile to/);
+    expect(out).toMatch(/work \+1/);
+
+    const resumePath = path.join(dataDir, 'profile', 'resume.json');
+    const resume = JSON.parse(fs.readFileSync(resumePath, 'utf8'));
+
+    expect(resume.basics.name).toBe('Casey Taylor');
+    expect(resume.work).toHaveLength(1);
+    expect(resume.skills.map(skill => skill.name)).toEqual([
+      'Kubernetes',
+      'AWS',
+      'Incident Response',
+    ]);
+  });
+
   it('match from local files', () => {
     const job = 'Title: Engineer\nCompany: ACME\nRequirements\n- JavaScript\n- Node.js\n';
     const resume = 'I am an engineer with JavaScript experience.';

--- a/test/fixtures/job-docx.txt
+++ b/test/fixtures/job-docx.txt
@@ -1,0 +1,5 @@
+Title: Engineer
+Company: ACME
+Requirements
+- JavaScript
+- Node.js

--- a/test/fixtures/job-explain.txt
+++ b/test/fixtures/job-explain.txt
@@ -1,0 +1,6 @@
+Title: Staff Engineer
+Company: ExampleCorp
+Requirements
+- Distributed systems experience
+- Certified Kubernetes administrator
+- Mentors senior engineers

--- a/test/fixtures/linkedin-profile.json
+++ b/test/fixtures/linkedin-profile.json
@@ -1,0 +1,47 @@
+{
+  "firstName": "Casey",
+  "lastName": "Taylor",
+  "headline": "Senior Site Reliability Engineer",
+  "summary": "Site reliability leader focused on resilient, measurable systems.",
+  "geoLocationName": "San Francisco Bay Area",
+  "contactInfo": {
+    "emailAddress": "casey@example.com",
+    "websites": [
+      { "url": "https://caseytaylor.dev" }
+    ],
+    "phoneNumbers": [
+      { "number": "+1 555-0100" }
+    ]
+  },
+  "positions": [
+    {
+      "companyName": "ExampleCorp",
+      "title": "Staff SRE",
+      "description": "Maintained infrastructure for multi-region services.",
+      "locationName": "Remote",
+      "timePeriod": {
+        "startDate": { "year": 2021, "month": 5 },
+        "endDate": { "year": 2024, "month": 1 }
+      },
+      "company": {
+        "companyPageUrl": "https://example.com"
+      }
+    }
+  ],
+  "educations": [
+    {
+      "schoolName": "State University",
+      "degreeName": "BSc",
+      "fieldOfStudy": "Computer Science",
+      "timePeriod": {
+        "startDate": { "year": 2012 },
+        "endDate": { "year": 2016 }
+      }
+    }
+  ],
+  "skills": [
+    { "name": "Kubernetes" },
+    { "name": "AWS" },
+    { "name": "Incident Response" }
+  ]
+}

--- a/test/fixtures/resume-docx.txt
+++ b/test/fixtures/resume-docx.txt
@@ -1,0 +1,1 @@
+I am an engineer with JavaScript experience.

--- a/test/fixtures/resume-explain.txt
+++ b/test/fixtures/resume-explain.txt
@@ -1,0 +1,2 @@
+Led distributed systems design and migrations to cloud-native stacks.
+Managed mentoring programs for staff engineers.

--- a/test/profile-import.test.js
+++ b/test/profile-import.test.js
@@ -1,0 +1,144 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let dataDir;
+
+async function readResume() {
+  const resumePath = path.join(dataDir, 'profile', 'resume.json');
+  const contents = await fs.readFile(resumePath, 'utf8');
+  return JSON.parse(contents);
+}
+
+describe('LinkedIn profile import', () => {
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-linkedin-'));
+    process.env.JOBBOT_DATA_DIR = dataDir;
+  });
+
+  afterEach(async () => {
+    if (dataDir) {
+      await fs.rm(dataDir, { recursive: true, force: true });
+      dataDir = undefined;
+    }
+    delete process.env.JOBBOT_DATA_DIR;
+  });
+
+  it('merges LinkedIn profile exports into the JSON resume', async () => {
+    const { initProfile, importLinkedInProfile } = await import('../src/profile.js');
+    await initProfile();
+
+    const fixture = path.resolve('test', 'fixtures', 'linkedin-profile.json');
+    const result = await importLinkedInProfile(fixture);
+
+    expect(result.basicsUpdated).toBeGreaterThan(0);
+    expect(result.workAdded).toBe(1);
+    expect(result.educationAdded).toBe(1);
+    expect(result.skillsAdded).toBe(3);
+
+    const resume = await readResume();
+    expect(resume.basics.name).toBe('Casey Taylor');
+    expect(resume.basics.label).toBe('Senior Site Reliability Engineer');
+    expect(resume.basics.summary).toMatch('Site reliability leader');
+    expect(resume.basics.location.city).toBe('San Francisco Bay Area');
+
+    expect(resume.work).toHaveLength(1);
+    expect(resume.work[0]).toMatchObject({
+      name: 'ExampleCorp',
+      position: 'Staff SRE',
+      location: 'Remote',
+      startDate: '2021-05',
+      endDate: '2024-01',
+      summary: 'Maintained infrastructure for multi-region services.',
+    });
+
+    expect(resume.education).toHaveLength(1);
+    expect(resume.education[0]).toMatchObject({
+      institution: 'State University',
+      studyType: 'BSc',
+      area: 'Computer Science',
+      startDate: '2012',
+      endDate: '2016',
+    });
+
+    expect(resume.skills.map(skill => skill.name)).toEqual([
+      'Kubernetes',
+      'AWS',
+      'Incident Response',
+    ]);
+  });
+
+  it('does not duplicate entries when importing the same profile again', async () => {
+    const { importLinkedInProfile } = await import('../src/profile.js');
+    const fixture = path.resolve('test', 'fixtures', 'linkedin-profile.json');
+
+    await importLinkedInProfile(fixture);
+    await importLinkedInProfile(fixture);
+
+    const resume = await readResume();
+    expect(resume.work).toHaveLength(1);
+    expect(resume.education).toHaveLength(1);
+    expect(resume.skills).toHaveLength(3);
+  });
+
+  it('fills missing resume fields without overwriting confirmed data', async () => {
+    const { initProfile, importLinkedInProfile } = await import('../src/profile.js');
+    const { path: resumePath } = await initProfile();
+    const base = JSON.parse(await fs.readFile(resumePath, 'utf8'));
+    base.basics.name = 'Existing Name';
+    base.basics.location.city = 'Existing City';
+    base.work.push({
+      name: 'PartialCo',
+      position: 'Engineer',
+      startDate: '2019-01',
+    });
+    base.skills = [{ name: 'Kubernetes' }];
+    await fs.writeFile(resumePath, `${JSON.stringify(base, null, 2)}\n`, 'utf8');
+
+    const partialProfile = {
+      firstName: 'Jamie',
+      lastName: 'Rivera',
+      headline: 'Platform Engineer',
+      summaryText: 'Focuses on developer workflows.',
+      profileLocation: { displayName: 'Seattle, Washington, United States' },
+      positions: [
+        {
+          companyName: 'PartialCo',
+          title: 'Engineer',
+          timePeriod: { startDate: { year: 2019, month: 1 } },
+        },
+        {
+          companyName: 'FutureLabs',
+          title: 'Staff Engineer',
+          timePeriod: {
+            startDate: { year: 2022, month: 3 },
+          },
+        },
+      ],
+      skills: ['Kubernetes', { name: 'Terraform' }],
+    };
+    const tmp = path.join(dataDir, 'partial-linkedin.json');
+    await fs.writeFile(tmp, `${JSON.stringify(partialProfile, null, 2)}\n`, 'utf8');
+
+    const result = await importLinkedInProfile(tmp);
+    expect(result.workAdded).toBe(1);
+    expect(result.skillsAdded).toBe(1);
+
+    const resume = await readResume();
+    expect(resume.basics.name).toBe('Existing Name');
+    expect(resume.basics.summary).toBe('Focuses on developer workflows.');
+    expect(resume.basics.location.city).toBe('Existing City');
+    expect(resume.basics.location.region).toBe('Washington');
+    expect(resume.basics.location.country).toBe('United States');
+    expect(resume.work).toHaveLength(2);
+    const futureRole = resume.work.find(job => job.name === 'FutureLabs');
+    expect(futureRole).toMatchObject({
+      name: 'FutureLabs',
+      position: 'Staff Engineer',
+      startDate: '2022-03',
+    });
+    expect(futureRole).not.toHaveProperty('endDate');
+    expect(resume.skills.map(skill => skill.name)).toEqual(['Kubernetes', 'Terraform']);
+  });
+});


### PR DESCRIPTION
## Summary
- finish the LinkedIn profile importer and expose helper exports for downstream tooling
- add a `jobbot import linkedin` CLI subcommand that reports how many sections were updated
- document the new workflow and extend tests to cover dedupe and partial LinkedIn exports

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d1bcfb85bc832f9111574fd63ffd0f