### PR TITLE
Normalize shortlist compensation filters to match CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,7 +717,9 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist archive job-123
 
 Automated CLI tests cover both the new-entry and refresh flows so `jobbot shortlist sync <job_id>`
 continues to stamp `synced_at` when metadata flags are omitted and when existing records are
-refreshed. These cases live alongside the broader shortlist suite in `test/cli.test.js`.
+refreshed. These cases live alongside the broader shortlist suite in `test/cli.test.js`, and
+`test/shortlist.test.js` now asserts that compensation filters succeed even when the query omits
+currency symbols—mirroring the CLI example above for `--compensation 185k`.
 
 Programmatic consumers can call `syncShortlistJob(jobId)` without metadata to refresh the
 timestamp while leaving prior fields intact; `test/shortlist.test.js` now locks in that

--- a/src/shortlist.js
+++ b/src/shortlist.js
@@ -295,7 +295,12 @@ function normalizeFilterTags(tags) {
 function normalizeFilters(filters = {}) {
   const normalized = {};
   for (const field of METADATA_FIELDS) {
-    const value = sanitizeString(filters[field]);
+    let value;
+    if (field === 'compensation') {
+      value = normalizeCompensationValue(filters[field]);
+    } else {
+      value = sanitizeString(filters[field]);
+    }
     if (value) normalized[field] = value.toLowerCase();
   }
   const tags = normalizeFilterTags(filters.tags);

--- a/test/shortlist.test.js
+++ b/test/shortlist.test.js
@@ -108,6 +108,23 @@ describe('shortlist metadata sync and filters', () => {
     expect(Object.keys(none.jobs)).toEqual([]);
   });
 
+  it('filters shortlist entries by compensation without a currency symbol', async () => {
+    const { syncShortlistJob, filterShortlist } = await import('../src/shortlist.js');
+
+    await syncShortlistJob('job-comp', {
+      location: 'Remote',
+      level: 'Staff',
+      compensation: '185k',
+      syncedAt: '2025-03-06T08:00:00Z',
+    });
+
+    const filtered = await filterShortlist({ compensation: '185k' });
+    expect(Object.keys(filtered.jobs)).toEqual(['job-comp']);
+    expect(filtered.jobs['job-comp'].metadata).toMatchObject({
+      compensation: '$185k',
+    });
+  });
+
   it('deduplicates shortlist tags ignoring case', async () => {
     const { addJobTags, getShortlist } = await import('../src/shortlist.js');
 


### PR DESCRIPTION
## Summary
- align shortlist filter normalization with CLI defaults
- cover symbolless compensation queries in shortlist unit tests
- document the new coverage in the shortlist README section

## Testing
- npm run lint
- npm run test:ci (fails: computeFitScore large requirements flake)
- VITEST_POOL=threads VITEST_MAX_THREADS=1 npm run test:ci (same flake)
- npx vitest run test/scoring.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d5c207e4a0832f917e13006c3e3fd8