### PR TITLE
Enforce prompt doc README link validation

### DIFF
--- a/docs/chore-catalog.md
+++ b/docs/chore-catalog.md
@@ -9,7 +9,10 @@ stays accurate.
 |------|-------|-----------|----------|
 | Lint & test sweep | All contributors | Every pull request and before publishing a release | `npm run lint`<br>`npm run test:ci` |
 | Secret scan before push | All contributors | Before every commit and prior to opening a pull request | `git diff --cached \| ./scripts/scan-secrets.py` |
-| Prompt docs audit | Prompt Docs maintainers | Whenever prompt documentation changes or monthly during content reviews | `npm run lint -- docs/prompts`<br>`git status docs/prompts docs/prompt-docs-summary.md` |
+| Prompt docs audit | Prompt Docs maintainers | Whenever prompt documentation changes or monthly during content reviews | `npm run chore:prompts -- --check`<br>`git status docs/prompts docs/prompt-docs-summary.md` |
+
+The prompt docs chore formats Markdown, runs spellcheck, validates the summary index, and now also
+verifies that every prompt document links back to the repository `README.md`.
 
 ## How to use this catalog
 

--- a/docs/simplification_suggestions.md
+++ b/docs/simplification_suggestions.md
@@ -83,8 +83,10 @@ would cut coordination overhead.
   scan pipeline).
 - Add npm scripts or `bin/` commands that encapsulate multi-step chores (for example, a single
   `npm run chore:prompts` task that runs spellcheck, formatting, and link validation for prompt docs).
-- The repository now ships `npm run chore:prompts`, which runs cspell over prompt docs and verifies
-  that `docs/prompt-docs-summary.md` only references existing files. The chore coverage lives in
+- The repository now ships `npm run chore:prompts`, which formats prompt docs with Prettier, runs
+  cspell, verifies that `docs/prompt-docs-summary.md` only references existing files, and now
+  ensures each prompt doc links back to the repository `README.md`. Pass
+  `--check` to run the formatting step in validation mode. The chore coverage lives in
   `test/chore-prompts.test.js`, which gives the spellcheck up to 20 seconds on CI to absorb
   occasional npm start-up slowness.
 - `npm run chore:reminders` prints the catalog as either a human-readable digest or JSON (pass

--- a/scripts/chore-prompts.js
+++ b/scripts/chore-prompts.js
@@ -7,6 +7,24 @@ import url from 'node:url';
 const ROOT_DIR = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), '..');
 const DOCS_DIR = path.join(ROOT_DIR, 'docs');
 const SUMMARY_PATH = path.join(DOCS_DIR, 'prompt-docs-summary.md');
+const ARGS = process.argv.slice(2);
+const CHECK_MODE = ARGS.includes('--check');
+
+async function listMarkdownFiles(dir) {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await listMarkdownFiles(fullPath);
+      files.push(...nested);
+    } else if (entry.isFile() && entry.name.toLowerCase().endsWith('.md')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
 
 function resolveBin(name) {
   const binName = process.platform === 'win32' ? `${name}.cmd` : name;
@@ -28,6 +46,32 @@ function runCommand(command, args, options = {}) {
       else reject(new Error(`${command} exited with code ${code}`));
     });
   });
+}
+
+async function runFormatting({ check } = {}) {
+  const prettierBin = resolveBin('prettier');
+  try {
+    await fs.access(prettierBin);
+  } catch {
+    throw new Error('prettier binary not found. Run `npm ci` to install dev dependencies.');
+  }
+
+  const patterns = ['docs/prompts/**/*.md', 'docs/prompt-docs-summary.md'];
+  const modeArgs = check ? ['--check'] : ['--write'];
+  const args = ['--log-level', 'warn', ...modeArgs, ...patterns];
+  console.log(check ? 'Checking prompt doc formatting...' : 'Formatting prompt docs...');
+  try {
+    await runCommand(prettierBin, args, { cwd: ROOT_DIR });
+  } catch (err) {
+    if (check) {
+      throw new Error(
+        'Prompt doc formatting check failed. Run `npm run chore:prompts` to apply fixes.',
+      );
+    }
+    throw err;
+  }
+  if (check) console.log('Prompt docs formatting check passed.');
+  else console.log('Prompt docs formatted.');
 }
 
 async function runSpellcheck() {
@@ -76,9 +120,56 @@ async function validatePromptSummaryLinks() {
   console.log('Prompt doc summary references are valid.');
 }
 
+async function ensurePromptDocsReferenceReadme() {
+  const promptRoot = path.join(DOCS_DIR, 'prompts');
+  const readmePath = path.join(ROOT_DIR, 'README.md');
+  let files = [];
+  try {
+    files = await listMarkdownFiles(promptRoot);
+  } catch (err) {
+    const message = err && typeof err.message === 'string' ? err.message : String(err);
+    throw new Error(`Failed to read prompt docs: ${message}`);
+  }
+
+  const linkPattern = /\[[^\]]+\]\(([^)]+)\)/g;
+  const missing = [];
+  for (const file of files) {
+    const relativeDir = path.dirname(file);
+    const relativeToReadme = path.relative(relativeDir, readmePath);
+    const normalized = relativeToReadme.split(path.sep).join('/');
+    const contents = await fs.readFile(file, 'utf8');
+
+    let hasReadmeLink = false;
+    for (const match of contents.matchAll(linkPattern)) {
+      const target = match[1].trim();
+      if (!target) continue;
+      if (!target.toLowerCase().includes('readme')) continue;
+      const [pathPart] = target.split('#');
+      const cleaned = pathPart.trim().replace(/\\+/g, '/');
+      if (cleaned === normalized) {
+        hasReadmeLink = true;
+        break;
+      }
+    }
+
+    if (!hasReadmeLink) {
+      missing.push(path.relative(ROOT_DIR, file));
+    }
+  }
+
+  if (missing.length > 0) {
+    const details = missing.map(item => ` - ${item}`).join('\n');
+    throw new Error(`Prompt docs missing README reference:\n${details}`);
+  }
+
+  console.log('Prompt docs reference README.md.');
+}
+
 async function main() {
+  await runFormatting({ check: CHECK_MODE });
   await runSpellcheck();
   await validatePromptSummaryLinks();
+  await ensurePromptDocsReferenceReadme();
   console.log('Prompt docs chore completed successfully.');
 }
 

--- a/test/chore-prompts.test.js
+++ b/test/chore-prompts.test.js
@@ -1,11 +1,12 @@
+import fs from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { describe, it, expect } from 'vitest';
 
 const repoRoot = path.resolve(__dirname, '..');
 
-function runChorePrompts() {
-  const result = spawnSync('npm', ['run', 'chore:prompts', '--', '--check'], {
+function runChorePrompts(extraArgs = ['--check']) {
+  const result = spawnSync('npm', ['run', 'chore:prompts', '--', ...extraArgs], {
     cwd: repoRoot,
     encoding: 'utf8',
     env: {
@@ -18,6 +19,36 @@ function runChorePrompts() {
 }
 
 describe('chore:prompts', () => {
+  const TIMEOUT = 20000;
+
+  it('fails in check mode when prompt docs need formatting', () => {
+    const tempFile = path.join(repoRoot, 'docs', 'prompts', 'codex', '__temp-format-test.md');
+    fs.writeFileSync(tempFile, '##Heading\ncontent\n');
+    try {
+      const { status } = runChorePrompts(['--check']);
+      expect(status).not.toBe(0);
+    } finally {
+      if (fs.existsSync(tempFile)) {
+        fs.unlinkSync(tempFile);
+      }
+    }
+  }, TIMEOUT);
+
+  it('fails in check mode when a prompt doc omits the README link', () => {
+    const tempFile = path.join(repoRoot, 'docs', 'prompts', 'codex', '__temp-readme-link.md');
+    fs.writeFileSync(tempFile, '# Temp prompt\n\nThis placeholder omits the README reference.\n');
+    try {
+      const { status, stdout, stderr } = runChorePrompts(['--check']);
+      expect(status).not.toBe(0);
+      const combined = `${stdout}\n${stderr}`;
+      expect(combined).toMatch(/README/i);
+    } finally {
+      if (fs.existsSync(tempFile)) {
+        fs.unlinkSync(tempFile);
+      }
+    }
+  }, TIMEOUT);
+
   // cspell scans the entire prompt docs tree; give CI ample time before declaring a timeout.
   it('runs the prompts chore script successfully', () => {
     const { status, stdout, stderr } = runChorePrompts();
@@ -26,5 +57,5 @@ describe('chore:prompts', () => {
       throw new Error(`chore:prompts exited with code ${status}:\n${combined}`);
     }
     expect(stdout).toContain('Prompt docs chore completed');
-  }, 20000);
+  }, TIMEOUT);
 });


### PR DESCRIPTION
## Summary
- add a README link check to `scripts/chore-prompts.js` alongside Prettier formatting and existing validations
- extend `test/chore-prompts.test.js` to cover formatting failures, missing README links, and increase timeouts
- document the new guard in the chore catalog and simplification suggestions

## Testing
- npm run lint
- npm run test:ci *(fails: vitest worker timeout after tests complete)*

------
https://chatgpt.com/codex/tasks/task_e_68d643faa50c832f84d77ac7558cbd66