### PR TITLE
Align shortlist archives with (unknown time) placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,11 +783,13 @@ shortlist history stay in sync. Archive views list the newest discard first so t
 visible immediately, while JSON exports include a newest-first `discarded` array,
 `last_discard` summary, and `discard_count`
 so downstream tools can surface the most recent rationale and how often a role has been reconsidered
-without traversing the full history. Add `--json` to the
+without traversing the full history. Missing timestamps surface as the shared `(unknown time)` placeholder
+in both CLI and JSON responses so downstream tooling can rely on a single sentinel. Add `--json` to the
 shortlist list command when piping entries into other tools; include `--out <path>` to persist the
 snapshot on disk. Filter by metadata or tags (`--location`, `--level`, `--compensation`, or repeated
 `--tag` flags) when triaging opportunities. Text output also surfaces `Discard Count` and `Last Discard Tags`
-when history exists so the rationale stays visible without opening the archive. The archive reader trims
+when history exists so the rationale stays visible without opening the archive. When the latest discard omits
+tags, the summary prints `Last Discard Tags: (none)` so the absence is explicit. The archive reader trims
 messy history entries, sorts them chronologically, and fills missing timestamps with `(unknown time)`
 so legacy discards still surface their rationale. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for
 refresh schedulers. Shells treat `$` as a variable prefix, so `--compensation "$185k"` expands to

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -1072,11 +1072,14 @@ function formatShortlistList(jobs) {
     if (normalizedDiscard.length > 0) {
       const latest = normalizedDiscard[0];
       const reason = latest.reason || 'Unknown reason';
-      const timestamp = latest.discarded_at || 'unknown time';
-      lines.push(`  Last Discard: ${reason} (${timestamp})`);
-      if (latest.tags && latest.tags.length > 0) {
-        lines.push(`  Last Discard Tags: ${latest.tags.join(', ')}`);
-      }
+      const timestamp = latest.discarded_at || '(unknown time)';
+      const timestampDisplay = timestamp.startsWith('(')
+        ? timestamp
+        : `(${timestamp})`;
+      lines.push(`  Last Discard: ${reason} ${timestampDisplay}`);
+      const hasTags = Array.isArray(latest.tags) && latest.tags.length > 0;
+      const tagSummary = hasTags ? latest.tags.join(', ') : '(none)';
+      lines.push(`  Last Discard Tags: ${tagSummary}`);
     }
     lines.push('');
   }
@@ -1085,6 +1088,7 @@ function formatShortlistList(jobs) {
 }
 
 function formatDiscardTimestamp(timestamp) {
+  if (timestamp === '(unknown time)') return '(unknown time)';
   return timestamp === 'unknown time' ? '(unknown time)' : timestamp;
 }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -76,11 +76,13 @@ revisit them later without blocking the workflow.
    optional `--location`, `--level`, `--compensation`, or explicit `--synced-at` overrides.
 4. The shortlist view exposes filters (location, level, compensation, tags) via
    `jobbot shortlist list --location <value>` (and repeated `--tag <value>` flags)
-   and records sync metadata with `jobbot shortlist sync` so future refreshes know
-   when entries were last updated. Text summaries now also show `Discard Count` and
-   `Last Discard Tags` for each job so candidates can spot churn without opening the
-   archive. Add `--json` (and optionally `--out <path>`) when exporting the filtered
-   shortlist to other tools.
+  and records sync metadata with `jobbot shortlist sync` so future refreshes know
+  when entries were last updated. Text summaries now also show `Discard Count` and
+  `Last Discard Tags` for each job so candidates can spot churn without opening the
+  archive. When a discard omits tags entirely, the summary line renders `Last Discard Tags: (none)`
+  so the absence is obvious. Add `--json` (and optionally `--out <path>`) when exporting the filtered
+  shortlist to other tools. Missing timestamps surface as `(unknown time)` in both CLI and JSON archives so
+  downstream scripts can rely on the same sentinel value when displaying legacy entries.
 5. Teams can automate recurring ingestion and matching runs with
    `jobbot schedule run --config <file> [--cycles <count>]`. Configured tasks pull
    boards on a cadence and compute fit scores against the latest resume so the

--- a/src/discards.js
+++ b/src/discards.js
@@ -91,8 +91,10 @@ function normalizeDiscardEntries(entries) {
     const reason = rawReason || 'Unknown reason';
     const sourceTimestamp = entry.discarded_at ?? entry.discardedAt;
     const discardedAt = toIsoTimestamp(sourceTimestamp);
+    const normalizedTimestamp =
+      discardedAt === 'unknown time' ? '(unknown time)' : discardedAt;
     const tags = normalizeTagList(entry.tags);
-    const payload = { reason, discarded_at: discardedAt };
+    const payload = { reason, discarded_at: normalizedTimestamp };
     if (tags) payload.tags = tags.slice();
     normalized.push(payload);
   }

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1371,6 +1371,22 @@ describe('jobbot CLI', () => {
     expect(output).toContain('Last Discard Tags: Remote, onsite');
   });
 
+  it('highlights when the latest discard has no tags in shortlist summaries', () => {
+    runCli([
+      'shortlist',
+      'discard',
+      'job-without-discard-tags',
+      '--reason',
+      'Keeping options open',
+      '--date',
+      '2025-03-09T08:30:00Z',
+    ]);
+
+    const output = runCli(['shortlist', 'list']);
+    expect(output).toContain('job-without-discard-tags');
+    expect(output).toContain('Last Discard Tags: (none)');
+  });
+
   it('deduplicates discard tags in shortlist archive output', () => {
     const archivePath = path.join(dataDir, 'discarded_jobs.json');
     fs.writeFileSync(

--- a/test/discards.test.js
+++ b/test/discards.test.js
@@ -145,7 +145,7 @@ describe('discarded job archive', () => {
       },
       {
         reason: 'Legacy without time',
-        discarded_at: 'unknown time',
+        discarded_at: '(unknown time)',
       },
     ]);
 


### PR DESCRIPTION
## Summary
- normalize discard archive timestamps so CLI and JSON outputs both use the `(unknown time)` placeholder
- adjust shortlist formatting to avoid double parentheses, keep `(none)` when tags are missing, and extend regression coverage
- document the shared placeholder handling in the shortlist sections of the README and user journeys

## Testing
- npm run lint
- npm run test:ci *(Vitest reported an `onTaskUpdate` timeout after completing all tests; reruns continue to pass)*

------
https://chatgpt.com/codex/tasks/task_e_68d643faa50c832f84d77ac7558cbd66