### PR TITLE
Gate native web CLI execution behind feature flag

### DIFF
--- a/docs/web-interface-roadmap.md
+++ b/docs/web-interface-roadmap.md
@@ -129,7 +129,14 @@
      future web endpoints inherit consistent payload validation.
 
 2. **CLI Integration Layer**
-   - Implement real CLI invocations behind feature flags.
+  - Implement real CLI invocations behind feature flags.
+    _Implemented (2025-12-30):_ [`src/web/command-adapter.js`](../src/web/command-adapter.js)
+    now requires setting `JOBBOT_WEB_ENABLE_NATIVE_CLI=1` (or passing
+    `enableNativeCli: true` to [`startWebServer`](../src/web/server.js))
+    before spawning the CLI. Otherwise callers must inject a mocked
+    adapter. Regression coverage in
+    [`test/web-command-adapter.test.js`](../test/web-command-adapter.test.js)
+    asserts native execution stays gated behind the feature flag.
    - Add structured logging, metrics, and error handling utilities.
      _Implemented (2025-12-20):_ [`src/web/server.js`](../src/web/server.js)
      now emits structured `web.command` telemetry for every command request,

--- a/src/web/command-adapter.js
+++ b/src/web/command-adapter.js
@@ -109,7 +109,9 @@ function resolveNativeCliFlag(value) {
     return value;
   }
   if (typeof value === 'number') {
-    return Number(value) !== 0;
+    const numericValue = Number(value);
+    if (!Number.isFinite(numericValue)) return false;
+    return numericValue !== 0;
   }
   if (typeof value === 'string') {
     const normalized = value.trim().toLowerCase();

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -371,10 +371,12 @@ export function startWebServer(options = {}) {
     csrfHeaderName,
     rateLimit,
     logger,
+    enableNativeCli,
     ...rest
   } = options;
   const commandAdapter =
-    providedCommandAdapter ?? createCommandAdapter({ logger, ...(commandAdapterOptions ?? {}) });
+    providedCommandAdapter ??
+    createCommandAdapter({ logger, enableNativeCli, ...(commandAdapterOptions ?? {}) });
   const resolvedCsrfToken =
     typeof providedCsrfToken === 'string' && providedCsrfToken.trim()
       ? providedCsrfToken.trim()

--- a/test/web-command-adapter.test.js
+++ b/test/web-command-adapter.test.js
@@ -198,6 +198,14 @@ describe('createCommandAdapter', () => {
     expect(cli.cmdSummarize).not.toHaveBeenCalled();
   });
 
+  it('treats non-finite numeric enableNativeCli options as disabled', async () => {
+    const adapter = createCommandAdapter({ enableNativeCli: Number(undefined) });
+
+    await expect(
+      adapter.summarize({ input: 'job.txt' }),
+    ).rejects.toMatchObject({ code: 'NATIVE_CLI_DISABLED' });
+  });
+
   it('throws when required match arguments are missing', async () => {
     const cli = { cmdMatch: vi.fn() };
     const adapter = createCommandAdapter({ cli });

--- a/test/web-command-adapter.test.js
+++ b/test/web-command-adapter.test.js
@@ -206,6 +206,14 @@ describe('createCommandAdapter', () => {
     ).rejects.toMatchObject({ code: 'NATIVE_CLI_DISABLED' });
   });
 
+  it('treats non-finite numeric enableNativeCli options as disabled', async () => {
+    const adapter = createCommandAdapter({ enableNativeCli: Number(undefined) });
+
+    await expect(
+      adapter.summarize({ input: 'job.txt' }),
+    ).rejects.toMatchObject({ code: 'NATIVE_CLI_DISABLED' });
+  });
+
   it('throws when required match arguments are missing', async () => {
     const cli = { cmdMatch: vi.fn() };
     const adapter = createCommandAdapter({ cli });

--- a/test/web-command-adapter.test.js
+++ b/test/web-command-adapter.test.js
@@ -3,7 +3,7 @@ vi.mock('node:child_process', async () => {
   return { ...actual, spawn: vi.fn() };
 });
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -14,8 +14,20 @@ import * as childProcess from 'node:child_process';
 import { createCommandAdapter } from '../src/web/command-adapter.js';
 
 describe('createCommandAdapter', () => {
+  let originalEnableNativeCli;
+
+  beforeEach(() => {
+    originalEnableNativeCli = process.env.JOBBOT_WEB_ENABLE_NATIVE_CLI;
+    delete process.env.JOBBOT_WEB_ENABLE_NATIVE_CLI;
+  });
+
   afterEach(() => {
     childProcess.spawn.mockReset();
+    if (originalEnableNativeCli === undefined) {
+      delete process.env.JOBBOT_WEB_ENABLE_NATIVE_CLI;
+    } else {
+      process.env.JOBBOT_WEB_ENABLE_NATIVE_CLI = originalEnableNativeCli;
+    }
   });
 
   function createTempJobFile(contents = 'Role: Example Engineer') {
@@ -350,6 +362,7 @@ describe('createCommandAdapter', () => {
   });
 
   it('spawns the CLI without shell interpolation when no cli module is provided', async () => {
+    process.env.JOBBOT_WEB_ENABLE_NATIVE_CLI = '1';
     const spawnMock = childProcess.spawn;
     spawnMock.mockImplementation((command, args, options) => {
       expect(command).toBe(process.execPath);
@@ -385,6 +398,7 @@ describe('createCommandAdapter', () => {
   });
 
   it('propagates stderr when the spawned CLI exits with a non-zero code', async () => {
+    process.env.JOBBOT_WEB_ENABLE_NATIVE_CLI = 'true';
     const spawnMock = childProcess.spawn;
     spawnMock.mockImplementation(() =>
       createSpawnedProcess({ stdout: '', stderr: 'boom\n', exitCode: 2 }),
@@ -402,5 +416,14 @@ describe('createCommandAdapter', () => {
     } finally {
       temp.cleanup();
     }
+  });
+
+  it('requires enabling native CLI execution when no inline adapter is provided', async () => {
+    const adapter = createCommandAdapter({ enableNativeCli: false });
+
+    await expect(adapter.summarize({ input: 'job.txt' })).rejects.toThrow(
+      /native cli execution is disabled/i,
+    );
+    expect(childProcess.spawn).not.toHaveBeenCalled();
   });
 });

--- a/test/web-server-integration.test.js
+++ b/test/web-server-integration.test.js
@@ -1,0 +1,108 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { startWebServer } from '../src/web/server.js';
+
+let tempDir;
+let previousDataDir;
+let previousEnableNativeCli;
+let activeServer;
+
+describe('web server integration with CLI', () => {
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-web-int-'));
+    previousDataDir = process.env.JOBBOT_DATA_DIR;
+    previousEnableNativeCli = process.env.JOBBOT_WEB_ENABLE_NATIVE_CLI;
+    process.env.JOBBOT_DATA_DIR = tempDir;
+    process.env.JOBBOT_WEB_ENABLE_NATIVE_CLI = '1';
+  });
+
+  afterEach(async () => {
+    if (activeServer) {
+      await activeServer.close();
+      activeServer = null;
+    }
+
+    if (previousDataDir === undefined) {
+      delete process.env.JOBBOT_DATA_DIR;
+    } else {
+      process.env.JOBBOT_DATA_DIR = previousDataDir;
+    }
+
+    if (previousEnableNativeCli === undefined) {
+      delete process.env.JOBBOT_WEB_ENABLE_NATIVE_CLI;
+    } else {
+      process.env.JOBBOT_WEB_ENABLE_NATIVE_CLI = previousEnableNativeCli;
+    }
+
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      tempDir = undefined;
+    }
+  });
+
+  it('executes the match command via the real CLI in a sandboxed data dir', async () => {
+    const resumePath = path.join(tempDir, 'resume.txt');
+    const jobPath = path.join(tempDir, 'job.txt');
+
+    await fs.writeFile(
+      resumePath,
+      [
+        'Jane Doe',
+        'Senior software engineer with extensive Node.js experience.',
+        'Skilled at designing resilient distributed systems.',
+      ].join('\n'),
+      'utf8',
+    );
+
+    await fs.writeFile(
+      jobPath,
+      [
+        'Title: Staff Software Engineer',
+        'Company: Example Labs',
+        'Location: Remote',
+        'Requirements:',
+        '- Node.js',
+        '- Distributed systems',
+      ].join('\n'),
+      'utf8',
+    );
+
+    activeServer = await startWebServer({
+      host: '127.0.0.1',
+      port: 0,
+      csrfToken: 'test-csrf-token',
+      rateLimit: { windowMs: 1000, max: 10 },
+    });
+
+    const response = await fetch(`${activeServer.url}/commands/match`, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        [activeServer.csrfHeaderName]: activeServer.csrfToken,
+      },
+      body: JSON.stringify({
+        resume: resumePath,
+        job: jobPath,
+        format: 'json',
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+
+    expect(payload).toMatchObject({
+      command: 'match',
+      format: 'json',
+    });
+    expect(payload.stdout).toContain('"score"');
+    expect(payload.data).toMatchObject({
+      title: 'Staff Software Engineer',
+      company: 'Example Labs',
+    });
+    expect(payload.data.requirements).toEqual(['Node.js', 'Distributed systems']);
+  });
+});


### PR DESCRIPTION
what: gate web command adapter spawns behind JOBBOT_WEB_ENABLE_NATIVE_CLI
why: align roadmap by requiring explicit opt-in before spawning the CLI
how to test:
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68de046f0824832f8bcb516fe65d4f53