### PR TITLE
Add blockers to DOCX match reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,8 +369,9 @@ If `summary` is omitted, the requirements section is still separated by a blank 
 
 `toDocxSummary` and `toDocxMatch` provide `.docx` exports with the same localized labels and bullet
 structure. Automated coverage in [`test/exporters.test.js`](test/exporters.test.js) inspects the
-generated `word/document.xml`, and [`test/cli.test.js`](test/cli.test.js) verifies the CLI's
-`--docx` flag writes those documents without altering stdout output.
+generated `word/document.xml`, confirms mandatory blockers render alongside missing requirements, and
+[`test/cli.test.js`](test/cli.test.js) verifies the CLI's `--docx` flag writes those documents
+without altering stdout output.
 
 Both exporters accept an optional `locale` field to translate labels.
 The default locale is `'en'`; Spanish (`'es'`) and French (`'fr'`) are also supported.

--- a/src/exporters.js
+++ b/src/exporters.js
@@ -346,5 +346,12 @@ export async function toDocxMatch({
     appendBulletList(paragraphs, gaps);
   }
 
+  const blockers = identifyBlockers(gaps);
+  if (blockers.length > 0) {
+    const blockersHeading = headingParagraph(t('blockers', locale), HeadingLevel.HEADING_2);
+    if (blockersHeading) paragraphs.push(blockersHeading);
+    appendBulletList(paragraphs, blockers);
+  }
+
   return packDocument(paragraphs);
 }

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -328,4 +328,23 @@ describe('exporters', () => {
     expect(xml).toContain('Correspondances');
     expect(xml).toContain('Manquants');
   });
+
+  it('includes blockers when DOCX match reports detect mandatory gaps', async () => {
+    const buffer = await toDocxMatch({
+      title: 'Security Engineer',
+      missing: [
+        'Must have active security clearance',
+        'Experience with Terraform automation',
+      ],
+      locale: 'en',
+    });
+
+    expect(buffer instanceof Uint8Array || Buffer.isBuffer(buffer)).toBe(true);
+    const zip = await JSZip.loadAsync(buffer);
+    const xml = await zip.file('word/document.xml').async('string');
+
+    expect(xml).toContain('Blockers');
+    const occurrences = (xml.match(/Must have active security clearance/g) || []).length;
+    expect(occurrences).toBeGreaterThan(1);
+  });
 });


### PR DESCRIPTION
## Summary
- mirror the Markdown blocker section in DOCX match exports by reusing the blocker detector
- add a Vitest that inspects the generated DOCX to ensure mandatory gaps surface under a Blockers heading
- document the new coverage in the README so contributors know DOCX parity is enforced

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d76aa9b5dc832faf4423a58e1a0551