### PR TITLE
Ensure deliverable bundles always include resume.pdf

### DIFF
--- a/README.md
+++ b/README.md
@@ -1343,11 +1343,12 @@ When a tailored run ships a `resume.json`, the bundler now compares it to the ba
 `profile/resume.json` and includes a `resume.diff.json` summary in the archive. The diff captures
 added, removed, and changed resume paths (for example, `skills[2]` or `work[0].company`), giving
 reviewers a quick snapshot of how the tailored variant diverges from the canonical profile without
-opening the full documents. Bundles also synthesize a `resume.txt` plain-text preview from the
-tailored JSON resume so ATS scanners and accessibility tooling can audit the output without opening
-the PDF. Unit coverage in [`test/deliverables.test.js`](test/deliverables.test.js) asserts the diff
-is emitted with accurate before/after values and the preview captures core resume sections, keeping
-the audit trail intact.
+opening the full documents. Bundles also synthesize both a `resume.pdf` derived from the tailored
+JSON resume and a `resume.txt` plain-text preview so ATS scanners and accessibility tooling can audit
+the output in whichever format they prefer. Unit coverage in
+[`test/deliverables.test.js`](test/deliverables.test.js) asserts the diff is emitted with accurate
+before/after values, the PDF renderer runs even when the original run did not persist a PDF, and the
+preview captures core resume sections, keeping the audit trail intact.
 
 See [DESIGN.md](DESIGN.md) for architecture details and roadmap.
 See [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) for a list of prompt documents.

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -106,13 +106,14 @@ aggressively to respect rate limits.
 2. The resume renderer clones the base profile, selects the most relevant bullets, and prepares a
    tailored artifact set: a synthesized `resume.txt` preview, the canonical `resume.json`, the
    localized match report (`match.md`/`match.json`), and a grounded cover letter. Run
-   `jobbot match --cover-letter <path>` to emit an ad-hoc Markdown template or
-   `jobbot tailor <job_id>` to save the full deliverables bundle under
-   `data/deliverables/{job_id}/{timestamp}/`. Tailoring runs accept `--timestamp` to control the
-   subdirectory label, `--out` to redirect the base path, and `--profile <resume.json>` when testing
-   alternative profile variants. All outputs cite the source fields they originate from so the user
-   can audit changes, and the preview keeps ATS tooling in sync with the JSON resume even when PDFs
-   are unavailable.
+  `jobbot match --cover-letter <path>` to emit an ad-hoc Markdown template or
+  `jobbot tailor <job_id>` to save the full deliverables bundle under
+  `data/deliverables/{job_id}/{timestamp}/`. Tailoring runs accept `--timestamp` to control the
+  subdirectory label, `--out` to redirect the base path, and `--profile <resume.json>` when testing
+  alternative profile variants. All outputs cite the source fields they originate from so the user
+  can audit changes. Bundles now guarantee both `resume.pdf` and `resume.txt` exist—older runs missing
+  the PDF are patched during bundling—so reviewers have accessible text and shareable print layouts
+  without regenerating deliverables.
 3. Users can tweak sections manually; the assistant suggests language improvements but refuses to
    fabricate experience.
 4. Generated files, diffs, and build logs live in `data/deliverables/{job_id}/` and are versioned by

--- a/src/resume-pdf.js
+++ b/src/resume-pdf.js
@@ -4,9 +4,18 @@ function sanitizeLine(line) {
   if (!line) return '';
   const normalized = line
     .replace(/\r/g, '')
-    .replace(/[\t]/g, '    ')
-    .replace(/[\u0000-\u001F\u007F-\u009F]/g, '?');
-  const asciiSafe = normalized.replace(/[^\x20-\x7E]/g, '?');
+    .replace(/[\t]/g, '    ');
+
+  let asciiSafe = '';
+  for (let index = 0; index < normalized.length; index += 1) {
+    const code = normalized.charCodeAt(index);
+    if (code < 32 || code === 127 || (code >= 128 && code <= 159) || code > 126) {
+      asciiSafe += '?';
+    } else {
+      asciiSafe += normalized[index];
+    }
+  }
+
   return asciiSafe
     .replace(/\\/g, '\\\\')
     .replace(/\(/g, '\\(')
@@ -50,7 +59,13 @@ function synthesizePdf(lines) {
   addObject(2, '<< /Type /Pages /Kids [3 0 R] /Count 1 >>');
   addObject(
     3,
-    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>',
+    [
+      '<< /Type /Page',
+      '/Parent 2 0 R',
+      '/MediaBox [0 0 612 792]',
+      '/Resources << /Font << /F1 4 0 R >> >>',
+      '/Contents 5 0 R >>',
+    ].join(' '),
   );
   addObject(4, '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>');
   addObject(

--- a/src/resume-pdf.js
+++ b/src/resume-pdf.js
@@ -1,0 +1,82 @@
+import { renderResumeTextPreview } from './resume-preview.js';
+
+function sanitizeLine(line) {
+  if (!line) return '';
+  const normalized = line
+    .replace(/\r/g, '')
+    .replace(/[\t]/g, '    ')
+    .replace(/[\u0000-\u001F\u007F-\u009F]/g, '?');
+  const asciiSafe = normalized.replace(/[^\x20-\x7E]/g, '?');
+  return asciiSafe
+    .replace(/\\/g, '\\\\')
+    .replace(/\(/g, '\\(')
+    .replace(/\)/g, '\\)');
+}
+
+function buildContentStream(lines) {
+  const body = [
+    'BT',
+    '/F1 12 Tf',
+    '14 TL',
+    '72 720 Td',
+  ];
+
+  lines.forEach((line, index) => {
+    if (index === 0) {
+      body.push(`(${sanitizeLine(line)}) Tj`);
+    } else {
+      body.push('T*');
+      body.push(`(${sanitizeLine(line)}) Tj`);
+    }
+  });
+
+  body.push('ET');
+  return body.join('\n');
+}
+
+function synthesizePdf(lines) {
+  const safeLines = lines.length > 0 ? lines : [''];
+  const contentStream = buildContentStream(safeLines);
+  const contentBuffer = Buffer.from(contentStream, 'utf8');
+  const offsets = [];
+  let output = '%PDF-1.4\n';
+
+  const addObject = (id, body) => {
+    offsets[id] = output.length;
+    output += `${id} 0 obj\n${body}\nendobj\n`;
+  };
+
+  addObject(1, '<< /Type /Catalog /Pages 2 0 R >>');
+  addObject(2, '<< /Type /Pages /Kids [3 0 R] /Count 1 >>');
+  addObject(
+    3,
+    '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>',
+  );
+  addObject(4, '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>');
+  addObject(
+    5,
+    `<< /Length ${contentBuffer.length} >>\nstream\n${contentBuffer.toString('latin1')}\nendstream`,
+  );
+
+  const xrefOffset = output.length;
+  output += 'xref\n';
+  output += '0 6\n';
+  output += '0000000000 65535 f \n';
+  for (let i = 1; i <= 5; i += 1) {
+    const offset = offsets[i] ?? 0;
+    output += `${String(offset).padStart(10, '0')} 00000 n \n`;
+  }
+  output += 'trailer\n';
+  output += '<< /Size 6 /Root 1 0 R >>\n';
+  output += 'startxref\n';
+  output += `${xrefOffset}\n`;
+  output += '%%EOF';
+
+  return Buffer.from(output, 'latin1');
+}
+
+export function renderResumePdf(resume) {
+  const preview = renderResumeTextPreview(resume);
+  const lines = preview.split(/\r?\n/);
+  return synthesizePdf(lines);
+}


### PR DESCRIPTION
## Summary
- add resume.pdf synthesis to bundleDeliverables so older runs emit PDFs
- document the PDF fallback in README and the Journey 4 narrative
- extend deliverables bundling tests to assert the synthesized PDF output

## Testing
- npm run lint
- npm run test:ci *(CLI analytics suite timed out in this environment)*
- npx vitest run test/deliverables.test.js

------
https://chatgpt.com/codex/tasks/task_e_68d9c941c444832f9ad1c894e4777288