### PR TITLE
Add jobbot profile CLI alias for resume management

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,12 +254,16 @@ Initialize a JSON Resume skeleton when you do not have an existing file:
 ```bash
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot init
 # Initialized profile at /tmp/jobbot-profile-XXXX/profile/resume.json
+
+# The profile namespace exposes the same initializer
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot profile init
 ```
 
-`jobbot init` writes `profile/resume.json` under the data directory with empty
-basics, work, education, skills, projects, certificates, and languages
-sections. The command is idempotent and preserves existing resumes; see
-`test/cli.test.js` and `test/profile.test.js` for coverage.
+`jobbot init` (and its `jobbot profile init` alias) writes `profile/resume.json`
+under the data directory with empty basics, work, education, skills, projects,
+certificates, and languages sections. The command is idempotent and preserves
+existing resumes; see `test/cli.test.js` and `test/profile.test.js` for
+coverage of both entry points.
 
 Import a LinkedIn profile export to seed the resume with verified contact,
 work history, education, and skills:
@@ -267,6 +271,9 @@ work history, education, and skills:
 ```bash
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot import linkedin linkedin-profile.json
 # Imported LinkedIn profile to /tmp/jobbot-profile-XXXX/profile/resume.json (basics +5, work +1, education +1, skills +3)
+
+# The profile namespace forwards to the same importer
+JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot profile import linkedin linkedin-profile.json
 ```
 
 The importer accepts LinkedIn JSON exports (downloadable from
@@ -274,7 +281,7 @@ The importer accepts LinkedIn JSON exports (downloadable from
 existing resume without overwriting confirmed fields. Work history, education,
 and skill entries are deduplicated so repeated imports keep the profile tidy.
 See `test/profile-import.test.js` for normalization edge cases and
-`test/cli.test.js` for CLI wiring.
+`test/cli.test.js` for CLI wiring (including the `jobbot profile import` path).
 
 Format parsed results as Markdown. The exporters escape Markdown control characters so job
 content cannot inject arbitrary links or formatting when rendered downstream:
@@ -431,6 +438,11 @@ JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot match --resume resume.txt --job job.txt 
 JOBBOT_DATA_DIR=$(mktemp -d) npx jobbot match --resume resume.txt --job job.txt --locale fr --docx match-fr.docx
 # => Markdown and DOCX outputs render translated labels
 ```
+
+Provide `--role <title>` and/or `--location <value>` when the source material omits those fields or
+when you want to override parsed metadata for reporting purposes. The overrides flow into Markdown,
+JSON, and DOCX outputs as well as the saved job snapshot so downstream tooling sees the adjusted
+context.
 
 Fit scoring recognizes common abbreviations so lexical-only resumes still match spelled-out
 requirements. `AWS` on a resume matches `Amazon Web Services`, `ML` pairs with `Machine learning`,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,7 +23,8 @@ User (CLI / future UI)
 
 Data persists inside the git-ignored `data/` directory:
 
-- `data/profile/` – canonical resume/profile artifacts managed by `jobbot profile` commands.
+- `data/profile/` – canonical resume/profile artifacts managed by `jobbot init` and
+  `jobbot profile` commands.
 - `data/jobs/` – normalized job postings written by `jobbot ingest …` commands.
 - `data/applications.json` and `data/application_events.json` – pipeline tracking state.
 - `data/deliverables/{job_id}/` – tailored resumes, cover letters, and build logs.
@@ -33,8 +34,9 @@ Data persists inside the git-ignored `data/` directory:
 `src/index.js` is the primary entry point for CLI commands. It orchestrates prompt selection, config
 loading, and error reporting. Commands fan out to domain modules that encapsulate each workflow:
 
-- **Resume:** `jobbot resume` commands coordinate with `src/resume.js` to normalize inputs and write
-  JSON Resume files under `data/profile/`.
+- **Profile:** `jobbot init` and `jobbot profile <init|import>` commands coordinate with
+  `src/profile.js`/`src/resume.js` to normalize inputs and write JSON Resume files under
+  `data/profile/`.
 - **Jobs:** `jobbot ingest` routes to `src/jobs.js`, which relies on provider adapters (for example
   `src/greenhouse.js`) to list openings, normalize snapshots, and persist them locally.
 - **Shortlist:** `jobbot shortlist` calls `src/shortlist.js` to tag, discard, and sync tracked roles.

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -10,9 +10,10 @@ translate them into backlog items, prompts, and acceptance tests.
 jobbot3000.
 
 1. The user selects a local resume file (PDF, Markdown, MDX, or plain text) or points to an existing
-   `resume.json`. When they start from scratch, `jobbot init` scaffolds
-   `data/profile/resume.json` with empty JSON Resume sections ready for editing.
-   When a LinkedIn data export is available, `jobbot import linkedin <file>`
+   `resume.json`. When they start from scratch, `jobbot init` (or
+   `jobbot profile init`) scaffolds `data/profile/resume.json` with empty JSON
+   Resume sections ready for editing. When a LinkedIn data export is available,
+   `jobbot import linkedin <file>` or `jobbot profile import linkedin <file>`
    merges contact details, work history, education, and skills into the same
    profile without overwriting confirmed fields.
 2. The CLI or UI calls the resume loader to extract clean text and metadata.


### PR DESCRIPTION
## Summary
- add a `jobbot profile` command that proxies to the existing init/import flows so the CLI matches documented entry points
- extend CLI coverage to exercise `jobbot profile init` and `jobbot profile import linkedin`
- document the new namespace across README, architecture, and user journey guides

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d4da14dbd0832f9caffee7c65b2481