### PR TITLE
Add web command adapter scaffolding

### DIFF
--- a/docs/web-interface-roadmap.md
+++ b/docs/web-interface-roadmap.md
@@ -89,7 +89,14 @@
      _Implemented (2025-11-23):_ [`src/web/server.js`](../src/web/server.js) now exposes an Express
      app with a `/health` route that aggregates pluggable status checks. Start the backend with
      `npm run web:server` to serve the health endpoint locally while wiring additional adapters.
-   - Build command adapter with a mocked CLI module and comprehensive tests.
+  - Build command adapter with a mocked CLI module and comprehensive tests.
+    _Implemented (2025-11-24):_ [`src/web/command-adapter.js`](../src/web/command-adapter.js)
+    now exposes `createCommandAdapter`, which wraps CLI command handlers, captures
+    stdout/stderr output, and normalizes arguments for summarize/match calls.
+    Regression coverage in
+    [`test/web-command-adapter.test.js`](../test/web-command-adapter.test.js)
+    uses mocked CLI functions to assert argument shaping, JSON parsing, and
+    error translation so future endpoints can reuse the adapter safely.
    - Establish shared TypeScript types and validation schemas.
 
 2. **CLI Integration Layer**

--- a/src/web/command-adapter.js
+++ b/src/web/command-adapter.js
@@ -1,0 +1,227 @@
+const COMMAND_METHODS = {
+  summarize: 'cmdSummarize',
+  match: 'cmdMatch',
+};
+
+function normalizeString(value, { name, required = false } = {}) {
+  if (value == null) {
+    if (required) {
+      throw new Error(`${name || 'value'} is required`);
+    }
+    return undefined;
+  }
+  const str = typeof value === 'string' ? value : String(value);
+  const trimmed = str.trim();
+  if (required && !trimmed) {
+    throw new Error(`${name || 'value'} cannot be empty`);
+  }
+  return trimmed || undefined;
+}
+
+function toFiniteNumber(value) {
+  if (value == null || value === '') return undefined;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : undefined;
+}
+
+function formatLogArg(arg) {
+  if (typeof arg === 'string') return arg;
+  if (typeof arg === 'number' || typeof arg === 'boolean') {
+    return String(arg);
+  }
+  if (arg instanceof Error) {
+    return arg.message || String(arg);
+  }
+  try {
+    return JSON.stringify(arg);
+  } catch {
+    return String(arg);
+  }
+}
+
+async function captureConsole(fn) {
+  const originalLog = console.log;
+  const originalError = console.error;
+  const logs = [];
+  const errors = [];
+  console.log = (...args) => {
+    logs.push(args.map(formatLogArg).join(' '));
+  };
+  console.error = (...args) => {
+    errors.push(args.map(formatLogArg).join(' '));
+  };
+  try {
+    const result = await fn();
+    return { result, stdout: logs.join('\n'), stderr: errors.join('\n') };
+  } catch (err) {
+    if (err && typeof err === 'object') {
+      err.stdout = logs.join('\n');
+      err.stderr = errors.join('\n');
+    }
+    throw err;
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+}
+
+function humanizeMethod(method) {
+  if (!method.startsWith('cmd')) return method;
+  const name = method.slice(3);
+  return name ? name.charAt(0).toLowerCase() + name.slice(1) : method;
+}
+
+function parseJsonOutput(command, stdout, stderr) {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    const error = new Error(`${command} command produced no JSON output`);
+    error.stdout = stdout;
+    error.stderr = stderr;
+    throw error;
+  }
+  try {
+    return JSON.parse(trimmed);
+  } catch (err) {
+    const parseError = new Error(`${command} command produced invalid JSON output`);
+    parseError.cause = err;
+    parseError.stdout = stdout;
+    parseError.stderr = stderr;
+    throw parseError;
+  }
+}
+
+export function createCommandAdapter(options = {}) {
+  const { cli: injectedCli } = options;
+  let cachedCliPromise;
+
+  function getCliModule() {
+    if (injectedCli) {
+      return Promise.resolve(injectedCli);
+    }
+    if (!cachedCliPromise) {
+      cachedCliPromise = import('../../bin/jobbot.js');
+    }
+    return cachedCliPromise;
+  }
+
+  async function runCli(method, args) {
+    const cli = await getCliModule();
+    const fn = cli?.[method];
+    if (typeof fn !== 'function') {
+      throw new Error(`unknown CLI command method: ${method}`);
+    }
+    const commandName = humanizeMethod(method);
+    try {
+      const { result, stdout, stderr } = await captureConsole(() => fn(args));
+      return { command: commandName, returnValue: result, stdout, stderr };
+    } catch (err) {
+      const error = new Error(`${commandName} command failed: ${err?.message ?? 'Unknown error'}`);
+      error.cause = err;
+      if (err && typeof err.stdout === 'string') {
+        error.stdout = err.stdout;
+      }
+      if (err && typeof err.stderr === 'string') {
+        error.stderr = err.stderr;
+      }
+      throw error;
+    }
+  }
+
+  async function summarize(options = {}) {
+    const input = normalizeString(options.input ?? options.source, {
+      name: 'input',
+      required: true,
+    });
+    const format = normalizeString(options.format)?.toLowerCase() ?? 'markdown';
+    const locale = normalizeString(options.locale);
+    const sentences = toFiniteNumber(options.sentences);
+    const timeout = toFiniteNumber(options.timeoutMs ?? options.timeout);
+    const maxBytes = toFiniteNumber(options.maxBytes);
+
+    const args = [input];
+    if (format === 'json') args.push('--json');
+    else if (format === 'text') args.push('--text');
+    if (Number.isFinite(sentences)) {
+      args.push('--sentences', String(sentences));
+    }
+    if (locale) {
+      args.push('--locale', locale);
+    }
+    if (Number.isFinite(timeout)) {
+      args.push('--timeout', String(timeout));
+    }
+    if (Number.isFinite(maxBytes) && maxBytes > 0) {
+      args.push('--max-bytes', String(maxBytes));
+    }
+
+    const { stdout, stderr, returnValue } = await runCli(COMMAND_METHODS.summarize, args);
+    const payload = {
+      command: 'summarize',
+      format,
+      stdout,
+      stderr,
+      returnValue,
+    };
+    if (format === 'json') {
+      payload.data = parseJsonOutput('summarize', stdout, stderr);
+    }
+    return payload;
+  }
+
+  async function match(options = {}) {
+    const resume = normalizeString(options.resume, { name: 'resume', required: true });
+    const job = normalizeString(options.job, { name: 'job', required: true });
+    const format = normalizeString(options.format)?.toLowerCase() ?? 'markdown';
+    const locale = normalizeString(options.locale);
+    const role = normalizeString(options.role);
+    const location = normalizeString(options.location);
+    const profile = normalizeString(options.profile);
+    const timeout = toFiniteNumber(options.timeoutMs ?? options.timeout);
+    const maxBytes = toFiniteNumber(options.maxBytes);
+    const explain = Boolean(options.explain);
+
+    const args = ['--resume', resume, '--job', job];
+    if (format === 'json') {
+      args.push('--json');
+    }
+    if (explain) {
+      args.push('--explain');
+    }
+    if (locale) {
+      args.push('--locale', locale);
+    }
+    if (role) {
+      args.push('--role', role);
+    }
+    if (location) {
+      args.push('--location', location);
+    }
+    if (profile) {
+      args.push('--profile', profile);
+    }
+    if (Number.isFinite(timeout)) {
+      args.push('--timeout', String(timeout));
+    }
+    if (Number.isFinite(maxBytes) && maxBytes > 0) {
+      args.push('--max-bytes', String(maxBytes));
+    }
+
+    const { stdout, stderr, returnValue } = await runCli(COMMAND_METHODS.match, args);
+    const payload = {
+      command: 'match',
+      format,
+      stdout,
+      stderr,
+      returnValue,
+    };
+    if (format === 'json') {
+      payload.data = parseJsonOutput('match', stdout, stderr);
+    }
+    return payload;
+  }
+
+  return {
+    summarize,
+    match,
+  };
+}

--- a/test/web-command-adapter.test.js
+++ b/test/web-command-adapter.test.js
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createCommandAdapter } from '../src/web/command-adapter.js';
+
+describe('createCommandAdapter', () => {
+  it('runs summarize with json format and parses output', async () => {
+    const cli = {
+      cmdSummarize: vi.fn(async args => {
+        expect(args).toEqual([
+          'job.txt',
+          '--json',
+          '--sentences',
+          '3',
+          '--locale',
+          'es',
+          '--timeout',
+          '20000',
+          '--max-bytes',
+          '4096',
+        ]);
+        console.log('{"summary":"ok"}');
+      }),
+    };
+
+    const adapter = createCommandAdapter({ cli });
+    const result = await adapter.summarize({
+      input: 'job.txt',
+      format: 'json',
+      sentences: 3,
+      locale: 'es',
+      timeoutMs: 20000,
+      maxBytes: 4096,
+    });
+
+    expect(result).toMatchObject({
+      command: 'summarize',
+      format: 'json',
+      stdout: '{"summary":"ok"}',
+      stderr: '',
+      data: { summary: 'ok' },
+    });
+    expect(cli.cmdSummarize).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs match with optional flags and parses json output', async () => {
+    const cli = {
+      cmdMatch: vi.fn(async args => {
+        expect(args).toEqual([
+          '--resume',
+          'resume.txt',
+          '--job',
+          'job.txt',
+          '--json',
+          '--explain',
+          '--locale',
+          'fr',
+          '--role',
+          'Engineer',
+          '--location',
+          'Remote',
+          '--profile',
+          'profile.json',
+          '--timeout',
+          '10000',
+          '--max-bytes',
+          '5120',
+        ]);
+        console.log('{"score":95}');
+      }),
+    };
+
+    const adapter = createCommandAdapter({ cli });
+    const result = await adapter.match({
+      resume: 'resume.txt',
+      job: 'job.txt',
+      format: 'json',
+      explain: true,
+      locale: 'fr',
+      role: 'Engineer',
+      location: 'Remote',
+      profile: 'profile.json',
+      timeoutMs: 10000,
+      maxBytes: 5120,
+    });
+
+    expect(result).toMatchObject({
+      command: 'match',
+      format: 'json',
+      stdout: '{"score":95}',
+      stderr: '',
+      data: { score: 95 },
+    });
+    expect(cli.cmdMatch).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when required summarize input is missing', async () => {
+    const cli = { cmdSummarize: vi.fn() };
+    const adapter = createCommandAdapter({ cli });
+    await expect(adapter.summarize({})).rejects.toThrow('input is required');
+    expect(cli.cmdSummarize).not.toHaveBeenCalled();
+  });
+
+  it('throws when required match arguments are missing', async () => {
+    const cli = { cmdMatch: vi.fn() };
+    const adapter = createCommandAdapter({ cli });
+    await expect(adapter.match({ job: 'job.txt' })).rejects.toThrow('resume is required');
+    await expect(adapter.match({ resume: 'resume.txt' })).rejects.toThrow('job is required');
+    expect(cli.cmdMatch).not.toHaveBeenCalled();
+  });
+
+  it('wraps CLI errors with captured stderr output', async () => {
+    const cli = {
+      cmdSummarize: vi.fn(async () => {
+        console.error('boom');
+        throw new Error('failed');
+      }),
+    };
+    const adapter = createCommandAdapter({ cli });
+    await expect(adapter.summarize({ input: 'job.txt' })).rejects.toMatchObject({
+      message: 'summarize command failed: failed',
+      stderr: 'boom',
+    });
+  });
+
+  it('throws when CLI method is missing', async () => {
+    const adapter = createCommandAdapter({ cli: {} });
+    await expect(adapter.summarize({ input: 'job.txt' })).rejects.toThrow(
+      'unknown CLI command method: cmdSummarize',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add src/web/command-adapter.js to wrap CLI summarize/match handlers for the web backend
- cover the adapter with Vitest suites that mock CLI functions and exercise success and error cases
- document the delivered command adapter milestone in docs/web-interface-roadmap.md

## Testing
- npm run lint
- npm run test:ci *(fails: Vitest emitted `Timeout calling "onTaskUpdate"` after all tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68da2d0c8d64832fab32667a617019ae