### PR TITLE
Narrate entire interview rehearsal plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -1089,21 +1089,24 @@ transcripts or feedback. Configure
 `JOBBOT_SPEECH_TRANSCRIBER` with a local command that accepts the audio path via `{{input}}`
 (or pass `--transcriber <command>` at runtime) to automatically transcribe recordings;
 the CLI records the derived transcript alongside an `audio_source` marker. Set
-`JOBBOT_SPEECH_SYNTHESIZER` (or pass `--speaker <command>`) to read dialog prompts aloud when
-`jobbot interviews plan --speak` is used so candidates can rehearse responses hands-free. The CLI
-accepts `--*-file` options for longer inputs (for example, `--transcript-file transcript.md`).
-Automated coverage in [`test/interviews.test.js`](test/interviews.test.js) and
-[`test/cli.test.js`](test/cli.test.js) verifies persistence, retrieval paths, stage/mode shortcuts,
-the defaulted rehearse metadata, audio transcription integration, synthesizer execution for dialog
-prompts, manual recordings inheriting the same Behavioral/Voice defaults (even when no transcript is
-provided), and the stage-specific rehearsal plans emitted by `jobbot interviews plan`. Plans now include a
-`Flashcards` checklist, a numbered `Question bank`, and a branching `Dialog tree` so candidates can
-drill concepts by focus area and practice follow-ups; the updated tests assert that all sections
-appear in JSON and CLI output. New coverage in [`test/interviews.test.js`](test/interviews.test.js)
-locks in the Onsite logistics plan’s dialog prompts alongside the recruiter screen pitch and
-timeline checkpoints, while [`test/cli.test.js`](test/cli.test.js) confirms the CLI surfaces the
-screen plan’s timeline reminders, stage transitions, and audio metadata consistently across
-releases.
+`JOBBOT_SPEECH_SYNTHESIZER` (or pass `--speaker <command>`) to narrate the entire study packet when
+`jobbot interviews plan --speak` is used—the stage header, summary, section checklists, resources,
+flashcards, question bank prompts, and dialog tree follow-ups all stream through the synthesizer so
+candidates can drill hands-free. The CLI accepts `--*-file` options for longer inputs (for example,
+`--transcript-file transcript.md`). Automated coverage in
+[`test/interviews.test.js`](test/interviews.test.js) and [`test/cli.test.js`](test/cli.test.js)
+verifies persistence, retrieval paths, stage/mode shortcuts, the defaulted rehearse metadata, audio
+transcription integration, synthesizer execution for the narrated sections (including resources and
+flashcards), manual recordings inheriting the same Behavioral/Voice defaults (even when no
+transcript is provided), and the stage-specific rehearsal plans emitted by `jobbot interviews plan`.
+Plans now include a `Flashcards` checklist, a numbered `Question bank`, and a branching `Dialog tree`
+so candidates can drill concepts by focus area and practice follow-ups; the updated tests assert that
+all sections appear in JSON and CLI output. New coverage in
+[`test/interviews.test.js`](test/interviews.test.js) locks in the Onsite logistics plan’s dialog
+prompts alongside the recruiter screen pitch and timeline checkpoints, while
+[`test/cli.test.js`](test/cli.test.js) confirms the CLI surfaces the screen plan’s timeline
+reminders, stage transitions, audio metadata, and synthesized study-packet narration consistently
+across releases.
 
 Recorded sessions now attach a `heuristics` block that summarizes brevity (word count, sentence
 count, average sentence length, and estimated words per minute when timestamps are present), filler

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -148,8 +148,9 @@ flow that preserves both sets of notes.
    `JOBBOT_SPEECH_TRANSCRIBER` (or pass `--transcriber <command>`) and run
    `jobbot rehearse <job_id> --audio <file>` to convert recorded answers into transcripts that are
    stored alongside the session metadata. Set `JOBBOT_SPEECH_SYNTHESIZER` (or pass
-   `--speaker <command>`) and call `jobbot interviews plan --stage <stage> --speak` to play the dialog
-   prompts aloud before answering.
+   `--speaker <command>`) and call `jobbot interviews plan --stage <stage> --speak` to hear the full
+   rehearsal packet—stage summary, checklist items, resources, flashcards, question prompts, and
+   dialog follow-ups—before answering.
 4. Sessions capture transcripts, user reflections, and coach feedback in
    `data/interviews/{job_id}/{session_id}.json` for future review via
    `jobbot interviews record`. Quick run-throughs can use

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -2143,9 +2143,15 @@ describe('jobbot CLI', () => {
     ]);
 
     const spoken = fs.readFileSync(spokenLog, 'utf8').trim().split('\n');
+    expect(spoken).toContain('Behavioral rehearsal plan');
+    expect(spoken).toContain('Section: Warm-up');
+    expect(spoken).toContain(
+      'Flashcard: STAR checkpoint — Anchor stories around Situation, Task, Action, Result.',
+    );
+    expect(spoken).toContain('Resource: STAR template cheat sheet');
     expect(spoken).toContain('Walk me through a recent project you led end-to-end.');
     expect(spoken).toContain('How did you bring partners along the way?');
     expect(spoken).toContain('Share a time you navigated conflict with a stakeholder.');
     expect(spoken).toContain('What trade-offs or data helped resolve it?');
-  });
+  }, 10000);
 });


### PR DESCRIPTION
## Summary
- expand `collectPlanVoicePrompts` so `jobbot interviews plan --speak` narrates the stage header, summary, section checklists, resources, flashcards, question prompts, and dialog follow-ups
- update README and the Journey 6 user story to document the full study-packet narration
- extend the CLI synthesizer test to assert the spoken output now includes the additional study context

## Testing
- `npm run lint`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68d5c207b4b0832f8944dce16840c89f