### PR TITLE
Fix architecture doc tracker references

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@ User (CLI / future UI)
          ├─► Resume ingestion (src/resume.js, src/profile.js)
          ├─► Job ingestion (src/jobs.js + adapters)
          ├─► Matching & scoring (src/match.js, src/scoring.js)
-         └─► Deliverables & trackers (src/deliverables.js, src/track.js)
+         └─► Deliverables & trackers (src/deliverables.js, src/application-events.js, src/lifecycle.js)
 ```
 
 Data persists inside the git-ignored `data/` directory:
@@ -39,9 +39,9 @@ loading, and error reporting. Commands fan out to domain modules that encapsulat
   `src/greenhouse.js`) to list openings, normalize snapshots, and persist them locally.
 - **Shortlist:** `jobbot shortlist` calls `src/shortlist.js` to tag, discard, and sync tracked roles.
 - **Tracker:** `jobbot track` commands write to `data/applications.json` and
-  `data/application_events.json` using helpers in `src/application-events.js`.
-- **Scheduling:** `jobbot schedule run` loads configuration via `src/schedule-config.js` and hands off
-  to `src/scheduler.js` to run repeated ingest/match workflows.
+  `data/application_events.json` using helpers in `src/application-events.js` and `src/lifecycle.js`.
+- **Scheduling:** `jobbot schedule run` loads configuration and executes recurring workflows via
+  `src/schedule.js`.
 
 ## Resume ingestion
 

--- a/test/architecture-doc.test.js
+++ b/test/architecture-doc.test.js
@@ -16,5 +16,7 @@ describe('architecture documentation', () => {
     expect(contents).toMatch(/Job ingestion/);
     expect(contents).toMatch(/Matching and scoring/);
     expect(contents).toMatch(/Deliverables/);
+    expect(contents).toMatch(/src\/application-events\.js/);
+    expect(contents).toMatch(/src\/lifecycle\.js/);
   });
 });


### PR DESCRIPTION
## Summary
- update the architecture map to call out src/application-events.js and src/lifecycle.js for tracker flows
- extend the architecture doc test to require those module references

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d4da14dbd0832f9caffee7c65b2481