### PR TITLE
Add simplification prompt and suggestions docs

### DIFF
--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -39,6 +39,8 @@ Codex CI prompt documents that CI skips Markdown- and MDX-only pull requests.
 | [docs/prompts/codex/refactor.md#upgrade-prompt][refactor-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/security.md][security-doc] | Codex Security Prompt | evergreen | yes |
 | [docs/prompts/codex/security.md#upgrade-prompt][security-up] | Upgrade Prompt | evergreen | yes |
+| [docs/prompts/codex/simplification.md][simplification-doc] | Codex Simplification Prompt | evergreen | yes |
+| [docs/prompts/codex/simplification.md#upgrade-prompt][simplification-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/spellcheck.md][spellcheck-doc] | Codex Spellcheck Prompt | evergreen | yes |
 | [docs/prompts/codex/spellcheck.md#upgrade-prompt][spellcheck-up] | Upgrade Prompt | evergreen | yes |
 | [docs/prompts/codex/style.md][style-doc] | Codex Style Prompt | evergreen | yes |
@@ -72,6 +74,8 @@ Codex CI prompt documents that CI skips Markdown- and MDX-only pull requests.
 [refactor-up]: prompts/codex/refactor.md#upgrade-prompt
 [security-doc]: prompts/codex/security.md
 [security-up]: prompts/codex/security.md#upgrade-prompt
+[simplification-doc]: prompts/codex/simplification.md
+[simplification-up]: prompts/codex/simplification.md#upgrade-prompt
 [spellcheck-doc]: prompts/codex/spellcheck.md
 [spellcheck-up]: prompts/codex/spellcheck.md#upgrade-prompt
 [style-doc]: prompts/codex/style.md

--- a/docs/prompts/codex/simplification.md
+++ b/docs/prompts/codex/simplification.md
@@ -1,0 +1,82 @@
+---
+title: 'Codex Simplification Prompt'
+slug: 'codex-simplification'
+---
+
+# Codex Simplification Prompt
+Use this prompt when simplifying workflows, onboarding, or internal tooling for the jobbot3000
+repository while preserving existing capabilities.
+
+```prompt
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Reduce complexity across product, operational, and developer experience flows without regressing
+features or coverage.
+
+USAGE NOTES:
+- Apply this prompt when streamlining architecture, polishing onboarding materials, or pruning
+  redundant utilities in jobbot3000.
+- Favor iterative, reversible steps that keep CI green.
+
+CONTEXT:
+- Follow [README.md](../../../README.md); review the [AGENTS spec](https://agentsmd.net/AGENTS.md)
+  for instruction semantics.
+- Consult [.github/workflows](../../../.github/workflows) to anticipate required CI checks.
+- Install dependencies with `npm ci` when package-lock.json changes or tooling is missing.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
+  See [scripts/scan-secrets.py](../../../scripts/scan-secrets.py).
+- Update [docs/prompt-docs-summary.md](../../prompt-docs-summary.md) when you modify prompt docs.
+- Keep references current; verify every linked file exists.
+
+REQUEST:
+1. Identify the complexity pain point (e.g., confusing module boundaries, arduous onboarding,
+   repetitive chores) and explain why it matters.
+2. Propose the smallest viable simplification that preserves current behavior and security
+   guarantees. Highlight trade-offs.
+3. Implement the change, update related docs, and describe the resulting developer experience.
+4. Run the commands listed above and address any failures.
+
+OUTPUT:
+A pull request summarizing the simplification and confirming passing checks.
+```
+
+Copy this block whenever simplifying jobbot3000.
+
+## Upgrade Prompt
+Type: evergreen
+
+Use this prompt when refining `docs/prompts/codex/simplification.md` itself.
+
+```upgrade
+SYSTEM:
+You are an automated contributor for the jobbot3000 repository.
+
+PURPOSE:
+Improve or expand the `docs/prompts/codex/simplification.md` prompt.
+
+USAGE NOTES:
+- Use this prompt to refine `docs/prompts/codex/simplification.md`.
+
+CONTEXT:
+- Follow [README.md](../../../README.md); review the [AGENTS spec](https://agentsmd.net/AGENTS.md)
+  for instruction semantics.
+- Consult [.github/workflows](../../../.github/workflows) to anticipate required CI checks.
+- Install dependencies with `npm ci` if tooling is missing.
+- Run `npm run lint` and `npm run test:ci` before committing.
+- Scan staged changes with `git diff --cached | ./scripts/scan-secrets.py`.
+  See [scripts/scan-secrets.py](../../../scripts/scan-secrets.py).
+- Update [docs/prompt-docs-summary.md](../../prompt-docs-summary.md) when you modify prompt docs.
+- Keep references current; verify every linked file exists.
+
+REQUEST:
+1. Revise `docs/prompts/codex/simplification.md` so the prompt remains accurate, actionable, and
+   aligned with current project practices.
+2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
+3. Run the commands listed above and resolve any failures.
+
+OUTPUT:
+A pull request that updates `docs/prompts/codex/simplification.md` with passing checks.
+```

--- a/docs/simplification_suggestions.md
+++ b/docs/simplification_suggestions.md
@@ -1,0 +1,81 @@
+# Simplification Suggestions for jobbot3000
+
+These recommendations target the most complex touchpoints in the repository. Each section summarizes
+an opportunity and breaks it into actionable next steps.
+
+## 1. Establish a Source-of-Truth Architecture Map
+The CLI and supporting modules span resume ingestion, ATS integrations, scheduling, and analytics.
+New contributors must infer relationships by reading files such as
+[`src/index.js`](../src/index.js), [`src/fetch.js`](../src/fetch.js), and
+[`src/analytics.js`](../src/analytics.js). Creating a lightweight architecture map would shorten
+onboarding and highlight reuse opportunities.
+
+**Suggested Steps**
+- Draft a high-level diagram (module graph or swim lanes) that shows how summarization, ingestion,
+  tracking, and exporter flows interact.
+- Embed the diagram in `README.md` or a new `docs/architecture.md`, linking to core modules and data
+  directories.
+- Annotate complex entry points (e.g., queue handling in `fetch.js`) with short docstrings that map
+  back to the architecture doc for deeper context.
+- Add an onboarding checklist referencing the architecture map so new contributors know which files
+  to read first.
+
+## 2. Introduce a Shared Adapter Interface for ATS Connectors
+Multiple files implement vendor-specific logic (`src/ashby.js`, `src/greenhouse.js`,
+`src/lever.js`, `src/smartrecruiters.js`, `src/workable.js`). Each file defines similar helpers for
+normalizing jobs, yet the calling conventions vary. A shared interface would remove repetitive
+boilerplate and clarify extension points.
+
+**Suggested Steps**
+- Define a `JobSourceAdapter` TypeScript definition (or JSDoc typedef) capturing the expected
+  methods (e.g., `listOpenings`, `normalizeJob`, `toApplicationEvent`).
+- Extract shared utilities—such as pagination, HTTP retrying, and data normalization—into
+  `src/jobs/adapters/common.js` so connectors import the same helpers.
+- Update existing connectors to implement the shared interface, gradually reducing bespoke argument
+  shapes.
+- Document the adapter contract in `docs/` with quick-start instructions for adding a new ATS.
+
+## 3. Modularize Resume and Profile Processing Pipelines
+Resume ingestion currently lives in [`src/resume.js`](../src/resume.js) while profile enrichment and
+scoring are spread across [`src/profile.js`](../src/profile.js), [`src/scoring.js`](../src/scoring.js),
+and [`src/application-events.js`](../src/application-events.js). Splitting the pipeline into distinct
+stages would make it easier to reason about transformations.
+
+**Suggested Steps**
+- Define explicit pipeline stages (load ➜ normalize ➜ enrich ➜ score) and move them into a
+  `src/pipeline/` directory with one module per stage.
+- Replace implicit data passing with a typed context object so each stage documents its inputs and
+  outputs.
+- Add table-driven tests that exercise the pipeline end-to-end with fixtures, improving confidence
+  for future refactors.
+- Provide a developer guide explaining how to insert new enrichment steps without breaking existing
+  flows.
+
+## 4. Automate Chore Work with a Task Catalog
+Recurring chores (lint rule updates, dependency bumps, prompt doc edits) are scattered across scripts
+and documentation, often requiring institutional knowledge. Consolidating them into a task catalog
+would cut coordination overhead.
+
+**Suggested Steps**
+- Create `docs/chore-catalog.md` summarizing each routine chore, its owner, frequency, and required
+  commands (e.g., `npm run lint`, `npm run test:ci`, secret scans).
+- Add npm scripts or `bin/` commands that encapsulate multi-step chores (for example, a single
+  `npm run chore:prompts` task that runs spellcheck, formatting, and link validation for prompt docs).
+- Configure CI to surface chore reminders (perhaps via scheduled GitHub Actions) pointing back to the
+  catalog.
+- Encourage contributors to append playbook entries whenever they discover a new repetitive task.
+
+## 5. Layer Simplified Abstractions Around Low-Level Utilities
+Low-level modules such as [`src/fetch.js`](../src/fetch.js) and [`src/index.js`](../src/index.js)
+expose powerful primitives (custom retry queues, sentence parsing) but require callers to understand
+intricate details. Introducing thin wrappers would preserve flexibility while providing ergonomic
+entry points.
+
+**Suggested Steps**
+- Publish a `src/services/http.js` wrapper that configures sensible defaults (timeouts, rate limits,
+  user-agent) so feature modules call a single helper instead of wiring `fetchWithRetry` manually.
+- Extract the sentence segmentation logic into a dedicated `SentenceExtractor` class with clearly
+  named methods (`next()`, `reset()`), making it easier to reuse outside `summarize`.
+- Write usage examples in JSDoc for the new wrappers and mirror them in the README to accelerate
+  discovery.
+- Monitor bundle size or performance in tests to ensure the abstractions do not introduce regressions.


### PR DESCRIPTION
what:
- add codex simplification prompt document
- record simplification suggestions for reducing complexity
- index new prompt doc in prompt summary table

why:
- provide reusable guidance for simplification-focused tasks
- capture actionable ideas to streamline onboarding and chores

how to test:
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d479bd97a0832f97112d3147aa0d71