### PR TITLE
Add skipped intake filter to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,13 +562,23 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot intake list --json | jq '.responses[1]'
 #   "recorded_at": "2025-02-01T12:40:00.000Z",
 #   "id": "987e6543-e21b-45d3-a456-426614174001"
 # }
+
+# Surface pending follow-ups:
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot intake list --skipped-only
+# Which benefits matter most?
+#   Status: Skipped
+#   Answer: (skipped)
+#   Notes: Circle back after research
+#   Asked At: 2025-02-01T12:40:00.000Z
+#   Recorded At: 2025-02-01T12:40:00.000Z
+#   ID: 987e6543-e21b-45d3-a456-426614174001
 ```
 
 Entries are appended to `data/profile/intake.json` with normalized timestamps, optional tags, notes,
 and a `status` field so follow-up planning can reference prior answers and revisit skipped prompts.
 Recorded timestamps reflect when the command runs. Automated coverage in
 [`test/intake.test.js`](test/intake.test.js) and [`test/cli.test.js`](test/cli.test.js) verifies the
-stored shape and CLI workflows.
+stored shape, CLI workflows, and the skipped-only view for follow-up planning.
 
 ## Conversion funnel analytics
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -470,9 +470,15 @@ async function cmdIntakeRecord(args) {
 
 async function cmdIntakeList(args) {
   const asJson = args.includes('--json');
-  const entries = await getIntakeResponses();
+  const skippedOnly = args.includes('--skipped-only');
+  const filters = skippedOnly ? { status: 'skipped' } : undefined;
+  const entries = await getIntakeResponses(filters);
   if (asJson) {
     console.log(JSON.stringify({ responses: entries }, null, 2));
+    return;
+  }
+  if (!entries.length) {
+    console.log(skippedOnly ? 'No skipped intake responses found' : 'No intake responses found');
     return;
   }
   console.log(formatIntakeList(entries));

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -682,6 +682,41 @@ describe('jobbot CLI', () => {
     });
   });
 
+  it('filters intake list to skipped prompts with --skipped-only', () => {
+    runCli([
+      'intake',
+      'record',
+      '--question',
+      'What motivates you?',
+      '--answer',
+      'Building accessible tools',
+    ]);
+
+    runCli([
+      'intake',
+      'record',
+      '--question',
+      'Which benefits matter most?',
+      '--skip',
+      '--notes',
+      'Circle back after research',
+    ]);
+
+    const skipped = runCli(['intake', 'list', '--skipped-only']);
+    expect(skipped).toContain('Which benefits matter most?');
+    expect(skipped).toContain('Status: Skipped');
+    expect(skipped).not.toContain('What motivates you?');
+
+    const skippedJson = JSON.parse(
+      runCli(['intake', 'list', '--json', '--skipped-only'])
+    );
+    expect(skippedJson.responses).toHaveLength(1);
+    expect(skippedJson.responses[0]).toMatchObject({
+      question: 'Which benefits matter most?',
+      status: 'skipped',
+    });
+  });
+
   it('tags shortlist entries and persists labels', () => {
     const output = runCli(['shortlist', 'tag', 'job-abc', 'dream', 'remote']);
     expect(output.trim()).toBe('Tagged job-abc with dream, remote');


### PR DESCRIPTION
## Summary
* add status filtering to `getIntakeResponses` so callers can request only skipped prompts
* surface a `--skipped-only` flag for `jobbot intake list` and document the follow-up view in the README
* extend the CLI suite to verify the skipped-only listing returns only pending prompts

## Testing
* npm run lint
* npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d1bcfb85bc832f9111574fd63ffd0f