### PR TITLE
✨ : – add evidence snippets to match payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,11 @@ console.log(match.score); // 67
 console.log(match.matched); // ['Experience with Node.js', 'Terraform proficiency']
 console.log(match.explanation);
 // Correspond 2 sur 3 exigences (67 %).\n// Points forts: Experience with Node.js; Terraform proficiency\n// Lacunes: Must have Kubernetes certification\n// Blocages: Must have Kubernetes certification
+console.log(match.evidence);
+// [
+//   { text: 'Experience with Node.js', source: 'requirements' },
+//   { text: 'Terraform proficiency', source: 'requirements' },
+// ]
 ```
 
 When only the matched or missing lists are present, the Markdown output starts with the
@@ -441,6 +446,9 @@ see which concrete words or abbreviations aligned without recomputing overlaps. 
 at 12 entries and cached per resume/requirement pairing to keep repeated evaluations (like multi-job
 comparisons) fast. Extremely large resumes (more than 5,000 unique tokens) skip overlap extraction to
 preserve cold-start latency targets.
+
+An `evidence` array lists the matched requirement snippets alongside their source label so consumers
+can cite the original job text without re-running the matcher or re-parsing CLI output.
 
 When a job already has tailoring or rehearsal artifacts, JSON match payloads attach a `prior_activity`
 block summarizing deliverable runs and interview sessions (including the latest coaching notes). The

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -98,7 +98,9 @@ aggressively to respect rate limits.
 
 1. For a selected job, the matcher scores fit using semantic + lexical signals and explains hits,
    gaps, and blockers. CLI users can run `jobbot match --explain` to append the narrative summary to
-   the Markdown report or add an `explanation` string to JSON payloads.
+   the Markdown report or add an `explanation` string to JSON payloads. JSON responses also surface an
+   `evidence` array containing the matched requirement snippets (tagged with their source) so prep
+   workflows can cite the original job text without recomputing matches.
 2. The resume renderer clones the base profile, selects the most relevant bullets, and prepares a
    tailored resume (PDF, text preview) plus optional cover letter. All outputs cite the source
    fields they originate from so the user can audit changes.

--- a/src/match.js
+++ b/src/match.js
@@ -38,7 +38,7 @@ export function matchResumeToJob(resumeText, jobInput, options = {}) {
     ? parsedJob.requirements.slice()
     : [];
 
-  const { score, matched, missing, must_haves_missed, keyword_overlap } = computeFitScore(
+  const { score, matched, missing, must_haves_missed, keyword_overlap, evidence } = computeFitScore(
     resumeText,
     requirements,
   );
@@ -53,6 +53,7 @@ export function matchResumeToJob(resumeText, jobInput, options = {}) {
     skills_gap: missing,
     must_haves_missed,
     keyword_overlap,
+    evidence,
   };
 
   const normalizedOptions = normalizeOptions(options);

--- a/src/scoring.js
+++ b/src/scoring.js
@@ -216,7 +216,14 @@ function collectKeywordOverlap(line, resumeSet, getNormalizedResume) {
  */
 export function computeFitScore(resumeText, requirements) {
   if (!Array.isArray(requirements) || requirements.length === 0) {
-    return { score: 0, matched: [], missing: [], must_haves_missed: [], keyword_overlap: [] };
+    return {
+      score: 0,
+      matched: [],
+      missing: [],
+      must_haves_missed: [],
+      keyword_overlap: [],
+      evidence: [],
+    };
   }
 
   const resumeSet = resumeTokens(resumeText);
@@ -228,6 +235,7 @@ export function computeFitScore(resumeText, requirements) {
   };
   const matched = [];
   const missing = [];
+  const evidence = [];
   let total = 0;
 
   for (const entry of requirements) {
@@ -235,11 +243,23 @@ export function computeFitScore(resumeText, requirements) {
     const trimmed = entry.trim();
     if (!trimmed) continue;
     total += 1;
-    (hasOverlap(trimmed, resumeSet, getNormalizedResume) ? matched : missing).push(trimmed);
+    if (hasOverlap(trimmed, resumeSet, getNormalizedResume)) {
+      matched.push(trimmed);
+      evidence.push({ text: trimmed, source: 'requirements' });
+    } else {
+      missing.push(trimmed);
+    }
   }
 
   if (total === 0)
-    return { score: 0, matched: [], missing: [], must_haves_missed: [], keyword_overlap: [] };
+    return {
+      score: 0,
+      matched: [],
+      missing: [],
+      must_haves_missed: [],
+      keyword_overlap: [],
+      evidence: [],
+    };
 
   const score = Math.round((matched.length / total) * 100);
   const mustHavesMissed = identifyBlockers(missing);
@@ -280,6 +300,7 @@ export function computeFitScore(resumeText, requirements) {
     missing,
     must_haves_missed: mustHavesMissed,
     keyword_overlap: keywordOverlapArray,
+    evidence,
   };
 }
 

--- a/test/cli-max-bytes.test.js
+++ b/test/cli-max-bytes.test.js
@@ -49,6 +49,7 @@ vi.mock('../src/scoring.js', () => ({
     missing: ['Ship faster'],
     must_haves_missed: [],
     keyword_overlap: [],
+    evidence: [{ text: 'Build things', source: 'requirements' }],
   }),
 }));
 

--- a/test/match.test.js
+++ b/test/match.test.js
@@ -37,6 +37,16 @@ describe('matchResumeToJob', () => {
     expect(result.skills_hit).toEqual(result.matched);
     expect(result.skills_gap).toEqual(result.missing);
     expect(Array.isArray(result.keyword_overlap)).toBe(true);
+    expect(result.evidence).toEqual([
+      {
+        text: 'Experience with Node.js',
+        source: 'requirements',
+      },
+      {
+        text: 'Terraform proficiency',
+        source: 'requirements',
+      },
+    ]);
   });
 
   it('optionally includes a localized explanation summary', () => {

--- a/test/schedule-config.test.js
+++ b/test/schedule-config.test.js
@@ -14,6 +14,7 @@ vi.mock('../src/scoring.js', () => ({
     missing: [],
     must_haves_missed: [],
     keyword_overlap: [],
+    evidence: [{ text: 'Team leadership', source: 'requirements' }],
   })),
 }));
 

--- a/test/scoring.test.js
+++ b/test/scoring.test.js
@@ -12,6 +12,9 @@ describe('computeFitScore', () => {
     expect(result.missing).toEqual(['Python']);
     expect(result.must_haves_missed).toEqual([]);
     expect(result.keyword_overlap).toEqual(['javascript']);
+    expect(result.evidence).toEqual([
+      { text: 'JavaScript', source: 'requirements' },
+    ]);
   });
 
   it('matches tokens case-insensitively', () => {
@@ -24,6 +27,7 @@ describe('computeFitScore', () => {
       missing: [],
       must_haves_missed: [],
       keyword_overlap: ['python'],
+      evidence: [{ text: 'python', source: 'requirements' }],
     });
   });
 
@@ -37,6 +41,7 @@ describe('computeFitScore', () => {
       missing: [],
       must_haves_missed: [],
       keyword_overlap: ['go'],
+      evidence: [{ text: 'Go', source: 'requirements' }],
     });
   });
 
@@ -48,6 +53,7 @@ describe('computeFitScore', () => {
       missing: ['JS'],
       must_haves_missed: [],
       keyword_overlap: [],
+      evidence: [],
     });
   });
 
@@ -61,6 +67,7 @@ describe('computeFitScore', () => {
       missing: [],
       must_haves_missed: [],
       keyword_overlap: ['javascript'],
+      evidence: [{ text: 'JavaScript', source: 'requirements' }],
     });
   });
 
@@ -72,6 +79,7 @@ describe('computeFitScore', () => {
       missing: [],
       must_haves_missed: [],
       keyword_overlap: [],
+      evidence: [],
     });
   });
 
@@ -83,6 +91,7 @@ describe('computeFitScore', () => {
       missing: [],
       must_haves_missed: [],
       keyword_overlap: [],
+      evidence: [],
     });
   });
 
@@ -107,6 +116,7 @@ describe('computeFitScore', () => {
         'artificial intelligence',
         'postgresql',
       ],
+      evidence: requirements.map(text => ({ text, source: 'requirements' })),
     });
   });
 
@@ -135,6 +145,7 @@ describe('computeFitScore', () => {
         'javascript',
         'typescript',
       ],
+      evidence: requirements.map(text => ({ text, source: 'requirements' })),
     });
   });
 
@@ -151,6 +162,7 @@ describe('computeFitScore', () => {
       'Security clearance required',
     ]);
     expect(result.keyword_overlap).toEqual([]);
+    expect(result.evidence).toEqual([]);
   });
 
   it('reports keyword overlap for matched requirements', () => {
@@ -167,6 +179,10 @@ describe('computeFitScore', () => {
       'systems',
       'experience',
       'amazon web services',
+    ]);
+    expect(result.evidence).toEqual([
+      { text: 'Distributed systems experience', source: 'requirements' },
+      { text: 'Amazon Web Services architecture expertise', source: 'requirements' },
     ]);
   });
 
@@ -187,6 +203,8 @@ describe('computeFitScore', () => {
 
     expect(first.keyword_overlap.length).toBeLessThanOrEqual(12);
     expect(second.keyword_overlap).toEqual(first.keyword_overlap);
+    expect(first.evidence).toHaveLength(first.matched.length);
+    expect(second.evidence).toEqual(first.evidence);
   });
 
   it('skips keyword overlap extraction when the resume has more than 5k unique tokens', () => {
@@ -197,6 +215,7 @@ describe('computeFitScore', () => {
 
     expect(result.matched).toEqual(requirements);
     expect(result.keyword_overlap).toEqual([]);
+    expect(result.evidence.map(entry => entry.text)).toEqual(result.matched);
   });
 
 


### PR DESCRIPTION
what: expose evidence arrays for matched requirements and document the field.
why: deliver the promised job text snippets in match outputs.
how to test: npm run lint && npm run test:ci.

------
https://chatgpt.com/codex/tasks/task_e_68d76aa9b5dc832faf4423a58e1a0551