### PR TITLE
Add Workable API token support for board ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,10 @@ capture so fetches are reproducible.
 Per-tenant rate limits prevent hammering board APIs: set
 `JOBBOT_GREENHOUSE_RATE_LIMIT_MS`, `JOBBOT_LEVER_RATE_LIMIT_MS`,
 `JOBBOT_ASHBY_RATE_LIMIT_MS`, `JOBBOT_SMARTRECRUITERS_RATE_LIMIT_MS`, or
-`JOBBOT_WORKABLE_RATE_LIMIT_MS` to throttle repeat requests. Greenhouse caches
+`JOBBOT_WORKABLE_RATE_LIMIT_MS` to throttle repeat requests. Provide
+`JOBBOT_WORKABLE_TOKEN` when your Workable tenant requires authenticated API
+access; the CLI adds an `Authorization: Bearer …` header during ingest while
+redacting the token from saved job snapshots. Greenhouse caches
 the last fetch timestamp per board and seeds the limiter across CLI runs so
 back-to-back syncs stay compliant. New coverage in
 [`test/fetch.test.js`](test/fetch.test.js) exercises the limiter queue, and


### PR DESCRIPTION
## Summary
- add optional Workable API token handling to use an Authorization header while redacting saved snapshots
- document the JOBBOT_WORKABLE_TOKEN environment variable for authenticated Workable tenants
- cover the token flow with a new Workable ingest test ensuring headers are sent and snapshots stay secret-free

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d1c9d8e0a4832fba4a5c7aab57c3e4