### PR TITLE
Advertise intake bullets subcommand in CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -726,6 +726,8 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot intake bullets --tag metrics
 
 Entries are appended to `data/profile/intake.json` with normalized timestamps, optional tags, notes,
 and a `status` field so follow-up planning can reference prior answers and revisit skipped prompts.
+Run `jobbot intake` without a subcommand to see the available modes (`record`, `list`, and `bullets`);
+the CLI suite in [`test/cli.test.js`](test/cli.test.js) keeps this usage output aligned.
 Recorded timestamps reflect when the command runs. Automated coverage in
 [`test/intake.test.js`](test/intake.test.js) and [`test/cli.test.js`](test/cli.test.js) verifies the
 stored shape, CLI workflows, and the skipped-only view for follow-up planning.

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -633,7 +633,7 @@ async function cmdIntake(args) {
   if (sub === 'record') return cmdIntakeRecord(args.slice(1));
   if (sub === 'list') return cmdIntakeList(args.slice(1));
   if (sub === 'bullets') return cmdIntakeBullets(args.slice(1));
-  console.error('Usage: jobbot intake <record|list> ...');
+  console.error('Usage: jobbot intake <record|list|bullets> ...');
   process.exit(2);
 }
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -947,6 +947,17 @@ describe('jobbot CLI', () => {
     expect(textOutput).toContain('Question: Share a metric-driven accomplishment');
   });
 
+  it('advertises all intake subcommands in usage output', () => {
+    const bin = path.resolve('bin', 'jobbot.js');
+    const result = spawnSync('node', [bin, 'intake'], {
+      encoding: 'utf8',
+      env: { ...process.env, JOBBOT_DATA_DIR: dataDir },
+    });
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Usage: jobbot intake <record|list|bullets> ...');
+  });
+
   it('tags shortlist entries and persists labels', () => {
     const output = runCli(['shortlist', 'tag', 'job-abc', 'dream', 'remote']);
     expect(output.trim()).toBe('Tagged job-abc with dream, remote');


### PR DESCRIPTION
## Summary
- make `jobbot intake` usage output mention the `bullets` subcommand
- add a CLI regression test that exercises the new usage text
- document the intake usage help in the README

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d39c91a580832f8454583295025742