### PR TITLE
📝 : chore catalog points to prompt chore

### DIFF
--- a/docs/chore-catalog.md
+++ b/docs/chore-catalog.md
@@ -9,7 +9,7 @@ stays accurate.
 |------|-------|-----------|----------|
 | Lint & test sweep | All contributors | Every pull request and before publishing a release | `npm run lint`<br>`npm run test:ci` |
 | Secret scan before push | All contributors | Before every commit and prior to opening a pull request | `git diff --cached \| ./scripts/scan-secrets.py` |
-| Prompt docs audit | Prompt Docs maintainers | Whenever prompt documentation changes or monthly during content reviews | `npm run lint -- docs/prompts`<br>`git status docs/prompts docs/prompt-docs-summary.md` |
+| Prompt docs audit | Prompt Docs maintainers | Whenever prompt documentation changes or monthly during content reviews | `npm run chore:prompts`<br>`npm run chore:prompts --write` *(when auto-fixing formatting)* |
 
 ## How to use this catalog
 
@@ -23,4 +23,5 @@ and expand the coverage expectations in `test/chore-catalog.test.js` as the cata
 
 Run `npm run chore:reminders` to print this catalog in a shareable digest (pass `--json` for machine-
 readable output). CI jobs can surface the same summary before merges so contributors remember to run
-each routine locally.
+each routine locally. The prompt chore wraps spellcheck, Prettier verification, and Markdown link
+validation; add `--all` when you want to reformat the entire prompt catalog.

--- a/test/chore-catalog.test.js
+++ b/test/chore-catalog.test.js
@@ -12,5 +12,6 @@ describe('chore catalog documentation', () => {
     expect(contents).toMatch(/npm run test:ci/);
     expect(contents).toMatch(/git diff --cached \\?\| \.\/scripts\/scan-secrets\.py/);
     expect(contents).toMatch(/Prompt Docs/i);
+    expect(contents).toMatch(/npm run chore:prompts/);
   });
 });


### PR DESCRIPTION
## Summary
- update `docs/chore-catalog.md` to reference the `npm run chore:prompts` helper and explain its formatting options
- extend the chore catalog doc test to require the prompt chore command so the documentation stays aligned

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d9b2ae29a0832fb7c936a8681ec84e