### PR TITLE
Add tighten-this critique to interview heuristics

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,7 +804,7 @@ DATA_DIR=$(mktemp -d)
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot interviews record job-123 prep-2025-02-01 \
   --stage Onsite \
   --mode Voice \
-  --transcript "Practiced system design walkthrough" \
+  --transcript "Practiced STAR story covering situation, task, action, and result." \
   --reflections "Tighten capacity estimates" \
   --feedback "Great storytelling" \
   --notes "Follow up on salary research" \
@@ -819,12 +819,30 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot interviews show job-123 prep-2025-02-01
 #   "recorded_at": "2025-02-01T09:00:00.000Z",
 #   "stage": "Onsite",
 #   "mode": "Voice",
-#   "transcript": "Practiced system design walkthrough",
+#   "transcript": "Practiced STAR story covering situation, task, action, and result.",
 #   "reflections": ["Tighten capacity estimates"],
 #   "feedback": ["Great storytelling"],
 #   "notes": "Follow up on salary research",
 #   "started_at": "2025-02-01T09:00:00.000Z",
-#   "ended_at": "2025-02-01T10:15:00.000Z"
+#   "ended_at": "2025-02-01T10:15:00.000Z",
+#   "heuristics": {
+#     "brevity": {
+#       "word_count": 9,
+#       "sentence_count": 1,
+#       "average_sentence_words": 9,
+#       "estimated_wpm": 0.1
+#     },
+#     "filler_words": {
+#       "total": 0,
+#       "counts": {}
+#     },
+#     "structure": {
+#       "star": {
+#         "mentioned": ["situation", "task", "action", "result"],
+#         "missing": []
+#       }
+#     }
+#   }
 # }
 
 # Generate a system design rehearsal plan tailored to the role
@@ -953,6 +971,15 @@ appear in JSON and CLI output. New coverage in [`test/interviews.test.js`](test/
 locks in the Onsite logistics plan’s dialog prompts, agenda review, energy resets, and thank-you
 follow-ups, while [`test/cli.test.js`](test/cli.test.js) confirms the CLI surfaces those transitions
 and audio metadata consistently across releases.
+
+Recorded sessions now attach a `heuristics` block that summarizes brevity (word count, sentence
+count, average sentence length, and estimated words per minute when timestamps are present), filler
+phrases, and STAR coverage so coaches can spot habits that need refinement. A new
+`critique.tighten_this` array highlights the biggest opportunities to tighten delivery—flagging
+missing STAR components, filler-word spikes, or overlong answers. Updated coverage in
+[`test/interviews.test.js`](test/interviews.test.js) exercises filler detection, STAR summaries, and
+the tighten-this critique, and the CLI suite in [`test/cli.test.js`](test/cli.test.js) asserts those
+heuristics persist in the archived JSON payloads.
 
 ## Deliverable bundles
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -147,6 +147,11 @@ flow that preserves both sets of notes.
    `jobbot interviews record`. Quick run-throughs can use
    `jobbot rehearse <job_id>` to auto-generate session identifiers and default the stage/mode to
    Behavioral/Voice before replaying them with `jobbot interviews show`.
+5. Recorded sessions attach heuristics that summarize brevity (word counts, sentence averages,
+   words per minute when timestamps exist), filler words, and STAR coverage so coaches can steer
+   follow-up drills toward habits that need the most attention. A `critique.tighten_this` list calls
+   out filler spikes, missing STAR components, or overlong answers so the next rehearsal targets the
+   highest-leverage edits.
 
 **Unhappy paths:** if the user misses sessions, the assistant nudges them with lighter-weight prep
 suggestions to prevent burnout.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1566,7 +1566,10 @@ describe('jobbot CLI', () => {
 
   it('records interview sessions with transcripts and notes', () => {
     const transcriptPath = path.join(dataDir, 'transcript.txt');
-    fs.writeFileSync(transcriptPath, 'Practiced STAR story\n');
+    fs.writeFileSync(
+      transcriptPath,
+      'Practiced STAR story covering situation, task, action, and result.\n',
+    );
 
     const reflectionsPath = path.join(dataDir, 'reflections.txt');
     fs.writeFileSync(reflectionsPath, 'Highlight quant impact\nTighter close');
@@ -1599,7 +1602,9 @@ describe('jobbot CLI', () => {
     const file = path.join(dataDir, 'interviews', 'job-123', 'session-1.json');
     const stored = JSON.parse(fs.readFileSync(file, 'utf8'));
 
-    expect(stored.transcript).toBe('Practiced STAR story');
+    expect(stored.transcript).toBe(
+      'Practiced STAR story covering situation, task, action, and result.'
+    );
     expect(stored.reflections).toEqual(['Highlight quant impact', 'Tighter close']);
     expect(stored.feedback).toEqual(['Coach praised clarity']);
     expect(stored.notes).toBe('Follow up with salary research');
@@ -1607,6 +1612,27 @@ describe('jobbot CLI', () => {
     expect(stored.mode).toBe('Voice');
     expect(stored.started_at).toBe('2025-02-01T09:00:00.000Z');
     expect(stored.ended_at).toBe('2025-02-01T10:30:00.000Z');
+    expect(stored.heuristics).toEqual({
+      brevity: {
+        word_count: 9,
+        sentence_count: 1,
+        average_sentence_words: 9,
+        estimated_wpm: 0.1,
+      },
+      filler_words: {
+        total: 0,
+        counts: {},
+      },
+      structure: {
+        star: {
+          mentioned: ['situation', 'task', 'action', 'result'],
+          missing: [],
+        },
+      },
+      critique: {
+        tighten_this: [],
+      },
+    });
 
     const shown = runCli(['interviews', 'show', 'job-123', 'session-1']);
     const parsed = JSON.parse(shown);
@@ -1673,6 +1699,7 @@ describe('jobbot CLI', () => {
       started_at: '2025-02-01T09:00:00.000Z',
       ended_at: '2025-02-01T09:45:00.000Z',
     });
+    expect(stored).toHaveProperty('heuristics');
   });
 
   it('defaults rehearse stage and mode when not provided', () => {


### PR DESCRIPTION
what: add tighten_this critique and docs
why: deliver tighten-this coaching promised in DESIGN.md
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d38e552264832f9c006b914e810bfa