### PR TITLE
Add rehearse defaults for stage and mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,10 +703,8 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot interviews show job-123 prep-2025-02-01
 #   "ended_at": "2025-02-01T10:15:00.000Z"
 # }
 
-# Capture a quick behavioral rehearsal with generated session IDs and stage/mode shortcuts
+# Capture a quick behavioral rehearsal with generated session IDs (defaults to Behavioral/Voice)
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot rehearse job-123 \
-  --behavioral \
-  --voice \
   --transcript "Walked through leadership story" \
   --reflections "Add quantified wins" \
   --feedback "Great pacing" \
@@ -715,11 +713,12 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot rehearse job-123 \
 ```
 
 Sessions are stored under `data/interviews/{job_id}/{session_id}.json` with ISO 8601 timestamps so
-coaches and candidates can revisit transcripts later. The CLI accepts `--*-file` options for longer
-inputs (for example, `--transcript-file transcript.md`). Automated coverage in
+coaches and candidates can revisit transcripts later. Stage and mode default to `Behavioral` and
+`Voice` when omitted, mirroring the quick-runthrough workflow. The CLI accepts `--*-file` options for
+longer inputs (for example, `--transcript-file transcript.md`). Automated coverage in
 [`test/interviews.test.js`](test/interviews.test.js) and [`test/cli.test.js`](test/cli.test.js)
-verifies persistence, retrieval paths, and the `jobbot rehearse` shorthand for behavioral/voice
-sessions.
+verifies persistence, retrieval paths, and both the stage/mode shortcuts and defaulted rehearse
+metadata.
 
 ## Deliverable bundles
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -1009,8 +1009,8 @@ async function cmdRehearse(args) {
   const feedbackInput = readContentFromArgs(rest, '--feedback', '--feedback-file');
   const notesInput = readContentFromArgs(rest, '--notes', '--notes-file');
 
-  const stage = resolveRehearsalStage(rest);
-  const mode = resolveRehearsalMode(rest);
+  const stage = resolveRehearsalStage(rest) || 'Behavioral';
+  const mode = resolveRehearsalMode(rest) || 'Voice';
   const startedAt = getFlag(rest, '--started-at');
   const endedAt = getFlag(rest, '--ended-at');
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -130,8 +130,8 @@ flow that preserves both sets of notes.
 4. Sessions capture transcripts, user reflections, and coach feedback in
    `data/interviews/{job_id}/{session_id}.json` for future review via
    `jobbot interviews record`. Quick run-throughs can use
-   `jobbot rehearse <job_id>` to auto-generate session identifiers and stage/mode defaults before
-   replaying them with `jobbot interviews show`.
+   `jobbot rehearse <job_id>` to auto-generate session identifiers and default the stage/mode to
+   Behavioral/Voice before replaying them with `jobbot interviews show`.
 
 **Unhappy paths:** if the user misses sessions, the assistant nudges them with lighter-weight prep
 suggestions to prevent burnout.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1234,4 +1234,34 @@ describe('jobbot CLI', () => {
       ended_at: '2025-02-01T09:45:00.000Z',
     });
   });
+
+  it('defaults rehearse stage and mode when not provided', () => {
+    const output = runCli([
+      'rehearse',
+      'job-quick',
+      '--transcript',
+      'Speed run behavioral prompts',
+      '--reflections',
+      'Anchor story with metrics',
+    ]);
+
+    const trimmed = output.trim();
+    expect(trimmed.startsWith('Recorded rehearsal ')).toBe(true);
+    const match = trimmed.match(/^Recorded rehearsal (.+) for job-quick$/);
+    expect(match).not.toBeNull();
+    const [, sessionId] = match;
+
+    const file = path.join(dataDir, 'interviews', 'job-quick', `${sessionId}.json`);
+    const stored = JSON.parse(fs.readFileSync(file, 'utf8'));
+
+    expect(stored).toMatchObject({
+      job_id: 'job-quick',
+      session_id: sessionId,
+      stage: 'Behavioral',
+      mode: 'Voice',
+      transcript: 'Speed run behavioral prompts',
+      reflections: ['Anchor story with metrics'],
+    });
+    expect(stored).toHaveProperty('recorded_at');
+  });
 });


### PR DESCRIPTION
## Summary
- confirm docs/user-journeys.md promised stage/mode defaults for `jobbot rehearse`
- add CLI coverage proving rehearse picks Behavioral/Voice when omitted
- default the command implementation and refresh README/user journey guidance

## Testing
- npm run lint
- npm run test:ci -- --testTimeout=10000 --maxWorkers=1

------
https://chatgpt.com/codex/tasks/task_e_68d1e140b4c4832f875fd5a04fbac8ae