### PR TITLE
Add CLI --max-bytes support to summarize, match, and ingest url

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ echo "First. Second. Third." | npx jobbot summarize - --sentences 2 --text
 npx jobbot summarize job.txt --docx output/summary.docx
 # => Markdown summary prints to stdout; DOCX saved to output/summary.docx
 
+# Bump the remote fetch limit to 5 MB when summarizing large postings
+npx jobbot summarize https://example.com/job --max-bytes 5242880
+
 # Localize summary headings in Spanish
 npx jobbot summarize job.txt --docx output/summary-es.docx --locale es
 # => Markdown and DOCX outputs use translated labels
@@ -108,7 +111,10 @@ override it. Responses
 over 1 MB are rejected; override with `maxBytes` to adjust. Only `http` and
 `https` URLs are supported; other protocols throw an error. Requests to
 loopback, link-local, carrier-grade NAT, or other private network addresses
-are blocked to prevent server-side request forgery (SSRF). Hostnames that
+are blocked to prevent server-side request forgery (SSRF). The CLI equivalents
+(`jobbot summarize`, `jobbot match`, and `jobbot ingest url`) accept `--max-bytes`
+to raise the limit for unusually large postings while retaining the default 1 MB
+guardrail for typical runs. Hostnames that
 resolve to those private ranges (for example, `127.0.0.1.nip.io`) are rejected
 as well; `test/fetch.test.js` now asserts both generic and nip.io guardrails.
 Calls targeting the same protocol/host pair are serialized so a host only sees
@@ -427,6 +433,9 @@ JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest workable --company example
 
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest url https://example.com/jobs/staff-engineer
 # Imported job 5d41402abc4b2a76 from https://example.com/jobs/staff-engineer
+
+# Raise the ingest snapshot limit to 5 MB for unusually long postings
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot ingest url https://example.com/big-role --max-bytes 5242880
 ```
 
 Each listing in the response is normalised to plain text, parsed for title,

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import { summarize as summarizeFirstSentence } from '../src/index.js';
 import { fetchTextFromUrl, DEFAULT_FETCH_HEADERS } from '../src/fetch.js';
 import { parseJobText } from '../src/parser.js';
@@ -1503,15 +1503,27 @@ async function main() {
   process.exit(2);
 }
 
-const entryUrl = (() => {
+const entryPath = (() => {
   try {
-    return pathToFileURL(process.argv[1] || '').href;
+    const entryCandidate = process.argv[1];
+    if (!entryCandidate) {
+      return undefined;
+    }
+    return fs.realpathSync(entryCandidate);
   } catch {
     return undefined;
   }
 })();
 
-if (entryUrl && import.meta.url === entryUrl) {
+const modulePath = (() => {
+  try {
+    return fs.realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return undefined;
+  }
+})();
+
+if (entryPath && modulePath && modulePath === entryPath) {
   main().catch(err => {
     console.error(err.message || String(err));
     process.exit(1);

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { summarize as summarizeFirstSentence } from '../src/index.js';
 import { fetchTextFromUrl, DEFAULT_FETCH_HEADERS } from '../src/fetch.js';
 import { parseJobText } from '../src/parser.js';
@@ -173,10 +174,10 @@ async function writeDocxFile(targetPath, buffer) {
   await fs.promises.writeFile(resolved, buffer);
 }
 
-async function cmdSummarize(args) {
+export async function cmdSummarize(args) {
   const usage =
     'Usage: jobbot summarize <file|url|-> [--json] [--text] [--sentences <count>] ' +
-    '[--docx <path>] [--locale <code>]';
+    '[--docx <path>] [--locale <code>] [--max-bytes <bytes>]';
   const input = args[0] || '-';
   const format = args.includes('--json')
     ? 'json'
@@ -197,11 +198,16 @@ async function cmdSummarize(args) {
     process.exit(2);
   }
   const timeoutMs = getNumberFlag(args, '--timeout', 10000);
+  const maxBytes = getNumberFlag(args, '--max-bytes');
   const count = getNumberFlag(args, '--sentences', 1);
   const fetchingRemote = isHttpUrl(input);
   const requestHeaders = fetchingRemote ? { ...DEFAULT_FETCH_HEADERS } : undefined;
+  const fetchOptions = { timeoutMs, headers: requestHeaders };
+  if (Number.isFinite(maxBytes) && maxBytes > 0) {
+    fetchOptions.maxBytes = maxBytes;
+  }
   const raw = fetchingRemote
-    ? await fetchTextFromUrl(input, { timeoutMs, headers: requestHeaders })
+    ? await fetchTextFromUrl(input, fetchOptions)
     : await readSource(input);
   const parsed = parseJobText(raw);
   const summary = summarizeFirstSentence(raw, count);
@@ -220,11 +226,11 @@ async function cmdSummarize(args) {
   else console.log(toMarkdownSummary(localizedPayload));
 }
 
-async function cmdMatch(args) {
+export async function cmdMatch(args) {
   const resumeIdx = args.indexOf('--resume');
   const usage =
     'Usage: jobbot match --resume <file> --job <file|url> [--json] [--explain] ' +
-    '[--docx <path>] [--locale <code>]';
+    '[--docx <path>] [--locale <code>] [--max-bytes <bytes>]';
   if (resumeIdx === -1 || !args[resumeIdx + 1]) {
     console.error(usage);
     process.exit(2);
@@ -250,13 +256,18 @@ async function cmdMatch(args) {
     process.exit(2);
   }
   const timeoutMs = getNumberFlag(args, '--timeout', 10000);
+  const maxBytes = getNumberFlag(args, '--max-bytes');
   const resumePath = args[resumeIdx + 1];
   const jobInput = args[jobIdx + 1];
   const resumeText = await loadResume(resumePath);
   const jobUrl = isHttpUrl(jobInput) ? jobInput : undefined;
   const requestHeaders = jobUrl ? { ...DEFAULT_FETCH_HEADERS } : undefined;
+  const fetchOptions = { timeoutMs, headers: requestHeaders };
+  if (Number.isFinite(maxBytes) && maxBytes > 0) {
+    fetchOptions.maxBytes = maxBytes;
+  }
   const jobRaw = jobUrl
-    ? await fetchTextFromUrl(jobUrl, { timeoutMs, headers: requestHeaders })
+    ? await fetchTextFromUrl(jobUrl, fetchOptions)
     : await readSource(jobInput);
   const parsed = parseJobText(jobRaw);
   const { score, matched, missing, must_haves_missed, keyword_overlap } = computeFitScore(
@@ -727,18 +738,23 @@ async function cmdIngestWorkable(args) {
   console.log(`Imported ${saved} ${noun} from ${account}`);
 }
 
-async function cmdIngestUrl(args) {
+export async function cmdIngestUrl(args) {
   const targetUrl = args[0];
   const rest = args.slice(1);
   if (!targetUrl) {
-    console.error('Usage: jobbot ingest url <url> [--timeout <ms>]');
+    console.error('Usage: jobbot ingest url <url> [--timeout <ms>] [--max-bytes <bytes>]');
     process.exit(2);
   }
 
   const timeoutMs = getNumberFlag(rest, '--timeout', 10000);
+  const maxBytes = getNumberFlag(rest, '--max-bytes');
 
   try {
-    const { id } = await ingestJobUrl({ url: targetUrl, timeoutMs });
+    const options = { url: targetUrl, timeoutMs };
+    if (Number.isFinite(maxBytes) && maxBytes > 0) {
+      options.maxBytes = maxBytes;
+    }
+    const { id } = await ingestJobUrl(options);
     console.log(`Imported job ${id} from ${targetUrl}`);
   } catch (err) {
     console.error(err.message || String(err));
@@ -757,7 +773,7 @@ async function cmdIngest(args) {
   console.error(
     'Usage: jobbot ingest <greenhouse|lever|ashby|smartrecruiters|workable> --company <slug>',
   );
-  console.error('   or: jobbot ingest url <url> [--timeout <ms>]');
+  console.error('   or: jobbot ingest url <url> [--timeout <ms>] [--max-bytes <bytes>]');
   process.exit(2);
 }
 
@@ -1487,7 +1503,17 @@ async function main() {
   process.exit(2);
 }
 
-main().catch(err => {
-  console.error(err.message || String(err));
-  process.exit(1);
-});
+const entryUrl = (() => {
+  try {
+    return pathToFileURL(process.argv[1] || '').href;
+  } catch {
+    return undefined;
+  }
+})();
+
+if (entryUrl && import.meta.url === entryUrl) {
+  main().catch(err => {
+    console.error(err.message || String(err));
+    process.exit(1);
+  });
+}

--- a/test/cli-max-bytes.test.js
+++ b/test/cli-max-bytes.test.js
@@ -1,0 +1,119 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../src/fetch.js', async () => {
+  const actual = await vi.importActual('../src/fetch.js');
+  return {
+    ...actual,
+    fetchTextFromUrl: vi.fn().mockResolvedValue(
+      'Title: Example\nCompany: Example Corp\nRequirements\n- Build things',
+    ),
+  };
+});
+
+vi.mock('../src/jobs.js', () => ({
+  jobIdFromSource: vi.fn().mockReturnValue('job-abc123'),
+  saveJobSnapshot: vi.fn().mockResolvedValue('/tmp/job-abc123.json'),
+}));
+
+vi.mock('../src/exporters.js', () => ({
+  toMarkdownSummary: vi.fn().mockReturnValue('## Summary\n\nBuild things'),
+  toJson: vi.fn().mockReturnValue('{"summary":"Build things"}'),
+  toDocxSummary: vi.fn().mockResolvedValue(Buffer.from('docx-summary')),
+  toMarkdownMatch: vi.fn().mockReturnValue('## Match Report'),
+  toMarkdownMatchExplanation: vi.fn().mockReturnValue('## Explanation'),
+  toDocxMatch: vi.fn().mockResolvedValue(Buffer.from('docx-match')),
+  formatMatchExplanation: vi.fn().mockReturnValue('explanation'),
+}));
+
+vi.mock('../src/parser.js', () => ({
+  parseJobText: vi.fn().mockReturnValue({
+    title: 'Example',
+    company: 'Example Corp',
+    requirements: ['Build things'],
+  }),
+}));
+
+vi.mock('../src/index.js', () => ({
+  summarize: vi.fn(),
+  summarizeFirstSentence: vi.fn().mockReturnValue('Build things'),
+}));
+
+vi.mock('../src/resume.js', () => ({
+  loadResume: vi.fn().mockResolvedValue('Resume text'),
+}));
+
+vi.mock('../src/scoring.js', () => ({
+  computeFitScore: vi.fn().mockReturnValue({
+    score: 82,
+    matched: ['Build things'],
+    missing: ['Ship faster'],
+    must_haves_missed: [],
+    keyword_overlap: [],
+  }),
+}));
+
+vi.mock('../src/url-ingest.js', () => ({
+  ingestJobUrl: vi.fn().mockResolvedValue({ id: 'job-url-1' }),
+}));
+
+// Validates the documented `--max-bytes` CLI flag forwards limits to the HTTP helpers.
+describe('CLI max-bytes forwarding', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes --max-bytes to summarize URL fetches', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { cmdSummarize } = await import('../bin/jobbot.js');
+    const { fetchTextFromUrl } = await import('../src/fetch.js');
+
+    await cmdSummarize(['http://example.com/posting', '--max-bytes', '4096']);
+
+    expect(fetchTextFromUrl).toHaveBeenCalledWith('http://example.com/posting', {
+      timeoutMs: 10000,
+      headers: { 'User-Agent': 'jobbot3000' },
+      maxBytes: 4096,
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it('passes --max-bytes to match URL fetches', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { cmdMatch } = await import('../bin/jobbot.js');
+    const { fetchTextFromUrl } = await import('../src/fetch.js');
+
+    await cmdMatch([
+      '--resume',
+      'resume.txt',
+      '--job',
+      'http://example.com/posting',
+      '--max-bytes',
+      '8192',
+    ]);
+
+    expect(fetchTextFromUrl).toHaveBeenCalledWith('http://example.com/posting', {
+      timeoutMs: 10000,
+      headers: { 'User-Agent': 'jobbot3000' },
+      maxBytes: 8192,
+    });
+
+    consoleSpy.mockRestore();
+  });
+
+  it('passes --max-bytes to ingest url command', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { cmdIngestUrl } = await import('../bin/jobbot.js');
+    const { ingestJobUrl } = await import('../src/url-ingest.js');
+
+    await cmdIngestUrl(['http://example.com/posting', '--max-bytes', '16384']);
+
+    expect(ingestJobUrl).toHaveBeenCalledWith({
+      url: 'http://example.com/posting',
+      timeoutMs: 10000,
+      maxBytes: 16384,
+    });
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- export the CLI command helpers so tests can import them without running the entrypoint
- thread the documented --max-bytes flag through summarize, match, and ingest url so remote fetches honour larger byte limits
- add a focused Vitest suite that mocks the CLI surface to prove the flag reaches fetchTextFromUrl and ingestJobUrl, and document the flag in README examples

## Future work inventory
- `rg "TODO|FIXME|future work" -n` surfaced no outstanding TODO blocks beyond prompt docs, but README already promised a `--max-bytes` flag that the CLI ignored. Shipping that doc gap was feasible in a single PR because the fetch layer already supports a `maxBytes` option and scheduler ingestion paths handle it today.

## Testing strategy
- Added new unit coverage that fails without the CLI forwarding `maxBytes`, covering summarize, match, and ingest url positive paths.
- Defers invalid-flag edge cases to a follow-up because existing parsing helpers silently ignore bad numbers; behaviour remains unchanged.

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py


------
https://chatgpt.com/codex/tasks/task_e_68d39c91a580832f8454583295025742