### PR TITLE
Normalize legacy discard timestamps to '(unknown time)'

### DIFF
--- a/README.md
+++ b/README.md
@@ -831,7 +831,8 @@ unit tests now assert that JSON snapshots propagate the same `(unknown time)` se
 consumers see identical state whether they read from the CLI or the JSON file. Additional coverage
 ensures legacy `Unknown Time` strings normalize to that sentinel so CLI and JSON outputs stay aligned.
 [`test/discards.test.js`](test/discards.test.js) now asserts archive order returns the latest discard
-first even when older entries remain, keeping the newest-first guarantee enforced.
+first even when older entries remain and that messy legacy timestamps normalize to the shared
+`(unknown time)` sentinel, keeping both the newest-first guarantee and timestamp semantics enforced.
 
 ## Intake responses
 

--- a/src/discards.js
+++ b/src/discards.js
@@ -61,8 +61,7 @@ function toIsoTimestamp(value) {
   if (value == null) return 'unknown time';
   const date = value instanceof Date ? value : new Date(value);
   if (Number.isNaN(date.getTime())) {
-    const fallback = sanitizeString(value);
-    return fallback || 'unknown time';
+    return 'unknown time';
   }
   return date.toISOString();
 }

--- a/src/shortlist.js
+++ b/src/shortlist.js
@@ -74,7 +74,7 @@ function normalizeDiscardTimestamp(input) {
   const value = sanitizeString(input);
   if (!value) return undefined;
   const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return value;
+  if (Number.isNaN(parsed.getTime())) return UNKNOWN_TIME_SENTINEL;
   return parsed.toISOString();
 }
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1530,6 +1530,34 @@ describe('jobbot CLI', () => {
     expect(output).toContain('Last Discard Tags: legacy, manual');
   });
 
+  it('treats invalid discard timestamps as (unknown time) in shortlist output', () => {
+    const shortlistPath = path.join(dataDir, 'shortlist.json');
+    const payload = {
+      jobs: {
+        'job-invalid': {
+          tags: [],
+          discarded: [
+            {
+              reason: 'Legacy invalid timestamp',
+              discarded_at: 'not-a-real-date',
+            },
+            {
+              reason: 'Legacy another invalid',
+              discarded_at: '13/32/2024',
+            },
+          ],
+          metadata: {},
+        },
+      },
+    };
+    fs.writeFileSync(shortlistPath, `${JSON.stringify(payload, null, 2)}\n`);
+
+    const output = runCli(['shortlist', 'list']);
+    expect(output).toContain('Last Discard: Legacy invalid timestamp (unknown time)');
+    expect(output).not.toContain('not-a-real-date');
+    expect(output).not.toContain('13/32/2024');
+  });
+
   it('includes last_discard metadata in shortlist list --json exports', () => {
     runCli([
       'shortlist',

--- a/test/discards.test.js
+++ b/test/discards.test.js
@@ -141,7 +141,7 @@ describe('discarded job archive', () => {
       },
       {
         reason: 'Unknown reason',
-        discarded_at: 'not a date',
+        discarded_at: '(unknown time)',
       },
       {
         reason: 'Legacy without time',


### PR DESCRIPTION
✅ : – normalize legacy discard timestamps

what:
- return the shared `(unknown time)` sentinel when discards include
  invalid timestamps.
- lock CLI, shortlist JSON, and archive readers to the sentinel with new
  coverage.
- document the broader test matrix in the shortlist section of the README.

why:
- keep legacy shortlist data aligned with the documented sentinel so
  downstream tooling sees consistent timestamps.

how to test:
- npm run lint
- npx vitest run test/shortlist.test.js
- npx vitest run test/cli.test.js --testNamePattern="invalid discard timestamps"
- npx vitest run test/discards.test.js

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68d9a6d56b18832f842f7a7b591d3ffd