### PR TITLE
Add null placeholder for missing board reminders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1338,6 +1338,11 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track board --json | jq '.columns[1]'
 # }
 ```
 
+Jobs that do not have a scheduled follow-up still include a `"reminder": null`
+placeholder in the JSON payload so downstream tooling can distinguish an
+explicit "no reminder" state without checking for a missing field. The text
+board continues to print `Reminder: (none)` in the same scenario.
+
 Notes stay attached to each entry so checklists remain visible alongside due
 reminders and outreach history when triaging the pipeline. Each job now shows
 the next reminder (with channel, note, and contact) directly on the board, and

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -634,9 +634,7 @@ async function cmdTrackBoard(args) {
   for (const column of columns) {
     for (const job of column.jobs) {
       const reminder = resolveReminderForJob(job.job_id);
-      if (reminder) {
-        job.reminder = reminder;
-      }
+      job.reminder = reminder ?? null;
     }
   }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -133,10 +133,11 @@ aggressively to respect rate limits.
    when one bucket is empty, showing `(none)` under empty headings so users can confirm nothing is
    pending there. When filters remove every reminder (for example, `--upcoming-only` on a day with
    only past-due entries), the CLI still prints an `Upcoming` heading with `(none)` so it is clear
-   nothing new is scheduled. Lifecycle board summaries surface the soonest upcoming reminder per job
-   and fall back to the most recent past-due entry when no future timestamp is scheduled. When a job
-   has no reminders at all, the board prints `Reminder: (none)` so idle opportunities are obvious at
-   a glance.
+    nothing new is scheduled. Lifecycle board summaries surface the soonest upcoming reminder per job
+    and fall back to the most recent past-due entry when no future timestamp is scheduled. When a job
+    has no reminders at all, the board prints `Reminder: (none)` so idle opportunities are obvious at
+    a glance, and the JSON board surfaces the same state with an explicit `"reminder": null`
+    placeholder for downstream automation.
 
 **Unhappy paths:** conflicting updates (e.g., two devices editing simultaneously) trigger a merge
 flow that preserves both sets of notes.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -966,7 +966,7 @@ describe('jobbot CLI', () => {
     const parsed = JSON.parse(json);
     const screening = parsed.columns.find(column => column.status === 'screening');
     const entry = screening.jobs.find(job => job.job_id === 'job-no-reminder');
-    expect(entry).not.toHaveProperty('reminder');
+    expect(entry).toHaveProperty('reminder', null);
   });
 
   it('archives discarded jobs with reasons', () => {


### PR DESCRIPTION
## Summary
- ensure `track board --json` emits `"reminder": null` when no follow-up is scheduled so downstream tools can detect the absence explicitly
- document the JSON placeholder in the README and Journey 5 narrative, and update the CLI suite to lock in the behavior

## Testing
- npm run lint
- npm run test:ci *(passes with Vitest reporting an `onTaskUpdate` timeout after all tests completed)*

------
https://chatgpt.com/codex/tasks/task_e_68d643faa50c832f84d77ac7558cbd66