### PR TITLE
Normalize shortlist compensation filters when symbol omitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,7 +747,9 @@ refresh schedulers. Shells treat `$` as a variable prefix, so `--compensation "$
 dollar sign (`--compensation "\$185k"`) when you need the digits preserved. Override the auto-attached
 symbol by setting `JOBBOT_SHORTLIST_CURRENCY` (for example, `JOBBOT_SHORTLIST_CURRENCY='€'`).
 Existing shortlist files missing a currency symbol are normalized on read using the same default so
-filters and reports stay consistent.
+filters and reports stay consistent. Programmatic filters apply the same default when the
+compensation criterion omits a symbol, letting `filterShortlist({ compensation: '185k' })`
+match stored `$185k` entries just like the CLI.
 Newest-first shortlist snapshots saved by earlier releases now derive `last_discard` from the
 leading entry, keeping the summary aligned with the exported history. Unit coverage in
 [`test/shortlist.test.js`](test/shortlist.test.js) locks in this legacy scenario alongside the discard

--- a/src/shortlist.js
+++ b/src/shortlist.js
@@ -296,7 +296,15 @@ function normalizeFilters(filters = {}) {
   const normalized = {};
   for (const field of METADATA_FIELDS) {
     const value = sanitizeString(filters[field]);
-    if (value) normalized[field] = value.toLowerCase();
+    if (!value) continue;
+    if (field === 'compensation') {
+      const normalizedComp = normalizeCompensationValue(value);
+      if (normalizedComp) {
+        normalized[field] = normalizedComp.toLowerCase();
+        continue;
+      }
+    }
+    normalized[field] = value.toLowerCase();
   }
   const tags = normalizeFilterTags(filters.tags);
   if (tags) normalized.tags = tags;

--- a/test/shortlist.test.js
+++ b/test/shortlist.test.js
@@ -215,6 +215,19 @@ describe('shortlist metadata sync and filters', () => {
     }
   });
 
+  it('matches compensation filters without an explicit currency symbol', async () => {
+    const { syncShortlistJob, filterShortlist } = await import('../src/shortlist.js');
+
+    await syncShortlistJob('job-compensation-filter', {
+      location: 'Remote',
+      compensation: '$180k',
+    });
+
+    const filtered = await filterShortlist({ compensation: '180k' });
+    expect(Object.keys(filtered.jobs)).toEqual(['job-compensation-filter']);
+    expect(filtered.jobs['job-compensation-filter'].metadata.compensation).toBe('$180k');
+  });
+
   it('exposes the latest discard summary alongside shortlist entries', async () => {
     const { discardJob, getShortlist, filterShortlist } = await import('../src/shortlist.js');
 


### PR DESCRIPTION
## Summary
- align shortlist filtering with the documented behavior by normalizing compensation filters when they are provided without a currency symbol
- add regression coverage proving `filterShortlist({ compensation: '180k' })` matches stored `$180k` entries and update the README to call out the programmatic support

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d5c207b4b0832f8944dce16840c89f