### PR TITLE
Add dialog trees to interview rehearsal plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,6 +781,17 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot interviews plan --stage system-design --rol
 # 1. Design a multi-region feature flag service. (Reliability)
 # 2. Scale a read-heavy API to millions of users. (Scalability)
 #
+# Dialog tree
+# - opener — Walk me through a recent project you led end-to-end.
+#   Follow-ups:
+#   * What made it high impact for the business?
+#   * Which metrics or signals proved it worked?
+#   * How did you bring partners along the way?
+# - resilience — Share a time you navigated conflict with a stakeholder.
+#   Follow-ups:
+#   * How did you surface the disagreement early?
+#   * What trade-offs or data helped resolve it?
+#
 # Requirements
 # - Clarify functional and non-functional requirements along with success metrics.
 # - List constraints around traffic, latency budgets, data retention, and compliance.
@@ -817,9 +828,9 @@ longer inputs (for example, `--transcript-file transcript.md`). Automated covera
 [`test/interviews.test.js`](test/interviews.test.js) and [`test/cli.test.js`](test/cli.test.js)
 verifies persistence, retrieval paths, stage/mode shortcuts, the defaulted rehearse metadata,
 manual recordings inheriting the same Behavioral/Voice defaults, and the stage-specific rehearsal
-plans emitted by `jobbot interviews plan`. Plans now include a `Flashcards` checklist and a
-numbered `Question bank` so candidates can drill concepts by focus area; the updated tests assert
-that both sections appear in JSON and CLI output.
+plans emitted by `jobbot interviews plan`. Plans now include a `Flashcards` checklist, a numbered
+`Question bank`, and a branching `Dialog tree` so candidates can drill concepts by focus area and
+practice follow-ups; the updated tests assert that all sections appear in JSON and CLI output.
 
 ## Deliverable bundles
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -1170,6 +1170,33 @@ function formatRehearsalPlan(plan) {
     }
   }
 
+  if (Array.isArray(plan.dialog_tree) && plan.dialog_tree.length > 0) {
+    let headerPrinted = false;
+    for (const node of plan.dialog_tree) {
+      const prompt = typeof node?.prompt === 'string' ? node.prompt.trim() : '';
+      if (!prompt) continue;
+      if (!headerPrinted) {
+        lines.push('');
+        lines.push('Dialog tree');
+        headerPrinted = true;
+      }
+      const id = typeof node?.id === 'string' ? node.id.trim() : '';
+      const label = id ? `${id} — ${prompt}` : prompt;
+      lines.push(`- ${label}`);
+      const followUps = Array.isArray(node?.follow_ups)
+        ? node.follow_ups
+            .map(entry => (typeof entry === 'string' ? entry.trim() : ''))
+            .filter(Boolean)
+        : [];
+      if (followUps.length > 0) {
+        lines.push('  Follow-ups:');
+        for (const followUp of followUps) {
+          lines.push(`  * ${followUp}`);
+        }
+      }
+    }
+  }
+
   while (lines.length > 0 && lines[lines.length - 1] === '') {
     lines.pop();
   }

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -128,8 +128,8 @@ flow that preserves both sets of notes.
 1. Once an interview is scheduled, `jobbot interviews plan --stage <stage> [--role <title>]`
    generates rehearsal plans tuned to behavioral, technical, system design, or take-home stages so
    candidates can focus prep on the right prompts.
-2. Study packets include curated reading, flashcards, and question banks; dialog trees enable deep
-   rehearsal with branching follow-ups inspired by "The Rehearsal".
+2. Study packets include curated reading, flashcards, and question banks; the CLI prints a `Dialog
+   tree` section with branching follow-ups inspired by "The Rehearsal".
 3. Optional voice mode uses local STT/TTS so the user can practice speaking answers aloud.
 4. Sessions capture transcripts, user reflections, and coach feedback in
    `data/interviews/{job_id}/{session_id}.json` for future review via

--- a/src/interviews.js
+++ b/src/interviews.js
@@ -127,6 +127,25 @@ const PLAN_LIBRARY = {
         tags: ['Influence'],
       },
     ],
+    dialogTree: [
+      {
+        id: 'opener',
+        prompt: 'Walk me through a recent project you led end-to-end.',
+        followUps: [
+          'What made it high impact for the business?',
+          'Which metrics or signals proved it worked?',
+          'How did you bring partners along the way?',
+        ],
+      },
+      {
+        id: 'resilience',
+        prompt: 'Share a time you navigated conflict with a stakeholder.',
+        followUps: [
+          'How did you surface the disagreement early?',
+          'What trade-offs or data helped resolve it?',
+        ],
+      },
+    ],
   },
   Technical: {
     duration: 60,
@@ -187,6 +206,24 @@ const PLAN_LIBRARY = {
       {
         prompt: 'Implement an LRU cache and explain your trade-offs.',
         tags: ['Data Structures'],
+      },
+    ],
+    dialogTree: [
+      {
+        id: 'debugging',
+        prompt: 'Talk me through how you debug a failing integration test.',
+        followUps: [
+          'Which signals tell you the regression lives in your code?',
+          'How do you keep collaborators unblocked while you investigate?',
+        ],
+      },
+      {
+        id: 'extension',
+        prompt: 'Imagine the interviewer asks you to extend the solution mid-session.',
+        followUps: [
+          'What parts of your design change first?',
+          'How do you verify performance after the change?',
+        ],
       },
     ],
   },
@@ -256,6 +293,24 @@ const PLAN_LIBRARY = {
         tags: ['Scalability'],
       },
     ],
+    dialogTree: [
+      {
+        id: 'scope',
+        prompt: 'Clarify requirements for a global notifications platform.',
+        followUps: [
+          'What volume and latency targets anchor your design?',
+          'Which compliance or privacy constraints shape the architecture?',
+        ],
+      },
+      {
+        id: 'deep-dive',
+        prompt: 'Pick one bottleneck you expect and walk through mitigation steps.',
+        followUps: [
+          'What telemetry proves the mitigation is working?',
+          'How would you stage the rollout to limit risk?',
+        ],
+      },
+    ],
   },
   'Take-Home': {
     duration: 90,
@@ -314,6 +369,24 @@ const PLAN_LIBRARY = {
         tags: ['Communication'],
       },
     ],
+    dialogTree: [
+      {
+        id: 'planning',
+        prompt: 'Describe how you plan the first hour of a take-home assignment.',
+        followUps: [
+          'What questions do you send the reviewer before starting?',
+          'How do you budget time for tests and polish?',
+        ],
+      },
+      {
+        id: 'handoff',
+        prompt: 'Explain how you package the final deliverable for review.',
+        followUps: [
+          'What context goes into the README or summary email?',
+          'How do you highlight trade-offs for future iterations?',
+        ],
+      },
+    ],
   },
 };
 
@@ -359,6 +432,24 @@ export function generateRehearsalPlan(options = {}) {
         })
         .filter(Boolean)
     : [];
+  const dialogTree = Array.isArray(template.dialogTree)
+    ? template.dialogTree
+        .map(node => {
+          const prompt = sanitizeString(node.prompt);
+          if (!prompt) return null;
+          const id = sanitizeString(node.id);
+          const followUps = Array.isArray(node.followUps)
+            ? node.followUps
+                .map(entry => sanitizeString(entry))
+                .filter(Boolean)
+            : [];
+          const payload = { prompt };
+          if (id) payload.id = id;
+          if (followUps.length > 0) payload.follow_ups = followUps;
+          return payload;
+        })
+        .filter(Boolean)
+    : [];
 
   return {
     stage: normalizedStage,
@@ -369,6 +460,7 @@ export function generateRehearsalPlan(options = {}) {
     resources: template.resources.slice(),
     flashcards,
     question_bank: questionBank,
+    dialog_tree: dialogTree,
   };
 }
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1533,6 +1533,8 @@ describe('jobbot CLI', () => {
     expect(output).toContain('Resources');
     expect(output).toContain('Flashcards');
     expect(output).toContain('Question bank');
+    expect(output).toContain('Dialog tree');
+    expect(output).toMatch(/Follow-ups:/);
     expect(output).toMatch(/- Outline/);
   });
 });

--- a/test/interviews.test.js
+++ b/test/interviews.test.js
@@ -183,6 +183,22 @@ describe('generateRehearsalPlan', () => {
     );
   });
 
+  it('supplies dialog trees with branching follow-ups', async () => {
+    const { generateRehearsalPlan } = await import('../src/interviews.js');
+
+    const plan = generateRehearsalPlan({ stage: 'behavioral' });
+
+    expect(Array.isArray(plan.dialog_tree)).toBe(true);
+    expect(plan.dialog_tree.length).toBeGreaterThan(0);
+    expect(plan.dialog_tree[0]).toMatchObject({
+      id: 'opener',
+      prompt: expect.stringContaining('recent project'),
+    });
+    expect(plan.dialog_tree[0].follow_ups).toEqual(
+      expect.arrayContaining([expect.stringMatching(/metrics/i)]),
+    );
+  });
+
   it('honors duration overrides for system design plans', async () => {
     const { generateRehearsalPlan } = await import('../src/interviews.js');
 


### PR DESCRIPTION
## Summary
- deliver the dialog tree rehearsal feature documented in `docs/user-journeys.md` by enriching interview plans with branching prompts and rendering them in the CLI
- expand plan unit tests and CLI assertions to cover the new `dialog_tree` payload alongside updated README guidance
- refresh documentation to describe the dialog tree section and outline the new coverage

## Testing
- npm run lint
- npm run test:ci

## Future-work inventory
- `docs/user-journeys.md` Journey 6 promised dialog trees for interview rehearsal plans; this addition ships the missing behavior in a single PR.


------
https://chatgpt.com/codex/tasks/task_e_68d31cdf7100832f9995c2fe0025d876