### PR TITLE
Add integration test for web command execution

### DIFF
--- a/docs/web-interface-roadmap.md
+++ b/docs/web-interface-roadmap.md
@@ -137,7 +137,12 @@
      The regression coverage in
      [`test/web-server.test.js`](../test/web-server.test.js) asserts both
      success and failure logs remain wired without leaking sensitive fields.
-   - Write integration tests that execute representative CLI commands in a sandboxed environment.
+  - Write integration tests that execute representative CLI commands in a sandboxed environment.
+    _Implemented (2025-12-22):_ [`test/web-server-integration.test.js`](../test/web-server-integration.test.js)
+    now boots the Express server with the real command adapter, calls the `match`
+    endpoint against sandboxed resume and job fixtures, verifies sanitized JSON
+    responses, and asserts job snapshots land inside the temporary
+    `JOBBOT_DATA_DIR` so web requests never escape their test environment.
    _Update (2025-11-30):_ The Express app now exposes `POST /commands/:command`, which validates
    requests against an allow-listed schema before delegating to the CLI via
    `createCommandAdapter`. Coverage in

--- a/test/web-server-integration.test.js
+++ b/test/web-server-integration.test.js
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const activeServers = [];
+const tempDirs = [];
+
+async function createTempDir() {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'jobbot-web-int-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+async function startServer(options) {
+  const { startWebServer } = await import('../src/web/server.js');
+  const server = await startWebServer({
+    host: '127.0.0.1',
+    port: 0,
+    csrfToken: 'integration-csrf-token',
+    rateLimit: { windowMs: 1000, max: 20 },
+    ...options,
+  });
+  activeServers.push(server);
+  return server;
+}
+
+function buildHeaders(server, overrides = {}) {
+  const headerName = server?.csrfHeaderName ?? 'x-jobbot-csrf';
+  const token = server?.csrfToken ?? 'integration-csrf-token';
+  return {
+    'content-type': 'application/json',
+    [headerName]: token,
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  while (activeServers.length > 0) {
+    const server = activeServers.pop();
+    await server.close();
+  }
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+describe('web server integration with CLI', () => {
+  it('executes the match command via the real CLI in a sandboxed data dir', async () => {
+    const workspaceDir = await createTempDir();
+    const sandboxDataDir = path.join(workspaceDir, 'data');
+    const resumePath = path.join(workspaceDir, 'resume.txt');
+    const jobPath = path.join(workspaceDir, 'job.txt');
+
+    await writeFile(
+      resumePath,
+      [
+        'Summary: Built Node.js services',
+        'Experience:',
+        '- Company: Example',
+        '  Details: Node.js and Terraform',
+      ].join('\n'),
+      'utf8',
+    );
+    await writeFile(
+      jobPath,
+      [
+        'Title: Platform Engineer',
+        'Company: ExampleCorp',
+        'Location: Remote',
+        'Summary: Build systems that scale.',
+        'Requirements:',
+        '- Node.js',
+        '- Terraform',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const server = await startServer({
+      commandAdapterOptions: {
+        env: { ...process.env, JOBBOT_DATA_DIR: sandboxDataDir },
+      },
+    });
+
+    const response = await fetch(`${server.url}/commands/match`, {
+      method: 'POST',
+      headers: buildHeaders(server),
+      body: JSON.stringify({
+        resume: resumePath,
+        job: jobPath,
+        format: 'json',
+        explain: true,
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload).toMatchObject({
+      command: 'match',
+      format: 'json',
+      stderr: '',
+      data: {
+        title: 'Platform Engineer',
+        score: 100,
+        matched: ['Node.js', 'Terraform'],
+        missing: [],
+      },
+    });
+    expect(typeof payload.stdout).toBe('string');
+    const stdoutJson = JSON.parse(payload.stdout);
+    expect(stdoutJson).toMatchObject({
+      title: 'Platform Engineer',
+      score: 100,
+      matched: ['Node.js', 'Terraform'],
+      missing: [],
+    });
+    expect(Array.isArray(payload.data.evidence)).toBe(true);
+    expect(payload.data.evidence[0]).toMatchObject({ source: 'requirements' });
+
+    const jobsDir = path.join(sandboxDataDir, 'jobs');
+    const jobFiles = await readdir(jobsDir);
+    expect(jobFiles.length).toBeGreaterThan(0);
+    const snapshotPath = path.join(jobsDir, jobFiles[0]);
+    const snapshot = JSON.parse(await readFile(snapshotPath, 'utf8'));
+    expect(snapshot).toMatchObject({
+      parsed: { title: 'Platform Engineer' },
+      source: { type: 'file' },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a Vitest integration suite that boots the Express web server with the real CLI adapter and runs the match endpoint end to end in a sandboxed data dir
- document the roadmap item for CLI integration tests as implemented

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py


------
https://chatgpt.com/codex/tasks/task_e_68de046f0824832f8bcb516fe65d4f53