### PR TITLE
Ensure build.json always records prior activity counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,7 @@ JOB_ID=$(ls "$DATA_DIR/jobs" | head -n1 | sed 's/\.json$//')
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot tailor "$JOB_ID"
 # => Generated deliverables for <job_id> at $DATA_DIR/deliverables/<job_id>/<timestamp>
 ls "$DATA_DIR/deliverables/$JOB_ID"
-# => cover_letter.md  match.json  match.md  resume.json  resume.txt
+# => build.json  cover_letter.md  match.json  match.md  resume.json  resume.txt
 rm -rf "$DATA_DIR"
 
 # Use --timestamp to control the subdirectory label and --out to change the base output directory
@@ -567,6 +567,16 @@ Provide `--role <title>` and/or `--location <value>` when the source material om
 when you want to override parsed metadata for reporting purposes. The overrides flow into Markdown,
 JSON, and DOCX outputs as well as the saved job snapshot so downstream tooling sees the adjusted
 context.
+
+Tailoring runs also produce a structured `build.json` log that records the job snapshot
+(`jobs/<job_id>.json`), the profile resume path, generated file list, and the match summary
+(score, matched/missing counts, blocker count, and locale) so reviewers can audit what each run
+produced without re-parsing the artifacts. Coverage in
+[`test/cli.test.js`](test/cli.test.js) asserts the log exists and includes the metadata above for
+every `jobbot tailor` invocation. The log always includes a `prior_activity` object with
+`deliverables_runs` and `interview_sessions` counts, defaulting to `0` when no earlier work has been
+recorded so reviewers can see at a glance whether a bundle represents the first pass or a later
+iteration.
 
 Fit scoring recognizes common abbreviations so lexical-only resumes still match spelled-out
 requirements. `AWS` on a resume matches `Amazon Web Services`, `ML` pairs with `Machine learning`,

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -116,7 +116,12 @@ aggressively to respect rate limits.
 3. Users can tweak sections manually; the assistant suggests language improvements but refuses to
    fabricate experience.
 4. Generated files, diffs, and build logs live in `data/deliverables/{job_id}/` and are versioned by
-   timestamp. Export the latest bundle (or a specific run with `--timestamp`) via
+   timestamp. Each run writes a `build.json` log summarizing the snapshot path, resume source,
+   generated artifacts, match metrics (score plus matched/missing/blocker counts), and prior-activity
+   counters so reviewers can trace how the bundle was produced without re-reading the markdown. Even
+   first-run logs include `deliverables_runs: 0` and `interview_sessions: 0` so teams can confirm a
+   bundle is the opening iteration before the follow-on tailoring sessions. Export the latest bundle
+   (or a specific run with `--timestamp`) via
    `jobbot deliverables bundle <job_id> --out <zip_path>` when sharing prep artifacts with mentors.
    Bundles now include a `resume.diff.json` summary whenever a tailored `resume.json` is present,
    highlighting added, removed, and changed resume fields so reviewers can scan adjustments without


### PR DESCRIPTION
## Summary
- close the backlog note that build.json logs include prior-activity counts by writing zeros when no history exists
- extend the CLI regression to assert build.json is emitted with the expected entries and prior_activity payload
- document the always-present prior_activity object in README and user journeys so the shipped behavior is clear

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d9b2ae29a0832fb7c936a8681ec84e