### PR TITLE
Add architecture pointer for fetch host queue docs

### DIFF
--- a/docs/simplification_suggestions.md
+++ b/docs/simplification_suggestions.md
@@ -14,6 +14,10 @@ _Update (2025-10-08):_ [`docs/architecture.md`](architecture.md) now documents t
 module graph, data directories, and onboarding checklist linked from the README so new contributors
 can ramp without spelunking through individual files first.
 
+_Update (2025-11-10):_ The host queue helper in [`src/fetch.js`](../src/fetch.js) now links directly
+to the architecture map so engineers debugging rate limits can jump from the code to the onboarding
+diagram immediately.
+
 **Suggested Steps**
 - Draft a high-level diagram (module graph or swim lanes) that shows how summarization, ingestion,
   tracking, and exporter flows interact.

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -30,6 +30,8 @@ const HOST_LAST_INVOCATION = new Map();
  *
  * Each invocation waits for the prior job to settle (successfully or not) before executing
  * `fn`. The queue is cleared once the current job finishes so subsequent callers can run.
+ * See docs/architecture.md (HTTP helpers queue) for how this guard fits into the ingestion
+ * pipeline and other rate-limit surfaces.
  *
  * Coverage:
  * - `fetchTextFromUrl serializes requests per host so fetches run sequentially`

--- a/test/fetch-docs-link.test.js
+++ b/test/fetch-docs-link.test.js
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, it, expect } from 'vitest';
+
+const FETCH_PATH = path.resolve('src', 'fetch.js');
+
+function readFetchFile() {
+  return fs.readFileSync(FETCH_PATH, 'utf8');
+}
+
+describe('fetch queue documentation', () => {
+  it('links the host queue helper to the architecture map for onboarding', () => {
+    const contents = readFetchFile();
+    const commentBlock = contents.match(/\/\*\*[^]*?\*\/\s*async function withHostQueue/);
+    expect(commentBlock).not.toBeNull();
+    expect(commentBlock[0]).toMatch(/docs\/architecture\.md/);
+  });
+});


### PR DESCRIPTION
## Summary
- document the `withHostQueue` helper in `src/fetch.js` with a pointer to the architecture map for faster onboarding context
- record the shipped documentation note in `docs/simplification_suggestions.md`
- add a regression test that asserts the host queue docstring references the architecture guide

## Testing
- `npm run lint`
- `npm run test:ci`
- `git diff --cached | ./scripts/scan-secrets.py`


------
https://chatgpt.com/codex/tasks/task_e_68d8ec4533a8832fb39b213cedf72102