### PR TITLE
✅ : – harden intake outcome detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -907,6 +907,34 @@ Recorded timestamps reflect when the command runs. Automated coverage in
 [`test/intake.test.js`](test/intake.test.js) and [`test/cli.test.js`](test/cli.test.js) verifies the
 stored shape, CLI workflows, and the skipped-only view for follow-up planning.
 
+Surface the next intake prompts with a question plan that flags missing context (career goals,
+location preferences, compensation guardrails, visa status, measurable outcomes, and tool stacks):
+
+```bash
+# Generate a plan highlighting the highest-impact questions to ask next
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot intake plan
+# Intake question plan
+# 1. What roles are you targeting next and what impact do you want to make?
+#    Reason: Resume summary is missing or too short to capture career goals.
+#    Tags: career, goals
+# ...
+
+# Export the same plan as structured JSON
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot intake plan --json | jq '.plan[0]'
+# {
+#   "id": "career_goals",
+#   "prompt": "What roles are you targeting next and what impact do you want to make?",
+#   "tags": [
+#     "career",
+#     "goals"
+#   ],
+#   "reason": "Resume summary is missing or too short to capture career goals."
+# }
+```
+
+[`test/intake-plan.test.js`](test/intake-plan.test.js) and the CLI coverage ensure the heuristics stay
+aligned with the documented prompts for both text and JSON output formats.
+
 ## Conversion funnel analytics
 
 Build a quick snapshot of outreach ➜ screening ➜ onsite ➜ offer ➜ acceptance conversions:

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -37,7 +37,8 @@ with retry options and explain how to manually fix the source file.
 
 1. After import, the LLM reviews the normalized profile and drafts a question plan that targets
    missing or ambiguous details (career goals, relocation preferences, compensation guardrails,
-   visa status, measurable outcomes, tools).
+   visa status, measurable outcomes, tools). `jobbot intake plan` surfaces the prioritized prompts
+   (add `--json` for structured exports) so contributors can capture the missing data immediately.
 2. The user answers via chat or a structured form. The assistant keeps asking follow-ups until it
    reaches a configured confidence threshold.
 3. Responses are appended to the profile as structured notes (`data/profile/intake.json`) via

--- a/src/intake-plan.js
+++ b/src/intake-plan.js
@@ -1,0 +1,233 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import { initProfile } from './profile.js';
+import { getIntakeResponses, setIntakeDataDir } from './intake.js';
+
+let overrideDir;
+
+function resolveDataDir() {
+  return overrideDir || process.env.JOBBOT_DATA_DIR || path.resolve('data');
+}
+
+export function setIntakePlanDataDir(dir) {
+  overrideDir = dir || undefined;
+  setIntakeDataDir(dir || undefined);
+}
+
+function loadResumeSync(resumePath) {
+  return fs.readFile(resumePath, 'utf8');
+}
+
+function hasAnsweredResponse(responses, { tags = [], keywords = [] }) {
+  if (!Array.isArray(responses) || responses.length === 0) return false;
+  const normalizedTags = tags.map(tag => tag.toLowerCase());
+  const keywordPatterns = keywords.map(keyword => new RegExp(keyword, 'i'));
+
+  for (const response of responses) {
+    if (!response || response.status !== 'answered') continue;
+    const responseTags = Array.isArray(response.tags)
+      ? response.tags.map(tag => String(tag).toLowerCase())
+      : [];
+    const question = typeof response.question === 'string' ? response.question : '';
+    const answer = typeof response.answer === 'string' ? response.answer : '';
+
+    if (normalizedTags.some(tag => responseTags.includes(tag))) {
+      return true;
+    }
+
+    if (
+      keywordPatterns.some(pattern => pattern.test(question) || pattern.test(answer))
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function hasResumeSummary(resume) {
+  const summary = resume?.basics?.summary;
+  if (typeof summary !== 'string') return false;
+  return summary.trim().length >= 40;
+}
+
+function hasLocationPreference(resume) {
+  const location = resume?.basics?.location;
+  if (!location || typeof location !== 'object') return false;
+  return Boolean(
+    (typeof location.city === 'string' && location.city.trim()) ||
+      (typeof location.region === 'string' && location.region.trim()) ||
+      (typeof location.country === 'string' && location.country.trim()),
+  );
+}
+
+function resumeHasQuantifiedWork(resume) {
+  if (!resume || typeof resume !== 'object') return false;
+  const work = Array.isArray(resume.work) ? resume.work : [];
+  const numericPattern =
+    /\b\d+(?:[.,]\d+)?(?:\s*(?:%|k|m|mm|bn|billion|million|thousand))?\b|\bpercent(?:age)?\b/i;
+  for (const role of work) {
+    if (!role || typeof role !== 'object') continue;
+    const fields = [];
+    if (typeof role.summary === 'string') fields.push(role.summary);
+    if (Array.isArray(role.highlights)) fields.push(...role.highlights);
+    for (const field of fields) {
+      if (typeof field === 'string' && numericPattern.test(field)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function resumeListsTools(resume) {
+  if (!resume || typeof resume !== 'object') return false;
+  const skills = Array.isArray(resume.skills) ? resume.skills : [];
+  const named = skills
+    .map(entry => (typeof entry?.name === 'string' ? entry.name.trim() : ''))
+    .filter(Boolean);
+  return named.length >= 3;
+}
+
+export function generateIntakeQuestionPlan({ resume, responses = [] } = {}) {
+  const plan = [];
+
+  const answered = Array.isArray(responses) ? responses : [];
+
+  if (
+    !hasResumeSummary(resume) &&
+    !hasAnsweredResponse(answered, {
+      tags: ['career', 'goals', 'mission'],
+      keywords: ['career', 'goal', 'mission statement', 'target role'],
+    })
+  ) {
+    plan.push({
+      id: 'career_goals',
+      prompt: 'What roles are you targeting next and what impact do you want to make?',
+      tags: ['career', 'goals'],
+      reason: 'Resume summary is missing or too short to capture career goals.',
+      priority: 1,
+    });
+  }
+
+  if (
+    (!hasLocationPreference(resume) ||
+      !hasAnsweredResponse(answered, {
+        tags: ['relocation', 'location', 'remote'],
+        keywords: ['relocat', 'location preference', 'remote work', 'commute'],
+      }))
+  ) {
+    plan.push({
+      id: 'relocation_preferences',
+      prompt: 'Where are you open to working and do you have relocation or remote constraints?',
+      tags: ['relocation', 'location'],
+      reason: 'Location preferences are not recorded in the profile.',
+      priority: 2,
+    });
+  }
+
+  if (
+    !hasAnsweredResponse(answered, {
+      tags: ['compensation', 'salary', 'pay', 'band'],
+      keywords: ['compensation', 'salary', 'target pay', 'pay range', 'band'],
+    })
+  ) {
+    plan.push({
+      id: 'compensation_guardrails',
+      prompt: 'What compensation range keeps you in the process and what trade-offs are flexible?',
+      tags: ['compensation'],
+      reason: 'Compensation guardrails are not captured in intake responses.',
+      priority: 3,
+    });
+  }
+
+  if (
+    !hasAnsweredResponse(answered, {
+      tags: ['visa', 'sponsorship', 'work authorization'],
+      keywords: ['visa', 'sponsor', 'work authorization', 'work permit'],
+    })
+  ) {
+    plan.push({
+      id: 'visa_status',
+      prompt: 'Do you need visa sponsorship or have any work authorization constraints?',
+      tags: ['visa'],
+      reason: 'Visa or work authorization details are not recorded.',
+      priority: 4,
+    });
+  }
+
+  if (
+    !resumeHasQuantifiedWork(resume) &&
+    !hasAnsweredResponse(answered, {
+      tags: ['metrics', 'results', 'impact'],
+      keywords: ['metric', 'impact', 'quantitative', 'results'],
+    })
+  ) {
+    plan.push({
+      id: 'measurable_outcomes',
+      prompt:
+        'Share a recent accomplishment with measurable outcomes (numbers, percentages, ' +
+        'or before/after impact).',
+      tags: ['metrics'],
+      reason: 'Work history lacks quantified achievements.',
+      priority: 5,
+    });
+  }
+
+  if (
+    !resumeListsTools(resume) &&
+    !hasAnsweredResponse(answered, {
+      tags: ['tools', 'stack', 'skills'],
+      keywords: ['tooling', 'tech stack', 'tools', 'skills you rely on'],
+    })
+  ) {
+    plan.push({
+      id: 'tool_stack',
+      prompt: 'Which tools, frameworks, or platforms do you rely on for your best work?',
+      tags: ['tools'],
+      reason: 'Resume does not enumerate core tools or stack preferences.',
+      priority: 6,
+    });
+  }
+
+  plan.sort((a, b) => a.priority - b.priority);
+  return plan.map(item => {
+    const { priority, ...rest } = item;
+    void priority;
+    return rest;
+  });
+}
+
+export async function loadIntakeQuestionPlan() {
+  const dataDir = resolveDataDir();
+  const { path: resumePath } = await initProfile();
+  let resumeRaw;
+  try {
+    resumeRaw = await loadResumeSync(resumePath);
+  } catch (err) {
+    if (err?.code === 'ENOENT') {
+      resumeRaw = '{}';
+    } else {
+      throw err;
+    }
+  }
+
+  let resume;
+  try {
+    resume = JSON.parse(resumeRaw);
+  } catch {
+    resume = {};
+  }
+
+  const responses = await getIntakeResponses();
+  const plan = generateIntakeQuestionPlan({ resume, responses });
+  return {
+    plan,
+    resumePath: resumePath.startsWith(dataDir)
+      ? resumePath
+      : path.resolve(resumePath),
+  };
+}
+
+export { hasAnsweredResponse };

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1276,6 +1276,31 @@ describe('jobbot CLI', () => {
     expect(textOutput).toContain('Question: Share a metric-driven accomplishment');
   });
 
+  it('generates an intake question plan when details are missing', () => {
+    const planOutput = runCli(['intake', 'plan']);
+    expect(planOutput).toContain('Intake question plan');
+    expect(planOutput).toContain('What roles are you targeting next');
+    expect(planOutput).toMatch(/Resume: .*profile\/resume\.json/);
+  });
+
+  it('exports the intake question plan as JSON', () => {
+    runCli([
+      'intake',
+      'record',
+      '--question',
+      'Where are you willing to relocate?',
+      '--answer',
+      'Open to West Coast US and remote-first roles.',
+      '--tags',
+      'relocation',
+    ]);
+
+    const payload = JSON.parse(runCli(['intake', 'plan', '--json']));
+    expect(Array.isArray(payload.plan)).toBe(true);
+    expect(payload.resume_path).toMatch(/profile\/resume\.json$/);
+    expect(payload.plan.length).toBeGreaterThan(0);
+  });
+
   it('advertises all intake subcommands in usage output', () => {
     const bin = path.resolve('bin', 'jobbot.js');
     const result = spawnSync('node', [bin, 'intake'], {
@@ -1284,7 +1309,7 @@ describe('jobbot CLI', () => {
     });
 
     expect(result.status).toBe(2);
-    expect(result.stderr).toContain('Usage: jobbot intake <record|list|bullets> ...');
+    expect(result.stderr).toContain('Usage: jobbot intake <record|list|bullets|plan> ...');
   });
 
   it('tags shortlist entries and persists labels', () => {

--- a/test/intake-plan.test.js
+++ b/test/intake-plan.test.js
@@ -1,0 +1,161 @@
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+let dataDir;
+
+async function resetDataDir() {
+  if (dataDir) {
+    const fs = await import('node:fs/promises');
+    await fs.rm(dataDir, { recursive: true, force: true });
+    dataDir = undefined;
+  }
+}
+
+describe('intake question plan', () => {
+  beforeEach(async () => {
+    const fs = await import('node:fs/promises');
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-intake-plan-'));
+    process.env.JOBBOT_DATA_DIR = dataDir;
+    const { setIntakePlanDataDir } = await import('../src/intake-plan.js');
+    setIntakePlanDataDir(dataDir);
+  });
+
+  afterEach(async () => {
+    await resetDataDir();
+    delete process.env.JOBBOT_DATA_DIR;
+    const { setIntakePlanDataDir } = await import('../src/intake-plan.js');
+    setIntakePlanDataDir(undefined);
+  });
+
+  it('suggests core questions when profile data is sparse', async () => {
+    const { initProfile } = await import('../src/profile.js');
+    await initProfile({ force: true });
+
+    const { plan } = await (await import('../src/intake-plan.js')).loadIntakeQuestionPlan();
+    const ids = plan.map(item => item.id);
+    expect(ids).toEqual([
+      'career_goals',
+      'relocation_preferences',
+      'compensation_guardrails',
+      'visa_status',
+      'measurable_outcomes',
+      'tool_stack',
+    ]);
+
+    const first = plan[0];
+    expect(first).toMatchObject({
+      id: 'career_goals',
+      tags: ['career', 'goals'],
+    });
+    expect(first.reason).toContain('summary');
+  });
+
+  it('omits topics already covered by intake responses or resume data', async () => {
+    const fs = await import('node:fs/promises');
+    const profileDir = path.join(dataDir, 'profile');
+    await fs.mkdir(profileDir, { recursive: true });
+    await fs.writeFile(
+      path.join(profileDir, 'resume.json'),
+      JSON.stringify(
+        {
+          basics: {
+            summary: 'Senior SRE focused on reliable user-facing platforms.',
+            location: { city: 'Seattle', region: 'WA', country: 'USA' },
+            },
+            work: [
+              {
+                summary:
+                  'Improved availability from 98.5% to 99.95% by ' +
+                  'automating incident response.',
+                highlights: ['Cut MTTR by 40% over six months.'],
+              },
+          ],
+          skills: [
+            { name: 'Go' },
+            { name: 'Kubernetes' },
+            { name: 'Terraform' },
+          ],
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    const { recordIntakeResponse } = await import('../src/intake.js');
+    await recordIntakeResponse({
+      question: 'Where are you willing to relocate?',
+      answer: 'Open to West Coast US and remote-first roles.',
+      tags: ['relocation'],
+    });
+    await recordIntakeResponse({
+      question: 'Share your compensation guardrails.',
+      answer: 'Targeting $185k-$210k base with total comp flexibility for high-growth teams.',
+      tags: ['compensation'],
+    });
+    await recordIntakeResponse({
+      question: 'Work authorization constraints?',
+      answer: 'US citizen, no sponsorship required.',
+      tags: ['visa'],
+    });
+
+    const { plan } = await (await import('../src/intake-plan.js')).loadIntakeQuestionPlan();
+    expect(plan).toEqual([]);
+  });
+
+  it('still asks for measurable outcomes when resume lacks numeric signals', async () => {
+    const fs = await import('node:fs/promises');
+    const profileDir = path.join(dataDir, 'profile');
+    await fs.mkdir(profileDir, { recursive: true });
+    await fs.writeFile(
+      path.join(profileDir, 'resume.json'),
+      JSON.stringify(
+        {
+          basics: {
+            summary:
+              'Product leader focused on empowering teams to ship user impact through clarity.',
+            location: { city: 'Denver', region: 'CO', country: 'USA' },
+          },
+          work: [
+            {
+              summary: 'Managed cross-functional team delivering onboarding improvements.',
+              highlights: [
+                'Shepherded rollout of new activation journey across design, marketing, and data.',
+              ],
+            },
+          ],
+          skills: [
+            { name: 'Product discovery' },
+            { name: 'Experimentation' },
+            { name: 'Cross-functional leadership' },
+          ],
+        },
+        null,
+        2,
+      ),
+      'utf8',
+    );
+
+    const { recordIntakeResponse } = await import('../src/intake.js');
+    await recordIntakeResponse({
+      question: 'Share your compensation guardrails.',
+      answer: 'Comfortable from $170k base with flexibility for equity.',
+      tags: ['compensation'],
+    });
+    await recordIntakeResponse({
+      question: 'Where are you open to working next?',
+      answer: 'Prefer Mountain West but open to hybrid coastal roles.',
+      tags: ['relocation'],
+    });
+    await recordIntakeResponse({
+      question: 'Any work authorization constraints?',
+      answer: 'Permanent resident, no sponsorship needed.',
+      tags: ['visa'],
+    });
+
+    const { plan } = await (await import('../src/intake-plan.js')).loadIntakeQuestionPlan();
+    expect(plan.map(item => item.id)).toEqual(['measurable_outcomes']);
+  });
+});


### PR DESCRIPTION
## Summary
- tighten the intake measurable-outcomes heuristic to require actual numeric markers instead of single letters
- add a regression test ensuring resumes without numbers still trigger the measurable_outcomes prompt

## Testing
- npm run lint
- npm run test:ci *(fails: Vitest reports `[vitest-worker]: Timeout calling "onTaskUpdate"` after all tests pass)*
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d781ee1ac4832f934fef10665735dd