### PR TITLE
Surface shortlist discard counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -738,8 +738,8 @@ so downstream tools can surface the most recent rationale and how often a role h
 without traversing the full history. Add `--json` to the
 shortlist list command when piping entries into other tools; include `--out <path>` to persist the
 snapshot on disk. Filter by metadata or tags (`--location`, `--level`, `--compensation`, or repeated
-`--tag` flags) when triaging opportunities. Text output also surfaces `Last Discard Tags` when tag
-history exists so the rationale stays visible without opening the archive. The archive reader trims
+`--tag` flags) when triaging opportunities. Text output also surfaces `Discard Count` and `Last Discard Tags`
+when history exists so the rationale stays visible without opening the archive. The archive reader trims
 messy history entries, sorts them chronologically, and fills missing timestamps with `(unknown time)`
 so legacy discards still surface their rationale. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for
 refresh schedulers. Shells treat `$` as a variable prefix, so `--compensation "$185k"` expands to

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -1066,6 +1066,7 @@ function formatShortlistList(jobs) {
     if (metadata.synced_at) lines.push(`  Synced At: ${metadata.synced_at}`);
     if (tags.length) lines.push(`  Tags: ${tags.join(', ')}`);
     const normalizedDiscard = normalizeDiscardEntries(discarded);
+    lines.push(`  Discard Count: ${normalizedDiscard.length}`);
     if (normalizedDiscard.length > 0) {
       const latest = normalizedDiscard[0];
       const reason = latest.reason || 'Unknown reason';

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -77,8 +77,10 @@ revisit them later without blocking the workflow.
 4. The shortlist view exposes filters (location, level, compensation, tags) via
    `jobbot shortlist list --location <value>` (and repeated `--tag <value>` flags)
    and records sync metadata with `jobbot shortlist sync` so future refreshes know
-   when entries were last updated. Add `--json` (and optionally
-   `--out <path>`) when exporting the filtered shortlist to other tools.
+   when entries were last updated. Text summaries now also show `Discard Count` and
+   `Last Discard Tags` for each job so candidates can spot churn without opening the
+   archive. Add `--json` (and optionally `--out <path>`) when exporting the filtered
+   shortlist to other tools.
 5. Teams can automate recurring ingestion and matching runs with
    `jobbot schedule run --config <file> [--cycles <count>]`. Configured tasks pull
    boards on a cadence and compute fit scores against the latest resume so the

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1368,6 +1368,32 @@ describe('jobbot CLI', () => {
     expect(output).not.toContain('Last Discard: Old news (2024-12-25T09:00:00.000Z)');
   });
 
+  it('surfaces discard counts in shortlist list summaries', () => {
+    runCli([
+      'shortlist',
+      'discard',
+      'job-discard-count',
+      '--reason',
+      'Initial pass',
+      '--date',
+      '2025-02-01T10:00:00Z',
+    ]);
+
+    runCli([
+      'shortlist',
+      'discard',
+      'job-discard-count',
+      '--reason',
+      'Revisit later',
+      '--date',
+      '2025-03-15T12:30:00Z',
+    ]);
+
+    const output = runCli(['shortlist', 'list']);
+    expect(output).toContain('job-discard-count');
+    expect(output).toContain('Discard Count: 2');
+  });
+
   it('shows last discard details for legacy entries without timestamps', () => {
     const shortlistPath = path.join(dataDir, 'shortlist.json');
     const legacyPayload = {


### PR DESCRIPTION
## Future work inventory
- `test/cli.test.js`: pending shortlist discard count coverage was the
  actionable item; text output lagged behind existing JSON `discard_count`
  support, so shipping the formatter brings parity.

## Summary
- ensure shortlist list formatting always prints a `Discard Count` line
- document shortlist output updates in README and user journeys
- keep CLI coverage that seeds two discards and expects the count in output

## Test matrix
- shortlist list surfaces `Discard Count: 2` after two discards are logged

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py


------
https://chatgpt.com/codex/tasks/task_e_68d5c207e4a0832f917e13006c3e3fd8