### PR TITLE
Add onsite rehearsal plan and CLI shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -801,6 +801,12 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot interviews plan --stage system-design --rol
 # - System design checklist
 # - Capacity planning worksheet
 
+# Prep the onsite loop with logistics and follow-up checklists
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot interviews plan --onsite
+# Onsite rehearsal plan
+# Suggested duration: 150 minutes
+# Sections cover agenda review, energy & logistics, story rotation, and follow-up tasks.
+
 # Capture a quick behavioral rehearsal with generated session IDs (defaults to Behavioral/Voice)
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot rehearse job-123 \
   --transcript "Walked through leadership story" \
@@ -819,7 +825,9 @@ verifies persistence, retrieval paths, stage/mode shortcuts, the defaulted rehea
 manual recordings inheriting the same Behavioral/Voice defaults, and the stage-specific rehearsal
 plans emitted by `jobbot interviews plan`. Plans now include a `Flashcards` checklist and a
 numbered `Question bank` so candidates can drill concepts by focus area; the updated tests assert
-that both sections appear in JSON and CLI output.
+that both sections appear in JSON and CLI output. New coverage in
+[`test/interviews.test.js`](test/interviews.test.js) also locks in the Onsite logistics plan so its
+agenda review, energy resets, and thank-you follow-ups stay consistent across releases.
 
 ## Deliverable bundles
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -1098,6 +1098,7 @@ function resolvePlanStage(args) {
   if (args.includes('--technical')) return 'technical';
   if (args.includes('--system-design') || args.includes('--system_design')) return 'system design';
   if (args.includes('--take-home') || args.includes('--takehome')) return 'take-home';
+  if (args.includes('--onsite')) return 'onsite';
   const explicit = getFlag(args, '--stage');
   return explicit;
 }

--- a/src/interviews.js
+++ b/src/interviews.js
@@ -32,6 +32,9 @@ const STAGE_ALIASES = new Map(
     ['take home', 'Take-Home'],
     ['take-home', 'Take-Home'],
     ['takehome', 'Take-Home'],
+    ['onsite', 'Onsite'],
+    ['on site', 'Onsite'],
+    ['on-site', 'Onsite'],
   ].map(([key, value]) => [key, value]),
 );
 
@@ -254,6 +257,74 @@ const PLAN_LIBRARY = {
       {
         prompt: 'Scale a read-heavy API to millions of users.',
         tags: ['Scalability'],
+      },
+    ],
+  },
+  Onsite: {
+    duration: 150,
+    summary(role) {
+      if (role) {
+        return (
+          `Coordinate the ${role} onsite loop with smooth transitions, steady energy, ` +
+          'and clear follow-ups.'
+        );
+      }
+      return (
+        'Coordinate the onsite loop with smooth transitions, steady energy, and clear follow-ups.'
+      );
+    },
+    sections(role) {
+      const panelLabel = role ? `${role} panel` : 'panel';
+      return [
+        {
+          title: 'Agenda review',
+          items: [
+            'Confirm interview schedule, formats, and expectations with your recruiter.',
+            `Note interviewer backgrounds and tailor intros for each ${panelLabel}.`,
+          ],
+        },
+        {
+          title: 'Energy & logistics',
+          items: [
+            'Plan meals, breaks, wardrobe, workspace, and travel buffers for the onsite day.',
+            'Stage materials (resume variants, notebook, metrics) and reminders for check-ins.',
+          ],
+        },
+        {
+          title: 'Story rotation',
+          items: [
+            'Map STAR stories to each session and vary examples across interviews.',
+            'List clarifying questions to open and close each room confidently.',
+          ],
+        },
+        {
+          title: 'Follow-up',
+          items: [
+            'Draft thank-you note bullet points per interviewer while details are fresh.',
+            'Capture risks, commitments, and next steps immediately after the loop.',
+          ],
+        },
+      ];
+    },
+    resources: ['Onsite checklist', 'Thank-you note templates'],
+    flashcards: [
+      {
+        front: 'Panel transitions',
+        back: 'Reset, summarize, and confirm expectations between interviews.',
+      },
+      {
+        front: 'Energy reset',
+        back: 'Plan hydration, nutrition, and breaks to stay sharp all day.',
+      },
+    ],
+    questionBank: [
+      {
+        prompt: 'How will you tailor your opener for each onsite session?',
+        tags: ['Communication'],
+      },
+      {
+        prompt: 'What signals do you want every interviewer to carry into the debrief?',
+        tags: ['Strategy'],
       },
     ],
   },

--- a/test/interviews.test.js
+++ b/test/interviews.test.js
@@ -207,4 +207,35 @@ describe('generateRehearsalPlan', () => {
     expect(deliverySection.items.join(' ')).toMatch(/lint/i);
     expect(plan.resources).toContain('Take-home submission rubric');
   });
+
+  it('supports onsite rehearsal plans focused on logistics and follow-up', async () => {
+    const { generateRehearsalPlan } = await import('../src/interviews.js');
+
+    const plan = generateRehearsalPlan({ stage: 'onsite', role: 'Engineering Manager' });
+
+    expect(plan.stage).toBe('Onsite');
+    expect(plan.duration_minutes).toBeGreaterThanOrEqual(120);
+    expect(plan.summary).toMatch(/onsite/i);
+    const sectionTitles = plan.sections.map(section => section.title);
+    expect(sectionTitles).toEqual(expect.arrayContaining(['Agenda review', 'Follow-up']));
+    const followUpSection = plan.sections.find(section => section.title === 'Follow-up');
+    expect(followUpSection.items.join(' ')).toMatch(/thank-you/i);
+    expect(plan.resources).toContain('Onsite checklist');
+    expect(plan.flashcards).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          front: 'Panel transitions',
+          back: expect.stringMatching(/expectations/i),
+        }),
+      ]),
+    );
+    expect(plan.question_bank).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          prompt: expect.stringMatching(/debrief/i),
+          tags: expect.arrayContaining(['Strategy']),
+        }),
+      ]),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add an onsite rehearsal template that covers agenda review, logistics, story rotation, and follow-up guidance
- expose a `--onsite` flag for `jobbot interviews plan` so the new template is easy to reach
- document the onsite plan and extend tests to lock in its logistics-focused guidance

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d31cdf7100832f9995c2fe0025d876