### PR TITLE
Expand match explanation blocker detection for location, salary, and seniority

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,10 +341,12 @@ aliases.
 
 The explanation helper also highlights blockers when missing requirements look like must-haves.
 Entries containing phrases such as “must”, “required”, “security clearance”, “visa”, “sponsorship”,
-“certification”, “license”, “authorization”, or “citizenship” are surfaced in a dedicated line so
-reviewers can distinguish urgent gaps from nice-to-have skills. Tests in
-[`test/exporters.test.js`](test/exporters.test.js) cover blocker detection and the fallback message
-when no mandatory requirements are found.
+“certification”, “license”, “authorization”, or “citizenship” now share the same spotlight as
+location constraints (“onsite”, “in-office”, “relocation”, “travel”), compensation language
+(“salary”, “compensation”, “base pay”), and seniority signals (“senior-level”, “years of experience”,
+“leadership”). They are surfaced in a dedicated line so reviewers can distinguish urgent gaps from
+nice-to-have skills. Tests in [`test/exporters.test.js`](test/exporters.test.js) cover the expanded
+blocker detection and the fallback message when no mandatory requirements are found.
 
 The summarizer extracts the first sentence, handling `.`, `!`, `?`, and consecutive terminal
 punctuation like `?!`, including when followed by closing quotes or parentheses. Terminators apply

--- a/src/exporters.js
+++ b/src/exporters.js
@@ -236,6 +236,21 @@ const BLOCKER_PATTERNS = [
   /\bauthorization\b/i,
   /\bcitizen(?:ship)?\b/i,
   /\bwork permit\b/i,
+  /\bonsite\b/i,
+  /\bon-site\b/i,
+  /\bin[-\s]?office\b/i,
+  /\bhybrid\b/i,
+  /\brelocat(?:e|ion)\b/i,
+  /\bcommute\b/i,
+  /\btravel\b/i,
+  /\bsalary\b/i,
+  /\bcompensation\b/i,
+  /\bpay range\b/i,
+  /\bbase (?:salary|pay)\b/i,
+  /\btotal compensation\b/i,
+  /\b(?:\d+\+?\s*(?:years?|yrs?)\s+of\s+experience)\b/i,
+  /\b(?:entry|mid|senior|staff|principal|lead)(?: |-)?level\b/i,
+  /\bleadership\b/i,
 ];
 
 function collectBlockers(requirements) {

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -245,6 +245,30 @@ describe('exporters', () => {
     expect(text).toContain(gapsLine);
   });
 
+  it('treats location, salary, and seniority requirements as blockers', () => {
+    const text = formatMatchExplanation({
+      matched: [],
+      missing: [
+        'Position is onsite in Austin, TX (no remote option)',
+        'Base salary range: $150k - $180k plus bonus',
+        'Senior-level engineering leadership required',
+      ],
+    });
+
+    const blockersLine = text
+      .split('\n')
+      .find(line => line.startsWith('Blockers:'));
+    expect(blockersLine).toBeDefined();
+    expect(blockersLine).toContain('Position is onsite in Austin, TX (no remote option)');
+    expect(blockersLine).toContain('Base salary range: $150k - $180k plus bonus');
+    expect(blockersLine).toContain('Senior-level engineering leadership required');
+
+    const gapsLine = text.split('\n').find(line => line.startsWith('Gaps:'));
+    expect(gapsLine).toContain('Position is onsite in Austin, TX (no remote option)');
+    expect(gapsLine).toContain('Base salary range: $150k - $180k plus bonus');
+    expect(gapsLine).toContain('Senior-level engineering leadership required');
+  });
+
   it('renders markdown explanation with escaped content', () => {
     const md = toMarkdownMatchExplanation({
       matched: ['Node.js (services)'],


### PR DESCRIPTION
what: expand match explanation blocker detection to include location, salary,
  and seniority phrases, update docs, and add a dedicated test.
why: design notes promise explanations highlight location/seniority/salary
  blockers alongside visa/clearance checks.
how to test: npm run lint && npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68d1c9d8e0a4832fba4a5c7aab57c3e4