### PR TITLE
Add French blocker localization to match explanations

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ generated `word/document.xml`, and [`test/cli.test.js`](test/cli.test.js) verifi
 `--docx` flag writes those documents without altering stdout output.
 
 Both exporters accept an optional `locale` field to translate labels.
-The default locale is `'en'`; Spanish (`'es'`) is also supported.
+The default locale is `'en'`; Spanish (`'es'`) and French (`'fr'`) are also supported.
 
 Use `toMarkdownMatch` to format fit score results; it also accepts `url`:
 
@@ -346,7 +346,8 @@ location constraints (“onsite”, “in-office”, “relocation”, “travel
 (“salary”, “compensation”, “base pay”), and seniority signals (“senior-level”, “years of experience”,
 “leadership”). They are surfaced in a dedicated line so reviewers can distinguish urgent gaps from
 nice-to-have skills. Tests in [`test/exporters.test.js`](test/exporters.test.js) cover the expanded
-blocker detection and the fallback message when no mandatory requirements are found.
+blocker detection, localized blocker labels (including the French strings), and the fallback
+message when no mandatory requirements are found.
 
 The summarizer extracts the first sentence, handling `.`, `!`, `?`, and consecutive terminal
 punctuation like `?!`, including when followed by closing quotes or parentheses. Terminators apply

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -10,6 +10,8 @@ export default {
   explanation: 'Explication',
   hits: 'Points forts',
   gaps: 'Lacunes',
+  blockers: 'Blocages',
+  noBlockers: 'Aucun blocage signalé.',
   noHits: 'Aucune correspondance directe depuis le CV.',
   noGaps: 'Aucune exigence manquante détectée.',
   coverageSummary: 'Correspond {matched} sur {total} exigences ({score} %).',

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -228,6 +228,18 @@ describe('exporters', () => {
     expect(text).toContain('No blockers flagged.');
   });
 
+  it('localizes blocker labels in French explanations', () => {
+    const blockers = formatMatchExplanation({
+      matched: [],
+      missing: ['Security clearance required'],
+      locale: 'fr',
+    });
+    expect(blockers).toContain('Blocages: Security clearance required');
+
+    const fallback = formatMatchExplanation({ matched: [], missing: [], locale: 'fr' });
+    expect(fallback).toContain('Aucun blocage signalé.');
+  });
+
   it('surfaces blockers based on must-have keywords', () => {
     const text = formatMatchExplanation({
       matched: [],


### PR DESCRIPTION
## what
- add French blocker/no-blocker strings and README note
- cover French localization with exporter test

## why
- README promises translated labels for each locale

## how to test
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d225cb342c832faeeeea8c9acd9e35