### PR TITLE
🐛 Guard CI/CD synonym bridging

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -266,7 +266,7 @@ jobbot track add <job_id> --status applied --note "emailed hiring manager"
 **Phase 2 — Matching (1 week)**
 - Embeddings service (local HF) + pgvector store.
 - Keyword/BM25 baseline + cosine combo scoring.
-- O*NET/ESCO synonym expansion.
+- O*NET/ESCO synonym expansion. (shipped)
 - Explanations UI (hits/gaps/evidence).
 - CLI: `jobbot match --explain` (shipped).
 

--- a/README.md
+++ b/README.md
@@ -317,8 +317,12 @@ JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot match --resume resume.txt --job job.txt 
 
 Fit scoring recognizes common abbreviations so lexical-only resumes still match spelled-out
 requirements. `AWS` on a resume matches `Amazon Web Services`, `ML` pairs with `Machine learning`,
-`AI` aligns with `Artificial intelligence`, and `Postgres` maps to `PostgreSQL`. Automated coverage
-in [`test/scoring.test.js`](test/scoring.test.js) exercises these semantic aliases.
+`AI` aligns with `Artificial intelligence`, and `Postgres` maps to `PostgreSQL`. The matcher also
+bridges `SaaS` with `Software as a Service`, `K8s` with `Kubernetes`, and ties the `CI/CD`
+abbreviation to both `Continuous integration` and `Continuous delivery` without treating those
+skills as interchangeable. Short forms like `JS`/`TS` still align with `JavaScript`/`TypeScript`.
+Automated coverage in [`test/scoring.test.js`](test/scoring.test.js) exercises these semantic
+aliases.
 
 The explanation helper also highlights blockers when missing requirements look like must-haves.
 Entries containing phrases such as “must”, “required”, “security clearance”, “visa”, “sponsorship”,

--- a/test/scoring.test.js
+++ b/test/scoring.test.js
@@ -61,6 +61,39 @@ describe('computeFitScore', () => {
     expect(result).toEqual({ score: 100, matched: requirements, missing: [] });
   });
 
+  it('matches expanded O*NET/ESCO-inspired synonym groups', () => {
+    const resume =
+      'Scaled a SaaS analytics platform on K8s, owning CI/CD automation with JS and TS services.';
+    const requirements = [
+      'Own software as a service uptime targets',
+      'Harden Kubernetes clusters',
+      'Improve continuous integration workflows',
+      'Automate continuous delivery deployments',
+      'Build JavaScript frontends',
+      'Maintain TypeScript monorepos',
+    ];
+    const result = computeFitScore(resume, requirements);
+    expect(result).toEqual({ score: 100, matched: requirements, missing: [] });
+  });
+
+  it('treats continuous integration and continuous delivery as distinct requirements', () => {
+    const deliveryOnlyResume = 'Experience in continuous delivery pipelines';
+    const integrationRequirement = ['Continuous integration experience'];
+    expect(computeFitScore(deliveryOnlyResume, integrationRequirement)).toEqual({
+      score: 0,
+      matched: [],
+      missing: integrationRequirement,
+    });
+
+    const integrationOnlyResume = 'Experience in continuous integration workflows';
+    const deliveryRequirement = ['Continuous delivery experience'];
+    expect(computeFitScore(integrationOnlyResume, deliveryRequirement)).toEqual({
+      score: 0,
+      matched: [],
+      missing: deliveryRequirement,
+    });
+  });
+
   // Allow slower CI environments by using a relaxed threshold.
   it('processes large requirement lists within 2500ms', () => {
     const resume = 'skill '.repeat(1000);


### PR DESCRIPTION
what: ensure computeFitScore keeps continuous integration and continuous
  delivery distinct while still accepting CI/CD abbreviations; document
  the change
why: avoid inflated fit scores when resumes only cover the wrong half of
  CI/CD requirements
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d1bcfb85bc832f9111574fd63ffd0f