### PR TITLE
Add allow-listed command endpoint for web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1603,6 +1603,23 @@ extended by passing custom check functions to
 and failing checks so future endpoints can rely on the health contract when the
 web interface expands beyond the CLI wrappers.
 
+Call allow-listed CLI commands through the new `POST /commands/:command`
+endpoint. Requests must contain valid JSON bodies that match the per-command
+schema; unexpected fields or type mismatches return a `400` status before the
+CLI is invoked. The route delegates to `createCommandAdapter`, so responses
+mirror the underlying CLI output:
+
+```bash
+curl -s \
+  -X POST http://127.0.0.1:3000/commands/summarize \
+  -H 'Content-Type: application/json' \
+  -d '{"input":"job.txt","format":"json","sentences":3}' | jq
+```
+
+Schema validation and error handling are locked down in
+[`test/web-server.test.js`](test/web-server.test.js) so new endpoints inherit
+the same guardrails.
+
 ## Documentation
 
 - [DESIGN.md](DESIGN.md) – architecture details and roadmap

--- a/docs/web-interface-roadmap.md
+++ b/docs/web-interface-roadmap.md
@@ -103,6 +103,11 @@
    - Implement real CLI invocations behind feature flags.
    - Add structured logging, metrics, and error handling utilities.
    - Write integration tests that execute representative CLI commands in a sandboxed environment.
+   _Update (2025-11-30):_ The Express app now exposes `POST /commands/:command`, which validates
+   requests against an allow-listed schema before delegating to the CLI via
+   `createCommandAdapter`. Coverage in
+   [`test/web-server.test.js`](../test/web-server.test.js) locks the sanitized payloads and error
+   handling so future endpoints inherit the same guardrails.
 
 3. **Frontend Shell**
    - Set up routing, layout, and theme providers.
@@ -148,7 +153,7 @@
 
 ## Safe Implementation Checklist
 
-- [ ] Command allow-list with schema validation
+- [x] Command allow-list with schema validation
 - [ ] Secure process spawning without shell interpolation
 - [ ] Input sanitization and output redaction
 - [ ] Logging with redacted secrets and trace IDs


### PR DESCRIPTION
## Summary
- implement schema validators for summarize and match payloads via a dedicated command registry
- expose a POST /commands/:command Express route that enforces the allow list, sanitizes inputs, and surfaces CLI errors safely
- document the endpoint in the README, update the web interface roadmap checklist, and extend web-server tests for happy and failure paths

## Testing
- npm run lint
- npm run test:ci *(fails: Vitest RPC timeout while running the full CLI suite in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da35a20538832fbd623c60b1bbb2da