### PR TITLE
Add discard counts to shortlist JSON exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,8 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --json
 #         "reason": "Not remote",
 #         "discarded_at": "2025-03-05T12:00:00.000Z",
 #         "tags": ["Remote", "onsite"]
-#       }
+#       },
+#       "discard_count": 1
 #     }
 #   }
 # }
@@ -535,8 +536,9 @@ The CLI stores shortlist labels, discard history, and sync metadata in `data/sho
 reasons, timestamps, optional tags, and location/level/compensation fields so recommendations can
 surface patterns later. Review past decisions with `jobbot shortlist archive [job_id]` (add `--json`
 to inspect all records at once), which reads from `data/discarded_jobs.json` so archive lookups and
-shortlist history stay in sync. JSON exports now include a `last_discard` summary so downstream tools
-can surface the most recent rationale without traversing the full history. Add `--json` to the
+shortlist history stay in sync. JSON exports now include a `last_discard` summary and `discard_count`
+so downstream tools can surface the most recent rationale and how often a role has been reconsidered
+without traversing the full history. Add `--json` to the
 shortlist list command when piping entries into other tools; include `--out <path>` to persist the
 snapshot on disk. Filter by metadata or tags (`--location`, `--level`, `--compensation`, or repeated
 `--tag` flags) when triaging opportunities. Text output also surfaces `Last Discard Tags` when tag

--- a/src/shortlist.js
+++ b/src/shortlist.js
@@ -237,6 +237,7 @@ function cloneRecord(record) {
     discarded: cloneDiscardList(record.discarded),
     metadata: record.metadata ? { ...record.metadata } : {},
   };
+  cloned.discard_count = cloned.discarded.length;
   const summary = getLastDiscardSummary(cloned.discarded);
   if (summary) cloned.last_discard = summary;
   return cloned;

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -921,6 +921,7 @@ describe('jobbot CLI', () => {
       discarded_at: '2025-03-07T09:30:00.000Z',
       tags: ['follow_up', 'calendared'],
     });
+    expect(json.jobs['job-json'].discard_count).toBe(2);
   });
 
   it('writes shortlist JSON snapshots to disk with --out', () => {
@@ -966,6 +967,7 @@ describe('jobbot CLI', () => {
         reason: 'Deprioritized',
         discarded_at: '2025-03-05T12:00:00.000Z',
       },
+      discard_count: 1,
     });
   });
 
@@ -1065,6 +1067,7 @@ describe('jobbot CLI', () => {
     expect(payload).toEqual({
       jobs: {
         'job-json': {
+          discard_count: 1,
           tags: ['Remote'],
           last_discard: {
             reason: 'Paused search',

--- a/test/shortlist.test.js
+++ b/test/shortlist.test.js
@@ -41,9 +41,11 @@ describe('shortlist metadata sync and filters', () => {
       compensation: '$180k',
       synced_at: '2025-02-03T04:05:06.000Z',
     });
+    expect(store.jobs['job-metadata'].discard_count).toBe(0);
 
     const byFilters = await filterShortlist({ location: 'remote', level: 'senior' });
     expect(Object.keys(byFilters.jobs)).toEqual(['job-metadata']);
+    expect(byFilters.jobs['job-metadata'].discard_count).toBe(0);
   });
 
   it('filters shortlist entries by tag', async () => {
@@ -122,9 +124,11 @@ describe('shortlist metadata sync and filters', () => {
       level: 'Senior',
       compensation: '$120k',
     });
+    expect(record.discard_count).toBe(0);
 
     const filtered = await filterShortlist({ compensation: '$120k' });
     expect(Object.keys(filtered.jobs)).toEqual(['job-legacy']);
+    expect(filtered.jobs['job-legacy'].discard_count).toBe(0);
   });
 
   it('applies JOBBOT_SHORTLIST_CURRENCY to legacy compensation values', async () => {
@@ -151,6 +155,7 @@ describe('shortlist metadata sync and filters', () => {
       const { getShortlist } = await import('../src/shortlist.js');
       const record = await getShortlist('job-euro');
       expect(record.metadata.compensation).toBe('€95k');
+      expect(record.discard_count).toBe(0);
     } finally {
       delete process.env.JOBBOT_SHORTLIST_CURRENCY;
     }
@@ -175,6 +180,7 @@ describe('shortlist metadata sync and filters', () => {
       discarded_at: '2025-03-07T09:30:00.000Z',
       tags: ['Focus', 'remote'],
     });
+    expect(snapshot.discard_count).toBe(2);
 
     const filtered = await filterShortlist();
     expect(filtered.jobs['job-history'].last_discard).toEqual({
@@ -182,5 +188,6 @@ describe('shortlist metadata sync and filters', () => {
       discarded_at: '2025-03-07T09:30:00.000Z',
       tags: ['Focus', 'remote'],
     });
+    expect(filtered.jobs['job-history'].discard_count).toBe(2);
   });
 });


### PR DESCRIPTION
## Summary
- confirmed repo TODO/future-work inventory has no other shortlist gaps; focused on completing the documented discard_count addition
- persist discard_count in shortlist clones so JSON exports reflect the discard history size
- extend shortlist unit and CLI integration tests plus README docs to cover the new field

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d1ea81e704832fb1468e961709407b