### PR TITLE
Add resume pipeline extension guide

### DIFF
--- a/docs/resume-pipeline-guide.md
+++ b/docs/resume-pipeline-guide.md
@@ -1,0 +1,66 @@
+# Resume pipeline developer guide
+
+The resume ingestion pipeline lives in [`src/pipeline/resume-pipeline.js`](../src/pipeline/resume-pipeline.js)
+and powers every import initiated by `jobbot init`, `jobbot profile import`, and test fixtures. The
+stages are defined in the exported `RESUME_PIPELINE_STAGES` array. Each stage receives a shared
+context object, mutates it with new data, and returns a serializable payload that is captured in the
+final `stages` list returned by `runResumePipeline`.
+
+```
+Load ➜ Normalize ➜ Enrich ➜ Score
+```
+
+Out of the box the pipeline ships a `load` stage (which delegates to `loadResume`) and an `analyze`
+stage that snapshots ambiguity heuristics, ATS warnings, and the calculated confidence score. When
+adding stages, keep the flow above in mind: normalization or enrichment logic belongs between the
+existing `load` and `analyze` steps, and any scoring/summarization stage should run after analysis so
+it can consume the derived signals.
+
+## Context object contract
+
+Every invocation of `runResumePipeline` starts with a context shaped as follows:
+
+- `filePath`: absolute path to the source resume.
+- `source`: `{ path: string }`, preserved in the final return value for downstream traceability.
+- `text`: populated by the `load` stage with the plain-text resume.
+- `metadata`: populated by the `load` stage when `withMetadata !== false`. Contains ATS warnings,
+  ambiguity hints, counts, and the combined parsing confidence score surfaced by
+  [`loadResume`](../src/resume.js).
+- `analysis`: populated by the `analyze` stage. Includes cloned `warnings`, `ambiguities`, and a
+  normalized `confidence` object so consumers can mutate the results without affecting cached
+  metadata.
+- `stages`: an array of `{ name, output }` snapshots returned by each stage. This keeps fixtures and
+  diagnostics stable when new stages are inserted.
+
+When introducing a new stage you may attach additional fields to `context` (for example
+`context.normalizedResume`), but be explicit about their purpose and document them in this file so
+future contributors understand the typed surface.
+
+## Adding a new enrichment stage
+
+1. Insert a new entry into `RESUME_PIPELINE_STAGES`. Stage objects use the shape
+   `{ name: string, run: (context, options) => Promise<StageOutput> }`.
+2. Assign a unique `name`. This label is recorded in the pipeline result and should match any
+   assertions you add in [`test/resume-pipeline.test.js`](../test/resume-pipeline.test.js).
+3. Use the `context` argument to read inputs from prior stages and write the outputs you want to
+   expose. Always return the stage output so the serialized `stages` array includes a standalone
+   snapshot.
+4. Accept an `options` argument when the stage needs feature flags (for example, `withMetadata` is
+   forwarded to the `load` stage today). Default to safe behaviour when the option is omitted.
+5. Update `test/resume-pipeline.test.js` to assert the new stage appears in the pipeline run and that
+   its `output` shape matches the documented contract. Table-driven fixtures in that suite make it
+   straightforward to validate additional fields.
+6. Extend any downstream tests that consume the pipeline (for example,
+   [`test/resume.test.js`](../test/resume.test.js)) so regressions surface when the new stage is
+   introduced.
+
+## Working with derived metadata
+
+Stages should never mutate the objects returned by `loadResume` in-place; always clone the arrays or
+objects you touch. The helper uses `cloneEntries` to provide this behaviour for warnings and
+ambiguities. Follow the same pattern for new stage outputs so callers can trust that pipeline results
+are immutable snapshots.
+
+When a stage derives aggregates that downstream tools rely on, add a short note to this guide and to
+`docs/simplification_suggestions.md` describing the contract. This keeps the roadmap aligned with the
+implementation and gives future contributors a single source of truth when adding adjacent stages.

--- a/docs/simplification_suggestions.md
+++ b/docs/simplification_suggestions.md
@@ -62,6 +62,10 @@ fixtures through the pipeline, asserting each stage's output (source metadata, A
 ambiguity heuristics, and confidence metrics) so future refactors can extend the stages with
 confidence.
 
+_Update (2025-10-26):_ [`docs/resume-pipeline-guide.md`](resume-pipeline-guide.md) now documents how
+to insert new stages, mutate the shared context safely, and extend the pipeline's regression suite so
+contributors can grow the enrichment flow without spelunking through implementation details.
+
 **Suggested Steps**
 - Define explicit pipeline stages (load ➜ normalize ➜ enrich ➜ score) and move them into a
   `src/pipeline/` directory with one module per stage.

--- a/test/resume-pipeline-doc.test.js
+++ b/test/resume-pipeline-doc.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const GUIDE_PATH = resolve('docs', 'resume-pipeline-guide.md');
+
+describe('resume pipeline developer guide', () => {
+  it('documents how to extend the resume pipeline safely', () => {
+    expect(existsSync(GUIDE_PATH)).toBe(true);
+
+    const contents = readFileSync(GUIDE_PATH, 'utf8');
+
+    expect(contents).toMatch(/# Resume pipeline developer guide/i);
+    expect(contents).toMatch(/Load\s*(?:➜|->)\s*Normalize\s*(?:➜|->)\s*Enrich\s*(?:➜|->)\s*Score/i);
+    expect(contents).toMatch(/src\/pipeline\/resume-pipeline\.js/);
+    expect(contents).toMatch(/context object/i);
+    expect(contents).toMatch(/test\/resume-pipeline\.test\.js/);
+    expect(contents).toMatch(/add(ing)? a new enrichment stage/i);
+  });
+});


### PR DESCRIPTION
## Summary
- add `docs/resume-pipeline-guide.md` so contributors can extend the resume pipeline without spelunking the implementation
- guard the guide with `test/resume-pipeline-doc.test.js`, which fails when the doc or key guidance disappears
- annotate `docs/simplification_suggestions.md` to point at the new guide and mark the backlog item as shipped

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d715c319c8832f813756bbd011eaac