### PR TITLE
Add sections grouping to track reminders JSON output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1536,6 +1536,20 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track reminders --now 2025-03-06T00:00:00Z
 # Upcoming
 # job-2 — 2025-03-07T15:00:00.000Z (call)
 #   Contact: Avery Hiring Manager
+
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track reminders --json | jq '.sections[0]'
+# {
+#   "heading": "Past Due",
+#   "reminders": [
+#     {
+#       "job_id": "job-1",
+#       "remind_at": "2025-03-05T09:00:00.000Z",
+#       "channel": "follow_up",
+#       "note": "Send status update",
+#       "past_due": true
+#     }
+#   ]
+# }
 ```
 
 Unit tests in [`test/application-events.test.js`](test/application-events.test.js)

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -658,30 +658,27 @@ async function cmdTrackReminders(args) {
     process.exit(1);
   }
 
+  const includePastDue = !upcomingOnly;
+  const pastDue = includePastDue ? reminders.filter(reminder => reminder.past_due) : [];
+  const upcoming = reminders.filter(reminder => !reminder.past_due);
+  const sections = [];
+  if (includePastDue) {
+    sections.push({ heading: 'Past Due', reminders: pastDue });
+  }
+  sections.push({ heading: 'Upcoming', reminders: upcoming });
+
   if (asJson) {
-    console.log(JSON.stringify({ reminders }, null, 2));
+    console.log(JSON.stringify({ reminders, sections }, null, 2));
     return;
   }
 
-  const includePastDue = !upcomingOnly;
-  const pastDue = includePastDue
-    ? reminders.filter(reminder => reminder.past_due)
-    : [];
-  const upcoming = reminders.filter(reminder => !reminder.past_due);
-
-  const groups = [];
-  if (includePastDue) {
-    groups.push({ heading: 'Past Due', items: pastDue });
-  }
-  groups.push({ heading: 'Upcoming', items: upcoming });
-
   const lines = [];
-  for (const group of groups) {
-    lines.push(group.heading);
-    if (group.items.length === 0) {
+  for (const section of sections) {
+    lines.push(section.heading);
+    if (section.reminders.length === 0) {
       lines.push('  (none)');
     } else {
-      for (const reminder of group.items) {
+      for (const reminder of section.reminders) {
         const descriptors = [];
         if (reminder.channel) descriptors.push(reminder.channel);
         const suffix = descriptors.length ? ` (${descriptors.join(', ')})` : '';

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -148,13 +148,14 @@ aggressively to respect rate limits.
    (add `--upcoming-only` to hide past-due entries and `--json` when piping into other tools).
    The digest prints `Past Due` and `Upcoming` sections so urgent follow-ups remain visible even
    when one bucket is empty, showing `(none)` under empty headings so users can confirm nothing is
-   pending there. When filters remove every reminder (for example, `--upcoming-only` on a day with
-   only past-due entries), the CLI still prints an `Upcoming` heading with `(none)` so it is clear
-    nothing new is scheduled. Lifecycle board summaries surface the soonest upcoming reminder per job
-    and fall back to the most recent past-due entry when no future timestamp is scheduled. When a job
-    has no reminders at all, the board prints `Reminder: (none)` so idle opportunities are obvious at
-    a glance, and the JSON board surfaces the same state with an explicit `"reminder": null`
-    placeholder for downstream automation.
+   pending there. JSON exports mirror the same grouping via a `sections` array so automation can
+   consume the digest structure without reimplementing it. When filters remove every reminder
+   (for example, `--upcoming-only` on a day with only past-due entries), the CLI still prints an
+   `Upcoming` heading with `(none)` so it is clear nothing new is scheduled. Lifecycle board
+   summaries surface the soonest upcoming reminder per job and fall back to the most recent past-due
+   entry when no future timestamp is scheduled. When a job has no reminders at all, the board prints
+   `Reminder: (none)` so idle opportunities are obvious at a glance, and the JSON board surfaces the
+   same state with an explicit `"reminder": null` placeholder for downstream automation.
 
 **Unhappy paths:** conflicting updates (e.g., two devices editing simultaneously) trigger a merge
 flow that preserves both sets of notes.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -775,6 +775,32 @@ describe('jobbot CLI', () => {
           past_due: false,
         },
       ],
+      sections: [
+        {
+          heading: 'Past Due',
+          reminders: [
+            {
+              job_id: 'job-1',
+              remind_at: '2025-03-05T09:00:00.000Z',
+              channel: 'follow_up',
+              note: 'Send status update',
+              past_due: true,
+            },
+          ],
+        },
+        {
+          heading: 'Upcoming',
+          reminders: [
+            {
+              job_id: 'job-2',
+              remind_at: '2025-03-07T15:00:00.000Z',
+              channel: 'call',
+              contact: 'Avery Hiring Manager',
+              past_due: false,
+            },
+          ],
+        },
+      ],
     });
   });
 


### PR DESCRIPTION
## Summary
- inventory future-work notes and ship the documented JSON sections for `track reminders`
- reuse the grouped sections for CLI output and include them in the `--json` payload
- update CLI tests and docs with the new sections array example

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68d9b2ae29a0832fb7c936a8681ec84e