### PR TITLE
Allow shortlist sync to touch entries without metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,10 @@ Automated CLI tests cover both the new-entry and refresh flows so `jobbot shortl
 continues to stamp `synced_at` when metadata flags are omitted and when existing records are
 refreshed. These cases live alongside the broader shortlist suite in `test/cli.test.js`.
 
+Programmatic consumers can call `syncShortlistJob(jobId)` without metadata to refresh the
+timestamp while leaving prior fields intact; `test/shortlist.test.js` now locks in that
+touch-only coverage.
+
 Shortlist tags deduplicate case-insensitively so reapplying a label with different casing keeps
 filters tidy. Legacy discard tag history is normalized the same way so `Last Discard Tags` and
 archive views never repeat labels when older records mix casing.

--- a/src/shortlist.js
+++ b/src/shortlist.js
@@ -221,24 +221,22 @@ function ensureJobRecord(store, jobId) {
 }
 
 function sanitizeMetadataInput(metadata) {
-  if (!metadata || typeof metadata !== 'object') {
-    throw new Error('metadata is required');
+  const source = metadata ?? {};
+  if (typeof source !== 'object' || Array.isArray(source)) {
+    throw new Error('metadata must be an object');
   }
   const normalized = {};
   for (const field of METADATA_FIELDS) {
-    const rawValue = metadata[field];
+    const rawValue = source[field];
     const value =
       field === 'compensation'
         ? normalizeCompensationValue(rawValue)
         : sanitizeString(rawValue);
     if (value) normalized[field] = value;
   }
-  const explicitSynced = metadata.syncedAt ?? metadata.synced_at;
+  const explicitSynced = source.syncedAt ?? source.synced_at;
   if (explicitSynced !== undefined) {
     normalized.synced_at = normalizeSyncedAt(explicitSynced);
-  }
-  if (Object.keys(normalized).length === 0) {
-    throw new Error('at least one metadata field is required');
   }
   if (!normalized.synced_at) {
     normalized.synced_at = new Date().toISOString();


### PR DESCRIPTION
## Summary
- allow `syncShortlistJob` to accept missing metadata and stamp a fresh `synced_at`
- add shortlist touch coverage to confirm creation and refresh without explicit metadata
- document the programmatic touch flow so the new unit test is discoverable

## Testing
- npm run lint
- npm run test:ci

## Test Matrix
- shortlist sync without metadata creates new entries with a timestamp
- shortlist sync without metadata refreshes existing entries while preserving other fields

------
https://chatgpt.com/codex/tasks/task_e_68d38e552264832f9c006b914e810bfa