### PR TITLE
Surface actionable scheduler errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,6 +465,54 @@ so repeated syncs are noiseless, and the Greenhouse test suite verifies the
 cache is written and that conditional requests short-circuit without touching
 the filesystem when nothing has changed.
 
+## Schedule recurring ingestion and matching
+
+Automate board refreshes and fit-score runs with `jobbot schedule run`. Provide
+tasks in a JSON file and let the CLI execute them on an interval:
+
+```jsonc
+{
+  "tasks": [
+    {
+      "id": "greenhouse-hourly",
+      "type": "ingest",
+      "provider": "greenhouse",
+      "company": "acme",
+      "intervalMinutes": 60
+    },
+    {
+      "id": "match-sample",
+      "type": "match",
+      "resume": "data/profile/resume.json",
+      "jobId": "5d41402abc4b2a76",
+      "intervalMinutes": 120,
+      "output": "data/matches/job-5d4140.json"
+    }
+  ]
+}
+```
+
+Run the scheduler and optionally limit each task to a fixed number of cycles
+(useful for CI or scripted runs):
+
+```bash
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot schedule run --config schedule.json --cycles 1
+```
+
+Omit `--cycles` to keep the process running until you interrupt it. Each
+completion is logged with a timestamp and task identifier, and matching tasks
+can persist their latest score summaries to disk when `output` is provided.
+Configuration parsing, task orchestration, and the CLI surface are covered in
+[`test/schedule-config.test.js`](test/schedule-config.test.js),
+[`test/scheduler.test.js`](test/scheduler.test.js), and the scheduler scenario
+in [`test/cli.test.js`](test/cli.test.js).
+
+If a match task points to a `jobId` without a saved snapshot in
+`$JOBBOT_DATA_DIR/jobs`, the scheduler now surfaces
+`match task <id> could not find job snapshot <jobId>` and suggests running
+`jobbot ingest` before re-queuing the task. Regression coverage lives alongside
+the other scheduler tests listed above.
+
 Job titles can be parsed from lines starting with `Title`, `Job Title`, `Position`, or `Role`.
 Headers can use colons or dash separators (for example, `Role - Staff Engineer`), and the same
 separators work for `Company` and `Location`. Parser unit tests cover both colon and dash cases so

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -76,6 +76,10 @@ revisit them later without blocking the workflow.
    and records sync metadata with `jobbot shortlist sync` so future refreshes know
    when entries were last updated. Add `--json` (and optionally
    `--out <path>`) when exporting the filtered shortlist to other tools.
+5. Teams can automate recurring ingestion and matching runs with
+   `jobbot schedule run --config <file> [--cycles <count>]`. Configured tasks pull
+   boards on a cadence and compute fit scores against the latest resume so the
+   shortlist stays fresh without manual commands.
 
 **Unhappy paths:** fetch failures or ToS blocks surface actionable error messages and never retry
 aggressively to respect rate limits.

--- a/src/schedule.js
+++ b/src/schedule.js
@@ -1,0 +1,559 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { ingestGreenhouseBoard } from './greenhouse.js';
+import { ingestLeverBoard } from './lever.js';
+import { ingestAshbyBoard } from './ashby.js';
+import { ingestSmartRecruitersBoard } from './smartrecruiters.js';
+import { ingestWorkableBoard } from './workable.js';
+import { ingestJobUrl } from './url-ingest.js';
+import { loadResume } from './resume.js';
+import { parseJobText } from './parser.js';
+import { computeFitScore } from './scoring.js';
+
+const DEFAULT_LOGGER = {
+  info: message => console.log(message),
+  error: message => console.error(message),
+};
+
+const INGEST_PROVIDERS = {
+  greenhouse: ingestGreenhouseBoard,
+  lever: ingestLeverBoard,
+  ashby: ingestAshbyBoard,
+  smartrecruiters: ingestSmartRecruitersBoard,
+  workable: ingestWorkableBoard,
+  url: ingestJobUrl,
+};
+
+function resolveDataDir() {
+  return process.env.JOBBOT_DATA_DIR || path.resolve('data');
+}
+
+function validateTasksInput(tasks) {
+  if (!Array.isArray(tasks)) {
+    throw new Error('tasks must be an array');
+  }
+  const seen = new Set();
+  for (const task of tasks) {
+    if (!task || typeof task !== 'object') {
+      throw new Error('task definitions must be objects');
+    }
+    if (typeof task.id !== 'string' || !task.id.trim()) {
+      throw new Error('task id is required');
+    }
+    if (seen.has(task.id)) {
+      throw new Error(`duplicate task id: ${task.id}`);
+    }
+    seen.add(task.id);
+    if (!Number.isFinite(task.intervalMs) || task.intervalMs <= 0) {
+      throw new Error(`task ${task.id} requires a positive intervalMs`);
+    }
+    if (task.initialDelayMs != null) {
+      if (!Number.isFinite(task.initialDelayMs) || task.initialDelayMs < 0) {
+        throw new Error(`task ${task.id} initialDelayMs must be >= 0`);
+      }
+    }
+    if (task.maxRuns != null) {
+      if (!Number.isFinite(task.maxRuns) || task.maxRuns <= 0) {
+        throw new Error(`task ${task.id} maxRuns must be > 0`);
+      }
+    }
+    if (typeof task.run !== 'function') {
+      throw new Error(`task ${task.id} must define a run() function`);
+    }
+  }
+}
+
+function formatTimestamp(nowFn) {
+  const value = nowFn ? nowFn() : new Date();
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+export function createTaskScheduler(
+  tasks,
+  { setTimeoutFn = setTimeout, clearTimeoutFn = clearTimeout, now = () => new Date() } = {},
+) {
+  validateTasksInput(tasks);
+
+  const states = tasks.map(task => ({
+    task,
+    timerId: null,
+    running: false,
+    runCount: 0,
+    active: task.maxRuns == null || task.maxRuns > 0,
+    pending: Promise.resolve(),
+  }));
+
+  let started = false;
+  let stopped = false;
+  let idleResolve;
+  let idleRejected = false;
+  const idlePromise = new Promise(resolve => {
+    idleResolve = resolve;
+  });
+
+  const maybeResolveIdle = () => {
+    if (idleRejected) return;
+    const allInactive = states.every(state => !state.active && !state.running);
+    if (allInactive) {
+      idleResolve();
+      idleRejected = true;
+    }
+  };
+
+  const scheduleNext = (state, delay) => {
+    if (!state.active || stopped) {
+      return;
+    }
+    state.timerId = setTimeoutFn(() => {
+      state.timerId = null;
+      execute(state);
+    }, delay);
+  };
+
+  const shouldContinue = state => {
+    if (stopped) return false;
+    if (state.task.maxRuns == null) return true;
+    return state.runCount < state.task.maxRuns;
+  };
+
+  const execute = state => {
+    if (!state.active || state.running) {
+      return state.pending;
+    }
+
+    state.running = true;
+    const runPromise = (async () => {
+      try {
+        const result = await state.task.run();
+        state.task.onSuccess?.(result, state.task);
+      } catch (err) {
+        state.task.onError?.(err, state.task);
+      } finally {
+        state.runCount += 1;
+        state.running = false;
+        if (shouldContinue(state)) {
+          scheduleNext(state, state.task.intervalMs);
+        } else {
+          state.active = false;
+          maybeResolveIdle();
+        }
+      }
+    })();
+
+    state.pending = runPromise;
+    return runPromise;
+  };
+
+  return {
+    start() {
+      if (started || stopped) return;
+      started = true;
+      for (const state of states) {
+        if (!state.active) continue;
+        const delay =
+          state.task.initialDelayMs != null ? state.task.initialDelayMs : state.task.intervalMs;
+        scheduleNext(state, delay);
+      }
+    },
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      for (const state of states) {
+        state.active = false;
+        if (state.timerId != null) {
+          clearTimeoutFn(state.timerId);
+          state.timerId = null;
+        }
+      }
+      maybeResolveIdle();
+    },
+    trigger(id) {
+      const state = states.find(candidate => candidate.task.id === id);
+      if (!state) {
+        throw new Error(`Unknown task: ${id}`);
+      }
+      state.active = true;
+      return execute(state);
+    },
+    whenIdle() {
+      maybeResolveIdle();
+      return idlePromise;
+    },
+    now,
+  };
+}
+
+function parseDuration(definition, field) {
+  if (definition[field] == null) return undefined;
+  const value = Number(definition[field]);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${field} must be a positive number`);
+  }
+  return value;
+}
+
+function resolveInterval(definition, fieldBase) {
+  const msKey = `${fieldBase}Ms`;
+  if (definition[msKey] != null) {
+    const value = parseDuration(definition, msKey);
+    if (value == null) {
+      throw new Error(`${msKey} must be positive`);
+    }
+    return value;
+  }
+  const minutesKey = `${fieldBase}Minutes`;
+  if (definition[minutesKey] != null) {
+    return parseDuration(definition, minutesKey) * 60 * 1000;
+  }
+  const secondsKey = `${fieldBase}Seconds`;
+  if (definition[secondsKey] != null) {
+    return parseDuration(definition, secondsKey) * 1000;
+  }
+  return undefined;
+}
+
+function normalizeIngestTask(definition) {
+  const providerRaw = typeof definition.provider === 'string' ? definition.provider.trim() : '';
+  if (!providerRaw) {
+    throw new Error(`ingest task ${definition.id} requires a provider`);
+  }
+  const provider = providerRaw.toLowerCase();
+  if (!Object.prototype.hasOwnProperty.call(INGEST_PROVIDERS, provider)) {
+    throw new Error(`unsupported ingest provider: ${provider}`);
+  }
+
+  const params = {};
+  if (provider === 'greenhouse') {
+    const board = definition.board || definition.company;
+    if (!board || typeof board !== 'string' || !board.trim()) {
+      throw new Error(`greenhouse task ${definition.id} requires a company/board value`);
+    }
+    params.board = board.trim();
+  } else if (provider === 'lever') {
+    const org = definition.org || definition.company;
+    if (!org || typeof org !== 'string' || !org.trim()) {
+      throw new Error(`lever task ${definition.id} requires an org/company value`);
+    }
+    params.org = org.trim();
+  } else if (provider === 'ashby') {
+    const org = definition.org || definition.company;
+    if (!org || typeof org !== 'string' || !org.trim()) {
+      throw new Error(`ashby task ${definition.id} requires an org/company value`);
+    }
+    params.org = org.trim();
+  } else if (provider === 'smartrecruiters') {
+    const company = definition.company;
+    if (!company || typeof company !== 'string' || !company.trim()) {
+      throw new Error(`smartrecruiters task ${definition.id} requires a company`);
+    }
+    params.company = company.trim();
+  } else if (provider === 'workable') {
+    const account = definition.account || definition.company;
+    if (!account || typeof account !== 'string' || !account.trim()) {
+      throw new Error(`workable task ${definition.id} requires an account`);
+    }
+    params.account = account.trim();
+  } else if (provider === 'url') {
+    const url = definition.url;
+    if (!url || typeof url !== 'string' || !url.trim()) {
+      throw new Error(`url ingest task ${definition.id} requires a url`);
+    }
+    params.url = url.trim();
+  }
+
+  if (definition.headers && typeof definition.headers === 'object') {
+    params.headers = definition.headers;
+  }
+  if (definition.timeoutMs != null) {
+    params.timeoutMs = parseDuration(definition, 'timeoutMs');
+  }
+  if (definition.maxBytes != null) {
+    params.maxBytes = parseDuration(definition, 'maxBytes');
+  }
+
+  return { provider, params };
+}
+
+function resolvePathRelative(value, baseDir) {
+  if (!value || typeof value !== 'string') return undefined;
+  if (path.isAbsolute(value)) return value;
+  return path.resolve(baseDir, value);
+}
+
+function normalizeMatchTask(definition, baseDir) {
+  const resumePath = resolvePathRelative(definition.resume, baseDir);
+  if (!resumePath) {
+    throw new Error(`match task ${definition.id} requires a resume path`);
+  }
+
+  const params = { resume: resumePath };
+
+  if (definition.jobFile) {
+    params.jobFile = resolvePathRelative(definition.jobFile, baseDir);
+  }
+  if (!params.jobFile && definition.jobId) {
+    if (typeof definition.jobId !== 'string' || !definition.jobId.trim()) {
+      throw new Error(`match task ${definition.id} requires a jobId or jobFile`);
+    }
+    params.jobId = definition.jobId.trim();
+  }
+  if (!params.jobFile && !params.jobId) {
+    throw new Error(`match task ${definition.id} requires a jobId or jobFile`);
+  }
+
+  if (definition.output) {
+    params.output = resolvePathRelative(definition.output, baseDir);
+  }
+
+  if (definition.locale) {
+    params.locale = String(definition.locale);
+  }
+
+  return params;
+}
+
+export async function loadScheduleConfig(configPath) {
+  if (!configPath || typeof configPath !== 'string') {
+    throw new Error('config path is required');
+  }
+  const resolvedPath = path.resolve(configPath);
+  const contents = await fs.readFile(resolvedPath, 'utf8');
+  let parsed;
+  try {
+    parsed = JSON.parse(contents);
+  } catch (err) {
+    throw new Error(`failed to parse schedule config: ${err.message || err}`);
+  }
+
+  if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.tasks)) {
+    throw new Error('schedule config must contain a tasks array');
+  }
+
+  const baseDir = path.dirname(resolvedPath);
+  const definitions = [];
+
+  for (const definition of parsed.tasks) {
+    if (!definition || typeof definition !== 'object') {
+      throw new Error('task entries must be objects');
+    }
+
+    const id = typeof definition.id === 'string' && definition.id.trim();
+    if (!id) {
+      throw new Error('each task requires an id');
+    }
+
+    const intervalMs = resolveInterval(definition, 'interval');
+    if (!intervalMs) {
+      throw new Error(
+        `task ${id} requires an interval (intervalMs, intervalSeconds, or intervalMinutes)`,
+      );
+    }
+
+    const initialDelayMs = resolveInterval(definition, 'initialDelay');
+    const maxRuns = definition.maxRuns != null ? parseDuration(definition, 'maxRuns') : undefined;
+
+    const typeRaw = typeof definition.type === 'string' ? definition.type.trim().toLowerCase() : '';
+    if (!typeRaw) {
+      throw new Error(`task ${id} requires a type`);
+    }
+
+    if (typeRaw === 'ingest') {
+      const { provider, params } = normalizeIngestTask({ ...definition, id });
+      definitions.push({
+        id,
+        type: 'ingest',
+        provider,
+        params,
+        intervalMs,
+        initialDelayMs,
+        maxRuns,
+      });
+    } else if (typeRaw === 'match') {
+      const params = normalizeMatchTask({ ...definition, id }, baseDir);
+      definitions.push({
+        id,
+        type: 'match',
+        params,
+        intervalMs,
+        initialDelayMs,
+        maxRuns,
+      });
+    } else {
+      throw new Error(`unsupported task type: ${typeRaw}`);
+    }
+  }
+
+  return definitions;
+}
+
+function resolveMaxRuns(taskDef, cycles) {
+  const fromDef = Number.isFinite(taskDef.maxRuns) ? taskDef.maxRuns : undefined;
+  const fromCycles = Number.isFinite(cycles) && cycles > 0 ? Math.floor(cycles) : undefined;
+  if (fromDef && fromCycles) return Math.min(fromDef, fromCycles);
+  return fromDef ?? fromCycles;
+}
+
+async function runIngestTask(taskDef) {
+  const fn = INGEST_PROVIDERS[taskDef.provider];
+  if (typeof fn !== 'function') {
+    throw new Error(`unsupported ingest provider: ${taskDef.provider}`);
+  }
+  const result = await fn(taskDef.params);
+  const target =
+    taskDef.params.board ||
+    taskDef.params.org ||
+    taskDef.params.company ||
+    taskDef.params.account ||
+    taskDef.params.url ||
+    'target';
+
+  if (result && result.notModified) {
+    return `No changes for ${taskDef.provider} ${target}`;
+  }
+
+  if (taskDef.provider === 'url' && result && result.id) {
+    return `Snapshot ${result.id} saved from ${target}`;
+  }
+
+  const saved = Number.isFinite(result?.saved) ? result.saved : 0;
+  const noun = saved === 1 ? 'job' : 'jobs';
+  return `Imported ${saved} ${noun} from ${taskDef.provider} ${target}`;
+}
+
+async function readJobRequirements(taskDef) {
+  const params = taskDef.params || {};
+  if (params.jobFile) {
+    let raw;
+    try {
+      raw = await fs.readFile(params.jobFile, 'utf8');
+    } catch (err) {
+      if (err?.code === 'ENOENT') {
+        throw new Error(
+          `match task ${taskDef.id} could not find job file at ${params.jobFile}. ` +
+            'Provide a valid path or reference a saved job snapshot with jobId.',
+        );
+      }
+      throw new Error(
+        `match task ${taskDef.id} failed to read job file ${params.jobFile}: ${err.message || err}`,
+      );
+    }
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && parsed.parsed && Array.isArray(parsed.parsed.requirements)) {
+        return {
+          requirements: parsed.parsed.requirements,
+          label: path.basename(params.jobFile),
+        };
+      }
+    } catch {
+      // fall back to text parsing
+    }
+    const parsedText = parseJobText(raw);
+    return {
+      requirements: parsedText.requirements || [],
+      label: path.basename(params.jobFile),
+    };
+  }
+
+  const jobId = params.jobId;
+  const jobPath = path.join(resolveDataDir(), 'jobs', `${jobId}.json`);
+  let raw;
+  try {
+    raw = await fs.readFile(jobPath, 'utf8');
+  } catch (err) {
+    if (err?.code === 'ENOENT') {
+      throw new Error(
+        `match task ${taskDef.id} could not find job snapshot ${jobId} at ${jobPath}. ` +
+          'Run jobbot ingest to capture the listing before scheduling this match task.',
+      );
+    }
+    throw new Error(
+      `match task ${taskDef.id} failed to read job snapshot ${jobId}: ${err.message || err}`,
+    );
+  }
+  const parsed = JSON.parse(raw);
+  if (parsed && parsed.parsed && Array.isArray(parsed.parsed.requirements)) {
+    return {
+      requirements: parsed.parsed.requirements,
+      label: jobId,
+    };
+  }
+  const text = parsed && typeof parsed.raw === 'string' ? parsed.raw : raw;
+  const parsedText = parseJobText(text);
+  return {
+    requirements: parsedText.requirements || [],
+    label: jobId,
+  };
+}
+
+async function runMatchTask(taskDef) {
+  const resumeText = await loadResume(taskDef.params.resume);
+  const { requirements, label } = await readJobRequirements(taskDef);
+  const result = computeFitScore(resumeText, requirements);
+
+  const summary = {
+    job: label,
+    score: Number.isFinite(result.score) ? Number(result.score.toFixed(2)) : result.score,
+    matched: result.matched || [],
+    missing: result.missing || [],
+    must_haves_missed: result.must_haves_missed || [],
+    keyword_overlap: result.keyword_overlap || [],
+    run_at: new Date().toISOString(),
+  };
+
+  if (taskDef.params.output) {
+    await fs.mkdir(path.dirname(taskDef.params.output), { recursive: true });
+    await fs.writeFile(taskDef.params.output, `${JSON.stringify(summary, null, 2)}\n`, 'utf8');
+  }
+
+  return `Fit score ${summary.score} for ${label}`;
+}
+
+export function buildScheduledTasks(
+  definitions,
+  { logger = DEFAULT_LOGGER, cycles, now = () => new Date() } = {},
+) {
+  if (!logger || typeof logger.info !== 'function' || typeof logger.error !== 'function') {
+    throw new Error('logger must expose info() and error() methods');
+  }
+
+  const tasks = [];
+  for (const definition of definitions) {
+    const maxRuns = resolveMaxRuns(definition, cycles);
+    const taskConfig = {
+      id: definition.id,
+      intervalMs: definition.intervalMs,
+      initialDelayMs: definition.initialDelayMs,
+      maxRuns,
+    };
+
+    if (definition.type === 'ingest') {
+      taskConfig.run = () => runIngestTask(definition);
+    } else if (definition.type === 'match') {
+      taskConfig.run = () => runMatchTask(definition);
+    } else {
+      throw new Error(`unsupported task type: ${definition.type}`);
+    }
+
+    taskConfig.onSuccess = message => {
+      const timestamp = formatTimestamp(now);
+      logger.info(`${timestamp} [${definition.id}] ${message}`);
+    };
+    taskConfig.onError = err => {
+      const timestamp = formatTimestamp(now);
+      const errorMessage = err && err.message ? err.message : String(err);
+      logger.error(`${timestamp} [${definition.id}] ${errorMessage}`);
+    };
+
+    tasks.push(taskConfig);
+  }
+
+  return tasks;
+}
+
+export default {
+  createTaskScheduler,
+  loadScheduleConfig,
+  buildScheduledTasks,
+};

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1471,10 +1471,14 @@ describe('jobbot CLI', () => {
     );
 
     const bin = path.resolve('bin', 'jobbot.js');
-    const result = spawnSync('node', [bin, 'schedule', 'run', '--config', configPath, '--cycles', '1'], {
-      encoding: 'utf8',
-      env: { ...process.env, JOBBOT_DATA_DIR: dataDir },
-    });
+    const result = spawnSync(
+      'node',
+      [bin, 'schedule', 'run', '--config', configPath, '--cycles', '1'],
+      {
+        encoding: 'utf8',
+        env: { ...process.env, JOBBOT_DATA_DIR: dataDir },
+      },
+    );
 
     expect(result.stderr).toMatch(/match task match-missing could not find job snapshot job-999/i);
     expect(result.stderr).toMatch(/jobbot ingest/i);

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -1388,6 +1388,96 @@ describe('jobbot CLI', () => {
     expect(payload.channels).toEqual({ email: 1, offer_accepted: 1, referral: 1 });
     expect(JSON.stringify(payload)).not.toContain('job-1');
     expect(JSON.stringify(payload)).not.toContain('job-2');
+  });
+
+  it('runs scheduled matching tasks from configuration', () => {
+    const resumePath = path.join(dataDir, 'resume.txt');
+    fs.writeFileSync(
+      resumePath,
+      [
+        'Summary',
+        'Engineer who leads cross-functional teams and improves reliability.',
+        '',
+        'Experience',
+        '2020-2024: Lead engineer driving reliability across services.',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const jobPath = path.join(dataDir, 'job.json');
+    fs.writeFileSync(
+      jobPath,
+      JSON.stringify(
+        {
+          parsed: {
+            requirements: ['Lead reliability programs', 'Collaborate across teams'],
+          },
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    const configPath = path.join(dataDir, 'schedule.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          tasks: [
+            {
+              id: 'match-sample',
+              type: 'match',
+              resume: resumePath,
+              jobFile: jobPath,
+              intervalSeconds: 1,
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    const output = runCli(['schedule', 'run', '--config', configPath, '--cycles', '1']);
+    expect(output).toContain('match-sample');
+    expect(output).toMatch(/score/i);
+  });
+
+  it('prints a helpful error when a scheduled match job snapshot is missing', () => {
+    const resumePath = path.join(dataDir, 'resume.txt');
+    fs.writeFileSync(resumePath, 'Summary\nLead engineer.\n');
+
+    const configPath = path.join(dataDir, 'schedule.json');
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          tasks: [
+            {
+              id: 'match-missing',
+              type: 'match',
+              resume: resumePath,
+              jobId: 'job-999',
+              intervalSeconds: 1,
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    const bin = path.resolve('bin', 'jobbot.js');
+    const result = spawnSync('node', [bin, 'schedule', 'run', '--config', configPath, '--cycles', '1'], {
+      encoding: 'utf8',
+      env: { ...process.env, JOBBOT_DATA_DIR: dataDir },
+    });
+
+    expect(result.stderr).toMatch(/match task match-missing could not find job snapshot job-999/i);
+    expect(result.stderr).toMatch(/jobbot ingest/i);
   });
 
   it('bundles the latest deliverables run into a zip archive', async () => {

--- a/test/schedule-config.test.js
+++ b/test/schedule-config.test.js
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+vi.mock('../src/greenhouse.js', () => ({
+  ingestGreenhouseBoard: vi.fn(async () => ({ saved: 3 })),
+}));
+
+vi.mock('../src/scoring.js', () => ({
+  computeFitScore: vi.fn(() => ({
+    score: 0.75,
+    matched: ['Team leadership'],
+    missing: [],
+    must_haves_missed: [],
+    keyword_overlap: [],
+  })),
+}));
+
+import { loadScheduleConfig, buildScheduledTasks } from '../src/schedule.js';
+import { ingestGreenhouseBoard } from '../src/greenhouse.js';
+import { computeFitScore } from '../src/scoring.js';
+
+describe('schedule config', () => {
+  let tmpDir;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-schedule-'));
+  });
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+    }
+  });
+
+  it('parses ingestion tasks with minute-based intervals', async () => {
+    const configPath = path.join(tmpDir, 'schedule.json');
+    await fs.writeFile(
+      configPath,
+      JSON.stringify(
+        {
+          tasks: [
+            {
+              id: 'greenhouse-hourly',
+              type: 'ingest',
+              provider: 'greenhouse',
+              company: 'acme',
+              intervalMinutes: 60,
+              initialDelayMinutes: 5,
+            },
+          ],
+        },
+        null,
+        2,
+      ),
+    );
+
+    const definitions = await loadScheduleConfig(configPath);
+    expect(definitions).toEqual([
+      expect.objectContaining({
+        id: 'greenhouse-hourly',
+        type: 'ingest',
+        provider: 'greenhouse',
+        params: expect.objectContaining({ board: 'acme' }),
+        intervalMs: 60 * 60 * 1000,
+        initialDelayMs: 5 * 60 * 1000,
+      }),
+    ]);
+  });
+
+  it('builds runnable tasks that invoke ingestion and matching workflows', async () => {
+    const resumePath = path.join(tmpDir, 'resume.txt');
+    await fs.writeFile(resumePath, 'Experienced engineer with leadership experience.');
+
+    const jobPath = path.join(tmpDir, 'job.json');
+    await fs.writeFile(
+      jobPath,
+      JSON.stringify({ parsed: { requirements: ['leadership', 'collaboration'] } }, null, 2),
+    );
+
+    const definitions = [
+      {
+        id: 'greenhouse-hourly',
+        type: 'ingest',
+        provider: 'greenhouse',
+        params: { board: 'acme' },
+        intervalMs: 1000,
+      },
+      {
+        id: 'match-sample',
+        type: 'match',
+        params: {
+          resume: resumePath,
+          jobFile: jobPath,
+        },
+        intervalMs: 2000,
+      },
+    ];
+
+    const logger = { info: vi.fn(), error: vi.fn() };
+    const tasks = buildScheduledTasks(definitions, { logger, cycles: 1 });
+
+    expect(tasks).toHaveLength(2);
+
+    const ingestTask = tasks.find(task => task.id === 'greenhouse-hourly');
+    const matchTask = tasks.find(task => task.id === 'match-sample');
+
+    const ingestMessage = await ingestTask.run();
+    ingestTask.onSuccess?.(ingestMessage, ingestTask);
+    expect(ingestGreenhouseBoard).toHaveBeenCalledWith(
+      expect.objectContaining({ board: 'acme' }),
+    );
+
+    const matchMessage = await matchTask.run();
+    matchTask.onSuccess?.(matchMessage, matchTask);
+    expect(computeFitScore).toHaveBeenCalled();
+
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('greenhouse-hourly'));
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('match-sample'));
+
+    expect(ingestTask.maxRuns).toBe(1);
+    expect(matchTask.maxRuns).toBe(1);
+  });
+
+  it('throws when required interval metadata is missing', async () => {
+    const configPath = path.join(tmpDir, 'invalid.json');
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        tasks: [{ id: 'bad', type: 'ingest', provider: 'greenhouse', company: 'acme' }],
+      }),
+    );
+
+    await expect(loadScheduleConfig(configPath)).rejects.toThrow(/interval/i);
+  });
+
+  it('surfaces an actionable error when a match job snapshot is missing', async () => {
+    const resumePath = path.join(tmpDir, 'resume.txt');
+    await fs.writeFile(resumePath, 'Seasoned engineer.');
+
+    const definitions = [
+      {
+        id: 'match-missing-job',
+        type: 'match',
+        params: {
+          resume: resumePath,
+          jobId: 'job-999',
+        },
+        intervalMs: 1000,
+      },
+    ];
+
+    const logger = { info: vi.fn(), error: vi.fn() };
+
+    const originalDataDir = process.env.JOBBOT_DATA_DIR;
+    process.env.JOBBOT_DATA_DIR = tmpDir;
+
+    try {
+      const tasks = buildScheduledTasks(definitions, { logger });
+      const matchTask = tasks.find(task => task.id === 'match-missing-job');
+      await expect(matchTask.run()).rejects.toThrow(
+        /match task match-missing-job could not find job snapshot job-999/i,
+      );
+    } finally {
+      if (originalDataDir === undefined) {
+        delete process.env.JOBBOT_DATA_DIR;
+      } else {
+        process.env.JOBBOT_DATA_DIR = originalDataDir;
+      }
+    }
+  });
+});

--- a/test/scheduler.test.js
+++ b/test/scheduler.test.js
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { createTaskScheduler } from '../src/schedule.js';
+
+describe('task scheduler', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('runs tasks after the initial delay and reschedules using the interval', async () => {
+    const start = Date.now();
+    const ticks = [];
+
+    const scheduler = createTaskScheduler([
+      {
+        id: 'ingest-hourly',
+        intervalMs: 1000,
+        initialDelayMs: 500,
+        run: async () => {
+          ticks.push(Date.now() - start);
+        },
+      },
+    ]);
+
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(ticks).toEqual([500]);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(ticks).toEqual([500, 1500]);
+
+    scheduler.stop();
+  });
+
+  it('never overlaps runs even when the task duration exceeds the interval', async () => {
+    const start = Date.now();
+    const launches = [];
+
+    const scheduler = createTaskScheduler([
+      {
+        id: 'slow-task',
+        intervalMs: 300,
+        initialDelayMs: 0,
+        run: () => {
+          launches.push(Date.now() - start);
+          return new Promise(resolve => {
+            setTimeout(() => resolve(), 1000);
+          });
+        },
+      },
+    ]);
+
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(300);
+    expect(launches).toEqual([0]);
+
+    await vi.advanceTimersByTimeAsync(600);
+    expect(launches).toEqual([0]);
+
+    await vi.advanceTimersByTimeAsync(400);
+    expect(launches).toEqual([0, 1300]);
+
+    scheduler.stop();
+  });
+
+  it('resolves when all finite tasks finish their allotted runs', async () => {
+    let runs = 0;
+
+    const scheduler = createTaskScheduler([
+      {
+        id: 'finite-task',
+        intervalMs: 200,
+        maxRuns: 2,
+        run: async () => {
+          runs += 1;
+        },
+      },
+    ]);
+
+    const idle = scheduler.whenIdle();
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(500);
+    await idle;
+
+    expect(runs).toBe(2);
+  });
+
+  it('invokes onError hooks and keeps scheduling after failures', async () => {
+    const errors = [];
+    let attempts = 0;
+
+    const scheduler = createTaskScheduler([
+      {
+        id: 'flaky-task',
+        intervalMs: 200,
+        onError: err => errors.push(err.message),
+        run: () => {
+          attempts += 1;
+          if (attempts === 1) {
+            throw new Error('boom');
+          }
+        },
+      },
+    ]);
+
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(errors).toEqual(['boom']);
+
+    await vi.advanceTimersByTimeAsync(200);
+    expect(attempts).toBe(2);
+
+    scheduler.stop();
+  });
+});


### PR DESCRIPTION
## Summary
- add explicit scheduler config validation for missing job snapshots and expose friendly guidance in CLI output
- document the new error path in the scheduler docs and README
- expand scheduler unit and CLI coverage to lock in the regression guardrails

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d380e657c4832f829eeeade404f7ac