### PR TITLE
Add chore catalog documentation and guardrail tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1036,6 +1036,8 @@ timestamps, and the CLI suite verifies `jobbot deliverables bundle` writes archi
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.
+See [docs/chore-catalog.md](docs/chore-catalog.md) for the recurring chores and required commands
+that keep those workflows green.
 
 ## Raspberry Pi console fonts
 

--- a/docs/chore-catalog.md
+++ b/docs/chore-catalog.md
@@ -1,0 +1,22 @@
+# Chore Catalog
+
+This catalog enumerates recurring maintenance work for jobbot3000. Each entry lists who keeps the
+routine fresh, how often to run it, and the exact commands to execute. Update this file whenever a
+new recurring task appears; `test/chore-catalog.test.js` guards the core commands so the catalog
+stays accurate.
+
+| Task | Owner | Frequency | Commands |
+|------|-------|-----------|----------|
+| Lint & test sweep | All contributors | Every pull request and before publishing a release | `npm run lint`<br>`npm run test:ci` |
+| Secret scan before push | All contributors | Before every commit and prior to opening a pull request | `git diff --cached \| ./scripts/scan-secrets.py` |
+| Prompt docs audit | Prompt Docs maintainers | Whenever prompt documentation changes or monthly during content reviews | `npm run lint -- docs/prompts`<br>`git status docs/prompts docs/prompt-docs-summary.md` |
+
+## How to use this catalog
+
+1. Identify the chores relevant to your change.
+2. Run the listed commands locally before pushing to keep trunk green.
+3. Note the results in your pull request description so reviewers can confirm the cadence was
+   followed.
+
+Add additional rows as new routines emerge (for example, dependency bumps or localization sweeps)
+and expand the coverage expectations in `test/chore-catalog.test.js` as the catalog grows.

--- a/docs/simplification_suggestions.md
+++ b/docs/simplification_suggestions.md
@@ -57,8 +57,9 @@ and documentation, often requiring institutional knowledge. Consolidating them i
 would cut coordination overhead.
 
 **Suggested Steps**
-- Create `docs/chore-catalog.md` summarizing each routine chore, its owner, frequency, and required
-  commands (e.g., `npm run lint`, `npm run test:ci`, secret scans).
+- Keep [`docs/chore-catalog.md`](chore-catalog.md) updated with each routine chore's owner,
+  frequency, and required commands (for example, `npm run lint`, `npm run test:ci`, and the secret
+  scan pipeline).
 - Add npm scripts or `bin/` commands that encapsulate multi-step chores (for example, a single
   `npm run chore:prompts` task that runs spellcheck, formatting, and link validation for prompt docs).
 - Configure CI to surface chore reminders (perhaps via scheduled GitHub Actions) pointing back to the

--- a/test/chore-catalog.test.js
+++ b/test/chore-catalog.test.js
@@ -1,0 +1,16 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const CATALOG_PATH = path.resolve('docs', 'chore-catalog.md');
+
+describe('chore catalog documentation', () => {
+  it('lists recurring chores with owners, cadence, and required commands', () => {
+    const contents = fs.readFileSync(CATALOG_PATH, 'utf8');
+    expect(contents).toContain('| Task | Owner | Frequency | Commands |');
+    expect(contents).toMatch(/npm run lint/);
+    expect(contents).toMatch(/npm run test:ci/);
+    expect(contents).toMatch(/git diff --cached \\?\| \.\/scripts\/scan-secrets\.py/);
+    expect(contents).toMatch(/Prompt Docs/i);
+  });
+});


### PR DESCRIPTION
## Summary
- documented recurring maintenance routines in `docs/chore-catalog.md` and linked the guide from the README
- added `test/chore-catalog.test.js` to ensure the catalog always lists lint, test, secret-scan, and prompt-doc chores
- refreshed `docs/simplification_suggestions.md` to point at the shipped catalog instead of the open TODO

## Testing
- npm run lint
- VITEST_MAX_THREADS=1 npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d47c2518c0832fb25b3189fa55c941