### PR TITLE
Add shared web request validation schemas

### DIFF
--- a/docs/web-interface-roadmap.md
+++ b/docs/web-interface-roadmap.md
@@ -93,11 +93,20 @@
     _Implemented (2025-11-24):_ [`src/web/command-adapter.js`](../src/web/command-adapter.js)
     now exposes `createCommandAdapter`, which wraps CLI command handlers, captures
     stdout/stderr output, and normalizes arguments for summarize/match calls.
-    Regression coverage in
+   Regression coverage in
     [`test/web-command-adapter.test.js`](../test/web-command-adapter.test.js)
     uses mocked CLI functions to assert argument shaping, JSON parsing, and
     error translation so future endpoints can reuse the adapter safely.
    - Establish shared TypeScript types and validation schemas.
+     _Implemented (2025-11-25):_ [`src/web/schemas.js`](../src/web/schemas.js)
+     now defines shared request types for summarize and match calls, enforcing
+     supported formats and numeric constraints before CLI execution. Regression
+     coverage in
+     [`test/web-command-adapter.test.js`](../test/web-command-adapter.test.js)
+     and
+     [`test/web-schemas.test.js`](../test/web-schemas.test.js)
+     guards the validation layer with happy-path and failure-path tests so
+     future web endpoints inherit consistent payload validation.
 
 2. **CLI Integration Layer**
    - Implement real CLI invocations behind feature flags.

--- a/src/web/command-adapter.js
+++ b/src/web/command-adapter.js
@@ -1,30 +1,11 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 
+import { normalizeMatchRequest, normalizeSummarizeRequest } from './schemas.js';
+
 const COMMAND_METHODS = {
   summarize: 'cmdSummarize',
   match: 'cmdMatch',
 };
-
-function normalizeString(value, { name, required = false } = {}) {
-  if (value == null) {
-    if (required) {
-      throw new Error(`${name || 'value'} is required`);
-    }
-    return undefined;
-  }
-  const str = typeof value === 'string' ? value : String(value);
-  const trimmed = str.trim();
-  if (required && !trimmed) {
-    throw new Error(`${name || 'value'} cannot be empty`);
-  }
-  return trimmed || undefined;
-}
-
-function toFiniteNumber(value) {
-  if (value == null || value === '') return undefined;
-  const num = Number(value);
-  return Number.isFinite(num) ? num : undefined;
-}
 
 function formatLogArg(arg) {
   if (typeof arg === 'string') return arg;
@@ -151,15 +132,8 @@ export function createCommandAdapter(options = {}) {
   }
 
   async function summarize(options = {}) {
-    const input = normalizeString(options.input ?? options.source, {
-      name: 'input',
-      required: true,
-    });
-    const format = normalizeString(options.format)?.toLowerCase() ?? 'markdown';
-    const locale = normalizeString(options.locale);
-    const sentences = toFiniteNumber(options.sentences);
-    const timeout = toFiniteNumber(options.timeoutMs ?? options.timeout);
-    const maxBytes = toFiniteNumber(options.maxBytes);
+    const normalized = normalizeSummarizeRequest(options);
+    const { input, format, locale, sentences, timeoutMs, maxBytes } = normalized;
 
     const args = [input];
     if (format === 'json') args.push('--json');
@@ -170,8 +144,8 @@ export function createCommandAdapter(options = {}) {
     if (locale) {
       args.push('--locale', locale);
     }
-    if (Number.isFinite(timeout)) {
-      args.push('--timeout', String(timeout));
+    if (Number.isFinite(timeoutMs)) {
+      args.push('--timeout', String(timeoutMs));
     }
     if (Number.isFinite(maxBytes) && maxBytes > 0) {
       args.push('--max-bytes', String(maxBytes));
@@ -192,16 +166,9 @@ export function createCommandAdapter(options = {}) {
   }
 
   async function match(options = {}) {
-    const resume = normalizeString(options.resume, { name: 'resume', required: true });
-    const job = normalizeString(options.job, { name: 'job', required: true });
-    const format = normalizeString(options.format)?.toLowerCase() ?? 'markdown';
-    const locale = normalizeString(options.locale);
-    const role = normalizeString(options.role);
-    const location = normalizeString(options.location);
-    const profile = normalizeString(options.profile);
-    const timeout = toFiniteNumber(options.timeoutMs ?? options.timeout);
-    const maxBytes = toFiniteNumber(options.maxBytes);
-    const explain = Boolean(options.explain);
+    const normalized = normalizeMatchRequest(options);
+    const { resume, job, format, locale, role, location, profile, timeoutMs, maxBytes, explain } =
+      normalized;
 
     const args = ['--resume', resume, '--job', job];
     if (format === 'json') {
@@ -222,8 +189,8 @@ export function createCommandAdapter(options = {}) {
     if (profile) {
       args.push('--profile', profile);
     }
-    if (Number.isFinite(timeout)) {
-      args.push('--timeout', String(timeout));
+    if (Number.isFinite(timeoutMs)) {
+      args.push('--timeout', String(timeoutMs));
     }
     if (Number.isFinite(maxBytes) && maxBytes > 0) {
       args.push('--max-bytes', String(maxBytes));

--- a/src/web/schemas.js
+++ b/src/web/schemas.js
@@ -1,0 +1,118 @@
+const SUPPORTED_FORMATS = ['markdown', 'text', 'json'];
+
+function assertPlainObject(value, name) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+}
+
+function normalizeString(value) {
+  if (value == null) return undefined;
+  const str = typeof value === 'string' ? value : String(value);
+  const trimmed = str.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function assertRequiredString(value, name) {
+  const normalized = normalizeString(value);
+  if (!normalized) {
+    throw new Error(`${name} is required`);
+  }
+  return normalized;
+}
+
+function coerceNumber(value) {
+  if (value == null || value === '') return undefined;
+  const num = Number(value);
+  return Number.isFinite(num) ? num : undefined;
+}
+
+function assertPositiveInteger(value, name) {
+  const numberValue = coerceNumber(value);
+  if (numberValue === undefined) return undefined;
+  if (!Number.isInteger(numberValue) || numberValue <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+  return numberValue;
+}
+
+function assertPositiveNumber(value, name) {
+  const numberValue = coerceNumber(value);
+  if (numberValue === undefined) return undefined;
+  if (numberValue <= 0) {
+    throw new Error(`${name} must be greater than 0`);
+  }
+  return numberValue;
+}
+
+function normalizeFormat(value) {
+  const normalized = normalizeString(value)?.toLowerCase() ?? 'markdown';
+  if (!SUPPORTED_FORMATS.includes(normalized)) {
+    throw new Error('format must be one of: markdown, text, json');
+  }
+  return normalized;
+}
+
+/**
+ * @typedef {Object} SummarizeRequest
+ * @property {string} input
+ * @property {'markdown'|'text'|'json'} [format]
+ * @property {string} [locale]
+ * @property {number} [sentences]
+ * @property {number} [timeoutMs]
+ * @property {number} [maxBytes]
+ */
+
+/**
+ * Normalizes summarize request options and enforces supported constraints.
+ * @param {unknown} options
+ * @returns {SummarizeRequest}
+ */
+export function normalizeSummarizeRequest(options) {
+  assertPlainObject(options, 'summarize options');
+  const input = assertRequiredString(options.input ?? options.source, 'input');
+  const format = normalizeFormat(options.format);
+  const locale = normalizeString(options.locale);
+  const sentences = assertPositiveInteger(options.sentences, 'sentences');
+  const timeoutMs = assertPositiveNumber(options.timeoutMs ?? options.timeout, 'timeout');
+  const maxBytes = assertPositiveInteger(options.maxBytes, 'maxBytes');
+
+  return { input, format, locale, sentences, timeoutMs, maxBytes };
+}
+
+/**
+ * @typedef {Object} MatchRequest
+ * @property {string} resume
+ * @property {string} job
+ * @property {'markdown'|'text'|'json'} [format]
+ * @property {boolean} [explain]
+ * @property {string} [locale]
+ * @property {string} [role]
+ * @property {string} [location]
+ * @property {string} [profile]
+ * @property {number} [timeoutMs]
+ * @property {number} [maxBytes]
+ */
+
+/**
+ * Normalizes match request options and enforces supported constraints.
+ * @param {unknown} options
+ * @returns {MatchRequest}
+ */
+export function normalizeMatchRequest(options) {
+  assertPlainObject(options, 'match options');
+  const resume = assertRequiredString(options.resume, 'resume');
+  const job = assertRequiredString(options.job, 'job');
+  const format = normalizeFormat(options.format);
+  const locale = normalizeString(options.locale);
+  const role = normalizeString(options.role);
+  const location = normalizeString(options.location);
+  const profile = normalizeString(options.profile);
+  const explain = Boolean(options.explain);
+  const timeoutMs = assertPositiveNumber(options.timeoutMs ?? options.timeout, 'timeout');
+  const maxBytes = assertPositiveInteger(options.maxBytes, 'maxBytes');
+
+  return { resume, job, format, locale, role, location, profile, explain, timeoutMs, maxBytes };
+}
+
+export const WEB_SUPPORTED_FORMATS = [...SUPPORTED_FORMATS];

--- a/test/web-command-adapter.test.js
+++ b/test/web-command-adapter.test.js
@@ -100,11 +100,44 @@ describe('createCommandAdapter', () => {
     expect(cli.cmdSummarize).not.toHaveBeenCalled();
   });
 
+  it('rejects unsupported summarize formats', async () => {
+    const cli = { cmdSummarize: vi.fn() };
+    const adapter = createCommandAdapter({ cli });
+
+    await expect(
+      adapter.summarize({ input: 'job.txt', format: 'xml' }),
+    ).rejects.toThrow("format must be one of: markdown, text, json");
+
+    expect(cli.cmdSummarize).not.toHaveBeenCalled();
+  });
+
+  it('rejects summarize requests with non-positive sentence counts', async () => {
+    const cli = { cmdSummarize: vi.fn() };
+    const adapter = createCommandAdapter({ cli });
+
+    await expect(
+      adapter.summarize({ input: 'job.txt', sentences: 0 }),
+    ).rejects.toThrow('sentences must be a positive integer');
+
+    expect(cli.cmdSummarize).not.toHaveBeenCalled();
+  });
+
   it('throws when required match arguments are missing', async () => {
     const cli = { cmdMatch: vi.fn() };
     const adapter = createCommandAdapter({ cli });
     await expect(adapter.match({ job: 'job.txt' })).rejects.toThrow('resume is required');
     await expect(adapter.match({ resume: 'resume.txt' })).rejects.toThrow('job is required');
+    expect(cli.cmdMatch).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported match formats', async () => {
+    const cli = { cmdMatch: vi.fn() };
+    const adapter = createCommandAdapter({ cli });
+
+    await expect(
+      adapter.match({ resume: 'resume.txt', job: 'job.txt', format: 'xml' }),
+    ).rejects.toThrow("format must be one of: markdown, text, json");
+
     expect(cli.cmdMatch).not.toHaveBeenCalled();
   });
 

--- a/test/web-schemas.test.js
+++ b/test/web-schemas.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeMatchRequest, normalizeSummarizeRequest } from '../src/web/schemas.js';
+
+describe('web request schemas', () => {
+  describe('normalizeSummarizeRequest', () => {
+    it('normalizes aliases and numeric strings', () => {
+      const options = normalizeSummarizeRequest({
+        source: 'input.md',
+        format: 'JSON',
+        sentences: '5',
+        timeout: '1500',
+        maxBytes: '2048',
+        locale: ' En-US ',
+      });
+
+      expect(options).toEqual({
+        input: 'input.md',
+        format: 'json',
+        sentences: 5,
+        timeoutMs: 1500,
+        maxBytes: 2048,
+        locale: 'En-US',
+      });
+    });
+
+    it('throws when options are not an object', () => {
+      expect(() => normalizeSummarizeRequest(null)).toThrow('summarize options must be an object');
+      expect(() => normalizeSummarizeRequest([])).toThrow('summarize options must be an object');
+    });
+  });
+
+  describe('normalizeMatchRequest', () => {
+    it('normalizes optional strings and boolean flags', () => {
+      const options = normalizeMatchRequest({
+        resume: 'resume.txt',
+        job: 'job.txt',
+        explain: 1,
+        role: '  Staff Engineer ',
+        location: ' Remote ',
+        profile: '',
+        timeoutMs: '3000',
+      });
+
+      expect(options).toEqual({
+        resume: 'resume.txt',
+        job: 'job.txt',
+        format: 'markdown',
+        locale: undefined,
+        role: 'Staff Engineer',
+        location: 'Remote',
+        profile: undefined,
+        explain: true,
+        timeoutMs: 3000,
+        maxBytes: undefined,
+      });
+    });
+
+    it('throws when options are not an object', () => {
+      expect(() => normalizeMatchRequest(null)).toThrow('match options must be an object');
+      expect(() => normalizeMatchRequest([])).toThrow('match options must be an object');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- inventory docs/web-interface-roadmap.md and ship the shared
  validation milestone for the web adapter
- add src/web/schemas.js and enforce the schemas inside the command
  adapter before invoking CLI handlers
- expand web command adapter tests, add schema unit coverage, and note
  the delivered validation in the roadmap

## Testing
- npm run lint
- npm run test:ci *(fails: computeFitScore resume tokenization
  performance exceeds the 200ms threshold on this container)*
- npx vitest run test/web-command-adapter.test.js test/web-schemas.test.js

------
https://chatgpt.com/codex/tasks/task_e_68da35a20538832fbd623c60b1bbb2da