### PR TITLE
Add urgency grouping to track reminders digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,13 +1101,17 @@ note-taking surface stays reliable.
 
 Surface follow-up work with `jobbot track reminders`. Pass `--now` to view from a
 given timestamp (defaults to the current time), `--upcoming-only` to suppress past-due
-entries, and `--json` for structured output:
+entries, and `--json` for structured output. The digest groups results by urgency so
+past-due work stays visible without scanning the whole list:
 
 ```bash
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track reminders --now 2025-03-06T00:00:00Z
-# job-1 — 2025-03-05T09:00:00.000Z (follow_up, past due)
+# Past Due
+# job-1 — 2025-03-05T09:00:00.000Z (follow_up)
 #   Note: Send status update
-# job-2 — 2025-03-07T15:00:00.000Z (call, upcoming)
+#
+# Upcoming
+# job-2 — 2025-03-07T15:00:00.000Z (call)
 #   Contact: Avery Hiring Manager
 ```
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -444,15 +444,27 @@ async function cmdTrackReminders(args) {
     return;
   }
 
+  const groups = [
+    { heading: 'Past Due', items: reminders.filter(reminder => reminder.past_due) },
+    { heading: 'Upcoming', items: reminders.filter(reminder => !reminder.past_due) },
+  ];
+
   const lines = [];
-  for (const reminder of reminders) {
-    const descriptors = [];
-    if (reminder.channel) descriptors.push(reminder.channel);
-    descriptors.push(reminder.past_due ? 'past due' : 'upcoming');
-    lines.push(`${reminder.job_id} — ${reminder.remind_at} (${descriptors.join(', ')})`);
-    if (reminder.note) lines.push(`  Note: ${reminder.note}`);
-    if (reminder.contact) lines.push(`  Contact: ${reminder.contact}`);
+  for (const group of groups) {
+    if (!group.items.length) continue;
+    lines.push(group.heading);
+    for (const reminder of group.items) {
+      const descriptors = [];
+      if (reminder.channel) descriptors.push(reminder.channel);
+      const suffix = descriptors.length ? ` (${descriptors.join(', ')})` : '';
+      lines.push(`${reminder.job_id} — ${reminder.remind_at}${suffix}`);
+      if (reminder.note) lines.push(`  Note: ${reminder.note}`);
+      if (reminder.contact) lines.push(`  Contact: ${reminder.contact}`);
+    }
+    lines.push('');
   }
+
+  if (lines[lines.length - 1] === '') lines.pop();
 
   console.log(lines.join('\n'));
 }

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -123,6 +123,8 @@ aggressively to respect rate limits.
    capture the next follow-up timestamp with each note, review recorded outreach with
    `jobbot track history <job_id>`, and surface upcoming commitments with `jobbot track reminders`
    (add `--upcoming-only` to hide past-due entries and `--json` when piping into other tools).
+   The digest prints `Past Due` and `Upcoming` sections so urgent follow-ups remain visible even
+   when one bucket is empty.
 
 **Unhappy paths:** conflicting updates (e.g., two devices editing simultaneously) trigger a merge
 flow that preserves both sets of notes.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -617,14 +617,21 @@ describe('jobbot CLI', () => {
       '2025-03-06T00:00:00Z',
     ]);
 
-    expect(fullOutput).toContain(
-      'job-1 — 2025-03-05T09:00:00.000Z (follow_up, past due)'
+    const lines = fullOutput.trim().split('\n');
+    const pastDueIndex = lines.indexOf('Past Due');
+    const upcomingIndex = lines.indexOf('Upcoming');
+
+    expect(pastDueIndex).toBeGreaterThan(-1);
+    expect(lines[pastDueIndex + 1]).toBe(
+      'job-1 — 2025-03-05T09:00:00.000Z (follow_up)'
     );
-    expect(fullOutput).toContain('  Note: Send status update');
-    expect(fullOutput).toContain(
-      'job-2 — 2025-03-07T15:00:00.000Z (call, upcoming)'
+    expect(lines[pastDueIndex + 2]).toBe('  Note: Send status update');
+
+    expect(upcomingIndex).toBeGreaterThan(-1);
+    expect(lines[upcomingIndex + 1]).toBe(
+      'job-2 — 2025-03-07T15:00:00.000Z (call)'
     );
-    expect(fullOutput).toContain('  Contact: Avery Hiring Manager');
+    expect(lines[upcomingIndex + 2]).toBe('  Contact: Avery Hiring Manager');
 
     const upcomingOnly = runCli([
       'track',
@@ -634,9 +641,10 @@ describe('jobbot CLI', () => {
       '--upcoming-only',
     ]);
 
-    expect(upcomingOnly).not.toContain('job-1');
+    expect(upcomingOnly).not.toContain('Past Due');
+    expect(upcomingOnly).toContain('Upcoming');
     expect(upcomingOnly).toContain(
-      'job-2 — 2025-03-07T15:00:00.000Z (call, upcoming)'
+      'job-2 — 2025-03-07T15:00:00.000Z (call)'
     );
   });
 


### PR DESCRIPTION
what: group track reminders output into Past Due/Upcoming sections and
      document the behavior.
why: align CLI with user journey promise that reminders are grouped by
     urgency.
how to test: npm run lint; npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d39c91a580832f8454583295025742