### PR TITLE
🧪 : align architecture doc with CLI entrypoint

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,7 +89,9 @@ Matching compares normalized job postings against the candidate profile.
   exercises raw text inputs, pre-parsed job objects, and French explanations so the
   helper stays aligned with the CLI output.
 - Performance-focused suites in `test/scoring.*.test.js` guard regression budgets.
-- Explanations highlight hits, gaps, and blockers. CLI output is formatted in `src/cli.js` helpers.
+- Explanations highlight hits, gaps, and blockers. CLI output is formatted in `bin/jobbot.js`
+  helpers that normalize shortlist, activity, and analytics summaries before printing them to the
+  terminal.
 
 ## Deliverables
 

--- a/test/architecture-doc.test.js
+++ b/test/architecture-doc.test.js
@@ -19,4 +19,11 @@ describe('architecture documentation', () => {
     expect(contents).toMatch(/src\/application-events\.js/);
     expect(contents).toMatch(/src\/lifecycle\.js/);
   });
+
+  it('references the current CLI entrypoint instead of stale helper paths', () => {
+    const contents = readFileSync(ARCHITECTURE_DOC_PATH, 'utf8');
+
+    expect(contents).toMatch(/bin\/jobbot\.js/);
+    expect(contents).not.toMatch(/src\/cli\.js/);
+  });
 });


### PR DESCRIPTION
what: add a regression test that enforces the architecture doc references
      bin/jobbot.js and update the doc to point at the real CLI helpers
why: the architecture doc still referenced a nonexistent src/cli.js helper
      path and drifted from the shipped layout
how to test: npm run lint && npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68d9c941c444832f9ad1c894e4777288