### PR TITLE
✨ enforce newest-first shortlist archive ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,8 @@ Unit tests in [`test/shortlist.test.js`](test/shortlist.test.js) and the CLI sui
 [`test/cli.test.js`](test/cli.test.js) exercise metadata updates, tag filters, discard tags, archive
 exports, and the persisted format. Additional CLI coverage locks in the `(unknown time)` placeholder
 for legacy discard entries so missing timestamps remain readable in archive output.
+[`test/discards.test.js`](test/discards.test.js) now asserts archive order returns the latest discard
+first even when older entries remain, keeping the newest-first guarantee enforced.
 
 ## Intake responses
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -819,9 +819,8 @@ function formatDiscardHistory(jobId, entries) {
   if (normalized.length === 0) {
     return `No discard history for ${jobId}`;
   }
-  const ordered = normalized.slice().reverse();
   const lines = [jobId];
-  for (const entry of ordered) {
+  for (const entry of normalized) {
     const timestamp = formatDiscardTimestamp(entry.discarded_at);
     lines.push(`- ${timestamp} — ${entry.reason}`);
     if (entry.tags && entry.tags.length > 0) {
@@ -840,7 +839,7 @@ function formatDiscardArchive(archive) {
     const entries = normalized[jobId];
     if (!entries || entries.length === 0) continue;
     lines.push(jobId);
-    for (const entry of entries.slice().reverse()) {
+    for (const entry of entries) {
       const timestamp = formatDiscardTimestamp(entry.discarded_at);
       lines.push(`- ${timestamp} — ${entry.reason}`);
       if (entry.tags && entry.tags.length > 0) {
@@ -905,9 +904,8 @@ async function cmdShortlistArchive(args) {
   try {
     if (jobId) {
       const history = await getDiscardedJobs(jobId);
-      const orderedHistory = history.slice().reverse();
       if (asJson) {
-        console.log(JSON.stringify({ job_id: jobId, history: orderedHistory }, null, 2));
+        console.log(JSON.stringify({ job_id: jobId, history }, null, 2));
       } else {
         console.log(formatDiscardHistory(jobId, history));
       }
@@ -915,12 +913,8 @@ async function cmdShortlistArchive(args) {
     }
 
     const archive = await getDiscardedJobs();
-    const orderedArchive = {};
-    for (const job of Object.keys(archive)) {
-      orderedArchive[job] = archive[job].slice().reverse();
-    }
     if (asJson) {
-      console.log(JSON.stringify({ discarded: orderedArchive }, null, 2));
+      console.log(JSON.stringify({ discarded: archive }, null, 2));
     } else {
       console.log(formatDiscardArchive(archive));
     }

--- a/src/discards.js
+++ b/src/discards.js
@@ -98,7 +98,7 @@ function normalizeDiscardEntries(entries) {
     if (Number.isNaN(aTime)) return 1;
     if (Number.isNaN(bTime)) return -1;
     if (aTime === bTime) return 0;
-    return aTime < bTime ? -1 : 1;
+    return aTime > bTime ? -1 : 1;
   });
   return normalized;
 }

--- a/test/discards.test.js
+++ b/test/discards.test.js
@@ -43,6 +43,21 @@ describe('discarded job archive', () => {
     expect(byId).toEqual(archive['job-123']);
   });
 
+  it('returns the newest discard entry first', async () => {
+    const { recordJobDiscard, getDiscardedJobs } = await import('../src/discards.js');
+    await recordJobDiscard('job-ordered', {
+      reason: 'Earlier concern',
+      date: '2025-03-01T10:00:00Z',
+    });
+    await recordJobDiscard('job-ordered', {
+      reason: 'Latest update',
+      date: '2025-04-05T09:30:00Z',
+    });
+
+    const history = await getDiscardedJobs('job-ordered');
+    expect(history.map(entry => entry.reason)).toEqual(['Latest update', 'Earlier concern']);
+  });
+
   it('rejects missing job ids or reasons', async () => {
     const { recordJobDiscard } = await import('../src/discards.js');
     await expect(recordJobDiscard('', { reason: 'Missing' })).rejects.toThrow('job id is required');


### PR DESCRIPTION
what:
- add coverage ensuring newest discards appear first
- update discard sorting & CLI output to honor README guarantee
- document the enforced newest-first check

why:
- README promises newest-first archive ordering

how to test:
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d225cb342c832faeeeea8c9acd9e35