### PR TITLE
Add localized timestamp source labels to match prior activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,8 +459,9 @@ session's `started_at` timestamp—or, if that is unavailable, the recording's f
 even partially captured sessions still surface when reviewing prior work. The session detail now
 annotates the timestamp source via `recorded_at_source` (`recorded_at`, `started_at`, or
 `file_mtime`) so reviewers know whether they're looking at an explicit log or a filesystem-derived
-fallback. When `--locale` is provided, the Prior Activity heading and bullet labels respect the
-requested language so localized reports stay consistent end to end.
+fallback, and the CLI renders the same annotation with a localized `Timestamp source: …` label inside
+the prior activity summary. When `--locale` is provided, the Prior Activity heading and bullet labels
+respect the requested language so localized reports stay consistent end to end.
 
 ```bash
 cat <<'EOF' > resume.txt

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -455,6 +455,10 @@ function formatPriorActivitySection(activity, locale = DEFAULT_LOCALE) {
         const descriptors = [];
         if (last.stage) descriptors.push(last.stage);
         if (last.mode) descriptors.push(last.mode);
+        if (last.recorded_at_source) {
+          const sourceLabel = t('priorActivityTimestampSourceLabel', locale);
+          descriptors.push(`${sourceLabel}: ${last.recorded_at_source}`);
+        }
         if (descriptors.length > 0) details.push(descriptors.join(' / '));
       }
       if (details.length > 0) {

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -198,9 +198,11 @@ suggestions to prevent burnout.
    `activity` block so planners can gauge momentum without exposing specific job identifiers, and
    `jobbot match` echoes that context in its `prior_activity` summary so reviewers see the latest
    tailoring/interview work alongside fit scores. When interview payloads only capture a
-   `started_at` timestamp (or when JSON omits timing entirely), the summary falls back to that value
-   or the session file's modification time so the chronology stays visible and notes the timestamp
-   provenance with `recorded_at_source`. Legacy deliverable directories that store files
+  `started_at` timestamp (or when JSON omits timing entirely), the summary falls back to that value
+  or the session file's modification time so the chronology stays visible and notes the timestamp
+  provenance with `recorded_at_source`. The CLI surfaces the same detail with a localized
+  `Timestamp source: …` annotation so readers can tell whether the time came from the log or a
+  filesystem fallback. Legacy deliverable directories that store files
    directly under a job folder count as a single run so older tailoring work remains part of the
    signal.
 3. Users can export anonymized aggregates with `jobbot analytics export --out <file>` for personal

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -25,4 +25,5 @@ export default {
   priorActivitySessionSingular: 'session',
   priorActivitySessionPlural: 'sessions',
   priorActivityCoachingNotesLabel: 'Coaching notes',
+  priorActivityTimestampSourceLabel: 'Timestamp source',
 };

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -25,4 +25,5 @@ export default {
   priorActivitySessionSingular: 'sesión',
   priorActivitySessionPlural: 'sesiones',
   priorActivityCoachingNotesLabel: 'Notas de coaching',
+  priorActivityTimestampSourceLabel: 'Fuente de la marca de tiempo',
 };

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -25,4 +25,5 @@ export default {
   priorActivitySessionSingular: 'session',
   priorActivitySessionPlural: 'sessions',
   priorActivityCoachingNotesLabel: 'Notes de coaching',
+  priorActivityTimestampSourceLabel: "Source de l'horodatage",
 };

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -439,6 +439,7 @@ describe('jobbot CLI', () => {
     expect(mdOut).toContain('## Prior Activity');
     expect(mdOut).toContain('Deliverables: 1 run');
     expect(mdOut).toContain('Interviews: 1 session');
+    expect(mdOut).toContain('Timestamp source: recorded_at');
 
     const localizedOut = runCli([
       'match',
@@ -453,6 +454,7 @@ describe('jobbot CLI', () => {
     expect(localizedOut).toContain('Entregables: 1 ejecución');
     expect(localizedOut).toContain('Entrevistas: 1 sesión');
     expect(localizedOut).toContain('  Notas de coaching:');
+    expect(localizedOut).toContain('Fuente de la marca de tiempo: recorded_at');
   });
 
   it('explains hits and gaps with match --explain', () => {


### PR DESCRIPTION
## Summary
- add localized timestamp source labels to the match prior activity section so CLI output reflects recorded_at_source metadata
- update locale dictionaries and docs to describe the new label for all supported languages
- extend CLI coverage to assert the label appears in English and Spanish reports

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d8ec4533a8832fb39b213cedf72102