### PR TITLE
✨ : – align prior activity docs with sessions metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,8 +500,11 @@ even partially captured sessions still surface when reviewing prior work. The se
 annotates the timestamp source via `recorded_at_source` (`recorded_at`, `started_at`, or
 `file_mtime`) so reviewers know whether they're looking at an explicit log or a filesystem-derived
 fallback, and the CLI renders the same annotation with a localized `Timestamp source: …` label inside
-the prior activity summary. When `--locale` is provided, the Prior Activity heading and bullet labels
-respect the requested language so localized reports stay consistent end to end.
+the prior activity summary. When a deliverable run exists, the summary also highlights how many
+interview sessions landed after the most recent tailoring pass via the localized `Sessions since last
+deliverable: …` annotation, helping teams connect bullet variants to subsequent conversations. When
+`--locale` is provided, the Prior Activity heading and bullet labels respect the requested language so
+localized reports stay consistent end to end.
 
 ```bash
 cat <<'EOF' > resume.txt

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -552,6 +552,12 @@ function formatPriorActivitySection(activity, locale = DEFAULT_LOCALE) {
         const descriptors = [];
         if (last.stage) descriptors.push(last.stage);
         if (last.mode) descriptors.push(last.mode);
+        if (typeof interviews.sessions_after_last_deliverable === 'number') {
+          const sinceLabel = t('priorActivitySessionsSinceLastDeliverable', locale);
+          descriptors.push(
+            `${sinceLabel}: ${interviews.sessions_after_last_deliverable}`,
+          );
+        }
         if (last.recorded_at_source) {
           const sourceLabel = t('priorActivityTimestampSourceLabel', locale);
           descriptors.push(`${sourceLabel}: ${last.recorded_at_source}`);
@@ -1679,6 +1685,10 @@ async function cmdTailor(args) {
 
   const deliverablesRuns = activity?.deliverables?.runs;
   const interviewSessions = activity?.interviews?.sessions;
+  const sessionsAfterLastDeliverable =
+    typeof activity?.interviews?.sessions_after_last_deliverable === 'number'
+      ? activity.interviews.sessions_after_last_deliverable
+      : undefined;
 
   const buildLog = {
     job_id: jobId,
@@ -1698,6 +1708,9 @@ async function cmdTailor(args) {
       interview_sessions: Number.isFinite(interviewSessions) ? interviewSessions : 0,
     },
   };
+  if (sessionsAfterLastDeliverable !== undefined) {
+    buildLog.prior_activity.sessions_after_last_deliverable = sessionsAfterLastDeliverable;
+  }
 
   await writeTextFile(path.join(runDir, 'build.json'), `${JSON.stringify(buildLog, null, 2)}\n`);
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -205,18 +205,19 @@ suggestions to prevent burnout.
    ➜ acceptance) and highlight the largest drop-off. JSON exports expose a `funnel.sankey`
    structure so visualization layers can consume nodes and links directly.
 2. Metadata from tailoring and rehearsal sessions feeds back into the recommender so it can surface
-   what worked (e.g., bullet variants correlated with interviews) while staying privacy-first. The
-   analytics export reports aggregate deliverable runs and interview session counts in an
-   `activity` block so planners can gauge momentum without exposing specific job identifiers, and
-   `jobbot match` echoes that context in its `prior_activity` summary so reviewers see the latest
-   tailoring/interview work alongside fit scores. When interview payloads only capture a
-  `started_at` timestamp (or when JSON omits timing entirely), the summary falls back to that value
-  or the session file's modification time so the chronology stays visible and notes the timestamp
-  provenance with `recorded_at_source`. The CLI surfaces the same detail with a localized
-  `Timestamp source: …` annotation so readers can tell whether the time came from the log or a
-  filesystem fallback. Legacy deliverable directories that store files
-   directly under a job folder count as a single run so older tailoring work remains part of the
-   signal.
+   the freshest work while staying privacy-first. The analytics export reports aggregate
+   deliverable runs, interview counts, and how many sessions landed after the most recent
+   tailoring pass inside an `activity` block so planners can gauge momentum without exposing
+   specific job identifiers. `jobbot match` echoes the same detail in its `prior_activity` summary,
+   pairing the latest coaching notes with a localized `Sessions since last deliverable`
+   annotation so reviewers can connect bullet work to ensuing conversations. When interview
+   payloads only capture a `started_at` timestamp (or when JSON omits timing entirely), the
+   summary falls back to that value or the session file's modification time so the chronology
+   stays visible and notes the timestamp provenance with `recorded_at_source`. The CLI surfaces
+   the same detail with a localized `Timestamp source: …` annotation so readers can tell whether
+   the time came from the log or a filesystem fallback. Legacy deliverable directories that store
+   files directly under a job folder count as a single run so older tailoring work remains part of
+   the signal.
 3. Users can export anonymized aggregates with `jobbot analytics export --out <file>` for personal
    record keeping without exposing raw PII.
 

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -26,4 +26,5 @@ export default {
   priorActivitySessionPlural: 'sessions',
   priorActivityCoachingNotesLabel: 'Coaching notes',
   priorActivityTimestampSourceLabel: 'Timestamp source',
+  priorActivitySessionsSinceLastDeliverable: 'Sessions since last deliverable',
 };

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -26,4 +26,5 @@ export default {
   priorActivitySessionPlural: 'sesiones',
   priorActivityCoachingNotesLabel: 'Notas de coaching',
   priorActivityTimestampSourceLabel: 'Fuente de la marca de tiempo',
+  priorActivitySessionsSinceLastDeliverable: 'Sesiones desde la última entrega',
 };

--- a/src/locales/fr.js
+++ b/src/locales/fr.js
@@ -26,4 +26,5 @@ export default {
   priorActivitySessionPlural: 'sessions',
   priorActivityCoachingNotesLabel: 'Notes de coaching',
   priorActivityTimestampSourceLabel: "Source de l'horodatage",
+  priorActivitySessionsSinceLastDeliverable: 'Sessions depuis le dernier livrable',
 };

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -486,6 +486,9 @@ describe('jobbot CLI', () => {
     expect(payload.prior_activity?.interviews?.last_session?.recorded_at_source).toBe(
       'recorded_at',
     );
+    expect(
+      payload.prior_activity?.interviews?.sessions_after_last_deliverable,
+    ).toBe(1);
 
     const mdOut = runCli([
       'match',
@@ -497,6 +500,7 @@ describe('jobbot CLI', () => {
     expect(mdOut).toContain('## Prior Activity');
     expect(mdOut).toContain('Deliverables: 1 run');
     expect(mdOut).toContain('Interviews: 1 session');
+    expect(mdOut).toContain('Sessions since last deliverable: 1');
     expect(mdOut).toContain('Timestamp source: recorded_at');
 
     const localizedOut = runCli([
@@ -512,6 +516,7 @@ describe('jobbot CLI', () => {
     expect(localizedOut).toContain('Entregables: 1 ejecución');
     expect(localizedOut).toContain('Entrevistas: 1 sesión');
     expect(localizedOut).toContain('  Notas de coaching:');
+    expect(localizedOut).toContain('Sesiones desde la última entrega: 1');
     expect(localizedOut).toContain('Fuente de la marca de tiempo: recorded_at');
   });
 


### PR DESCRIPTION
what: parse deliverable timestamps, expose sessions-since-last-deliverable data,
and refresh Journey 2 docs to match the shipped metric.
why: the doc still referenced "bullet variants correlated with interviews" instead
of the new prior-activity annotation.
how to test: npm run lint; npm run test:ci (fails with vitest onTaskUpdate timeout)


------
https://chatgpt.com/codex/tasks/task_e_68d9c941c444832f9ad1c894e4777288