### PR TITLE
✅ : omit discard summaries for untouched shortlist entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,6 +713,7 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --location remote
 #   Compensation: $185k
 #   Synced At: 2025-03-06T08:00:00.000Z
 #   Tags: dream, remote
+#   Discard Count: 1
 #   Last Discard: Not remote (2025-03-05T12:00:00.000Z)
 #   Last Discard Tags: Remote, onsite
 
@@ -723,6 +724,7 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot shortlist list --tag dream --tag remote
 #   Compensation: $185k
 #   Synced At: 2025-03-06T08:00:00.000Z
 #   Tags: dream, remote
+#   Discard Count: 1
 #   Last Discard: Not remote (2025-03-05T12:00:00.000Z)
 #   Last Discard Tags: Remote, onsite
 
@@ -793,7 +795,9 @@ in both CLI and JSON responses so downstream tooling can rely on a single sentin
 shortlist list command when piping entries into other tools; include `--out <path>` to persist the
 snapshot on disk. Filter by metadata or tags (`--location`, `--level`, `--compensation`, or repeated
 `--tag` flags) when triaging opportunities. Text output also surfaces `Discard Count` and `Last Discard Tags`
-when history exists so the rationale stays visible without opening the archive. When the latest discard omits
+when history exists so the rationale stays visible without opening the archive. Entries without discard history
+omit those lines entirely to keep summaries compact. CLI coverage in [`test/cli.test.js`](test/cli.test.js)
+asserts the omission so regressions are caught early. When the latest discard omits
 tags, the summary prints `Last Discard Tags: (none)` so the absence is explicit. The archive reader trims
 messy history entries, sorts them chronologically, and fills missing timestamps with `(unknown time)`
 so legacy discards still surface their rationale. Metadata syncs stamp a `synced_at` ISO 8601 timestamp for

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -1066,8 +1066,8 @@ function formatShortlistList(jobs) {
     if (metadata.synced_at) lines.push(`  Synced At: ${metadata.synced_at}`);
     if (tags.length) lines.push(`  Tags: ${tags.join(', ')}`);
     const normalizedDiscard = normalizeDiscardEntries(discarded);
-    lines.push(`  Discard Count: ${normalizedDiscard.length}`);
     if (normalizedDiscard.length > 0) {
+      lines.push(`  Discard Count: ${normalizedDiscard.length}`);
       const latest = normalizedDiscard[0];
       const reason = latest.reason || 'Unknown reason';
       const timestamp = latest.discarded_at || '(unknown time)';

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -78,8 +78,9 @@ revisit them later without blocking the workflow.
    `jobbot shortlist list --location <value>` (and repeated `--tag <value>` flags)
   and records sync metadata with `jobbot shortlist sync` so future refreshes know
   when entries were last updated. Text summaries now also show `Discard Count` and
-  `Last Discard Tags` for each job so candidates can spot churn without opening the
-  archive. When a discard omits tags entirely, the summary line renders `Last Discard Tags: (none)`
+  `Last Discard Tags` for each job when history exists so candidates can spot churn without opening the
+  archive. Entries without discards omit those summary lines entirely to keep the output compact. When a
+  discard omits tags entirely, the summary line renders `Last Discard Tags: (none)`
   so the absence is obvious. Add `--json` (and optionally `--out <path>`) when exporting the filtered
   shortlist to other tools. Missing timestamps surface as `(unknown time)` in both CLI and JSON archives so
   downstream scripts can rely on the same sentinel value when displaying legacy entries; see

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1465,6 +1465,21 @@ describe('jobbot CLI', () => {
     expect(output).toContain('Discard Count: 2');
   });
 
+  it('omits discard summaries when a shortlist entry has no history', () => {
+    runCli(['shortlist', 'sync', 'job-no-history', '--location', 'Remote']);
+
+    const output = runCli(['shortlist', 'list']);
+    const blocks = output
+      .split(/\n{2,}/)
+      .map(block => block.trim())
+      .filter(Boolean);
+    const jobBlock = blocks.find(block => block.startsWith('job-no-history'));
+    expect(jobBlock).toBeDefined();
+    expect(jobBlock).not.toContain('Discard Count:');
+    expect(jobBlock).not.toContain('Last Discard:');
+    expect(jobBlock).not.toContain('Last Discard Tags:');
+  });
+
   it('shows last discard details for legacy entries without timestamps', () => {
     const shortlistPath = path.join(dataDir, 'shortlist.json');
     const legacyPayload = {


### PR DESCRIPTION
what:
- hide discard summary lines when shortlist entries have no history
- document the omission and cover it with a new CLI test

why:
- match the documented promise and keep shortlist output concise

how to test:
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d76aa9b5dc832faf4423a58e1a0551