### PR TITLE
🎤 : Narrate voice plan metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1172,9 +1172,10 @@ transcripts or feedback. Configure
 (or pass `--transcriber <command>` at runtime) to automatically transcribe recordings;
 the CLI records the derived transcript alongside an `audio_source` marker. Set
 `JOBBOT_SPEECH_SYNTHESIZER` (or pass `--speaker <command>`) to narrate the entire study packet when
-`jobbot interviews plan --speak` is used—the stage header, summary, section checklists, resources,
-flashcards, question bank prompts, and dialog tree follow-ups all stream through the synthesizer so
-candidates can drill hands-free. The CLI accepts `--*-file` options for longer inputs (for example,
+`jobbot interviews plan --speak` is used—the stage header, role focus, suggested duration, summary,
+section checklists, resources, flashcards, question bank prompts, and dialog tree follow-ups all
+stream through the synthesizer so candidates can drill hands-free. The CLI accepts `--*-file`
+options for longer inputs (for example,
 `--transcript-file transcript.md`). Automated coverage in
 [`test/interviews.test.js`](test/interviews.test.js) and [`test/cli.test.js`](test/cli.test.js)
 verifies persistence, retrieval paths, stage/mode shortcuts, the defaulted rehearse metadata, audio

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -1608,6 +1608,16 @@ function collectPlanVoicePrompts(plan) {
     prompts.push(`${stage} rehearsal plan`);
   }
 
+  const role = normalize(plan.role);
+  if (role) {
+    prompts.push(`Role focus: ${role}`);
+  }
+
+  const duration = plan.duration_minutes;
+  if (Number.isFinite(duration)) {
+    prompts.push(`Suggested duration: ${duration} minutes`);
+  }
+
   const summary = normalize(plan.summary);
   if (summary) {
     prompts.push(summary);

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -2275,6 +2275,8 @@ describe('jobbot CLI', () => {
       'plan',
       '--stage',
       'behavioral',
+      '--role',
+      'Engineering Manager',
       '--speak',
       '--speaker',
       synthesizer,
@@ -2282,6 +2284,8 @@ describe('jobbot CLI', () => {
 
     const spoken = fs.readFileSync(spokenLog, 'utf8').trim().split('\n');
     expect(spoken).toContain('Behavioral rehearsal plan');
+    expect(spoken).toContain('Role focus: Engineering Manager');
+    expect(spoken).toContain('Suggested duration: 45 minutes');
     expect(spoken).toContain('Section: Warm-up');
     expect(spoken).toContain(
       'Flashcard: STAR checkpoint — Anchor stories around Situation, Task, Action, Result.',


### PR DESCRIPTION
what: add coverage for audio role focus & duration; speak metadata.
why: README promised the voice loop narrates the full study packet.
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d715c319c8832f813756bbd011eaac