### PR TITLE
Respect analytics data dir override in compensation summary

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -43,7 +43,8 @@ A privacy-first, open-source, self-hosted assistant that helps an individual can
 6. **Tracker**  
    A Kanban of opportunities → applied → interview → offer, with checklists, notes, and due reminders.  
 
-Stretch (v1.x): portfolio site generator, role heatmap, compensation tracker, referral finder (manual inputs only), CLI-only “headless” mode.
+Stretch (v1.x): portfolio site generator, role heatmap, referral finder (manual inputs only), CLI-only “headless” mode.
+Compensation tracker shipped via the CLI's `jobbot analytics compensation` summary.
 
 ---
 

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -45,7 +45,12 @@ import { ingestGreenhouseBoard } from '../src/greenhouse.js';
 import { ingestLeverBoard } from '../src/lever.js';
 import { ingestSmartRecruitersBoard } from '../src/smartrecruiters.js';
 import { ingestAshbyBoard } from '../src/ashby.js';
-import { computeFunnel, exportAnalyticsSnapshot, formatFunnelReport } from '../src/analytics.js';
+import {
+  computeFunnel,
+  exportAnalyticsSnapshot,
+  formatFunnelReport,
+  computeCompensationSummary,
+} from '../src/analytics.js';
 import { ingestWorkableBoard } from '../src/workable.js';
 import { ingestJobUrl } from '../src/url-ingest.js';
 import { bundleDeliverables } from '../src/deliverables.js';
@@ -1206,6 +1211,74 @@ async function cmdShortlist(args) {
   process.exit(2);
 }
 
+const NUMBER_FORMATTERS = new Map();
+
+function formatNumber(value, decimals) {
+  const key = decimals;
+  let formatter = NUMBER_FORMATTERS.get(key);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat('en-US', {
+      minimumFractionDigits: decimals,
+      maximumFractionDigits: decimals,
+    });
+    NUMBER_FORMATTERS.set(key, formatter);
+  }
+  return formatter.format(value);
+}
+
+function formatCurrencyAmount(currency, value) {
+  if (!Number.isFinite(value)) return 'n/a';
+  const rounded = Math.round(value * 100) / 100;
+  const decimals = Number.isInteger(rounded) ? 0 : 2;
+  const formatted = formatNumber(rounded, decimals);
+  if (!currency || currency === 'unspecified') return formatted;
+  if (/^[A-Za-z]{2,}$/.test(currency)) return `${currency} ${formatted}`;
+  return `${currency}${formatted}`;
+}
+
+function formatCompensationSummary(summary) {
+  if (!summary || !summary.totals) {
+    return 'No compensation data available';
+  }
+  const totals = summary.totals;
+  const parsed = totals.parsed ?? 0;
+  const withComp = totals.with_compensation ?? 0;
+  const unparsed = totals.unparsed ?? 0;
+  const lines = [
+    `Compensation summary (${parsed} parsed of ${withComp} entries; ${unparsed} unparsed)`,
+  ];
+
+  if (Array.isArray(summary.currencies) && summary.currencies.length > 0) {
+    for (const entry of summary.currencies) {
+      const stats = entry.stats ?? {};
+      const count = stats.count ?? 0;
+      const range = stats.range ?? 0;
+      const label = entry.currency === 'unspecified' ? 'Unspecified' : entry.currency;
+      const descriptor = count === 1 ? 'job' : 'jobs';
+      const rangeLabel = range > 0 ? ` (${range} range${range === 1 ? '' : 's'})` : '';
+      lines.push(`- ${label} — ${count} ${descriptor}${rangeLabel}`);
+      const minFormatted = formatCurrencyAmount(entry.currency, stats.minimum ?? 0);
+      const maxFormatted = formatCurrencyAmount(entry.currency, stats.maximum ?? 0);
+      const avgFormatted = formatCurrencyAmount(entry.currency, stats.average ?? 0);
+      const medianFormatted = formatCurrencyAmount(entry.currency, stats.median ?? 0);
+      lines.push(`  Range: ${minFormatted} – ${maxFormatted}`);
+      lines.push(`  Average midpoint: ${avgFormatted}`);
+      lines.push(`  Median midpoint: ${medianFormatted}`);
+    }
+  } else {
+    lines.push('No parsed compensation entries found.');
+  }
+
+  if (Array.isArray(summary.issues) && summary.issues.length > 0) {
+    lines.push('Unparsed entries:');
+    for (const issue of summary.issues) {
+      lines.push(`- ${issue.job_id}: ${issue.value}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
 async function cmdAnalyticsFunnel(args) {
   const format = args.includes('--json') ? 'json' : 'text';
   const funnel = await computeFunnel();
@@ -1230,11 +1303,22 @@ async function cmdAnalyticsExport(args) {
   console.log(payload.trimEnd());
 }
 
+async function cmdAnalyticsCompensation(args) {
+  const asJson = args.includes('--json');
+  const summary = await computeCompensationSummary();
+  if (asJson) {
+    console.log(JSON.stringify(summary, null, 2));
+    return;
+  }
+  console.log(formatCompensationSummary(summary));
+}
+
 async function cmdAnalytics(args) {
   const sub = args[0];
   if (sub === 'funnel') return cmdAnalyticsFunnel(args.slice(1));
   if (sub === 'export') return cmdAnalyticsExport(args.slice(1));
-  console.error('Usage: jobbot analytics <funnel|export> [options]');
+  if (sub === 'compensation') return cmdAnalyticsCompensation(args.slice(1));
+  console.error('Usage: jobbot analytics <funnel|export|compensation> [options]');
   process.exit(2);
 }
 

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -6,6 +6,34 @@ import { STATUSES } from './lifecycle.js';
 let overrideDir;
 
 const KNOWN_STATUSES = new Set(STATUSES.map(status => status.toLowerCase()));
+const CURRENCY_SYMBOL_PREFIX_RE = /^\p{Sc}+/u;
+const ADDITIONAL_CURRENCY_SYMBOL_RE = /\p{Sc}/gu;
+const COMPENSATION_VALUE_RE = /(\d+(?:[.,]\d+)?)(?:\s*(k|m|b))?/gi;
+const CURRENCY_CODE_PATTERN = /\b([A-Z]{3,4})\b/g;
+const KNOWN_CURRENCY_CODES = new Set([
+  'USD',
+  'EUR',
+  'GBP',
+  'CAD',
+  'AUD',
+  'NZD',
+  'CHF',
+  'SEK',
+  'NOK',
+  'DKK',
+  'JPY',
+  'CNY',
+  'HKD',
+  'SGD',
+  'INR',
+  'BRL',
+  'MXN',
+  'ZAR',
+  'PLN',
+  'TRY',
+  'KRW',
+  'ILS',
+]);
 
 function resolveDataDir() {
   return overrideDir || process.env.JOBBOT_DATA_DIR || path.resolve('data');
@@ -344,6 +372,248 @@ function formatStageLine(stage, index) {
   const percentLabel = percent === undefined ? 'n/a' : `${percent}%`;
   const dropSuffix = stage.dropOff > 0 ? `, ${stage.dropOff} drop-off` : '';
   return `${base} (${percentLabel} conversion${dropSuffix})`;
+}
+
+function stripKnownCurrencyCodes(text) {
+  if (!text) return '';
+  return text.replace(CURRENCY_CODE_PATTERN, (match, code) => {
+    return KNOWN_CURRENCY_CODES.has(code) ? ' ' : match;
+  });
+}
+
+function extractCurrencyPrefix(raw) {
+  const trimmed = raw.trim();
+  if (!trimmed) return { currency: '', remainder: '' };
+  const symbolMatch = trimmed.match(CURRENCY_SYMBOL_PREFIX_RE);
+  if (symbolMatch) {
+    return {
+      currency: symbolMatch[0],
+      remainder: trimmed.slice(symbolMatch[0].length).trim(),
+    };
+  }
+  const prefix = trimmed.slice(0, 4);
+  const codeMatch = prefix.match(/^[A-Z]{3,4}/);
+  if (codeMatch && KNOWN_CURRENCY_CODES.has(codeMatch[0])) {
+    return {
+      currency: codeMatch[0],
+      remainder: trimmed.slice(codeMatch[0].length).trim(),
+    };
+  }
+  return { currency: '', remainder: trimmed };
+}
+
+function toNumericAmount(value, suffix, fallbackSuffix) {
+  const sanitized = value.replace(/[\s,]/g, '');
+  const parsed = Number.parseFloat(sanitized);
+  if (!Number.isFinite(parsed)) return null;
+  const suffixKey = (suffix || fallbackSuffix || '').toLowerCase();
+  if (suffixKey === 'k') return parsed * 1_000;
+  if (suffixKey === 'm') return parsed * 1_000_000;
+  if (suffixKey === 'b') return parsed * 1_000_000_000;
+  return parsed;
+}
+
+function isRangeConnector(text) {
+  if (!text) return true;
+  const normalized = text.replace(/[\s,]+/g, ' ').trim().toLowerCase();
+  if (!normalized) return true;
+  if (/^[-–—]+$/.test(normalized)) return true;
+  if (normalized === 'to') return true;
+  return false;
+}
+
+function roundAmount(value) {
+  return Math.round(value * 100) / 100;
+}
+
+function parseCompensationEntry(jobId, rawValue) {
+  if (typeof rawValue !== 'string') return null;
+  const trimmed = rawValue.trim();
+  if (!trimmed) return null;
+
+  const { currency, remainder } = extractCurrencyPrefix(trimmed);
+  const scrubbed = stripKnownCurrencyCodes(
+    remainder.replace(ADDITIONAL_CURRENCY_SYMBOL_RE, ' '),
+  );
+
+  const entries = [];
+  let lastSuffix;
+  let previousEnd = 0;
+  for (const match of scrubbed.matchAll(COMPENSATION_VALUE_RE)) {
+    const [, number, suffix] = match;
+    if (!number) continue;
+    const start = match.index ?? scrubbed.indexOf(match[0], previousEnd);
+    const gapFromPrevious = scrubbed.slice(previousEnd, start);
+    previousEnd = start + match[0].length;
+
+    const numeric = toNumericAmount(number, suffix, lastSuffix);
+    if (numeric == null) continue;
+
+    const entry = {
+      numeric,
+      number,
+      appliedSuffix: (suffix || lastSuffix || '').toLowerCase(),
+      gapFromPrevious,
+    };
+    entries.push(entry);
+
+    if (suffix) {
+      const appliedSuffix = suffix.toLowerCase();
+      let index = entries.length - 2;
+      let connector = gapFromPrevious;
+      while (index >= 0) {
+        const previous = entries[index];
+        if (previous.appliedSuffix) break;
+        if (!isRangeConnector(connector)) break;
+        const updated = toNumericAmount(previous.number, appliedSuffix, appliedSuffix);
+        if (updated == null) break;
+        previous.numeric = updated;
+        previous.appliedSuffix = appliedSuffix;
+        connector = entries[index].gapFromPrevious;
+        index -= 1;
+      }
+      lastSuffix = appliedSuffix;
+    }
+  }
+
+  const values = entries.map(entry => entry.numeric);
+
+  if (values.length === 0) return null;
+  values.sort((a, b) => a - b);
+  const minimum = roundAmount(values[0]);
+  const maximum = roundAmount(values[values.length - 1]);
+  const midpoint = roundAmount((values[0] + values[values.length - 1]) / 2);
+  return {
+    job_id: jobId,
+    currency: currency || 'unspecified',
+    original: trimmed,
+    minimum,
+    maximum,
+    midpoint,
+  };
+}
+
+function computeAverage(values) {
+  if (!values.length) return 0;
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return roundAmount(total / values.length);
+}
+
+function computeMedian(values) {
+  if (values.length === 0) return 0;
+  const mid = Math.floor(values.length / 2);
+  if (values.length % 2 === 1) {
+    return roundAmount(values[mid]);
+  }
+  return roundAmount((values[mid - 1] + values[mid]) / 2);
+}
+
+function summarizeCurrencyEntries(currency, entries) {
+  const sorted = entries
+    .slice()
+    .sort((a, b) => a.midpoint - b.midpoint || a.job_id.localeCompare(b.job_id));
+  const stats = {
+    count: sorted.length,
+    single_value: 0,
+    range: 0,
+    minimum: sorted.length ? sorted[0].minimum : 0,
+    maximum: sorted.length ? sorted[sorted.length - 1].maximum : 0,
+    average: 0,
+    median: 0,
+  };
+
+  const midpoints = [];
+  for (const entry of sorted) {
+    if (entry.minimum === entry.maximum) stats.single_value += 1;
+    else stats.range += 1;
+    midpoints.push(entry.midpoint);
+  }
+
+  stats.average = computeAverage(midpoints);
+  stats.median = computeMedian(midpoints);
+  if (sorted.length > 0) {
+    stats.minimum = sorted.reduce(
+      (min, entry) => Math.min(min, entry.minimum),
+      sorted[0].minimum,
+    );
+    stats.maximum = sorted.reduce(
+      (max, entry) => Math.max(max, entry.maximum),
+      sorted[0].maximum,
+    );
+  }
+
+  return { currency, stats, jobs: sorted };
+}
+
+export async function computeCompensationSummary() {
+  const { getShortlist, setShortlistDataDir, getShortlistDataDir } = await import(
+    './shortlist.js'
+  );
+
+  const analyticsOverride = overrideDir;
+  let previousShortlistOverride;
+
+  let snapshot;
+  if (analyticsOverride !== undefined) {
+    if (typeof getShortlistDataDir === 'function') {
+      previousShortlistOverride = getShortlistDataDir();
+    }
+    if (typeof setShortlistDataDir === 'function') {
+      setShortlistDataDir(analyticsOverride);
+    }
+    try {
+      snapshot = await getShortlist();
+    } finally {
+      if (typeof setShortlistDataDir === 'function') {
+        setShortlistDataDir(previousShortlistOverride);
+      }
+    }
+  } else {
+    snapshot = await getShortlist();
+  }
+  const jobs = snapshot && typeof snapshot === 'object' ? snapshot.jobs : undefined;
+  const entries = jobs && typeof jobs === 'object' ? Object.entries(jobs) : [];
+
+  const totals = {
+    shortlisted_jobs: entries.length,
+    with_compensation: 0,
+    parsed: 0,
+    unparsed: 0,
+  };
+
+  const grouped = new Map();
+  const issues = [];
+
+  for (const [jobId, record] of entries) {
+    const compensation = record?.metadata?.compensation;
+    if (typeof compensation !== 'string' || !compensation.trim()) {
+      continue;
+    }
+    totals.with_compensation += 1;
+    const parsed = parseCompensationEntry(jobId, compensation);
+    if (!parsed) {
+      totals.unparsed += 1;
+      issues.push({ job_id: jobId, value: compensation });
+      continue;
+    }
+    totals.parsed += 1;
+    const key = parsed.currency;
+    if (!grouped.has(key)) grouped.set(key, []);
+    grouped.get(key).push(parsed);
+  }
+
+  const currencies = [...grouped.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([currency, list]) => summarizeCurrencyEntries(currency, list));
+
+  issues.sort((a, b) => a.job_id.localeCompare(b.job_id));
+
+  return {
+    generated_at: new Date().toISOString(),
+    totals,
+    currencies,
+    issues,
+  };
 }
 
 export async function computeFunnel() {

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -8,7 +8,8 @@ let overrideDir;
 const KNOWN_STATUSES = new Set(STATUSES.map(status => status.toLowerCase()));
 const CURRENCY_SYMBOL_PREFIX_RE = /^\p{Sc}+/u;
 const ADDITIONAL_CURRENCY_SYMBOL_RE = /\p{Sc}/gu;
-const COMPENSATION_VALUE_RE = /(\d+(?:[.,]\d+)?)(?:\s*(k|m|b))?/gi;
+const COMPENSATION_VALUE_RE =
+  /((?:\d{1,3}(?:[.,\s]\d{3})+|\d+)(?:[.,]\d+)?)(?:\s*(k|m|b))?/gi;
 const CURRENCY_CODE_PATTERN = /\b([A-Z]{3,4})\b/g;
 const KNOWN_CURRENCY_CODES = new Set([
   'USD',

--- a/src/shortlist.js
+++ b/src/shortlist.js
@@ -5,6 +5,10 @@ import { recordJobDiscard } from './discards.js';
 
 let overrideDir;
 
+export function getShortlistDataDir() {
+  return overrideDir;
+}
+
 const METADATA_FIELDS = ['location', 'level', 'compensation'];
 
 const CURRENCY_SYMBOL_RE = /^\p{Sc}/u;

--- a/test/analytics.test.js
+++ b/test/analytics.test.js
@@ -264,6 +264,134 @@ describe('analytics conversion funnel', () => {
     expect(serialized).not.toContain('job-screening');
   });
 
+  it('summarizes shortlist compensation metadata by currency', async () => {
+    const { syncShortlistJob } = await import('../src/shortlist.js');
+
+    await syncShortlistJob('job-dollar', {
+      location: 'Remote',
+      compensation: '185k',
+    });
+
+    process.env.JOBBOT_SHORTLIST_CURRENCY = '€';
+    try {
+      await syncShortlistJob('job-euro-fixed', {
+        location: 'Berlin',
+        compensation: '95k',
+      });
+      await syncShortlistJob('job-euro-range', {
+        location: 'Berlin',
+        compensation: '€95 – 140k',
+      });
+    } finally {
+      delete process.env.JOBBOT_SHORTLIST_CURRENCY;
+    }
+
+    await syncShortlistJob('job-unparsed', {
+      location: 'Remote',
+      compensation: 'Competitive',
+    });
+
+    const { computeCompensationSummary, setAnalyticsDataDir } = await import(
+      '../src/analytics.js'
+    );
+    setAnalyticsDataDir(dataDir);
+    restoreAnalyticsDir = async () => setAnalyticsDataDir(undefined);
+
+    const summary = await computeCompensationSummary();
+
+    expect(typeof summary.generated_at).toBe('string');
+    expect(summary.totals).toEqual({
+      shortlisted_jobs: 4,
+      with_compensation: 4,
+      parsed: 3,
+      unparsed: 1,
+    });
+
+    const usd = summary.currencies.find(entry => entry.currency === '$');
+    expect(usd).toBeDefined();
+    expect(usd.stats).toMatchObject({
+      count: 1,
+      single_value: 1,
+      range: 0,
+      minimum: 185000,
+      maximum: 185000,
+      average: 185000,
+      median: 185000,
+    });
+    expect(usd.jobs).toEqual([
+      expect.objectContaining({
+        job_id: 'job-dollar',
+        original: '$185k',
+        minimum: 185000,
+        maximum: 185000,
+      }),
+    ]);
+
+    const euro = summary.currencies.find(entry => entry.currency === '€');
+    expect(euro).toBeDefined();
+    expect(euro.stats).toMatchObject({
+      count: 2,
+      single_value: 1,
+      range: 1,
+      minimum: 95000,
+      maximum: 140000,
+      average: 106250,
+      median: 106250,
+    });
+    expect(euro.jobs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          job_id: 'job-euro-fixed',
+          original: '€95k',
+          minimum: 95000,
+          maximum: 95000,
+        }),
+        expect.objectContaining({
+          job_id: 'job-euro-range',
+          original: '€95 – 140k',
+          minimum: 95000,
+          maximum: 140000,
+        }),
+      ])
+    );
+
+    expect(summary.issues).toEqual([
+      { job_id: 'job-unparsed', value: 'Competitive' },
+    ]);
+  });
+
+  it('respects analytics data directory overrides when summarizing compensation', async () => {
+    const { syncShortlistJob } = await import('../src/shortlist.js');
+    await syncShortlistJob('job-override', {
+      location: 'Remote',
+      compensation: '$120k',
+    });
+
+    const { computeCompensationSummary, setAnalyticsDataDir } = await import(
+      '../src/analytics.js'
+    );
+    setAnalyticsDataDir(dataDir);
+    restoreAnalyticsDir = async () => setAnalyticsDataDir(undefined);
+
+    delete process.env.JOBBOT_DATA_DIR;
+
+    try {
+      const summary = await computeCompensationSummary();
+
+      expect(summary.totals).toMatchObject({
+        shortlisted_jobs: 1,
+        with_compensation: 1,
+        parsed: 1,
+        unparsed: 0,
+      });
+      const usd = summary.currencies.find(entry => entry.currency === '$');
+      expect(usd).toBeDefined();
+      expect(usd?.stats).toMatchObject({ count: 1, minimum: 120000, maximum: 120000 });
+    } finally {
+      process.env.JOBBOT_DATA_DIR = dataDir;
+    }
+  });
+
   it('summarizes deliverable runs and interview sessions without exposing job ids', async () => {
     const fs = await import('node:fs/promises');
     const deliverablesRoot = path.join(dataDir, 'deliverables');


### PR DESCRIPTION
## Summary
- propagate the analytics data dir override into shortlist compensation summaries so overrides stay consistent
- expose a shortlist data-dir getter to restore previous overrides while reading analytics snapshots
- document the override behavior and add a regression test covering analytics compensation lookups

## Testing
- npm run lint
- npm run test:ci *(fails: computeFitScore resume tokenization performance > tokenizes a 120k-line resume within 200ms on a cold run — passes when run alone)*
- npx vitest run test/scoring.resume.perf.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d5c207e4a0832f917e13006c3e3fd8