### PR TITLE
Preserve track reminder headings when buckets are empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1165,7 +1165,8 @@ JSON payloads expose the same `reminder` object for downstream tooling.
 Surface follow-up work with `jobbot track reminders`. Pass `--now` to view from a
 given timestamp (defaults to the current time), `--upcoming-only` to suppress past-due
 entries, and `--json` for structured output. The digest groups results by urgency so
-past-due work stays visible without scanning the whole list:
+past-due work stays visible without scanning the whole list. Empty sections print `(none)` so
+you can confirm there isn't hidden work before moving on:
 
 ```bash
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track reminders --now 2025-03-06T00:00:00Z
@@ -1180,7 +1181,8 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track reminders --now 2025-03-06T00:00:00Z
 
 Unit tests in [`test/application-events.test.js`](test/application-events.test.js)
 cover reminder extraction, including past-due filtering. The CLI suite in
-[`test/cli.test.js`](test/cli.test.js) verifies the `--json` output.
+[`test/cli.test.js`](test/cli.test.js) verifies the `--json` output and ensures the
+`Past Due`/`Upcoming` headings stick around with `(none)` placeholders when a bucket is empty.
 
 To capture discard reasons for shortlist triage:
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -462,22 +462,32 @@ async function cmdTrackReminders(args) {
     return;
   }
 
-  const groups = [
-    { heading: 'Past Due', items: reminders.filter(reminder => reminder.past_due) },
-    { heading: 'Upcoming', items: reminders.filter(reminder => !reminder.past_due) },
-  ];
+  const includePastDue = !upcomingOnly;
+  const pastDue = includePastDue
+    ? reminders.filter(reminder => reminder.past_due)
+    : [];
+  const upcoming = reminders.filter(reminder => !reminder.past_due);
+
+  const groups = [];
+  if (includePastDue) {
+    groups.push({ heading: 'Past Due', items: pastDue });
+  }
+  groups.push({ heading: 'Upcoming', items: upcoming });
 
   const lines = [];
   for (const group of groups) {
-    if (!group.items.length) continue;
     lines.push(group.heading);
-    for (const reminder of group.items) {
-      const descriptors = [];
-      if (reminder.channel) descriptors.push(reminder.channel);
-      const suffix = descriptors.length ? ` (${descriptors.join(', ')})` : '';
-      lines.push(`${reminder.job_id} — ${reminder.remind_at}${suffix}`);
-      if (reminder.note) lines.push(`  Note: ${reminder.note}`);
-      if (reminder.contact) lines.push(`  Contact: ${reminder.contact}`);
+    if (group.items.length === 0) {
+      lines.push('  (none)');
+    } else {
+      for (const reminder of group.items) {
+        const descriptors = [];
+        if (reminder.channel) descriptors.push(reminder.channel);
+        const suffix = descriptors.length ? ` (${descriptors.join(', ')})` : '';
+        lines.push(`${reminder.job_id} — ${reminder.remind_at}${suffix}`);
+        if (reminder.note) lines.push(`  Note: ${reminder.note}`);
+        if (reminder.contact) lines.push(`  Contact: ${reminder.contact}`);
+      }
     }
     lines.push('');
   }

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -127,7 +127,8 @@ aggressively to respect rate limits.
    `jobbot track history <job_id>`, and surface upcoming commitments with `jobbot track reminders`
    (add `--upcoming-only` to hide past-due entries and `--json` when piping into other tools).
    The digest prints `Past Due` and `Upcoming` sections so urgent follow-ups remain visible even
-   when one bucket is empty.
+   when one bucket is empty, showing `(none)` under empty headings so users can confirm nothing is
+   pending there.
 
 **Unhappy paths:** conflicting updates (e.g., two devices editing simultaneously) trigger a merge
 flow that preserves both sets of notes.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -648,6 +648,41 @@ describe('jobbot CLI', () => {
     );
   });
 
+  it('keeps reminder section headings when a bucket is empty', () => {
+    runCli([
+      'track',
+      'log',
+      'job-3',
+      '--channel',
+      'call',
+      '--date',
+      '2025-03-02T10:00:00Z',
+      '--contact',
+      'Avery Hiring Manager',
+      '--remind-at',
+      '2025-03-07T15:00:00Z',
+    ]);
+
+    const output = runCli([
+      'track',
+      'reminders',
+      '--now',
+      '2025-03-03T00:00:00Z',
+    ]);
+
+    const lines = output.trim().split('\n');
+    const pastDueIndex = lines.indexOf('Past Due');
+    const upcomingIndex = lines.indexOf('Upcoming');
+
+    expect(pastDueIndex).toBeGreaterThan(-1);
+    expect(lines[pastDueIndex + 1]).toBe('  (none)');
+
+    expect(upcomingIndex).toBeGreaterThan(-1);
+    expect(lines[upcomingIndex + 1]).toBe(
+      'job-3 — 2025-03-07T15:00:00.000Z (call)'
+    );
+  });
+
   it('summarizes lifecycle statuses with track board', () => {
     runCli(['track', 'add', 'job-1', '--status', 'screening', '--note', 'Awaiting recruiter']);
     runCli(['track', 'add', 'job-2', '--status', 'onsite']);


### PR DESCRIPTION
## Summary
- ensure `jobbot track reminders` always prints `Past Due`/`Upcoming` headings with a `(none)` placeholder when that bucket has no entries
- document the empty-state behavior in README.md and docs/user-journeys.md alongside the related CLI test coverage
- add a CLI regression test covering the empty-bucket presentation

## Future work inventory
- docs/user-journeys.md notes that the reminders digest keeps both `Past Due` and `Upcoming` sections visible even when a bucket is empty; the CLI previously skipped empty headings, so this doc-driven gap was actionable in a single PR

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d475690530832f93affb07a9e61e8f