### PR TITLE
Default interview records to Behavioral/Voice by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,8 +781,9 @@ coaches and candidates can revisit transcripts later. Stage and mode default to 
 `Voice` when omitted, mirroring the quick-runthrough workflow. The CLI accepts `--*-file` options for
 longer inputs (for example, `--transcript-file transcript.md`). Automated coverage in
 [`test/interviews.test.js`](test/interviews.test.js) and [`test/cli.test.js`](test/cli.test.js)
-verifies persistence, retrieval paths, stage/mode shortcuts, the defaulted rehearse metadata, and the
-stage-specific rehearsal plans emitted by `jobbot interviews plan`.
+verifies persistence, retrieval paths, stage/mode shortcuts, the defaulted rehearse metadata,
+manual recordings inheriting the same Behavioral/Voice defaults, and the stage-specific rehearsal
+plans emitted by `jobbot interviews plan`.
 
 ## Deliverable bundles
 

--- a/src/interviews.js
+++ b/src/interviews.js
@@ -340,8 +340,8 @@ export async function recordInterviewSession(jobId, sessionId, data = {}) {
     throw new Error('at least one session field is required');
   }
 
-  const stage = sanitizeString(data.stage);
-  const mode = sanitizeString(data.mode);
+  const stage = sanitizeString(data.stage) || 'Behavioral';
+  const mode = sanitizeString(data.mode) || 'Voice';
   const startedAt = normalizeTimestamp(data.startedAt ?? data.started_at, 'start');
   const endedAt = normalizeTimestamp(data.endedAt ?? data.ended_at, 'end');
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1266,6 +1266,27 @@ describe('jobbot CLI', () => {
     expect(parsed).toEqual(stored);
   });
 
+  it('defaults interviews record stage and mode when omitted', () => {
+    const output = runCli([
+      'interviews',
+      'record',
+      'job-456',
+      'session-default',
+      '--transcript',
+      'Practiced elevator pitch',
+      '--reflections',
+      'Tighten closing ask',
+    ]);
+
+    expect(output.trim()).toBe('Recorded session session-default for job-456');
+
+    const file = path.join(dataDir, 'interviews', 'job-456', 'session-default.json');
+    const stored = JSON.parse(fs.readFileSync(file, 'utf8'));
+
+    expect(stored.stage).toBe('Behavioral');
+    expect(stored.mode).toBe('Voice');
+  });
+
   it('records rehearsal sessions with stage and mode shortcuts', () => {
     const output = runCli([
       'rehearse',

--- a/test/interviews.test.js
+++ b/test/interviews.test.js
@@ -100,6 +100,27 @@ describe('interview session archive', () => {
     const result = await getInterviewSession('job-404', 'missing');
     expect(result).toBeNull();
   });
+
+  it('defaults stage and mode when omitted', async () => {
+    const { setInterviewDataDir, recordInterviewSession } = await import('../src/interviews.js');
+
+    setInterviewDataDir(dataDir);
+
+    const recorded = await recordInterviewSession('job-default', 'session-default', {
+      transcript: 'Practiced elevator pitch.',
+    });
+
+    expect(recorded).toMatchObject({
+      stage: 'Behavioral',
+      mode: 'Voice',
+    });
+
+    const disk = await readSession('job-default', 'session-default');
+    expect(disk).toMatchObject({
+      stage: 'Behavioral',
+      mode: 'Voice',
+    });
+  });
 });
 
 describe('generateRehearsalPlan', () => {


### PR DESCRIPTION
## Summary
- default `recordInterviewSession` to persist Behavioral/Voice when stage or mode are omitted
- extend CLI and unit coverage so manual `jobbot interviews record` calls receive those defaults
- update README to note the new coverage for manual interview recordings

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d225cb342c832faeeeea8c9acd9e35