### PR TITLE
feat: localize prior activity summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,8 @@ session's `started_at` timestamp—or, if that is unavailable, the recording's f
 even partially captured sessions still surface when reviewing prior work. The session detail now
 annotates the timestamp source via `recorded_at_source` (`recorded_at`, `started_at`, or
 `file_mtime`) so reviewers know whether they're looking at an explicit log or a filesystem-derived
-fallback.
+fallback. When `--locale` is provided, the Prior Activity heading and bullet labels respect the
+requested language so localized reports stay consistent end to end.
 
 ```bash
 cat <<'EOF' > resume.txt

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -15,5 +15,14 @@ export default {
   blockers: 'Blockers',
   noBlockers: 'No blockers flagged.',
   coverageSummary: 'Matched {matched} of {total} requirements ({score}%).',
-  greeting: 'Hello, {name}!'
+  greeting: 'Hello, {name}!',
+  priorActivityHeading: 'Prior Activity',
+  priorActivityDeliverablesLabel: 'Deliverables',
+  priorActivityRunSingular: 'run',
+  priorActivityRunPlural: 'runs',
+  priorActivityLastRunSuffix: ' (last run {timestamp})',
+  priorActivityInterviewsLabel: 'Interviews',
+  priorActivitySessionSingular: 'session',
+  priorActivitySessionPlural: 'sessions',
+  priorActivityCoachingNotesLabel: 'Coaching notes',
 };

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -15,5 +15,14 @@ export default {
   blockers: 'Obstáculos',
   noBlockers: 'No se identificaron obstáculos.',
   coverageSummary: 'Coincidió con {matched} de {total} requisitos ({score}%).',
-  greeting: '¡Hola, {name}!'
+  greeting: '¡Hola, {name}!',
+  priorActivityHeading: 'Actividad previa',
+  priorActivityDeliverablesLabel: 'Entregables',
+  priorActivityRunSingular: 'ejecución',
+  priorActivityRunPlural: 'ejecuciones',
+  priorActivityLastRunSuffix: ' (última ejecución {timestamp})',
+  priorActivityInterviewsLabel: 'Entrevistas',
+  priorActivitySessionSingular: 'sesión',
+  priorActivitySessionPlural: 'sesiones',
+  priorActivityCoachingNotesLabel: 'Notas de coaching',
 };

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -15,5 +15,14 @@ export default {
   noHits: 'Aucune correspondance directe depuis le CV.',
   noGaps: 'Aucune exigence manquante détectée.',
   coverageSummary: 'Correspond {matched} sur {total} exigences ({score} %).',
-  greeting: 'Bonjour, {name}!'
+  greeting: 'Bonjour, {name}!',
+  priorActivityHeading: 'Activités précédentes',
+  priorActivityDeliverablesLabel: 'Livrables',
+  priorActivityRunSingular: 'exécution',
+  priorActivityRunPlural: 'exécutions',
+  priorActivityLastRunSuffix: ' (dernière exécution {timestamp})',
+  priorActivityInterviewsLabel: 'Entretiens',
+  priorActivitySessionSingular: 'session',
+  priorActivitySessionPlural: 'sessions',
+  priorActivityCoachingNotesLabel: 'Notes de coaching',
 };

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -388,6 +388,20 @@ describe('jobbot CLI', () => {
     expect(mdOut).toContain('## Prior Activity');
     expect(mdOut).toContain('Deliverables: 1 run');
     expect(mdOut).toContain('Interviews: 1 session');
+
+    const localizedOut = runCli([
+      'match',
+      '--resume',
+      resumePath,
+      '--job',
+      jobPath,
+      '--locale',
+      'es',
+    ]);
+    expect(localizedOut).toContain('## Actividad previa');
+    expect(localizedOut).toContain('Entregables: 1 ejecución');
+    expect(localizedOut).toContain('Entrevistas: 1 sesión');
+    expect(localizedOut).toContain('  Notas de coaching:');
   });
 
   it('explains hits and gaps with match --explain', () => {


### PR DESCRIPTION
✨ : –
what: localize match prior activity headings/labels and extend
i18n coverage to pass new locale regression tests
why: README promises localized match output and the section stayed
en even when --locale was set
how to test: npm run lint && npm run test:ci
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68d4da14dbd0832f9caffee7c65b2481