### PR TITLE
Ensure shortlist archive displays (unknown time) placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,8 @@ Existing shortlist files missing a currency symbol are normalized on read using 
 filters and reports stay consistent.
 Unit tests in [`test/shortlist.test.js`](test/shortlist.test.js) and the CLI suite in
 [`test/cli.test.js`](test/cli.test.js) exercise metadata updates, tag filters, discard tags, archive
-exports, and the persisted format.
+exports, and the persisted format. Additional CLI coverage locks in the `(unknown time)` placeholder
+for legacy discard entries so missing timestamps remain readable in archive output.
 
 ## Intake responses
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -733,6 +733,10 @@ function formatShortlistList(jobs) {
   return lines.join('\n');
 }
 
+function formatDiscardTimestamp(timestamp) {
+  return timestamp === 'unknown time' ? '(unknown time)' : timestamp;
+}
+
 function formatDiscardHistory(jobId, entries) {
   const normalized = normalizeDiscardEntries(entries);
   if (normalized.length === 0) {
@@ -740,7 +744,8 @@ function formatDiscardHistory(jobId, entries) {
   }
   const lines = [jobId];
   for (const entry of normalized) {
-    lines.push(`- ${entry.discarded_at} — ${entry.reason}`);
+    const timestamp = formatDiscardTimestamp(entry.discarded_at);
+    lines.push(`- ${timestamp} — ${entry.reason}`);
     if (entry.tags && entry.tags.length > 0) {
       lines.push(`  Tags: ${entry.tags.join(', ')}`);
     }
@@ -758,7 +763,8 @@ function formatDiscardArchive(archive) {
     if (!entries || entries.length === 0) continue;
     lines.push(jobId);
     for (const entry of entries) {
-      lines.push(`- ${entry.discarded_at} — ${entry.reason}`);
+      const timestamp = formatDiscardTimestamp(entry.discarded_at);
+      lines.push(`- ${timestamp} — ${entry.reason}`);
       if (entry.tags && entry.tags.length > 0) {
         lines.push(`  Tags: ${entry.tags.join(', ')}`);
       }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -631,6 +631,21 @@ describe('jobbot CLI', () => {
     expect(emptyJob.trim()).toBe('No discard history for job-missing');
   });
 
+  it('renders legacy discard timestamps as (unknown time)', () => {
+    const archivePath = path.join(dataDir, 'discarded_jobs.json');
+    const legacyArchive = {
+      'job-legacy': [
+        { reason: 'Legacy entry without timestamp' },
+        { reason: 'Legacy blank timestamp', discarded_at: '   ' },
+      ],
+    };
+    fs.writeFileSync(archivePath, `${JSON.stringify(legacyArchive, null, 2)}\n`, 'utf8');
+
+    const output = runCli(['shortlist', 'archive', 'job-legacy']);
+    expect(output).toContain('- (unknown time) — Legacy entry without timestamp');
+    expect(output).toContain('- (unknown time) — Legacy blank timestamp');
+  });
+
   it('records intake responses and lists them', () => {
     const output = runCli([
       'intake',


### PR DESCRIPTION
## Summary
- format shortlist archive and history output so legacy discards render `(unknown time)` when timestamps are missing
- document the additional CLI coverage in the shortlist documentation
- add a CLI regression test that seeds legacy data and asserts the `(unknown time)` placeholder

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d1e140b4c4832f875fd5a04fbac8ae