### PR TITLE
Expose package entrypoint exports for lifecycle helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1385,6 +1385,8 @@ including hypotheses, minimum sample sizes, guardrail metrics, and sequential
 stopping rules. Use them to compare resume tone variations, onsite follow-up
 cadences, or offer-negotiation scripts while automatically adjusting for multiple
 comparisons and guarding against p-hacking/data dredging anti-patterns.
+Tests in [`test/package-export.test.js`](test/package-export.test.js) ensure the package entrypoint
+continues to re-export these helpers.
 
 ```js
 import {

--- a/docs/prompt-docs-summary.md
+++ b/docs/prompt-docs-summary.md
@@ -1,4 +1,5 @@
 <!-- spellchecker: disable -->
+
 # Prompt Docs Summary
 
 This index lists prompt documents for the jobbot3000 repository, organized by task type.
@@ -13,47 +14,43 @@ Codex CI prompt documents that CI skips Markdown- and MDX-only pull requests.
 
 ## jobbot3000
 
-| Path | Prompt | Type | One-click? |
-|------|--------|------|------------|
-| [docs/prompts/codex/accessibility.md][accessibility-doc] | Codex Accessibility Prompt | evergreen | yes |
-| [docs/prompts/codex/accessibility.md#upgrade-prompt][accessibility-up] | Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/automation.md][automation-doc] | Codex Automation Prompt (DEV/CRITIC) | evergreen | yes |
-| [docs/prompts/codex/automation.md#upgrade-prompt][automation-up] | Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/chore.md][chore-doc] | Codex Chore Prompt (maintenance tasks) | evergreen | yes |
-| [docs/prompts/codex/chore.md#upgrade-prompt][chore-up] | Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/ci.md][ci-doc] | Codex CI Prompt | evergreen | yes |
-| [docs/prompts/codex/ci.md#upgrade-prompt][ci-up] | Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/docs.md][docs-doc] | Codex Docs Prompt | evergreen | yes |
-| [docs/prompts/codex/docs.md#upgrade-prompt][docs-up] | Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/feature.md][feature-doc] | Codex Feature Prompt | evergreen | yes |
-| [docs/prompts/codex/feature.md#upgrade-prompt][feature-up] | Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/fix.md][fix-doc] | Codex Fix Prompt (bug fixes) | evergreen | yes |
-| [docs/prompts/codex/fix.md#upgrade-prompt][fix-up] | Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/localization.md][localization-doc] | Codex Localization Prompt | evergreen | yes |
-| [docs/prompts/codex/localization.md#upgrade-prompt][localization-up] | Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/performance.md][performance-doc] | Codex Performance Prompt | evergreen | yes |
-| [docs/prompts/codex/performance.md#upgrade-prompt][performance-up] | Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/implement.md][implement-doc] | Codex Implement Prompt | evergreen | yes |
-| [docs/prompts/codex/implement.md#upgrade-prompt][implement-up] | Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/refactor.md][refactor-doc] | Codex Refactor Prompt | evergreen | yes |
-| [docs/prompts/codex/refactor.md#upgrade-prompt][refactor-up] | Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/security.md][security-doc] | Codex Security Prompt | evergreen | yes |
-| [docs/prompts/codex/security.md#upgrade-prompt][security-up] | Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/simplification.md][simplification-doc] | Codex Simplification Prompt | evergreen | yes |
-| [docs/prompts/codex/simplification.md#upgrade-prompt][simplification-up] | Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/spellcheck.md][spellcheck-doc] | Codex Spellcheck Prompt | evergreen | yes |
-| [docs/prompts/codex/spellcheck.md#upgrade-prompt][spellcheck-up] | Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/style.md][style-doc] | Codex Style Prompt | evergreen | yes |
-| [docs/prompts/codex/style.md#upgrade-prompt][style-up] | Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/test.md][test-doc] | Codex Test Prompt (Vitest) | evergreen | yes |
-| [docs/prompts/codex/test.md#upgrade-prompt][test-up] | Upgrade Prompt (docs) | evergreen | yes |
-| [docs/prompts/codex/upgrade.md][upgrade-doc] | Codex Upgrade Prompt | evergreen | yes |
-| [docs/prompts/codex/upgrade.md#upgrade-prompt][upgrade-up] | Upgrade Prompt | evergreen | yes |
+| Path                                                                     | Prompt                                 | Type      | One-click? |
+| ------------------------------------------------------------------------ | -------------------------------------- | --------- | ---------- |
+| [docs/prompts/codex/accessibility.md][accessibility-doc]                 | Codex Accessibility Prompt             | evergreen | yes        |
+| [docs/prompts/codex/accessibility.md#upgrade-prompt][accessibility-up]   | Upgrade Prompt                         | evergreen | yes        |
+| [docs/prompts/codex/chore.md][chore-doc]                                 | Codex Chore Prompt (maintenance tasks) | evergreen | yes        |
+| [docs/prompts/codex/chore.md#upgrade-prompt][chore-up]                   | Upgrade Prompt                         | evergreen | yes        |
+| [docs/prompts/codex/ci.md][ci-doc]                                       | Codex CI Prompt                        | evergreen | yes        |
+| [docs/prompts/codex/ci.md#upgrade-prompt][ci-up]                         | Upgrade Prompt                         | evergreen | yes        |
+| [docs/prompts/codex/docs.md][docs-doc]                                   | Codex Docs Prompt                      | evergreen | yes        |
+| [docs/prompts/codex/docs.md#upgrade-prompt][docs-up]                     | Upgrade Prompt                         | evergreen | yes        |
+| [docs/prompts/codex/feature.md][feature-doc]                             | Codex Feature Prompt                   | evergreen | yes        |
+| [docs/prompts/codex/feature.md#upgrade-prompt][feature-up]               | Upgrade Prompt                         | evergreen | yes        |
+| [docs/prompts/codex/fix.md][fix-doc]                                     | Codex Fix Prompt (bug fixes)           | evergreen | yes        |
+| [docs/prompts/codex/fix.md#upgrade-prompt][fix-up]                       | Upgrade Prompt                         | evergreen | yes        |
+| [docs/prompts/codex/localization.md][localization-doc]                   | Codex Localization Prompt              | evergreen | yes        |
+| [docs/prompts/codex/localization.md#upgrade-prompt][localization-up]     | Upgrade Prompt                         | evergreen | yes        |
+| [docs/prompts/codex/performance.md][performance-doc]                     | Codex Performance Prompt               | evergreen | yes        |
+| [docs/prompts/codex/performance.md#upgrade-prompt][performance-up]       | Upgrade Prompt                         | evergreen | yes        |
+| [docs/prompts/codex/implement.md][implement-doc]                         | Codex Implement Prompt                 | evergreen | yes        |
+| [docs/prompts/codex/implement.md#upgrade-prompt][implement-up]           | Upgrade Prompt                         | evergreen | yes        |
+| [docs/prompts/codex/refactor.md][refactor-doc]                           | Codex Refactor Prompt                  | evergreen | yes        |
+| [docs/prompts/codex/refactor.md#upgrade-prompt][refactor-up]             | Upgrade Prompt                         | evergreen | yes        |
+| [docs/prompts/codex/security.md][security-doc]                           | Codex Security Prompt                  | evergreen | yes        |
+| [docs/prompts/codex/security.md#upgrade-prompt][security-up]             | Upgrade Prompt                         | evergreen | yes        |
+| [docs/prompts/codex/simplification.md][simplification-doc]               | Codex Simplification Prompt            | evergreen | yes        |
+| [docs/prompts/codex/simplification.md#upgrade-prompt][simplification-up] | Upgrade Prompt                         | evergreen | yes        |
+| [docs/prompts/codex/spellcheck.md][spellcheck-doc]                       | Codex Spellcheck Prompt                | evergreen | yes        |
+| [docs/prompts/codex/spellcheck.md#upgrade-prompt][spellcheck-up]         | Upgrade Prompt                         | evergreen | yes        |
+| [docs/prompts/codex/style.md][style-doc]                                 | Codex Style Prompt                     | evergreen | yes        |
+| [docs/prompts/codex/style.md#upgrade-prompt][style-up]                   | Upgrade Prompt                         | evergreen | yes        |
+| [docs/prompts/codex/test.md][test-doc]                                   | Codex Test Prompt (Vitest)             | evergreen | yes        |
+| [docs/prompts/codex/test.md#upgrade-prompt][test-up]                     | Upgrade Prompt (docs)                  | evergreen | yes        |
+| [docs/prompts/codex/upgrade.md][upgrade-doc]                             | Codex Upgrade Prompt                   | evergreen | yes        |
+| [docs/prompts/codex/upgrade.md#upgrade-prompt][upgrade-up]               | Upgrade Prompt                         | evergreen | yes        |
 
 [accessibility-doc]: prompts/codex/accessibility.md
 [accessibility-up]: prompts/codex/accessibility.md#upgrade-prompt
-[automation-doc]: prompts/codex/automation.md
-[automation-up]: prompts/codex/automation.md#upgrade-prompt
 [chore-doc]: prompts/codex/chore.md
 [chore-up]: prompts/codex/chore.md#upgrade-prompt
 [ci-doc]: prompts/codex/ci.md

--- a/docs/prompts/codex/accessibility.md
+++ b/docs/prompts/codex/accessibility.md
@@ -1,6 +1,6 @@
 ---
-title: 'Codex Accessibility Prompt'
-slug: 'codex-accessibility'
+title: "Codex Accessibility Prompt"
+slug: "codex-accessibility"
 ---
 
 # Codex Accessibility Prompt

--- a/docs/prompts/codex/automation.md
+++ b/docs/prompts/codex/automation.md
@@ -1,6 +1,6 @@
 ---
-title: 'Codex Automation Prompt'
-slug: 'codex-automation'
+title: "Codex Automation Prompt"
+slug: "codex-automation"
 ---
 
 # Codex Automation Prompt

--- a/docs/prompts/codex/chore.md
+++ b/docs/prompts/codex/chore.md
@@ -1,9 +1,10 @@
 ---
-title: 'Codex Chore Prompt'
-slug: 'codex-chore'
+title: "Codex Chore Prompt"
+slug: "codex-chore"
 ---
 
 # Codex Chore Prompt
+
 Use this prompt when performing maintenance for the jobbot3000 repository.
 
 ```prompt
@@ -41,6 +42,7 @@ A pull request summarizing the maintenance work and confirming passing checks.
 Copy this block whenever running chore tasks in jobbot3000.
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 Use this prompt when refreshing `docs/prompts/codex/chore.md` itself.

--- a/docs/prompts/codex/ci.md
+++ b/docs/prompts/codex/ci.md
@@ -1,6 +1,6 @@
 ---
-title: 'Codex CI Prompt'
-slug: 'codex-ci'
+title: "Codex CI Prompt"
+slug: "codex-ci"
 ---
 
 # Codex CI Prompt

--- a/docs/prompts/codex/docs.md
+++ b/docs/prompts/codex/docs.md
@@ -1,11 +1,11 @@
 ---
-title: 'Codex Docs Prompt'
-slug: 'codex-docs'
+title: "Codex Docs Prompt"
+slug: "codex-docs"
 ---
 
 # Codex Docs Prompt
 
-```prompt
+````prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
@@ -42,13 +42,15 @@ CONTEXT:
 
   ```bash
   node -e "console.log('docs sample works')"
-  ```
+````
+
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Verify links with `npx markdown-link-check <file>`; fix or remove broken URLs.
 - Confirm referenced files exist before referencing them.
 
 REQUEST:
+
 1. Identify the doc section to update and confirm all referenced files exist.
 2. Revise text or examples for clarity while keeping repository conventions intact.
 3. Check links with `npx markdown-link-check <file>` and repair any failures.
@@ -57,7 +59,8 @@ REQUEST:
 
 OUTPUT:
 A pull request URL summarizing the documentation update.
-```
+
+````
 
 ## Upgrade Instructions
 
@@ -80,13 +83,15 @@ CONTEXT:
 
   ```bash
   node -e "console.log('docs sample works')"
-  ```
+````
+
 - Run `npm run lint` and `npm run test:ci` before committing.
 - Scan staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` (see [scripts/scan-secrets.py](../../../scripts/scan-secrets.py)).
 - Verify links with `npx markdown-link-check <file>`; fix or remove broken URLs.
 - Confirm referenced files exist before referencing them.
 
 REQUEST:
+
 1. Revise `docs/prompts/codex/docs.md` so this prompt stays accurate and actionable. Keep examples aligned with current project practices.
 2. Clarify context, refresh links, and ensure referenced files in this prompt exist.
 3. Check links with `npx markdown-link-check <file>`.
@@ -95,4 +100,7 @@ REQUEST:
 
 OUTPUT:
 A pull request that updates `docs/prompts/codex/docs.md` with passing checks.
+
+```
+
 ```

--- a/docs/prompts/codex/feature.md
+++ b/docs/prompts/codex/feature.md
@@ -1,9 +1,10 @@
 ---
-title: 'Codex Feature Prompt'
-slug: 'codex-feature'
+title: "Codex Feature Prompt"
+slug: "codex-feature"
 ---
 
 # Codex Feature Prompt
+
 Use this prompt when shipping a small, well-tested feature for jobbot3000.
 
 Use this prompt when shipping a focused feature for jobbot3000.

--- a/docs/prompts/codex/fix.md
+++ b/docs/prompts/codex/fix.md
@@ -1,6 +1,6 @@
 ---
-title: 'Codex Fix Prompt'
-slug: 'codex-fix'
+title: "Codex Fix Prompt"
+slug: "codex-fix"
 ---
 
 # Codex Fix Prompt

--- a/docs/prompts/codex/implement.md
+++ b/docs/prompts/codex/implement.md
@@ -1,6 +1,6 @@
 ---
-title: 'Codex Implement Prompt'
-slug: 'codex-implement'
+title: "Codex Implement Prompt"
+slug: "codex-implement"
 ---
 
 # Codex Implement Prompt
@@ -11,11 +11,13 @@ describes the expected behavior; your job is to finish it without disrupting
 existing functionality.
 
 ## When to use it
+
 - A TODO, FIXME, or "future work" item is already documented in the codebase or docs.
 - Shipping the improvement unblocks user value without requiring a multi-PR migration.
 - You can add (and keep) targeted automated tests to prove the change.
 
 ## Prompt block
+
 ```prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.

--- a/docs/prompts/codex/localization.md
+++ b/docs/prompts/codex/localization.md
@@ -1,6 +1,6 @@
 ---
-title: 'Codex Localization Prompt'
-slug: 'codex-localization'
+title: "Codex Localization Prompt"
+slug: "codex-localization"
 ---
 
 # Codex Localization Prompt
@@ -45,6 +45,7 @@ A pull request summarizing the localization changes with passing checks.
 ```
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 ```upgrade

--- a/docs/prompts/codex/performance.md
+++ b/docs/prompts/codex/performance.md
@@ -1,13 +1,14 @@
 ---
-title: 'Codex Performance Prompt'
-slug: 'codex-performance'
+title: "Codex Performance Prompt"
+slug: "codex-performance"
 ---
 
 # Codex Performance Prompt
+
 Use this prompt whenever you need to improve runtime performance in jobbot3000 without
 changing public behavior.
 
-```prompt
+````prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
@@ -48,9 +49,10 @@ CONTEXT:
       // code under test
     }
   });
-  ```
+````
 
 REQUEST:
+
 1. Identify a bottleneck and write a repeatable benchmark or automated test that exposes it.
 2. Capture baseline metrics (for example, with Node's
    [`console.time`](https://nodejs.org/api/console.html#consoletime) or
@@ -61,7 +63,8 @@ REQUEST:
 
 OUTPUT:
 A pull request summarizing the performance improvement with verified metrics and passing CI.
-```
+
+````
 
 ## Upgrade Instructions
 
@@ -90,4 +93,4 @@ REQUEST:
 
 OUTPUT:
 A pull request that updates `docs/prompts/codex/performance.md` with passing checks.
-```
+````

--- a/docs/prompts/codex/refactor.md
+++ b/docs/prompts/codex/refactor.md
@@ -1,6 +1,6 @@
 ---
-title: 'Codex Refactor Prompt'
-slug: 'codex-refactor'
+title: "Codex Refactor Prompt"
+slug: "codex-refactor"
 ---
 
 # Codex Refactor Prompt

--- a/docs/prompts/codex/security.md
+++ b/docs/prompts/codex/security.md
@@ -1,9 +1,10 @@
 ---
-title: 'Codex Security Prompt'
-slug: 'codex-security'
+title: "Codex Security Prompt"
+slug: "codex-security"
 ---
 
 # Codex Security Prompt
+
 Use this prompt when you need to triage or remediate security vulnerabilities in jobbot3000.
 
 ```prompt
@@ -49,14 +50,14 @@ Copy this block whenever addressing security-related work in jobbot3000.
 ### Example: Generating a secure token
 
 ```ts
-import { randomBytes } from 'node:crypto';
+import { randomBytes } from "node:crypto";
 
 export function generateToken(): string {
-  return randomBytes(32).toString('hex');
+  return randomBytes(32).toString("hex");
 }
 
 if (generateToken().length !== 64) {
-  throw new Error('Token length is incorrect');
+  throw new Error("Token length is incorrect");
 }
 ```
 
@@ -64,6 +65,7 @@ Run it with `ts-node --esm` (Node.js ≥20) to verify the token length is 64.
 See [`randomBytes`](https://nodejs.org/api/crypto.html#cryptorandombytessize-callback) for details.
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 ## Upgrade Instructions

--- a/docs/prompts/codex/simplification.md
+++ b/docs/prompts/codex/simplification.md
@@ -1,9 +1,10 @@
 ---
-title: 'Codex Simplification Prompt'
-slug: 'codex-simplification'
+title: "Codex Simplification Prompt"
+slug: "codex-simplification"
 ---
 
 # Codex Simplification Prompt
+
 Use this prompt when simplifying workflows, onboarding, or internal tooling for the jobbot3000
 repository while preserving existing capabilities.
 
@@ -46,6 +47,7 @@ A pull request summarizing the simplification and confirming passing checks.
 Copy this block whenever simplifying jobbot3000.
 
 ## Upgrade Prompt
+
 Type: evergreen
 
 Use this prompt when refining `docs/prompts/codex/simplification.md` itself.

--- a/docs/prompts/codex/spellcheck.md
+++ b/docs/prompts/codex/spellcheck.md
@@ -1,6 +1,6 @@
 ---
-title: 'Codex Spellcheck Prompt'
-slug: 'codex-spellcheck'
+title: "Codex Spellcheck Prompt"
+slug: "codex-spellcheck"
 ---
 
 # Codex Spellcheck Prompt

--- a/docs/prompts/codex/style.md
+++ b/docs/prompts/codex/style.md
@@ -1,11 +1,11 @@
 ---
-title: 'Codex Style Prompt'
-slug: 'codex-style'
+title: "Codex Style Prompt"
+slug: "codex-style"
 ---
 
 # Codex Style Prompt
 
-```prompt
+````prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
@@ -36,12 +36,14 @@ Remove unnecessary code while keeping output stable:
 ```js
 const greet = (name) => `Hi, ${name}!`;
 console.log(greet('Codex'));
-```
+````
+
 Run it with `node -e "const greet = (name) => \`Hi, ${name}!\`; console.log(greet('Codex'))"`.
 
 OUTPUT:
 A pull request URL summarizing the style improvements.
-```
+
+````
 
 ## Upgrade Instructions
 
@@ -70,4 +72,4 @@ REQUEST:
 
 OUTPUT:
 A pull request that updates `docs/prompts/codex/style.md` with passing checks.
-```
+````

--- a/docs/prompts/codex/test.md
+++ b/docs/prompts/codex/test.md
@@ -1,11 +1,11 @@
 ---
-title: 'Codex Test Prompt'
-slug: 'codex-test'
+title: "Codex Test Prompt"
+slug: "codex-test"
 ---
 
 # Codex Test Prompt
 
-```prompt
+````prompt
 SYSTEM:
 You are an automated contributor for the jobbot3000 repository.
 
@@ -26,10 +26,12 @@ import { test, expect } from 'vitest';
 test('math works', () => {
   expect(1 + 1).toBe(2);
 });
-```
+````
+
 Run it with `npx vitest run path/to/test-file`.
 
 CONTEXT:
+
 - Follow [README.md](../../../README.md); see the [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to anticipate CI checks.
 - Tests live in [test/](../../../test) and use the `*.test.js` naming convention.
@@ -42,6 +44,7 @@ CONTEXT:
 - Ensure any code samples compile with `node` (v20+) or `ts-node`.
 
 REQUEST:
+
 1. Identify missing or weak tests.
 2. Add or update tests to cover edge cases.
 3. Ensure tests are deterministic and isolated.
@@ -49,7 +52,8 @@ REQUEST:
 
 OUTPUT:
 A pull request URL summarizing the test improvement.
-```
+
+````
 
 ## Upgrade Instructions
 
@@ -80,4 +84,4 @@ REQUEST:
 
 OUTPUT:
 A pull request that updates `docs/prompts/codex/test.md` with passing checks.
-```
+````

--- a/docs/prompts/codex/upgrade.md
+++ b/docs/prompts/codex/upgrade.md
@@ -1,6 +1,6 @@
 ---
-title: 'Codex Upgrade Prompt'
-slug: 'codex-upgrade'
+title: "Codex Upgrade Prompt"
+slug: "codex-upgrade"
 ---
 
 # Codex Upgrade Prompt

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "license": "MIT",
   "type": "module",
+  "main": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js"
+  },
   "bin": {
     "jobbot": "bin/jobbot.js"
   },

--- a/test/package-export.test.js
+++ b/test/package-export.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import {
+  summarize,
+  listExperimentsForStatus,
+  getExperimentById,
+  analyzeExperiment,
+} from 'jobbot3000';
+
+describe('jobbot3000 package exports', () => {
+  it('re-exports the documented public API from the package root', async () => {
+    const module = await import('../src/index.js');
+    expect(summarize).toBe(module.summarize);
+    expect(listExperimentsForStatus).toBe(module.listExperimentsForStatus);
+    expect(getExperimentById).toBe(module.getExperimentById);
+    expect(analyzeExperiment).toBe(module.analyzeExperiment);
+  });
+});


### PR DESCRIPTION
## Summary
- expose `src/index.js` through the package entrypoint so the documented `import { … } from 'jobbot3000'` example resolves
- add `test/package-export.test.js` to pin the package-level exports and reference it from the lifecycle experiment docs
- format prompt documentation with Prettier so `chore:prompts` stays green

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d781ee1ac4832f934fef10665735dd