### PR TITLE
✨ : – add resume pipeline coverage

### DIFF
--- a/docs/simplification_suggestions.md
+++ b/docs/simplification_suggestions.md
@@ -50,6 +50,13 @@ scoring are spread across [`src/profile.js`](../src/profile.js), [`src/scoring.j
 and [`src/application-events.js`](../src/application-events.js). Splitting the pipeline into distinct
 stages would make it easier to reason about transformations.
 
+_Update (2025-10-17):_ [`src/pipeline/resume-pipeline.js`](../src/pipeline/resume-pipeline.js)
+introduces a typed, stage-driven resume pipeline. The new
+[`test/resume-pipeline.test.js`](../test/resume-pipeline.test.js) table-drives markdown and text
+fixtures through the pipeline, asserting each stage's output (source metadata, ATS warnings,
+ambiguity heuristics, and confidence metrics) so future refactors can extend the stages with
+confidence.
+
 **Suggested Steps**
 - Define explicit pipeline stages (load ➜ normalize ➜ enrich ➜ score) and move them into a
   `src/pipeline/` directory with one module per stage.

--- a/src/pipeline/resume-pipeline.js
+++ b/src/pipeline/resume-pipeline.js
@@ -1,0 +1,85 @@
+import path from 'node:path';
+
+import { loadResume } from '../resume.js';
+
+/**
+ * Stage-driven helper that runs the resume ingestion pipeline against a single source file.
+ * Each stage mutates the shared context with typed outputs so downstream consumers can
+ * inspect intermediate results (plain-text resume, metadata, warning heuristics) or insert
+ * new stages without rewriting the orchestration logic. The default implementation wires the
+ * existing `loadResume` helper into a reusable pipeline surface.
+ */
+
+function cloneEntries(entries) {
+  if (!Array.isArray(entries)) return [];
+  return entries.map(entry => ({ ...entry }));
+}
+
+const RESUME_PIPELINE_STAGES = [
+  {
+    name: 'load',
+    run: async (context, options = {}) => {
+      const withMetadata = options.withMetadata !== false;
+      const result = await loadResume(context.filePath, { withMetadata });
+      if (typeof result === 'string') {
+        context.text = result;
+        context.metadata = undefined;
+        return { text: result, metadata: undefined };
+      }
+      const { text, metadata } = result;
+      context.text = text;
+      context.metadata = metadata;
+      return { text, metadata };
+    },
+  },
+  {
+    name: 'analyze',
+    run: context => {
+      const metadata = context.metadata || {};
+      const warnings = cloneEntries(metadata.warnings);
+      const ambiguities = cloneEntries(metadata.ambiguities);
+      const confidence = metadata.confidence
+        ? { ...metadata.confidence }
+        : { score: undefined, signals: [] };
+
+      const analysis = {
+        warnings,
+        ambiguities,
+        warningCount: warnings.length,
+        ambiguityCount: ambiguities.length,
+        confidence,
+      };
+
+      context.analysis = analysis;
+      return analysis;
+    },
+  },
+];
+
+export async function runResumePipeline(filePath, options = {}) {
+  if (typeof filePath !== 'string' || !filePath.trim()) {
+    throw new Error('resume path is required');
+  }
+
+  const resolved = path.resolve(filePath);
+  const context = {
+    filePath: resolved,
+    source: { path: resolved },
+    stages: [],
+  };
+
+  for (const stage of RESUME_PIPELINE_STAGES) {
+    const output = await stage.run(context, options);
+    context.stages.push({ name: stage.name, output });
+  }
+
+  return {
+    source: context.source,
+    text: context.text,
+    metadata: context.metadata,
+    analysis: context.analysis,
+    stages: context.stages.map(stage => ({ name: stage.name, output: stage.output })),
+  };
+}
+
+export { RESUME_PIPELINE_STAGES };

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -935,7 +935,7 @@ describe('jobbot CLI', () => {
       reason: 'Changed priorities',
       discarded_at: '2025-03-08T09:30:00.000Z',
     });
-  });
+  }, 15000);
 
   it('reports when discard archive is empty', () => {
     const emptyAll = runCli(['shortlist', 'archive']);

--- a/test/fixtures/resume-pipeline.md
+++ b/test/fixtures/resume-pipeline.md
@@ -1,0 +1,14 @@
+# Experience
+
+Senior Developer at Example Corp
+- Increased revenue by XX% year over year while leading distributed teams.
+- Built internal tooling to automate reporting.
+
+# Skills
+
+| Skill | Years |
+| ----- | ----- |
+| Node.js | 5 |
+| Leadership | 7 |
+
+![Diagram](diagram.png)

--- a/test/resume-pipeline.test.js
+++ b/test/resume-pipeline.test.js
@@ -1,0 +1,62 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { runResumePipeline } from '../src/pipeline/resume-pipeline.js';
+
+const FIXTURE_DIR = path.resolve('test', 'fixtures');
+
+const CASES = [
+  {
+    name: 'markdown resume with ATS warnings and placeholder metrics',
+    file: 'resume-pipeline.md',
+    expect: {
+      format: 'markdown',
+      warningTypes: ['tables', 'images'],
+      requiredAmbiguityTypes: ['metric'],
+    },
+  },
+  {
+    name: 'plain text resume without warnings',
+    file: 'resume.txt',
+    expect: {
+      format: 'text',
+      warningTypes: [],
+      requiredAmbiguityTypes: ['metrics'],
+    },
+  },
+];
+
+describe('resume pipeline', () => {
+  for (const testCase of CASES) {
+    it(`processes ${testCase.name}`, async () => {
+      const filePath = path.join(FIXTURE_DIR, testCase.file);
+      const context = await runResumePipeline(filePath);
+
+      expect(context.source.path).toBe(filePath);
+      expect(context.metadata.format).toBe(testCase.expect.format);
+      expect(Array.isArray(context.stages)).toBe(true);
+      expect(context.stages.map(stage => stage.name)).toEqual(
+        expect.arrayContaining(['load', 'analyze']),
+      );
+
+      const warningTypes = (context.analysis.warnings || []).map(entry => entry.type);
+      expect(new Set(warningTypes)).toEqual(new Set(testCase.expect.warningTypes));
+
+      const ambiguityTypes = (context.analysis.ambiguities || []).map(entry => entry.type);
+      for (const type of testCase.expect.requiredAmbiguityTypes) {
+        expect(ambiguityTypes).toContain(type);
+      }
+    });
+  }
+
+  it('summarizes analysis metrics for downstream consumers', async () => {
+    const filePath = path.join(FIXTURE_DIR, 'resume-pipeline.md');
+    const { analysis } = await runResumePipeline(filePath);
+
+    expect(analysis.warningCount).toBe(2);
+    expect(analysis.ambiguityCount).toBeGreaterThanOrEqual(2);
+    expect(analysis.confidence.score).toBeGreaterThan(0);
+    expect(analysis.confidence.signals.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add a stage-driven resume pipeline helper that wraps the existing resume loader so stages expose typed outputs
- table-drive resume pipeline coverage across markdown and text fixtures to close the documented future-work item
- document the shipped pipeline in docs/simplification_suggestions.md and extend the shortlist archive CLI test timeout for stability

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d4b28cdeb0832f868f216a40da3097