### PR TITLE
Harden web command endpoint with CSRF and rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1604,6 +1604,13 @@ extended by passing custom check functions to
 and failing checks so future endpoints can rely on the health contract when the
 web interface expands beyond the CLI wrappers.
 
+Every server start prints a one-time CSRF secret. Attach the emitted header and
+token (for example, `X-Jobbot-Csrf: <token>`) to every `POST /commands` request.
+Missing or invalid CSRF headers return `403` errors before the CLI adapter runs.
+The command endpoint also enforces a per-client rate limit (30 requests per
+minute by default) and responds with `429`/`Retry-After` metadata when callers
+exceed the budget.
+
 Call allow-listed CLI commands through the new `POST /commands/:command`
 endpoint. Requests must contain valid JSON bodies that match the per-command
 schema; unexpected fields or type mismatches return a `400` status before the
@@ -1614,6 +1621,7 @@ mirror the underlying CLI output:
 curl -s \
   -X POST http://127.0.0.1:3000/commands/summarize \
   -H 'Content-Type: application/json' \
+  -H 'X-Jobbot-Csrf: replace-with-token-from-server-startup' \
   -d '{"input":"job.txt","format":"json","sentences":3}' | jq
 ```
 

--- a/docs/web-interface-roadmap.md
+++ b/docs/web-interface-roadmap.md
@@ -82,6 +82,12 @@
   verifies the secure spawn configuration and error propagation when the CLI
   process fails.
 - Apply rate limiting and CSRF defenses even in local deployments to simplify production hardening.
+  _Implemented (2025-12-11):_ [`src/web/server.js`](../src/web/server.js) now enforces a
+  startup-provided CSRF header and in-memory per-client rate limiting on
+  `POST /commands`. Coverage in [`test/web-server.test.js`](../test/web-server.test.js)
+  verifies 403 responses for missing tokens and 429 responses once
+  callers exhaust the request budget. [`scripts/web-server.js`](../scripts/web-server.js) prints the
+  header name and token on boot so the frontend can attach it securely.
 - Store sensitive configuration (API tokens, credentials) via environment variables managed through
   secure storage solutions.
 - Log sensitive fields using redaction filters and enforce secure log transport when deployed beyond

--- a/scripts/web-server.js
+++ b/scripts/web-server.js
@@ -44,6 +44,10 @@ async function main() {
   });
 
   console.log(`jobbot web server listening on ${server.url}`);
+  console.log(
+    `Attach ${server.csrfHeaderName}: ${server.csrfToken} to POST /commands requests.`,
+  );
+  console.log('Treat the CSRF token as a secret.');
   console.log('Press Ctrl+C to stop.');
 
   await new Promise((resolve, reject) => {

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -1,8 +1,56 @@
 import express from 'express';
+import { randomBytes } from 'node:crypto';
 import { performance } from 'node:perf_hooks';
 
 import { createCommandAdapter } from './command-adapter.js';
 import { ALLOW_LISTED_COMMANDS, validateCommandPayload } from './command-registry.js';
+
+function createInMemoryRateLimiter(options = {}) {
+  const windowMs = Number(options.windowMs ?? 60000);
+  if (!Number.isFinite(windowMs) || windowMs <= 0) {
+    throw new Error('rateLimit.windowMs must be a positive number');
+  }
+  const maxRaw = options.max ?? 30;
+  const max = Math.trunc(Number(maxRaw));
+  if (!Number.isFinite(max) || max <= 0) {
+    throw new Error('rateLimit.max must be a positive integer');
+  }
+
+  const buckets = new Map();
+  return {
+    limit: max,
+    windowMs,
+    check(key) {
+      const now = Date.now();
+      const entry = buckets.get(key);
+      if (!entry || entry.reset <= now) {
+        const reset = now + windowMs;
+        buckets.set(key, { count: 1, reset });
+        return { allowed: true, remaining: Math.max(0, max - 1), reset };
+      }
+
+      entry.count += 1;
+      const allowed = entry.count <= max;
+      const remaining = Math.max(0, max - entry.count);
+      return { allowed, remaining, reset: entry.reset };
+    },
+  };
+}
+
+function normalizeCsrfOptions(csrf = {}) {
+  const headerName =
+    typeof csrf.headerName === 'string' && csrf.headerName.trim()
+      ? csrf.headerName.trim()
+      : 'x-jobbot-csrf';
+  const token = typeof csrf.token === 'string' ? csrf.token.trim() : '';
+  if (!token) {
+    throw new Error('csrf.token must be provided');
+  }
+  return {
+    headerName,
+    token,
+  };
+}
 
 function normalizeInfo(info) {
   if (!info || typeof info !== 'object') return {};
@@ -95,9 +143,11 @@ async function runHealthChecks(checks) {
   return results;
 }
 
-export function createWebApp({ info, healthChecks, commandAdapter } = {}) {
+export function createWebApp({ info, healthChecks, commandAdapter, csrf, rateLimit } = {}) {
   const normalizedInfo = normalizeInfo(info);
   const normalizedChecks = normalizeHealthChecks(healthChecks);
+  const csrfOptions = normalizeCsrfOptions(csrf);
+  const rateLimiter = createInMemoryRateLimiter(rateLimit);
   const app = express();
   const availableCommands = new Set(
     ALLOW_LISTED_COMMANDS.filter(name => typeof commandAdapter?.[name] === 'function'),
@@ -122,6 +172,24 @@ export function createWebApp({ info, healthChecks, commandAdapter } = {}) {
     const commandParam = typeof req.params.command === 'string' ? req.params.command.trim() : '';
     if (!availableCommands.has(commandParam)) {
       res.status(404).json({ error: `Unknown command "${commandParam}"` });
+      return;
+    }
+
+    const providedToken = req.get(csrfOptions.headerName);
+    if ((providedToken ?? '').trim() !== csrfOptions.token) {
+      res.status(403).json({ error: 'Invalid or missing CSRF token' });
+      return;
+    }
+
+    const rateKey = req.ip || req.socket?.remoteAddress || 'unknown';
+    const rateStatus = rateLimiter.check(rateKey);
+    res.set('X-RateLimit-Limit', String(rateLimiter.limit));
+    res.set('X-RateLimit-Remaining', String(Math.max(0, rateStatus.remaining)));
+    res.set('X-RateLimit-Reset', new Date(rateStatus.reset).toISOString());
+    if (!rateStatus.allowed) {
+      const retryAfterSeconds = Math.max(1, Math.ceil((rateStatus.reset - Date.now()) / 1000));
+      res.set('Retry-After', String(retryAfterSeconds));
+      res.status(429).json({ error: 'Too many requests' });
       return;
     }
 
@@ -172,9 +240,28 @@ export function startWebServer(options = {}) {
   if (!Number.isFinite(port) || port < 0 || port > 65535) {
     throw new Error('port must be a number between 0 and 65535');
   }
-  const { commandAdapter: providedCommandAdapter, ...rest } = options;
+  const {
+    commandAdapter: providedCommandAdapter,
+    csrfToken: providedCsrfToken,
+    csrfHeaderName,
+    rateLimit,
+    ...rest
+  } = options;
   const commandAdapter = providedCommandAdapter ?? createCommandAdapter();
-  const app = createWebApp({ ...rest, commandAdapter });
+  const resolvedCsrfToken =
+    typeof providedCsrfToken === 'string' && providedCsrfToken.trim()
+      ? providedCsrfToken.trim()
+      : (process.env.JOBBOT_WEB_CSRF_TOKEN || '').trim() || randomBytes(32).toString('hex');
+  const resolvedHeaderName =
+    typeof csrfHeaderName === 'string' && csrfHeaderName.trim()
+      ? csrfHeaderName.trim()
+      : 'x-jobbot-csrf';
+  const app = createWebApp({
+    ...rest,
+    commandAdapter,
+    csrf: { token: resolvedCsrfToken, headerName: resolvedHeaderName },
+    rateLimit,
+  });
 
   return new Promise((resolve, reject) => {
     const server = app
@@ -186,6 +273,8 @@ export function startWebServer(options = {}) {
           host,
           port: actualPort,
           url: `http://${host}:${actualPort}`,
+          csrfToken: resolvedCsrfToken,
+          csrfHeaderName: resolvedHeaderName,
           async close() {
             await new Promise((resolveClose, rejectClose) => {
               server.close(err => {

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -175,12 +175,6 @@ export function createWebApp({ info, healthChecks, commandAdapter, csrf, rateLim
       return;
     }
 
-    const providedToken = req.get(csrfOptions.headerName);
-    if ((providedToken ?? '').trim() !== csrfOptions.token) {
-      res.status(403).json({ error: 'Invalid or missing CSRF token' });
-      return;
-    }
-
     const rateKey = req.ip || req.socket?.remoteAddress || 'unknown';
     const rateStatus = rateLimiter.check(rateKey);
     res.set('X-RateLimit-Limit', String(rateLimiter.limit));
@@ -190,6 +184,12 @@ export function createWebApp({ info, healthChecks, commandAdapter, csrf, rateLim
       const retryAfterSeconds = Math.max(1, Math.ceil((rateStatus.reset - Date.now()) / 1000));
       res.set('Retry-After', String(retryAfterSeconds));
       res.status(429).json({ error: 'Too many requests' });
+      return;
+    }
+
+    const providedToken = req.get(csrfOptions.headerName);
+    if ((providedToken ?? '').trim() !== csrfOptions.token) {
+      res.status(403).json({ error: 'Invalid or missing CSRF token' });
       return;
     }
 

--- a/test/web-server.test.js
+++ b/test/web-server.test.js
@@ -4,9 +4,25 @@ let activeServers = [];
 
 async function startServer(options) {
   const { startWebServer } = await import('../src/web/server.js');
-  const server = await startWebServer({ host: '127.0.0.1', port: 0, ...options });
+  const server = await startWebServer({
+    host: '127.0.0.1',
+    port: 0,
+    csrfToken: 'test-csrf-token',
+    rateLimit: { windowMs: 1000, max: 50 },
+    ...options,
+  });
   activeServers.push(server);
   return server;
+}
+
+function buildCommandHeaders(server, overrides = {}) {
+  const headerName = server?.csrfHeaderName ?? 'x-jobbot-csrf';
+  const token = server?.csrfToken ?? 'test-csrf-token';
+  return {
+    'content-type': 'application/json',
+    [headerName]: token,
+    ...overrides,
+  };
 }
 
 afterEach(async () => {
@@ -131,7 +147,7 @@ describe('web server command endpoint', () => {
     const server = await startServer({ commandAdapter });
     const response = await fetch(`${server.url}/commands/summarize`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: buildCommandHeaders(server),
       body: JSON.stringify({
         input: 'job.txt',
         format: 'json',
@@ -158,7 +174,7 @@ describe('web server command endpoint', () => {
     const server = await startServer({ commandAdapter: {} });
     const response = await fetch(`${server.url}/commands/unknown`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: buildCommandHeaders(server),
       body: JSON.stringify({}),
     });
 
@@ -175,7 +191,7 @@ describe('web server command endpoint', () => {
     const server = await startServer({ commandAdapter });
     const response = await fetch(`${server.url}/commands/summarize`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: buildCommandHeaders(server),
       body: JSON.stringify({ input: 'job.txt', unexpected: true }),
     });
 
@@ -198,7 +214,7 @@ describe('web server command endpoint', () => {
     const server = await startServer({ commandAdapter });
     const response = await fetch(`${server.url}/commands/summarize`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: buildCommandHeaders(server),
       body: JSON.stringify({ input: 'job.txt' }),
     });
 
@@ -226,7 +242,7 @@ describe('web server command endpoint', () => {
     const server = await startServer({ commandAdapter });
     const response = await fetch(`${server.url}/commands/summarize`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: buildCommandHeaders(server),
       body: JSON.stringify({ input: 'job.txt' }),
     });
 
@@ -248,7 +264,7 @@ describe('web server command endpoint', () => {
     const server = await startServer({ commandAdapter });
     const response = await fetch(`${server.url}/commands/summarize`, {
       method: 'POST',
-      headers: { 'content-type': 'application/json' },
+      headers: buildCommandHeaders(server),
       body: '{',
     });
 
@@ -256,5 +272,60 @@ describe('web server command endpoint', () => {
     const payload = await response.json();
     expect(payload.error).toMatch(/invalid json payload/i);
     expect(commandAdapter.summarize).not.toHaveBeenCalled();
+  });
+
+  it('rejects command requests without a valid CSRF token', async () => {
+    const commandAdapter = {
+      summarize: vi.fn(),
+    };
+
+    const server = await startServer({ commandAdapter });
+    const response = await fetch(`${server.url}/commands/summarize`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ input: 'job.txt' }),
+    });
+
+    expect(response.status).toBe(403);
+    const payload = await response.json();
+    expect(payload.error).toMatch(/csrf/i);
+    expect(commandAdapter.summarize).not.toHaveBeenCalled();
+  });
+
+  it('rate limits repeated command requests per client', async () => {
+    const commandAdapter = {
+      summarize: vi.fn(async () => ({ ok: true })),
+    };
+
+    const server = await startServer({
+      commandAdapter,
+      rateLimit: { windowMs: 5000, max: 2 },
+    });
+
+    const headers = buildCommandHeaders(server);
+    const body = JSON.stringify({ input: 'job.txt' });
+
+    const first = await fetch(`${server.url}/commands/summarize`, {
+      method: 'POST',
+      headers,
+      body,
+    });
+    expect(first.status).toBe(200);
+
+    const second = await fetch(`${server.url}/commands/summarize`, {
+      method: 'POST',
+      headers,
+      body,
+    });
+    expect(second.status).toBe(200);
+
+    const third = await fetch(`${server.url}/commands/summarize`, {
+      method: 'POST',
+      headers,
+      body,
+    });
+    expect(third.status).toBe(429);
+    expect(await third.json()).toMatchObject({ error: expect.stringMatching(/too many/i) });
+    expect(commandAdapter.summarize).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- enforce a startup-provided CSRF header and in-memory rate limiter on the Express command endpoint, exposing the generated token via the startup descriptor and CLI script
- document the CSRF requirement, rate limiting behavior, and startup log in the README and security roadmap
- extend the web server tests to cover missing-CSRF failures and per-client throttling semantics

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68dc4eec0ec0832fbe08107ff563916f