### PR TITLE
Improve shortlist sync CLI feedback

### DIFF
--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -1107,12 +1107,15 @@ async function cmdShortlistSync(args) {
     process.exit(2);
   }
 
-  if (!hasMetadata(metadata)) {
+  const hasUserProvidedMetadata = hasMetadata(metadata);
+
+  if (!hasUserProvidedMetadata) {
     metadata.syncedAt = new Date().toISOString();
   }
 
   await syncShortlistJob(jobId, metadata);
-  console.log(`Synced ${jobId} metadata`);
+  const suffix = hasUserProvidedMetadata ? ' with refreshed fields' : '';
+  console.log(`Synced ${jobId} metadata${suffix}`);
 }
 
 function formatShortlistList(jobs) {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1621,7 +1621,7 @@ describe('jobbot CLI', () => {
       '--synced-at',
       '2025-04-05T06:07:08Z',
     ]);
-    expect(syncOutput.trim()).toBe('Synced job-sync metadata');
+    expect(syncOutput.trim()).toBe('Synced job-sync metadata with refreshed fields');
 
     const store = JSON.parse(
       fs.readFileSync(path.join(dataDir, 'shortlist.json'), 'utf8')


### PR DESCRIPTION
what: note refreshed metadata in `shortlist sync` output
why: README promises the CLI calls out refreshed fields
how: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d8d9b86020832f839ba116d1648e1d