### PR TITLE
Allow rehearse command to log placeholder interview sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1005,7 +1005,9 @@ JOBBOT_SPEECH_SYNTHESIZER="node local/say.js --text {{input}}" \
 
 Sessions are stored under `data/interviews/{job_id}/{session_id}.json` with ISO 8601 timestamps so
 coaches and candidates can revisit transcripts later. Stage and mode default to `Behavioral` and
-`Voice` when omitted, mirroring the quick-runthrough workflow. Configure
+`Voice` when omitted, mirroring the quick-runthrough workflow. Run `jobbot rehearse <job_id>` with no
+additional flags to log a placeholder session that captures those defaults before you add richer
+transcripts or feedback. Configure
 `JOBBOT_SPEECH_TRANSCRIBER` with a local command that accepts the audio path via `{{input}}`
 (or pass `--transcriber <command>` at runtime) to automatically transcribe recordings;
 the CLI records the derived transcript alongside an `audio_source` marker. Set
@@ -1015,8 +1017,8 @@ accepts `--*-file` options for longer inputs (for example, `--transcript-file tr
 Automated coverage in [`test/interviews.test.js`](test/interviews.test.js) and
 [`test/cli.test.js`](test/cli.test.js) verifies persistence, retrieval paths, stage/mode shortcuts,
 the defaulted rehearse metadata, audio transcription integration, synthesizer execution for dialog
-prompts, manual recordings inheriting the same Behavioral/Voice defaults, and the stage-specific
-rehearsal plans emitted by `jobbot interviews plan`. Plans now include a
+prompts, manual recordings inheriting the same Behavioral/Voice defaults (even when no transcript is
+provided), and the stage-specific rehearsal plans emitted by `jobbot interviews plan`. Plans now include a
 `Flashcards` checklist, a numbered `Question bank`, and a branching `Dialog tree` so candidates can
 drill concepts by focus area and practice follow-ups; the updated tests assert that all sections
 appear in JSON and CLI output. New coverage in [`test/interviews.test.js`](test/interviews.test.js)

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -151,8 +151,9 @@ flow that preserves both sets of notes.
 4. Sessions capture transcripts, user reflections, and coach feedback in
    `data/interviews/{job_id}/{session_id}.json` for future review via
    `jobbot interviews record`. Quick run-throughs can use
-   `jobbot rehearse <job_id>` to auto-generate session identifiers and default the stage/mode to
-   Behavioral/Voice before replaying them with `jobbot interviews show`.
+   `jobbot rehearse <job_id>`—even without additional flags—to auto-generate session identifiers,
+   default the stage/mode to Behavioral/Voice, and log placeholder metadata before replaying them
+   with `jobbot interviews show` once richer notes are available.
 5. Recorded sessions attach heuristics that summarize brevity (word counts, sentence averages,
    words per minute when timestamps exist), filler words, and STAR coverage so coaches can steer
    follow-up drills toward habits that need the most attention. A `critique.tighten_this` list calls

--- a/src/interviews.js
+++ b/src/interviews.js
@@ -885,10 +885,6 @@ export async function recordInterviewSession(jobId, sessionId, data = {}) {
   const notes = normalizeNotes(data.notes);
   const audioSource = normalizeAudioSource(data.audioSource ?? data.audio_source);
 
-  if (!transcript && !reflections && !feedback && !notes) {
-    throw new Error('at least one session field is required');
-  }
-
   const stage = sanitizeString(data.stage) || 'Behavioral';
   const mode = sanitizeString(data.mode) || 'Voice';
   const startedAt = normalizeTimestamp(data.startedAt ?? data.started_at, 'start');

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1842,6 +1842,32 @@ describe('jobbot CLI', () => {
     expect(stored).toHaveProperty('recorded_at');
   });
 
+  it('records quick rehearsal sessions without additional fields', () => {
+    const output = runCli(['rehearse', 'job-empty']);
+
+    const trimmed = output.trim();
+    expect(trimmed.startsWith('Recorded rehearsal ')).toBe(true);
+    const match = trimmed.match(/^Recorded rehearsal (.+) for job-empty$/);
+    expect(match).not.toBeNull();
+    const [, sessionId] = match;
+
+    const file = path.join(dataDir, 'interviews', 'job-empty', `${sessionId}.json`);
+    const stored = JSON.parse(fs.readFileSync(file, 'utf8'));
+
+    expect(stored).toMatchObject({
+      job_id: 'job-empty',
+      session_id: sessionId,
+      stage: 'Behavioral',
+      mode: 'Voice',
+    });
+    expect(stored).toHaveProperty('recorded_at');
+    expect(stored).not.toHaveProperty('transcript');
+    expect(stored).not.toHaveProperty('reflections');
+    expect(stored).not.toHaveProperty('feedback');
+    expect(stored).not.toHaveProperty('notes');
+    expect(stored).not.toHaveProperty('heuristics');
+  });
+
   it('transcribes audio rehearsals when a local speech transcriber is configured', () => {
     const audioPath = path.join(dataDir, 'voice-note.txt');
     fs.writeFileSync(audioPath, 'Discussed roadmap alignment');

--- a/test/interviews.test.js
+++ b/test/interviews.test.js
@@ -81,7 +81,7 @@ describe('interview session archive', () => {
     expect(fetched).toEqual(disk);
   });
 
-  it('rejects missing identifiers or empty payloads', async () => {
+  it('rejects missing identifiers', async () => {
     const { setInterviewDataDir, recordInterviewSession } = await import('../src/interviews.js');
     setInterviewDataDir(dataDir);
 
@@ -91,9 +91,32 @@ describe('interview session archive', () => {
     await expect(recordInterviewSession('job', '', { transcript: 'x' })).rejects.toThrow(
       'session id is required'
     );
-    await expect(recordInterviewSession('job', 's1', {})).rejects.toThrow(
-      'at least one session field is required'
+  });
+
+  it('records sessions with default metadata when optional fields are omitted', async () => {
+    const { setInterviewDataDir, recordInterviewSession, getInterviewSession } = await import(
+      '../src/interviews.js'
     );
+
+    setInterviewDataDir(dataDir);
+
+    const recorded = await recordInterviewSession('job-empty', 'session-empty', {});
+
+    expect(recorded).toMatchObject({
+      job_id: 'job-empty',
+      session_id: 'session-empty',
+      stage: 'Behavioral',
+      mode: 'Voice',
+    });
+    expect(recorded).toHaveProperty('recorded_at');
+    expect(recorded).not.toHaveProperty('transcript');
+    expect(recorded).not.toHaveProperty('reflections');
+    expect(recorded).not.toHaveProperty('feedback');
+    expect(recorded).not.toHaveProperty('notes');
+    expect(recorded).not.toHaveProperty('heuristics');
+
+    const fromDisk = await getInterviewSession('job-empty', 'session-empty');
+    expect(fromDisk).toEqual(recorded);
   });
 
   it('rejects identifiers that escape the interviews directory', async () => {


### PR DESCRIPTION
## Summary
- allow `recordInterviewSession` to persist sessions even when transcript, reflections, feedback, and notes are omitted so `jobbot rehearse` can log quick placeholders
- extend the CLI suite and interview unit tests to cover the no-input rehearsal workflow and default metadata expectations
- document the placeholder workflow in README and Journey 6 guidance so docs match the shipped behavior

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d484848144832f8e01831f4f2af0cd