### PR TITLE
Add prior activity section to Markdown match exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,9 @@ annotates the timestamp source via `recorded_at_source` (`recorded_at`, `started
 fallback. When `--locale` is provided, the Prior Activity heading and bullet labels respect the
 requested language so localized reports stay consistent end to end.
 
+Library consumers can call `toMarkdownMatch` with the same `prior_activity` payload to render the
+section when generating reports outside of the CLI.
+
 ```bash
 cat <<'EOF' > resume.txt
 Designed large-scale services and mentored senior engineers.

--- a/test/cli-max-bytes.test.js
+++ b/test/cli-max-bytes.test.js
@@ -23,6 +23,7 @@ vi.mock('../src/exporters.js', () => ({
   toMarkdownMatchExplanation: vi.fn().mockReturnValue('## Explanation'),
   toDocxMatch: vi.fn().mockResolvedValue(Buffer.from('docx-match')),
   formatMatchExplanation: vi.fn().mockReturnValue('explanation'),
+  formatPriorActivitySection: vi.fn().mockReturnValue(''),
 }));
 
 vi.mock('../src/parser.js', () => ({

--- a/test/exporters.test.js
+++ b/test/exporters.test.js
@@ -122,6 +122,53 @@ describe('exporters', () => {
     expect(output).toBe('## Matched\n- JS\n\n## Missing\n- Rust');
   });
 
+  it('appends prior activity details to markdown match reports', () => {
+    const output = toMarkdownMatch({
+      title: 'Dev',
+      matched: ['JS'],
+      prior_activity: {
+        deliverables: {
+          runs: 2,
+          last_run_at: '2025-03-05T12:00:00.000Z',
+        },
+        interviews: {
+          sessions: 1,
+          last_session: {
+            recorded_at: '2025-03-06T10:00:00.000Z',
+            stage: 'Screen',
+            mode: 'Voice',
+            critique: { tighten_this: ['Tighten intro'] },
+          },
+        },
+      },
+    });
+
+    expect(output).toContain('## Prior Activity');
+    expect(output).toContain('- Deliverables: 2 runs (last run 2025-03-05T12:00:00.000Z)');
+    expect(output).toContain('- Interviews: 1 session (2025-03-06T10:00:00.000Z, Screen / Voice)');
+    expect(output).toContain('  Coaching notes:');
+    expect(output).toContain('  - Tighten intro');
+  });
+
+  it('localizes prior activity markdown output', () => {
+    const output = toMarkdownMatch({
+      locale: 'es',
+      prior_activity: {
+        deliverables: { runs: 1 },
+        interviews: {
+          sessions: 1,
+          last_session: {
+            recorded_at: '2025-03-07T09:30:00.000Z',
+          },
+        },
+      },
+    });
+
+    expect(output).toContain('## Actividad previa');
+    expect(output).toContain('- Entregables: 1 ejecución');
+    expect(output).toContain('- Entrevistas: 1 sesión (2025-03-07T09:30:00.000Z)');
+  });
+
   it('escapes markdown control characters to prevent injection in summaries', () => {
     const output = toMarkdownSummary({
       title: '[Lead](javascript:alert(1))',


### PR DESCRIPTION
## Summary
- extend `toMarkdownMatch` so Markdown reports include the Prior Activity section when `prior_activity` data is supplied
- expose `formatPriorActivitySection` from the exporters module and reuse it in the CLI to eliminate duplicate formatting logic
- document the library usage for `prior_activity` and cover localization + content scenarios in exporter tests

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d781ee1ac4832f934fef10665735dd