### PR TITLE
✨ : – Surface actionable notes for lifecycle experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1444,10 +1444,13 @@ const analysis = analyzeExperiment('screening_resume_language', {
 });
 
 console.log(analysis.recommendationSummary);
+console.log(analysis.actionableNotes);
 ```
 
 Actionable summaries pair recommendations with the supporting effect sizes, guardrail
-checks, and adjusted p-values so users can make confident changes quickly. See
+checks, and adjusted p-values so users can make confident changes quickly. `actionableNotes`
+surface experiment-specific guidance (for example, anonymization or follow-up prompts) so
+the UI can mirror the playbooks without hard-coding prose. See
 [`docs/lifecycle-experiments.md`](docs/lifecycle-experiments.md) for the full set of
 experiments, analysis plans, and reporting guardrails.
 

--- a/docs/lifecycle-experiments.md
+++ b/docs/lifecycle-experiments.md
@@ -32,9 +32,10 @@ variants do not win at the expense of professionalism, sentiment, or negotiation
    adjusts p-values with Bonferroni corrections, and checks every guardrail before issuing a
    recommendation.
 4. **Surface actionable insights.** The return payload highlights the winning variant (if any), the
-   supporting effect sizes, adjusted p-values, and any guardrail breaches. Feed the
-   `recommendationSummary` and `supportingData` back into the lifecycle UI so users can adopt changes
-   confidently.
+   supporting effect sizes, adjusted p-values, any guardrail breaches, and experiment-specific
+   `actionableNotes`. Feed the `recommendationSummary`, `actionableNotes`, and `supportingData` back
+   into the lifecycle UI so users can adopt changes confidently without duplicating prose from the
+   playbook definitions.
 5. **Archive the analysis for future runs.** Call `archiveExperimentAnalysis(id, result, options)`
    with the object returned from `analyzeExperiment` (pass `recordedAt` to override the default
    timestamp) so the outcome is written to `data/experiment_analyses.json`. Retrieve prior runs with

--- a/src/lifecycle-experiments.js
+++ b/src/lifecycle-experiments.js
@@ -264,6 +264,22 @@ function cloneAnalysisResult(result) {
   return JSON.parse(JSON.stringify(result));
 }
 
+function normalizeActionableNotes(notes) {
+  if (!Array.isArray(notes)) return [];
+  const normalized = [];
+  const seen = new Set();
+  for (const note of notes) {
+    if (typeof note !== 'string') continue;
+    const trimmed = note.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    normalized.push(trimmed);
+  }
+  return normalized;
+}
+
 function sortEntriesByRecordedAt(entries) {
   entries.sort((a, b) => {
     const aTime = Date.parse(a.recorded_at);
@@ -385,6 +401,7 @@ export function analyzeExperiment(id, dataset) {
   if (!experiment) {
     throw new Error(`unknown experiment: ${id}`);
   }
+  const actionableNotes = normalizeActionableNotes(experiment.actionableNotes);
   validateDatasetKeys(dataset);
 
   const { analysisPlan } = experiment;
@@ -493,6 +510,7 @@ export function analyzeExperiment(id, dataset) {
   return {
     experiment: { id: experiment.id, name: experiment.name },
     recommendationSummary,
+    actionableNotes,
     primaryMetric: {
       id: analysisPlan.primaryMetric.id,
       name: analysisPlan.primaryMetric.name,

--- a/test/experiments.test.js
+++ b/test/experiments.test.js
@@ -98,6 +98,24 @@ describe('lifecycle experiments', () => {
     expect(variantResult.recommendation).toMatch(/wrong direction/i);
   });
 
+  test('returns actionable notes for downstream experiment surfaces', () => {
+    const experiment = getExperimentById('screening_resume_language');
+    expect(Array.isArray(experiment.actionableNotes)).toBe(true);
+
+    const result = analyzeExperiment('screening_resume_language', {
+      primaryMetric: {
+        control: { successes: 18, trials: 200 },
+        variants: {
+          warm_language: { successes: 34, trials: 200 },
+        },
+      },
+    });
+
+    expect(result.actionableNotes).toEqual(experiment.actionableNotes);
+    expect(result.actionableNotes).not.toBe(experiment.actionableNotes);
+    expect(result.actionableNotes.length).toBeGreaterThan(0);
+  });
+
   test('rejects analysis requests that are not pre-registered', () => {
     expect(() =>
       analyzeExperiment('screening_resume_language', {
@@ -130,6 +148,9 @@ describe('lifecycle experiments', () => {
 
     expect(entry.recorded_at).toBe('2025-03-02T18:00:00.000Z');
     expect(entry.result.recommendationSummary).toContain('resume');
+    expect(entry.result.actionableNotes).toEqual(
+      expect.arrayContaining(analysis.actionableNotes),
+    );
 
     const history = await getExperimentAnalysisHistory('screening_resume_language');
     expect(history).toHaveLength(1);


### PR DESCRIPTION
what: expose actionableNotes in analyzeExperiment results and docs
why: lifecycle playbooks describe actionable notes that were not returned
how: npm run lint && npm run test:ci
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68d8ec4533a8832fb39b213cedf72102