### PR TITLE
Add CLI speech transcription and prompt playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,20 +829,36 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot rehearse job-123 \
   --feedback "Great pacing" \
   --notes "Send thank-you email"
 # Recorded rehearsal prep-2025-02-01T09-00-00Z for job-123
+
+# Transcribe a quick voice rehearsal with a local STT command
+JOBBOT_SPEECH_TRANSCRIBER="node local/transcribe.js --file {{input}}" \
+  JOBBOT_DATA_DIR=$DATA_DIR npx jobbot rehearse job-123 --audio recordings/answer.wav
+# Recorded rehearsal prep-2025-02-01T09-00-00Z for job-123
+
+# Read behavioral dialog prompts aloud with a local TTS command
+JOBBOT_SPEECH_SYNTHESIZER="node local/say.js --text {{input}}" \
+  JOBBOT_DATA_DIR=$DATA_DIR npx jobbot interviews plan --stage behavioral --speak
 ```
 
 Sessions are stored under `data/interviews/{job_id}/{session_id}.json` with ISO 8601 timestamps so
 coaches and candidates can revisit transcripts later. Stage and mode default to `Behavioral` and
-`Voice` when omitted, mirroring the quick-runthrough workflow. The CLI accepts `--*-file` options for
-longer inputs (for example, `--transcript-file transcript.md`). Automated coverage in
-[`test/interviews.test.js`](test/interviews.test.js) and [`test/cli.test.js`](test/cli.test.js)
-verifies persistence, retrieval paths, stage/mode shortcuts, the defaulted rehearse metadata,
-manual recordings inheriting the same Behavioral/Voice defaults, and the stage-specific rehearsal
-plans emitted by `jobbot interviews plan`. Plans now include a `Flashcards` checklist, a numbered
-`Question bank`, and a branching `Dialog tree` so candidates can drill concepts by focus area and
-practice follow-ups; the updated tests assert that all sections appear in JSON and CLI output. New
-coverage in [`test/interviews.test.js`](test/interviews.test.js) also locks in the Onsite logistics
-plan so its agenda review, energy resets, and thank-you follow-ups stay consistent across releases.
+`Voice` when omitted, mirroring the quick-runthrough workflow. Configure
+`JOBBOT_SPEECH_TRANSCRIBER` with a local command that accepts the audio path via `{{input}}`
+(or pass `--transcriber <command>` at runtime) to automatically transcribe recordings;
+the CLI records the derived transcript alongside an `audio_source` marker. Set
+`JOBBOT_SPEECH_SYNTHESIZER` (or pass `--speaker <command>`) to read dialog prompts aloud when
+`jobbot interviews plan --speak` is used so candidates can rehearse responses hands-free. The CLI
+accepts `--*-file` options for longer inputs (for example, `--transcript-file transcript.md`).
+Automated coverage in [`test/interviews.test.js`](test/interviews.test.js) and
+[`test/cli.test.js`](test/cli.test.js) verifies persistence, retrieval paths, stage/mode shortcuts,
+the defaulted rehearse metadata, audio transcription integration, synthesizer execution for dialog
+prompts, manual recordings inheriting the same Behavioral/Voice defaults, and the stage-specific
+rehearsal plans emitted by `jobbot interviews plan`. Plans now include a
+`Flashcards` checklist, a numbered `Question bank`, and a branching `Dialog tree` so candidates can
+drill concepts by focus area and practice follow-ups; the updated tests assert that all sections
+appear in JSON and CLI output. New coverage in [`test/interviews.test.js`](test/interviews.test.js)
+also locks in the Onsite logistics plan so its agenda review, energy resets, thank-you follow-ups,
+and stored audio metadata stay consistent across releases.
 
 ## Deliverable bundles
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -47,6 +47,7 @@ import { computeFunnel, exportAnalyticsSnapshot, formatFunnelReport } from '../s
 import { ingestWorkableBoard } from '../src/workable.js';
 import { ingestJobUrl } from '../src/url-ingest.js';
 import { bundleDeliverables } from '../src/deliverables.js';
+import { transcribeAudio, synthesizeSpeech } from '../src/speech.js';
 
 function isHttpUrl(s) {
   return /^https?:\/\//i.test(s);
@@ -1204,14 +1205,75 @@ function formatRehearsalPlan(plan) {
   return lines.join('\n');
 }
 
+function collectPlanVoicePrompts(plan) {
+  if (!plan || typeof plan !== 'object' || Array.isArray(plan)) {
+    return [];
+  }
+
+  const prompts = [];
+
+  if (Array.isArray(plan.dialog_tree)) {
+    for (const node of plan.dialog_tree) {
+      const prompt = typeof node?.prompt === 'string' ? node.prompt.trim() : '';
+      if (prompt) prompts.push(prompt);
+      const followUps = Array.isArray(node?.follow_ups) ? node.follow_ups : [];
+      for (const followUp of followUps) {
+        const value = typeof followUp === 'string' ? followUp.trim() : '';
+        if (value) prompts.push(value);
+      }
+    }
+  }
+
+  if (Array.isArray(plan.question_bank)) {
+    for (const question of plan.question_bank) {
+      const prompt = typeof question?.prompt === 'string' ? question.prompt.trim() : '';
+      if (prompt) prompts.push(prompt);
+    }
+  }
+
+  const seen = new Set();
+  const ordered = [];
+  for (const item of prompts) {
+    const key = item.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    ordered.push(item);
+  }
+  return ordered;
+}
+
+async function speakPlanPrompts(plan, options) {
+  const prompts = collectPlanVoicePrompts(plan);
+  for (const prompt of prompts) {
+    await synthesizeSpeech(prompt, options);
+  }
+}
+
 async function cmdInterviewsPlan(args) {
   const asJson = args.includes('--json');
-  const filtered = args.filter(arg => arg !== '--json');
+  const speak = args.includes('--speak');
+  const filtered = args.filter((arg, index) => {
+    if (arg === '--json' || arg === '--speak') return false;
+    if (arg === '--speaker') return false;
+    if (index > 0 && args[index - 1] === '--speaker') return false;
+    return true;
+  });
   const stageInput = resolvePlanStage(filtered);
   const role = getFlag(filtered, '--role');
   const durationMinutes = getNumberFlag(filtered, '--duration');
+  const speakerCommand = getFlag(args, '--speaker');
 
   const plan = generateRehearsalPlan({ stage: stageInput, role, durationMinutes });
+
+  if (speak) {
+    try {
+      await speakPlanPrompts(plan, { command: speakerCommand });
+    } catch (err) {
+      const message = err && typeof err.message === 'string' ? err.message : String(err);
+      console.error(message);
+      process.exit(1);
+    }
+  }
 
   if (asJson) {
     console.log(JSON.stringify({ plan }, null, 2));
@@ -1239,7 +1301,8 @@ async function cmdRehearse(args) {
     console.error(
       'Usage: jobbot rehearse <job_id> [--session <id>] [--stage <value>] [--mode <value>] ' +
         '[--behavioral] [--technical] [--onsite] [--voice] [--text] ' +
-        '[--transcript <text>|--transcript-file <path>] ' +
+        '[--transcript <text>|--transcript-file <path>] [--audio <path>] ' +
+        '[--transcriber <command>] ' +
         '[--reflections <text>|--reflections-file <path>] ' +
         '[--feedback <text>|--feedback-file <path>] ' +
         '[--notes <text>|--notes-file <path>] ' +
@@ -1248,15 +1311,34 @@ async function cmdRehearse(args) {
     process.exit(2);
   }
 
-  const transcriptInput = readContentFromArgs(rest, '--transcript', '--transcript-file');
+  let transcriptInput = readContentFromArgs(rest, '--transcript', '--transcript-file');
   const reflectionsInput = readContentFromArgs(rest, '--reflections', '--reflections-file');
   const feedbackInput = readContentFromArgs(rest, '--feedback', '--feedback-file');
   const notesInput = readContentFromArgs(rest, '--notes', '--notes-file');
+  const audioInput = getFlag(rest, '--audio');
+  const transcriberCommand = getFlag(rest, '--transcriber');
 
   const stage = resolveRehearsalStage(rest) || 'Behavioral';
   const mode = resolveRehearsalMode(rest) || 'Voice';
   const startedAt = getFlag(rest, '--started-at');
   const endedAt = getFlag(rest, '--ended-at');
+
+  if (audioInput && transcriptInput) {
+    console.error('Cannot combine --audio with --transcript/--transcript-file');
+    process.exit(2);
+  }
+
+  let audioSource;
+  if (audioInput) {
+    const resolvedAudio = path.resolve(process.cwd(), audioInput);
+    try {
+      transcriptInput = await transcribeAudio(resolvedAudio, { command: transcriberCommand });
+    } catch (err) {
+      console.error(err?.message || String(err));
+      process.exit(1);
+    }
+    audioSource = { type: 'file', name: path.basename(resolvedAudio) };
+  }
 
   const payload = {
     transcript: transcriptInput,
@@ -1268,6 +1350,10 @@ async function cmdRehearse(args) {
     startedAt,
     endedAt,
   };
+
+  if (audioSource) {
+    payload.audioSource = audioSource;
+  }
 
   const entry = await recordInterviewSession(jobId, sessionId, payload);
   console.log(`Recorded rehearsal ${entry.session_id} for ${entry.job_id}`);

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -130,7 +130,12 @@ flow that preserves both sets of notes.
    candidates can focus prep on the right prompts.
 2. Study packets include curated reading, flashcards, and question banks; the CLI prints a `Dialog
    tree` section with branching follow-ups inspired by "The Rehearsal".
-3. Optional voice mode uses local STT/TTS so the user can practice speaking answers aloud.
+3. Optional voice mode uses local STT/TTS so the user can practice speaking answers aloud. Configure
+   `JOBBOT_SPEECH_TRANSCRIBER` (or pass `--transcriber <command>`) and run
+   `jobbot rehearse <job_id> --audio <file>` to convert recorded answers into transcripts that are
+   stored alongside the session metadata. Set `JOBBOT_SPEECH_SYNTHESIZER` (or pass
+   `--speaker <command>`) and call `jobbot interviews plan --stage <stage> --speak` to play the dialog
+   prompts aloud before answering.
 4. Sessions capture transcripts, user reflections, and coach feedback in
    `data/interviews/{job_id}/{session_id}.json` for future review via
    `jobbot interviews record`. Quick run-throughs can use

--- a/src/interviews.js
+++ b/src/interviews.js
@@ -599,6 +599,19 @@ function normalizeNotes(input) {
   return value;
 }
 
+function normalizeAudioSource(input) {
+  if (!input || typeof input !== 'object') return undefined;
+  const type = sanitizeString(input.type) || 'file';
+  if (type.toLowerCase() !== 'file') return undefined;
+  const name =
+    sanitizeString(input.name) ||
+    sanitizeString(input.filename) ||
+    sanitizeString(input.file) ||
+    sanitizeString(input.path);
+  if (!name) return undefined;
+  return { type: 'file', name };
+}
+
 function resolveSessionPath(jobId, sessionId) {
   const baseDir = resolveDataDir();
   const jobDir = path.join(baseDir, 'interviews', jobId);
@@ -613,6 +626,7 @@ export async function recordInterviewSession(jobId, sessionId, data = {}) {
   const reflections = normalizeNoteList(data.reflections, 'reflections');
   const feedback = normalizeNoteList(data.feedback, 'feedback');
   const notes = normalizeNotes(data.notes);
+  const audioSource = normalizeAudioSource(data.audioSource ?? data.audio_source);
 
   if (!transcript && !reflections && !feedback && !notes) {
     throw new Error('at least one session field is required');
@@ -638,6 +652,7 @@ export async function recordInterviewSession(jobId, sessionId, data = {}) {
   if (reflections) entry.reflections = reflections;
   if (feedback) entry.feedback = feedback;
   if (notes) entry.notes = notes;
+  if (audioSource) entry.audio_source = audioSource;
   if (startedAt) entry.started_at = startedAt;
   if (endedAt) entry.ended_at = endedAt;
 

--- a/src/speech.js
+++ b/src/speech.js
@@ -1,0 +1,152 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+let overrideTranscriberCommand;
+let overrideSynthesizerCommand;
+
+export function setSpeechTranscriberCommand(command) {
+  overrideTranscriberCommand = command || undefined;
+}
+
+export function setSpeechSynthesizerCommand(command) {
+  overrideSynthesizerCommand = command || undefined;
+}
+
+function resolveTranscriberCommand(optionCommand) {
+  const candidate =
+    optionCommand ??
+    overrideTranscriberCommand ??
+    process.env.JOBBOT_SPEECH_TRANSCRIBER;
+  if (typeof candidate !== 'string') {
+    throw new Error('speech transcriber command is not configured.');
+  }
+  const trimmed = candidate.trim();
+  if (!trimmed) {
+    throw new Error('speech transcriber command is not configured.');
+  }
+  return trimmed;
+}
+
+function resolveSynthesizerCommand(optionCommand) {
+  const candidate =
+    optionCommand ??
+    overrideSynthesizerCommand ??
+    process.env.JOBBOT_SPEECH_SYNTHESIZER;
+  if (typeof candidate !== 'string') {
+    throw new Error('speech synthesizer command is not configured.');
+  }
+  const trimmed = candidate.trim();
+  if (!trimmed) {
+    throw new Error('speech synthesizer command is not configured.');
+  }
+  return trimmed;
+}
+
+function shellEscape(value) {
+  if (value === undefined || value === null) return "''";
+  const str = String(value);
+  if (str === '') return "''";
+  const SINGLE_QUOTE = "'";
+  const ESCAPED_QUOTE = "'\\'" + "'";
+  return SINGLE_QUOTE + str.split(SINGLE_QUOTE).join(ESCAPED_QUOTE) + SINGLE_QUOTE;
+}
+
+function runShellCommand(command) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, { shell: true, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', chunk => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', chunk => {
+      stderr += chunk;
+    });
+    child.on('error', err => {
+      reject(new Error(`speech transcriber failed: ${err.message}`));
+    });
+    child.on('close', code => {
+      if (code !== 0) {
+        const message = stderr.trim() || `speech transcriber exited with code ${code}`;
+        reject(new Error(message));
+        return;
+      }
+      const text = stdout.trim();
+      if (!text) {
+        reject(new Error('speech transcriber produced no output'));
+        return;
+      }
+      resolve(text);
+    });
+  });
+}
+
+function runSpeechCommand(command, { input } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, { shell: true, stdio: ['pipe', 'ignore', 'pipe'] });
+    let stderr = '';
+
+    if (input !== undefined && input !== null) {
+      child.stdin.write(String(input));
+    }
+    child.stdin.end();
+
+    child.stderr.on('data', chunk => {
+      stderr += chunk;
+    });
+    child.on('error', err => {
+      reject(new Error(`speech synthesizer failed: ${err.message}`));
+    });
+    child.on('close', code => {
+      if (code !== 0) {
+        const message = stderr.trim() || `speech synthesizer exited with code ${code}`;
+        reject(new Error(message));
+        return;
+      }
+      resolve();
+    });
+  });
+}
+
+export async function transcribeAudio(filePath, options = {}) {
+  if (!filePath || typeof filePath !== 'string') {
+    throw new Error('audio file path is required');
+  }
+  const resolved = path.resolve(filePath);
+  try {
+    await fs.access(resolved);
+  } catch {
+    throw new Error(`audio file not found: ${resolved}`);
+  }
+
+  const commandTemplate = resolveTranscriberCommand(options.command);
+  const escapedPath = shellEscape(resolved);
+  const command = commandTemplate.includes('{{input}}')
+    ? commandTemplate.split('{{input}}').join(escapedPath)
+    : `${commandTemplate} ${escapedPath}`;
+
+  return runShellCommand(command);
+}
+
+export async function synthesizeSpeech(text, options = {}) {
+  if (text == null) {
+    throw new Error('speech text is required');
+  }
+  const value = String(text);
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error('speech text is required');
+  }
+
+  const commandTemplate = resolveSynthesizerCommand(options.command);
+  let shouldPipeInput = true;
+  let command = commandTemplate;
+
+  if (commandTemplate.includes('{{input}}')) {
+    command = commandTemplate.split('{{input}}').join(shellEscape(trimmed));
+    shouldPipeInput = false;
+  }
+
+  await runSpeechCommand(command, { input: shouldPipeInput ? trimmed : undefined });
+}

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -3,9 +3,13 @@ import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { summarize } from '../src/index.js';
 import JSZip from 'jszip';
 import { STATUSES } from '../src/lifecycle.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 let dataDir;
 
@@ -1558,6 +1562,39 @@ describe('jobbot CLI', () => {
     expect(stored).toHaveProperty('recorded_at');
   });
 
+  it('transcribes audio rehearsals when a local speech transcriber is configured', () => {
+    const audioPath = path.join(dataDir, 'voice-note.txt');
+    fs.writeFileSync(audioPath, 'Discussed roadmap alignment');
+
+    const transcriberScript = path.resolve(__dirname, 'fixtures', 'transcriber.js');
+    const previous = process.env.JOBBOT_SPEECH_TRANSCRIBER;
+    process.env.JOBBOT_SPEECH_TRANSCRIBER = `node ${transcriberScript} --file {{input}}`;
+
+    try {
+      const output = runCli(['rehearse', 'job-voice', '--audio', audioPath]);
+      const trimmed = output.trim();
+      expect(trimmed.startsWith('Recorded rehearsal ')).toBe(true);
+      const match = trimmed.match(/^Recorded rehearsal (.+) for job-voice$/);
+      expect(match).not.toBeNull();
+      const [, sessionId] = match;
+
+      const file = path.join(dataDir, 'interviews', 'job-voice', `${sessionId}.json`);
+      const stored = JSON.parse(fs.readFileSync(file, 'utf8'));
+
+      expect(stored).toMatchObject({
+        job_id: 'job-voice',
+        session_id: sessionId,
+        stage: 'Behavioral',
+        mode: 'Voice',
+        transcript: 'Transcribed: Discussed roadmap alignment',
+        audio_source: { type: 'file', name: 'voice-note.txt' },
+      });
+    } finally {
+      if (previous === undefined) delete process.env.JOBBOT_SPEECH_TRANSCRIBER;
+      else process.env.JOBBOT_SPEECH_TRANSCRIBER = previous;
+    }
+  });
+
   it('generates rehearsal plans for interviews', () => {
     const output = runCli([
       'interviews',
@@ -1577,5 +1614,33 @@ describe('jobbot CLI', () => {
     expect(output).toContain('Dialog tree');
     expect(output).toMatch(/Follow-ups:/);
     expect(output).toMatch(/- Outline/);
+  });
+
+  it('speaks dialog prompts with a configured speech synthesizer', () => {
+    const spokenLog = path.join(dataDir, 'spoken.txt');
+    const synthesizer = [
+      'node',
+      path.resolve(__dirname, 'fixtures', 'synthesizer.js'),
+      '--out',
+      spokenLog,
+      '--text',
+      '{{input}}',
+    ].join(' ');
+
+    runCli([
+      'interviews',
+      'plan',
+      '--stage',
+      'behavioral',
+      '--speak',
+      '--speaker',
+      synthesizer,
+    ]);
+
+    const spoken = fs.readFileSync(spokenLog, 'utf8').trim().split('\n');
+    expect(spoken).toContain('Walk me through a recent project you led end-to-end.');
+    expect(spoken).toContain('How did you bring partners along the way?');
+    expect(spoken).toContain('Share a time you navigated conflict with a stakeholder.');
+    expect(spoken).toContain('What trade-offs or data helped resolve it?');
   });
 });

--- a/test/fixtures/synthesizer.js
+++ b/test/fixtures/synthesizer.js
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const args = process.argv.slice(2);
+const outIndex = args.indexOf('--out');
+if (outIndex === -1) {
+  console.error('Missing --out');
+  process.exit(1);
+}
+const outPath = path.resolve(args[outIndex + 1]);
+const textIndex = args.indexOf('--text');
+let text = '';
+if (textIndex !== -1) {
+  text = args[textIndex + 1] ?? '';
+} else {
+  text = fs.readFileSync(0, 'utf8');
+}
+fs.mkdirSync(path.dirname(outPath), { recursive: true });
+fs.appendFileSync(outPath, `${text}\n`, 'utf8');

--- a/test/fixtures/transcriber.js
+++ b/test/fixtures/transcriber.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const result = {};
+  for (let i = 0; i < args.length; i += 1) {
+    const key = args[i];
+    if (key === '--file' || key === '--input') {
+      result.file = args[i + 1];
+      i += 1;
+    } else if (!result.file) {
+      result.file = key;
+    }
+  }
+  return result;
+}
+
+const { file } = parseArgs(process.argv);
+if (!file) {
+  console.error('Usage: transcriber.js --file <path>');
+  process.exit(2);
+}
+
+const resolved = path.resolve(process.cwd(), file);
+let contents;
+try {
+  contents = fs.readFileSync(resolved, 'utf8');
+} catch (err) {
+  const reason = err && typeof err.message === 'string' ? `: ${err.message}` : '';
+  console.error(`transcriber: failed to read ${resolved}${reason}`);
+  process.exit(1);
+}
+
+const text = contents.trim();
+if (!text) {
+  console.error('transcriber: audio file was empty');
+  process.exit(1);
+}
+
+process.stdout.write(`Transcribed: ${text}\n`);

--- a/test/interviews.test.js
+++ b/test/interviews.test.js
@@ -121,6 +121,22 @@ describe('interview session archive', () => {
       mode: 'Voice',
     });
   });
+
+  it('stores audio source metadata when provided', async () => {
+    const { setInterviewDataDir, recordInterviewSession } = await import('../src/interviews.js');
+
+    setInterviewDataDir(dataDir);
+
+    const recorded = await recordInterviewSession('job-audio', 'session-audio', {
+      transcript: 'Voice rehearsal summary',
+      audioSource: { type: 'file', name: 'answer.wav' },
+    });
+
+    expect(recorded.audio_source).toEqual({ type: 'file', name: 'answer.wav' });
+
+    const disk = await readSession('job-audio', 'session-audio');
+    expect(disk.audio_source).toEqual({ type: 'file', name: 'answer.wav' });
+  });
 });
 
 describe('generateRehearsalPlan', () => {


### PR DESCRIPTION
## Summary
- add speech utilities so the CLI can transcribe audio rehearsals and store their audio_source metadata
- expose --audio/--transcriber on jobbot rehearse plus --speak/--speaker on interviews plan with docs for the voice workflow
- cover the STT and TTS paths with new CLI and interview tests backed by local fixtures

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d380e657c4832f829eeeade404f7ac