### PR TITLE
Add dialog trees to interview rehearsal plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,6 +777,12 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot interviews plan --stage system-design --rol
 # - Capacity planning → Quantify QPS, latency budgets, and storage needs upfront.
 # - Resilience checklist → Map failure domains, redundancy, and rollback strategies.
 #
+# Dialog tree: Capacity challenge
+# - Interviewer: Traffic doubled overnight. How do you steady the system?
+#   Follow-ups:
+#     - Which metrics guide your first moves?
+#     - How do you communicate the trade-offs to partners?
+#
 # Question bank
 # 1. Design a multi-region feature flag service. (Reliability)
 # 2. Scale a read-heavy API to millions of users. (Scalability)
@@ -817,9 +823,10 @@ longer inputs (for example, `--transcript-file transcript.md`). Automated covera
 [`test/interviews.test.js`](test/interviews.test.js) and [`test/cli.test.js`](test/cli.test.js)
 verifies persistence, retrieval paths, stage/mode shortcuts, the defaulted rehearse metadata,
 manual recordings inheriting the same Behavioral/Voice defaults, and the stage-specific rehearsal
-plans emitted by `jobbot interviews plan`. Plans now include a `Flashcards` checklist and a
-numbered `Question bank` so candidates can drill concepts by focus area; the updated tests assert
-that both sections appear in JSON and CLI output.
+plans emitted by `jobbot interviews plan`. Plans now include a `Flashcards` checklist, a branching
+`Dialog tree`, and a numbered `Question bank` so candidates can drill concepts by focus area; the
+updated tests assert that all sections appear in JSON and CLI output, including the new
+`dialog_trees` payload for automation.
 
 ## Deliverable bundles
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -1151,6 +1151,29 @@ function formatRehearsalPlan(plan) {
     }
   }
 
+  if (Array.isArray(plan.dialog_trees) && plan.dialog_trees.length > 0) {
+    for (const tree of plan.dialog_trees) {
+      const title = typeof tree?.title === 'string' ? tree.title.trim() : '';
+      lines.push('');
+      lines.push(title ? `Dialog tree: ${title}` : 'Dialog tree');
+      const prompt = typeof tree?.prompt === 'string' ? tree.prompt.trim() : '';
+      if (prompt) {
+        lines.push(`- ${prompt}`);
+      }
+      if (Array.isArray(tree?.follow_ups) && tree.follow_ups.length > 0) {
+        const followUps = tree.follow_ups
+          .map(entry => (typeof entry === 'string' ? entry.trim() : ''))
+          .filter(Boolean);
+        if (followUps.length > 0) {
+          lines.push('  Follow-ups:');
+          for (const followUp of followUps) {
+            lines.push(`    - ${followUp}`);
+          }
+        }
+      }
+    }
+  }
+
   if (Array.isArray(plan.question_bank) && plan.question_bank.length > 0) {
     const entries = plan.question_bank
       .map((question, index) => {

--- a/src/interviews.js
+++ b/src/interviews.js
@@ -127,6 +127,16 @@ const PLAN_LIBRARY = {
         tags: ['Influence'],
       },
     ],
+    dialogTrees: [
+      {
+        title: 'Behavioral ambiguity',
+        prompt: 'Interviewer: Tell me about a time you led through ambiguity.',
+        followUps: [
+          'How did you surface the main trade-offs?',
+          'What outcome mattered most to stakeholders?',
+        ],
+      },
+    ],
   },
   Technical: {
     duration: 60,
@@ -187,6 +197,16 @@ const PLAN_LIBRARY = {
       {
         prompt: 'Implement an LRU cache and explain your trade-offs.',
         tags: ['Data Structures'],
+      },
+    ],
+    dialogTrees: [
+      {
+        title: 'Debugging deep dive',
+        prompt: 'Interviewer: A deploy introduced a latency spike. Where do you start?',
+        followUps: [
+          'Which signals confirm if the spike is systemic?',
+          'When do you roll back versus mitigate in place?',
+        ],
       },
     ],
   },
@@ -256,6 +276,16 @@ const PLAN_LIBRARY = {
         tags: ['Scalability'],
       },
     ],
+    dialogTrees: [
+      {
+        title: 'Capacity challenge',
+        prompt: 'Interviewer: Traffic doubled overnight. How do you steady the system?',
+        followUps: [
+          'Which metrics guide your first moves?',
+          'How do you communicate the trade-offs to partners?',
+        ],
+      },
+    ],
   },
   'Take-Home': {
     duration: 90,
@@ -314,6 +344,16 @@ const PLAN_LIBRARY = {
         tags: ['Communication'],
       },
     ],
+    dialogTrees: [
+      {
+        title: 'Reviewer sync',
+        prompt: 'Interviewer: Walk me through the scoping decisions in your submission.',
+        followUps: [
+          'What corners did you intentionally cut?',
+          'How would you extend the solution with another day?',
+        ],
+      },
+    ],
   },
 };
 
@@ -333,6 +373,34 @@ export function generateRehearsalPlan(options = {}) {
           const back = sanitizeString(card.back);
           if (!front || !back) return null;
           return { front, back };
+        })
+        .filter(Boolean)
+    : [];
+  const dialogTrees = Array.isArray(template.dialogTrees)
+    ? template.dialogTrees
+        .map(tree => {
+          const title = sanitizeString(tree.title);
+          const prompt = sanitizeString(tree.prompt);
+          let followUps;
+          if (Array.isArray(tree.followUps) && tree.followUps.length > 0) {
+            const normalized = [];
+            const seen = new Set();
+            for (const entry of tree.followUps) {
+              const value = sanitizeString(entry);
+              if (!value) continue;
+              const key = value.toLowerCase();
+              if (seen.has(key)) continue;
+              seen.add(key);
+              normalized.push(value);
+            }
+            if (normalized.length > 0) followUps = normalized;
+          }
+          if (!prompt && (!followUps || followUps.length === 0)) return null;
+          const payload = {};
+          if (title) payload.title = title;
+          if (prompt) payload.prompt = prompt;
+          if (followUps) payload.follow_ups = followUps;
+          return Object.keys(payload).length > 0 ? payload : null;
         })
         .filter(Boolean)
     : [];
@@ -368,6 +436,7 @@ export function generateRehearsalPlan(options = {}) {
     sections,
     resources: template.resources.slice(),
     flashcards,
+    dialog_trees: dialogTrees,
     question_bank: questionBank,
   };
 }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1532,6 +1532,7 @@ describe('jobbot CLI', () => {
     expect(output).toContain('Architecture');
     expect(output).toContain('Resources');
     expect(output).toContain('Flashcards');
+    expect(output).toContain('Dialog tree');
     expect(output).toContain('Question bank');
     expect(output).toMatch(/- Outline/);
   });

--- a/test/interviews.test.js
+++ b/test/interviews.test.js
@@ -183,6 +183,26 @@ describe('generateRehearsalPlan', () => {
     );
   });
 
+  it('includes dialog trees with follow-up prompts for deeper rehearsal', async () => {
+    const { generateRehearsalPlan } = await import('../src/interviews.js');
+
+    const plan = generateRehearsalPlan({ stage: 'behavioral' });
+
+    expect(Array.isArray(plan.dialog_trees)).toBe(true);
+    expect(plan.dialog_trees.length).toBeGreaterThan(0);
+    expect(plan.dialog_trees).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          title: expect.stringContaining('Behavioral'),
+          prompt: expect.stringContaining('Interviewer'),
+          follow_ups: expect.arrayContaining([
+            expect.stringContaining('trade-off'),
+          ]),
+        }),
+      ]),
+    );
+  });
+
   it('honors duration overrides for system design plans', async () => {
     const { generateRehearsalPlan } = await import('../src/interviews.js');
 


### PR DESCRIPTION
## Summary
- add dialog tree scaffolds to each interview stage and surface them in CLI output
- extend README with the new dialog tree example for system design plans
- cover dialog tree JSON and CLI behavior with updated tests

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d31cdf7100832f9995c2fe0025d876