### PR TITLE
Add locations to plain-text date ambiguity hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ order so callers can highlight every placeholder directly in downstream editors.
 Plain text and PDF resumes receive the same aggregate `dates`, `metrics`, and
 `titles` hints, with additional coverage in `test/resume.test.js` confirming the
 non-Markdown path.
+Month-range heuristics now tag the first ambiguous month with its source line and column even when no
+placeholder tokens (such as `20XX`) exist, keeping plain-text imports aligned with the Markdown branch.
 
 Initialize a JSON Resume skeleton when you do not have an existing file:
 

--- a/src/resume.js
+++ b/src/resume.js
@@ -316,13 +316,28 @@ function detectAmbiguities(raw) {
 
   const ambiguities = [];
   const lines = raw.split(/\r?\n/);
-  for (const line of lines) {
+  const lineStarts = createLineStartIndex(raw);
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
     if (!MONTH_NAME_RE.test(line)) continue;
     if (YEAR_RE.test(line)) continue;
-    ambiguities.push({
+
+    let location;
+    const match = line.match(MONTH_NAME_RE);
+    if (match) {
+      const columnIndex = line.indexOf(match[0]);
+      if (columnIndex !== -1) {
+        const absoluteIndex = (lineStarts[i] ?? 0) + columnIndex;
+        location = findLocation(lineStarts, absoluteIndex);
+      }
+    }
+
+    const entry = {
       type: 'dates',
       message: 'Detected month references without four-digit years; confirm date ranges are clear.',
-    });
+    };
+    if (location) entry.location = location;
+    ambiguities.push(entry);
     break;
   }
 

--- a/test/resume.test.js
+++ b/test/resume.test.js
@@ -198,6 +198,9 @@ describe('loadResume', () => {
         expect.objectContaining({ type: 'titles' }),
       ]),
     );
+
+    const dateHint = result.metadata.ambiguities.find(entry => entry.type === 'dates');
+    expect(dateHint?.location).toMatchObject({ line: 5, column: 1 });
   });
 
   it('retains duplicate placeholder values and preserves document order', async () => {


### PR DESCRIPTION
## Summary
- inventory noted that README.md already promises line-and-column metadata for ambiguity hints, but the plain-text month-range heuristic emitted entries without a location
- extend the plain-text aggregate date heuristic in src/resume.js so it computes line offsets, finds the first month token, and attaches the resolved {line, column}
- tighten test/resume.test.js to require the aggregate "dates" hint to include the expected location and document the behavior in README.md

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d4b28cdeb0832f868f216a40da3097