### PR TITLE
feat: secure web command spawning

### DIFF
--- a/docs/web-interface-roadmap.md
+++ b/docs/web-interface-roadmap.md
@@ -73,6 +73,14 @@
 - Validate payloads with a shared schema library (e.g., Zod) on both frontend and backend to ensure
   alignment.
 - Avoid shell invocation; use `spawn`/`execFile` with explicit argument arrays.
+  _Implemented (2025-12-06):_ [`src/web/command-adapter.js`](../src/web/command-adapter.js)
+  now executes CLI commands via `child_process.spawn` with `shell: false`,
+  `windowsHide: true`, and explicit argument arrays. The adapter streams
+  stdout/stderr, rejects on non-zero exit codes, and surfaces correlation IDs
+  to callers. Regression coverage in
+  [`test/web-command-adapter.test.js`](../test/web-command-adapter.test.js)
+  verifies the secure spawn configuration and error propagation when the CLI
+  process fails.
 - Apply rate limiting and CSRF defenses even in local deployments to simplify production hardening.
 - Store sensitive configuration (API tokens, credentials) via environment variables managed through
   secure storage solutions.
@@ -169,7 +177,7 @@
 ## Safe Implementation Checklist
 
 - [x] Command allow-list with schema validation
-- [ ] Secure process spawning without shell interpolation
+- [x] Secure process spawning without shell interpolation
 - [ ] Input sanitization and output redaction
 - [ ] Logging with redacted secrets and trace IDs
 - [ ] Automated tests spanning unit → e2e layers

--- a/test/web-command-adapter.test.js
+++ b/test/web-command-adapter.test.js
@@ -1,8 +1,58 @@
-import { describe, expect, it, vi } from 'vitest';
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual('node:child_process');
+  return { ...actual, spawn: vi.fn() };
+});
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+import { EventEmitter } from 'node:events';
+import * as childProcess from 'node:child_process';
 
 import { createCommandAdapter } from '../src/web/command-adapter.js';
 
 describe('createCommandAdapter', () => {
+  afterEach(() => {
+    childProcess.spawn.mockReset();
+  });
+
+  function createTempJobFile(contents = 'Role: Example Engineer') {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'jobbot-web-adapter-'));
+    const filePath = path.join(dir, 'posting.txt');
+    fs.writeFileSync(filePath, `${contents}\n`, 'utf8');
+    return {
+      dir,
+      filePath,
+      cleanup() {
+        fs.rmSync(dir, { recursive: true, force: true });
+      },
+    };
+  }
+
+  function createSpawnedProcess({ stdout = '', stderr = '', exitCode = 0, signal = null } = {}) {
+    const child = new EventEmitter();
+    const stdoutStream = new PassThrough();
+    const stderrStream = new PassThrough();
+    stdoutStream.setEncoding('utf8');
+    stderrStream.setEncoding('utf8');
+
+    child.stdout = stdoutStream;
+    child.stderr = stderrStream;
+    child.kill = vi.fn();
+
+    setImmediate(() => {
+      if (stdout) stdoutStream.write(stdout);
+      stdoutStream.end();
+      if (stderr) stderrStream.write(stderr);
+      stderrStream.end();
+      child.emit('close', exitCode, signal);
+    });
+
+    return child;
+  }
+
   it('runs summarize with json format and parses output', async () => {
     const cli = {
       cmdSummarize: vi.fn(async args => {
@@ -231,5 +281,60 @@ describe('createCommandAdapter', () => {
     await expect(adapter.summarize({ input: 'job.txt' })).rejects.toThrow(
       'unknown CLI command method: cmdSummarize',
     );
+  });
+
+  it('spawns the CLI without shell interpolation when no cli module is provided', async () => {
+    const spawnMock = childProcess.spawn;
+    spawnMock.mockImplementation((command, args, options) => {
+      expect(command).toBe(process.execPath);
+      expect(options).toMatchObject({
+        shell: false,
+        windowsHide: true,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      return createSpawnedProcess({ stdout: '{"summary":"ok"}\n' });
+    });
+
+    const temp = createTempJobFile('We are hiring a senior engineer.');
+
+    try {
+      const adapter = createCommandAdapter();
+      const result = await adapter.summarize({ input: temp.filePath, format: 'json' });
+
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+      const [spawnCommand, spawnArgs] = spawnMock.mock.calls[0];
+      expect(spawnCommand).toBe(process.execPath);
+      const expectedCliPath = fs.realpathSync(path.join(process.cwd(), 'bin', 'jobbot.js'));
+      expect(spawnArgs[0]).toBe(expectedCliPath);
+      expect(spawnArgs.slice(1)).toEqual(['summarize', temp.filePath, '--json']);
+      expect(result).toMatchObject({
+        command: 'summarize',
+        format: 'json',
+        stdout: '{"summary":"ok"}\n',
+        data: { summary: 'ok' },
+      });
+    } finally {
+      temp.cleanup();
+    }
+  });
+
+  it('propagates stderr when the spawned CLI exits with a non-zero code', async () => {
+    const spawnMock = childProcess.spawn;
+    spawnMock.mockImplementation(() =>
+      createSpawnedProcess({ stdout: '', stderr: 'boom\n', exitCode: 2 }),
+    );
+
+    const temp = createTempJobFile('The role requires leadership.');
+
+    try {
+      const adapter = createCommandAdapter();
+      await expect(adapter.summarize({ input: temp.filePath })).rejects.toMatchObject({
+        message: expect.stringContaining('summarize command failed'),
+        stderr: 'boom\n',
+      });
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+    } finally {
+      temp.cleanup();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- execute web CLI commands via child_process.spawn with shell disabled and explicit arguments
- add regression tests for the spawned command adapter and document the shipped hardening work

## Testing
- npm run lint
- npm run test:ci *(fails: Vitest worker reported `Timeout calling "onTaskUpdate"` after all tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68db65ee5440832f8aae29520a04a9c5