### PR TITLE
Add CLI support for ingesting individual job URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,12 +396,15 @@ JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest smartrecruiters --company example
 
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest workable --company example
 # Imported 4 jobs from example
+
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest url https://example.com/jobs/staff-engineer
+# Imported job 5d41402abc4b2a76 from https://example.com/jobs/staff-engineer
 ```
 
 Each listing in the response is normalised to plain text, parsed for title,
 location, and requirements, and written to `data/jobs/{job_id}.json` with a
 `source.type` reflecting the provider (`greenhouse`, `lever`, `ashby`,
-`smartrecruiters`, or `workable`). Updates reuse the same job identifier so
+`smartrecruiters`, `workable`, or `url`). Updates reuse the same job identifier so
 downstream tooling can diff revisions over time. Tests in
 [`test/greenhouse.test.js`](test/greenhouse.test.js),
 [`test/lever.test.js`](test/lever.test.js), [`test/ashby.test.js`](test/ashby.test.js),
@@ -409,7 +412,9 @@ downstream tooling can diff revisions over time. Tests in
 [`test/workable.test.js`](test/workable.test.js) verify the ingest
 pipelines fetch board content, persist structured snapshots, surface fetch
 errors, and retain the `User-Agent: jobbot3000` request header alongside each
-capture so fetches are reproducible.
+capture so fetches are reproducible. [`test/jobs.test.js`](test/jobs.test.js)
+adds coverage for direct URL ingestion, ensuring snapshots store normalized
+request headers and reject unsupported protocols.
 Per-tenant rate limits prevent hammering board APIs: set
 `JOBBOT_GREENHOUSE_RATE_LIMIT_MS`, `JOBBOT_LEVER_RATE_LIMIT_MS`,
 `JOBBOT_ASHBY_RATE_LIMIT_MS`, `JOBBOT_SMARTRECRUITERS_RATE_LIMIT_MS`, or

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -37,6 +37,7 @@ import { ingestSmartRecruitersBoard } from '../src/smartrecruiters.js';
 import { ingestAshbyBoard } from '../src/ashby.js';
 import { computeFunnel, exportAnalyticsSnapshot, formatFunnelReport } from '../src/analytics.js';
 import { ingestWorkableBoard } from '../src/workable.js';
+import { ingestJobUrl } from '../src/url-ingest.js';
 import { bundleDeliverables } from '../src/deliverables.js';
 
 function isHttpUrl(s) {
@@ -582,6 +583,25 @@ async function cmdIngestWorkable(args) {
   console.log(`Imported ${saved} ${noun} from ${account}`);
 }
 
+async function cmdIngestUrl(args) {
+  const targetUrl = args[0];
+  const rest = args.slice(1);
+  if (!targetUrl) {
+    console.error('Usage: jobbot ingest url <url> [--timeout <ms>]');
+    process.exit(2);
+  }
+
+  const timeoutMs = getNumberFlag(rest, '--timeout', 10000);
+
+  try {
+    const { id } = await ingestJobUrl({ url: targetUrl, timeoutMs });
+    console.log(`Imported job ${id} from ${targetUrl}`);
+  } catch (err) {
+    console.error(err.message || String(err));
+    process.exit(1);
+  }
+}
+
 async function cmdIngest(args) {
   const sub = args[0];
   if (sub === 'greenhouse') return cmdIngestGreenhouse(args.slice(1));
@@ -589,9 +609,11 @@ async function cmdIngest(args) {
   if (sub === 'ashby') return cmdIngestAshby(args.slice(1));
   if (sub === 'smartrecruiters') return cmdIngestSmartRecruiters(args.slice(1));
   if (sub === 'workable') return cmdIngestWorkable(args.slice(1));
+  if (sub === 'url') return cmdIngestUrl(args.slice(1));
   console.error(
     'Usage: jobbot ingest <greenhouse|lever|ashby|smartrecruiters|workable> --company <slug>',
   );
+  console.error('   or: jobbot ingest url <url> [--timeout <ms>]');
   process.exit(2);
 }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -55,8 +55,9 @@ revisit them later without blocking the workflow.
 1. The user searches company boards via supported fetchers (Greenhouse, Lever, SmartRecruiters,
    Ashby, Workable) or pastes individual URLs into the CLI/UI. For example,
    `jobbot ingest greenhouse --company acme` pulls the latest public postings into the local
-   data directory, and `jobbot ingest lever --company acme` performs the same for Lever-hosted
-   listings.
+   data directory, `jobbot ingest lever --company acme` performs the same for Lever-hosted
+   listings, and `jobbot ingest url https://example.com/jobs/staff-engineer` snapshots a
+   single posting on demand.
 2. The fetch pipeline de-duplicates listings, normalizes HTML to text, and stores raw + parsed
    copies under `data/jobs/{job_id}.json` alongside fetch metadata (timestamp, source, request
    headers). Job identifiers are hashed from the source URL or file path so repeat fetches update

--- a/src/url-ingest.js
+++ b/src/url-ingest.js
@@ -1,0 +1,67 @@
+import { fetchTextFromUrl, DEFAULT_FETCH_HEADERS } from './fetch.js';
+import { parseJobText } from './parser.js';
+import { jobIdFromSource, saveJobSnapshot } from './jobs.js';
+
+const DEFAULT_TIMEOUT_MS = 10000;
+
+function normalizeUrl(value) {
+  if (!value || typeof value !== 'string') {
+    throw new Error('job url is required');
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error('job url is required');
+  }
+  if (!/^https?:\/\//i.test(trimmed)) {
+    throw new Error('job url must use http or https');
+  }
+  return trimmed;
+}
+
+function normalizeHeaders(headers) {
+  if (!headers || typeof headers !== 'object') {
+    return undefined;
+  }
+  const normalized = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined || value === null) continue;
+    if (typeof key !== 'string') continue;
+    const trimmedKey = key.trim();
+    if (!trimmedKey) continue;
+    const stringValue = typeof value === 'string' ? value.trim() : String(value);
+    if (!stringValue) continue;
+    normalized[trimmedKey] = stringValue;
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
+export async function ingestJobUrl({
+  url,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  headers,
+  maxBytes,
+} = {}) {
+  const targetUrl = normalizeUrl(url);
+  const extraHeaders = normalizeHeaders(headers);
+  const requestHeaders = extraHeaders
+    ? { ...DEFAULT_FETCH_HEADERS, ...extraHeaders }
+    : { ...DEFAULT_FETCH_HEADERS };
+
+  const fetchOptions = { timeoutMs, headers: requestHeaders };
+  if (Number.isFinite(maxBytes) && maxBytes > 0) {
+    fetchOptions.maxBytes = maxBytes;
+  }
+
+  const raw = await fetchTextFromUrl(targetUrl, fetchOptions);
+  const parsed = parseJobText(raw);
+  const id = jobIdFromSource(targetUrl);
+  const path = await saveJobSnapshot({
+    id,
+    raw,
+    parsed,
+    source: { type: 'url', value: targetUrl },
+    requestHeaders,
+  });
+
+  return { id, path, parsed, raw };
+}

--- a/test/jobs.test.js
+++ b/test/jobs.test.js
@@ -3,6 +3,11 @@ import os from 'node:os';
 import path from 'node:path';
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 
+vi.mock('../src/fetch.js', () => ({
+  fetchTextFromUrl: vi.fn(),
+  DEFAULT_FETCH_HEADERS: { 'User-Agent': 'jobbot3000' },
+}));
+
 let dataDir;
 
 function jobsDir() {
@@ -84,5 +89,47 @@ describe('job snapshots', () => {
     expect(snapshot.raw).toBe('new');
     expect(snapshot.parsed).toEqual({ title: 'New' });
     expect(snapshot.fetched_at).toBe('2025-04-05T07:08:09.000Z');
+  });
+
+  it('ingests individual job URLs and persists snapshots with request metadata', async () => {
+    const url = 'https://example.com/jobs/789';
+    const { fetchTextFromUrl } = await import('../src/fetch.js');
+    fetchTextFromUrl.mockResolvedValue(
+      [
+        'Title: Staff Engineer',
+        'Company: Example Corp',
+        'Location: Remote',
+        'Requirements',
+        '- Build reliable systems',
+      ].join('\n'),
+    );
+
+    const { ingestJobUrl } = await import('../src/url-ingest.js');
+    const result = await ingestJobUrl({ url });
+
+    expect(fetchTextFromUrl).toHaveBeenCalledWith(url, {
+      timeoutMs: 10000,
+      headers: { 'User-Agent': 'jobbot3000' },
+    });
+
+    const snapshot = await readSnapshot(result.id);
+    expect(snapshot.source).toEqual({
+      type: 'url',
+      value: url,
+      headers: { 'User-Agent': 'jobbot3000' },
+    });
+    expect(snapshot.parsed).toMatchObject({
+      title: 'Staff Engineer',
+      company: 'Example Corp',
+      location: 'Remote',
+    });
+    expect(snapshot.parsed.requirements).toEqual(['Build reliable systems']);
+  });
+
+  it('rejects unsupported URL protocols during ingestion', async () => {
+    const { ingestJobUrl } = await import('../src/url-ingest.js');
+    await expect(ingestJobUrl({ url: 'ftp://example.com/job.txt' })).rejects.toThrow(
+      /must use http or https/i,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- add an ingestJobUrl helper that fetches, parses, and snapshots single postings
- expose `jobbot ingest url` CLI workflow and update docs to reflect the new path
- extend job snapshot tests to cover direct URL ingestion and invalid protocols

## Testing
- npm run lint
- npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68d1c9d8e0a4832fba4a5c7aab57c3e4