### PR TITLE
✨ : – track analytics activity counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,7 +690,10 @@ cover outreach counts, acceptance detection, JSON formatting, the largest drop-o
 anonymized snapshot export. The `analytics export` subcommand captures aggregate status counts and
 event channels without embedding raw job identifiers so personal records stay scrubbed. JSON exports
 now include a `funnel.sankey` payload describing nodes and links for outreach ➜ acceptance flows,
-making it trivial to render Sankey diagrams without recomputing the stage math.
+making it trivial to render Sankey diagrams without recomputing the stage math. They also surface
+an `activity` summary that counts how many deliverable runs and interview sessions exist across the
+data directory without revealing the associated job IDs, giving the recommender a privacy-preserving
+signal about tailoring and rehearsal momentum.
 
 When outreach events exist without a matching lifecycle status, the report now prints a
 `Missing data: …` line listing the affected job IDs so you can backfill outcomes quickly.

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -147,7 +147,9 @@ suggestions to prevent burnout.
    ➜ acceptance) and highlight the largest drop-off. JSON exports expose a `funnel.sankey`
    structure so visualization layers can consume nodes and links directly.
 2. Metadata from tailoring and rehearsal sessions feeds back into the recommender so it can surface
-   what worked (e.g., bullet variants correlated with interviews) while staying privacy-first.
+   what worked (e.g., bullet variants correlated with interviews) while staying privacy-first. The
+   analytics export reports aggregate deliverable runs and interview session counts in an
+   `activity` block so planners can gauge momentum without exposing specific job identifiers.
 3. Users can export anonymized aggregates with `jobbot analytics export --out <file>` for personal
    record keeping without exposing raw PII.
 

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -263,4 +263,71 @@ describe('analytics conversion funnel', () => {
     expect(serialized).not.toContain('job-accepted');
     expect(serialized).not.toContain('job-screening');
   });
+
+  it('summarizes deliverable runs and interview sessions without exposing job ids', async () => {
+    const fs = await import('node:fs/promises');
+    const deliverablesRoot = path.join(dataDir, 'deliverables');
+    const job1Run1Dir = path.join(deliverablesRoot, 'job-1', '2025-02-01T10-00-00Z');
+    const job1Run2Dir = path.join(deliverablesRoot, 'job-1', '2025-02-05T09-00-00Z');
+    const job2RunDir = path.join(deliverablesRoot, 'job-2', '2025-03-01T08-00-00Z');
+    await fs.mkdir(job1Run1Dir, { recursive: true });
+    await fs.writeFile(path.join(job1Run1Dir, 'resume.pdf'), 'binary');
+    await fs.mkdir(job1Run2Dir, { recursive: true });
+    await fs.writeFile(path.join(job1Run2Dir, 'cover-letter.docx'), 'binary');
+    await fs.mkdir(job2RunDir, { recursive: true });
+    await fs.writeFile(path.join(job2RunDir, 'notes.txt'), 'binary');
+
+    const interviewsRoot = path.join(dataDir, 'interviews');
+    const jobAlphaDir = path.join(interviewsRoot, 'job-alpha');
+    const jobBetaDir = path.join(interviewsRoot, 'job-beta');
+    await fs.mkdir(jobAlphaDir, { recursive: true });
+    await fs.writeFile(
+      path.join(jobAlphaDir, 'session-1.json'),
+      JSON.stringify({ transcript: 'Great session' }, null, 2)
+    );
+    await fs.writeFile(
+      path.join(jobAlphaDir, 'session-2.json'),
+      JSON.stringify({ transcript: 'Follow-up session' }, null, 2)
+    );
+    await fs.mkdir(jobBetaDir, { recursive: true });
+    await fs.writeFile(
+      path.join(jobBetaDir, 'session-a.json'),
+      JSON.stringify({ transcript: 'Phone screen' }, null, 2)
+    );
+
+    const { exportAnalyticsSnapshot, setAnalyticsDataDir } = await import('../src/analytics.js');
+    setAnalyticsDataDir(dataDir);
+    restoreAnalyticsDir = async () => setAnalyticsDataDir(undefined);
+
+    const snapshot = await exportAnalyticsSnapshot();
+    expect(snapshot.activity).toEqual({
+      deliverables: { jobs: 2, runs: 3 },
+      interviews: { jobs: 2, sessions: 3 },
+    });
+
+    const serialized = JSON.stringify(snapshot);
+    expect(serialized).not.toContain('job-1');
+    expect(serialized).not.toContain('job-2');
+    expect(serialized).not.toContain('job-alpha');
+    expect(serialized).not.toContain('job-beta');
+  });
+
+  it('counts flat deliverable folders without timestamped runs as a single run', async () => {
+    const fs = await import('node:fs/promises');
+    const deliverablesRoot = path.join(dataDir, 'deliverables');
+    const flatJobDir = path.join(deliverablesRoot, 'job-flat');
+    await fs.mkdir(deliverablesRoot, { recursive: true });
+    await fs.mkdir(flatJobDir, { recursive: true });
+    await fs.writeFile(path.join(flatJobDir, 'resume.pdf'), 'binary');
+
+    const { exportAnalyticsSnapshot, setAnalyticsDataDir } = await import('../src/analytics.js');
+    setAnalyticsDataDir(dataDir);
+    restoreAnalyticsDir = async () => setAnalyticsDataDir(undefined);
+
+    const snapshot = await exportAnalyticsSnapshot();
+    expect(snapshot.activity).toEqual({
+      deliverables: { jobs: 1, runs: 1 },
+      interviews: { jobs: 0, sessions: 0 },
+    });
+  });
 });


### PR DESCRIPTION
what: add analytics activity summary + tests + docs; fix flat counts
why: docs promise recommender visibility into tailoring momentum
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d1ea81e704832fb1468e961709407b