### PR TITLE
✨ : – Extend resume ambiguity heuristics to plain text

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ or quantified metrics are absent, and the `confidence` score reflects those
 signals so review tools can triage follow-up work. Ambiguity entries now include
 the `{ line, column }` location of each occurrence and are emitted in document
 order so callers can highlight every placeholder directly in downstream editors.
+Plain text and PDF resumes receive the same aggregate `dates`, `metrics`, and
+`titles` hints, with additional coverage in `test/resume.test.js` confirming the
+non-Markdown path.
 
 Initialize a JSON Resume skeleton when you do not have an existing file:
 


### PR DESCRIPTION
## Summary
- apply aggregate resume ambiguity heuristics to all formats so plain text and PDF imports surface dates/metrics/title hints
- add a plain text-focused test and tighten duplicate placeholder assertions to ignore aggregate hints
- document the broadened coverage in the resume import section

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d2437acec0832f82f52d4fb0e48678