### PR TITLE
feat: surface next shortlist reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1187,7 +1187,10 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track board --json | jq '.columns[1]'
 Notes stay attached to each entry so checklists remain visible alongside due
 reminders and outreach history when triaging the pipeline. Each job now shows
 the next reminder (with channel, note, and contact) directly on the board, and
-JSON payloads expose the same `reminder` object for downstream tooling.
+JSON payloads expose the same `reminder` object for downstream tooling. When a
+job carries multiple reminders, the board surfaces the soonest upcoming entry
+and falls back to the most recent past-due reminder when no future timestamp is
+scheduled.
 
 Surface follow-up work with `jobbot track reminders`. Pass `--now` to view from a
 given timestamp (defaults to the current time), `--upcoming-only` to suppress past-due

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -128,7 +128,8 @@ aggressively to respect rate limits.
    (add `--upcoming-only` to hide past-due entries and `--json` when piping into other tools).
    The digest prints `Past Due` and `Upcoming` sections so urgent follow-ups remain visible even
    when one bucket is empty, showing `(none)` under empty headings so users can confirm nothing is
-   pending there.
+   pending there. Lifecycle board summaries surface the soonest upcoming reminder per job and fall
+   back to the most recent past-due entry when no future timestamp is scheduled.
 
 **Unhappy paths:** conflicting updates (e.g., two devices editing simultaneously) trigger a merge
 flow that preserves both sets of notes.


### PR DESCRIPTION
## Summary
- prefer the soonest upcoming reminder when rendering `jobbot track board` and retain the latest past-due reminder as a fallback
- extend the CLI test suite with coverage for jobs that carry both past-due and upcoming reminders
- clarify the README and user journey docs so they document the board’s reminder precedence

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d4b28cdeb0832f868f216a40da3097