### PR TITLE
feat: ship intake bullet synthesis and resume perf guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,8 @@ even when the first requirement follows
 the header on the same line. Leading numbers without punctuation remain intact. Requirement headers
 are located in a single pass to avoid re-scanning large job postings, and resume scoring tokenizes
 via a manual scanner and caches tokens (up to 60k lines) to avoid repeated work. Automated tests
-exercise this path with 120k-line resumes to ensure the tokenizer stays under 200ms. Requirement bullets
+exercise this path with 120k-line resumes to ensure the tokenizer stays under 190ms on a cold run.
+Requirement bullets
 are scanned without regex or temporary arrays, improving large input performance. Blank or
 non-string requirement entries are skipped so invalid bullets don't affect scoring.
 
@@ -601,6 +602,23 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot intake list --skipped-only
 #   Asked At: 2025-02-01T12:40:00.000Z
 #   Recorded At: 2025-02-01T12:40:00.000Z
 #   ID: 987e6543-e21b-45d3-a456-426614174001
+
+# Turn answered prompts into bullet suggestions tagged by competency
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot intake bullets --json
+# {
+#   "bullets": [
+#     {
+#       "text": "Led SRE incident response overhaul",
+#       "tags": ["Leadership", "SRE"],
+#       "source": {
+#         "question": "Tell me about a leadership win",
+#         "response_id": "123e4567-e89b-12d3-a456-426614174000"
+#       }
+#     }
+#   ]
+# }
+# Filter suggestions to specific skills
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot intake bullets --tag metrics
 ```
 
 Entries are appended to `data/profile/intake.json` with normalized timestamps, optional tags, notes,

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -43,6 +43,8 @@ with retry options and explain how to manually fix the source file.
    `jobbot intake record`. When a candidate postpones a prompt, `jobbot intake record --skip` marks
    it for follow-up while preserving tags/notes so the model can circle back. The assistant
    synthesizes updated bullet point options tagged by skill or competency.
+   Run `jobbot intake bullets [--tag <value>] [--json]` to export those suggestions for tailoring
+   sessions.
 4. All interactions are stored locally with timestamps and provenance metadata for later review.
 
 **Unhappy paths:** the user can skip or postpone questions. Skips are marked so the assistant can

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -12,6 +12,7 @@ function tokenize(text) {
   const tokens = new Set();
   let start = -1;
   let needsLower = false;
+  let lowerKey;
 
   for (let i = 0; i < key.length; i++) {
     const code = key.charCodeAt(i);
@@ -26,18 +27,25 @@ function tokenize(text) {
       }
       if (isUpper) needsLower = true;
     } else if (start !== -1) {
-      let token = key.slice(start, i);
-      if (needsLower) token = token.toLowerCase();
-      tokens.add(token);
+      const end = i;
+      if (needsLower) {
+        if (!lowerKey) lowerKey = key.toLowerCase();
+        tokens.add(lowerKey.slice(start, end));
+      } else {
+        tokens.add(key.slice(start, end));
+      }
       start = -1;
       needsLower = false;
     }
   }
 
   if (start !== -1) {
-    let token = key.slice(start);
-    if (needsLower) token = token.toLowerCase();
-    tokens.add(token);
+    if (needsLower) {
+      if (!lowerKey) lowerKey = key.toLowerCase();
+      tokens.add(lowerKey.slice(start));
+    } else {
+      tokens.add(key.slice(start));
+    }
   }
 
   // Simple cache eviction to bound memory.
@@ -173,4 +181,10 @@ export function computeFitScore(resumeText, requirements) {
 
   const score = Math.round((matched.length / total) * 100);
   return { score, matched, missing };
+}
+
+export function __resetScoringCachesForTest() {
+  TOKEN_CACHE.clear();
+  cachedResume = '';
+  cachedTokens = new Set();
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -735,6 +735,56 @@ describe('jobbot CLI', () => {
     });
   });
 
+  it('surfaces intake bullet suggestions and supports tag filters', () => {
+    const leadershipOutput = runCli([
+      'intake',
+      'record',
+      '--question',
+      'Tell me about a leadership win',
+      '--answer',
+      'Led SRE incident response overhaul',
+      '--tags',
+      'Leadership,SRE',
+      '--notes',
+      'Focus on coordination',
+    ]);
+    expect(leadershipOutput.trim()).toMatch(/^Recorded intake response/);
+
+    const metricsOutput = runCli([
+      'intake',
+      'record',
+      '--question',
+      'Share a metric-driven accomplishment',
+      '--answer',
+      'Increased activation by 25%\nReduced churn by 10%',
+      '--tags',
+      'Metrics',
+    ]);
+    expect(metricsOutput.trim()).toMatch(/^Recorded intake response/);
+
+    const payload = JSON.parse(runCli(['intake', 'bullets', '--json']));
+    expect(payload.bullets).toHaveLength(3);
+    expect(payload.bullets[0]).toMatchObject({
+      text: 'Led SRE incident response overhaul',
+      tags: ['Leadership', 'SRE'],
+      source: {
+        question: 'Tell me about a leadership win',
+        type: 'intake',
+      },
+    });
+
+    const filtered = JSON.parse(runCli(['intake', 'bullets', '--json', '--tag', 'metrics']));
+    expect(filtered.bullets).toHaveLength(2);
+    expect(filtered.bullets.map(entry => entry.text)).toEqual([
+      'Increased activation by 25%',
+      'Reduced churn by 10%',
+    ]);
+
+    const textOutput = runCli(['intake', 'bullets']);
+    expect(textOutput).toContain('Led SRE incident response overhaul');
+    expect(textOutput).toContain('Question: Share a metric-driven accomplishment');
+  });
+
   it('tags shortlist entries and persists labels', () => {
     const output = runCli(['shortlist', 'tag', 'job-abc', 'dream', 'remote']);
     expect(output.trim()).toBe('Tagged job-abc with dream, remote');

--- a/test/scoring.resume.perf.test.js
+++ b/test/scoring.resume.perf.test.js
@@ -1,14 +1,22 @@
+import { randomUUID } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
 import { describe, it, expect } from 'vitest';
-import { computeFitScore } from '../src/scoring.js';
+import { computeFitScore, __resetScoringCachesForTest } from '../src/scoring.js';
+
+const LARGE_RESUME = Array.from({ length: 120000 }, (_, i) => `Skill ${i}`).join('\n');
+const REQUIREMENTS = ['Skill 123', 'Skill 119999'];
 
 describe('computeFitScore resume tokenization performance', () => {
-  it('tokenizes a 120k-line resume within 240ms', () => {
-    const resume = Array.from({ length: 120000 }, (_, i) => `Skill ${i}`).join('\n');
-    const requirements = ['Skill 123', 'Skill 119999'];
+  it('tokenizes a 120k-line resume within 190ms on a cold run', () => {
+    // Warm up the JIT on a tiny input so the cold-run measurement below only captures
+    // the resume tokenization path. Each invocation uses a unique resume string to avoid
+    // triggering the module-level cache.
+    __resetScoringCachesForTest();
+    computeFitScore('Warm up', ['Skill 0']);
     const start = performance.now();
-    computeFitScore(resume, requirements);
+    computeFitScore(`${LARGE_RESUME}\n${randomUUID()}`, REQUIREMENTS);
     const duration = performance.now() - start;
-    expect(duration).toBeLessThan(240);
+
+    expect(duration).toBeLessThan(190);
   });
 });


### PR DESCRIPTION
## What
- expose `jobbot intake bullets` CLI output and examples
- synthesize bullet suggestions from answered intake responses
- harden resume tokenization to stay <190ms and add cache reset hook

## Why
- close documented intake bullet follow-up with tests and docs
- keep resume performance promises under worst-case loads

## How to test
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d1e140b4c4832f875fd5a04fbac8ae