### PR TITLE
Add environment configuration presets for the web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1604,6 +1604,16 @@ extended by passing custom check functions to
 and failing checks so future endpoints can rely on the health contract when the
 web interface expands beyond the CLI wrappers.
 
+Environment presets now live in
+[`loadWebConfig`](src/web/config.js), which provides development, staging, and
+production defaults for hosts, ports, and rate limits. The `web:server` script
+respects `JOBBOT_WEB_ENV`, `JOBBOT_WEB_HOST`, `JOBBOT_WEB_PORT`, and matching
+rate-limit overrides (`JOBBOT_WEB_RATE_LIMIT_WINDOW_MS`,
+`JOBBOT_WEB_RATE_LIMIT_MAX`) alongside new command-line flags such as
+`--env`, `--rate-limit-window-ms`, and `--rate-limit-max`. Tests in
+[`test/web-config.test.js`](test/web-config.test.js) lock the presets and
+override hierarchy in place so deployments stay consistent across tiers.
+
 Every server start prints a one-time CSRF secret. Attach the emitted header and
 token (for example, `X-Jobbot-Csrf: <token>`) to every `POST /commands` request.
 Missing or invalid CSRF headers return `403` errors before the CLI adapter runs.

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -34,6 +34,20 @@ Unset the variable with `unset JOBBOT_DATA_DIR` (POSIX shells) or
 uses `path.resolve('data')` when the variable is not provided, so existing users
 retain their data directories.
 
+The experimental web server reads tier-aware defaults from
+[`loadWebConfig`](../src/web/config.js). Override them with:
+
+- `JOBBOT_WEB_ENV` (`development`, `staging`, or `production`) to pick a preset.
+- `JOBBOT_WEB_HOST` / `JOBBOT_WEB_PORT` to customize bind address and port.
+- `JOBBOT_WEB_RATE_LIMIT_WINDOW_MS` / `JOBBOT_WEB_RATE_LIMIT_MAX` for rate
+  limiting budgets.
+- `JOBBOT_WEB_CSRF_HEADER` / `JOBBOT_WEB_CSRF_TOKEN` to supply custom CSRF
+  metadata when embedding the backend behind a proxy.
+
+These variables mirror the new CLI flags exposed by
+`npm run web:server`; see [`test/web-config.test.js`](../test/web-config.test.js)
+for the supported combinations.
+
 ## Speech command integration
 
 `speech.js` tokenizes user-provided transcription and synthesis commands into a

--- a/docs/web-interface-roadmap.md
+++ b/docs/web-interface-roadmap.md
@@ -164,6 +164,12 @@
 6. **Hardening and Packaging**
    - Implement rate limiting, input sanitization, and CSRF tokens.
    - Add configuration for local, staging, and production environments.
+     _Implemented (2025-12-18):_ [`src/web/config.js`](../src/web/config.js)
+     centralizes environment presets (development/staging/production) and
+     powers `scripts/web-server.js` so the CLI picks up consistent hosts,
+     ports, and rate limits per tier. Regression coverage in
+     [`test/web-config.test.js`](../test/web-config.test.js) locks the
+     defaults and override semantics in place.
    - Provide Dockerfile and docker-compose for reproducible deployment.
    - Document operational playbooks (monitoring, alerting, on-call runbooks).
 
@@ -212,7 +218,9 @@
   adapter, asserting the HTTP stack, schema validation, and sanitized payloads
   round-trip real job text without mocks.
 - [ ] Accessibility and performance audits
-- [ ] Deployment artifacts and environment parity
+- [ ] Deployment artifacts and environment parity *(configuration presets
+  shipped via [`src/web/config.js`](../src/web/config.js); container images
+  remain outstanding)*
 
 ## Roadmap Timeline (Quarterly)
 

--- a/scripts/web-server.js
+++ b/scripts/web-server.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs/promises';
 import process from 'node:process';
+import { loadWebConfig } from '../src/web/config.js';
 import { startWebServer } from '../src/web/server.js';
 
 function getFlag(args, name) {
@@ -10,19 +11,22 @@ function getFlag(args, name) {
 }
 
 function printUsage() {
-  console.error('Usage: node scripts/web-server.js [--port <number>] [--host <value>]');
+  console.error(
+    'Usage: node scripts/web-server.js [--env <environment>] [--host <value>] [--port <number>] ' +
+      '[--rate-limit-window-ms <number>] [--rate-limit-max <number>] [--csrf-header <value>] ' +
+      '[--csrf-token <value>]',
+  );
 }
 
 async function main() {
   const args = process.argv.slice(2);
-  const host = getFlag(args, '--host') ?? '127.0.0.1';
-  const portArg = getFlag(args, '--port');
-  const port = portArg === undefined ? 3000 : Number(portArg);
-
-  if (Number.isNaN(port) || port < 0 || port > 65535) {
-    printUsage();
-    throw new Error('--port must be a number between 0 and 65535');
-  }
+  const env = getFlag(args, '--env');
+  const hostOverride = getFlag(args, '--host');
+  const portOverride = getFlag(args, '--port');
+  const rateWindowOverride = getFlag(args, '--rate-limit-window-ms');
+  const rateMaxOverride = getFlag(args, '--rate-limit-max');
+  const csrfHeaderOverride = getFlag(args, '--csrf-header');
+  const csrfTokenOverride = getFlag(args, '--csrf-token');
 
   let version = 'dev';
   try {
@@ -36,14 +40,37 @@ async function main() {
     // Ignore version lookup failures; fall back to "dev".
   }
 
+  let config;
+  try {
+    config = loadWebConfig({
+      env,
+      host: hostOverride,
+      port: portOverride,
+      rateLimit: {
+        windowMs: rateWindowOverride,
+        max: rateMaxOverride,
+      },
+      csrfHeaderName: csrfHeaderOverride,
+      csrfToken: csrfTokenOverride,
+      version,
+    });
+  } catch (err) {
+    printUsage();
+    throw err;
+  }
+
   const server = await startWebServer({
-    host,
-    port,
-    info: { service: 'jobbot-web', version },
+    host: config.host,
+    port: config.port,
+    info: config.info,
     healthChecks: [],
+    rateLimit: config.rateLimit,
+    csrfToken: config.csrfToken,
+    csrfHeaderName: config.csrfHeaderName,
   });
 
   console.log(`jobbot web server listening on ${server.url}`);
+  console.log(`Environment: ${config.env}`);
   console.log(
     `Attach ${server.csrfHeaderName}: ${server.csrfToken} to POST /commands requests.`,
   );

--- a/src/web/config.js
+++ b/src/web/config.js
@@ -1,0 +1,129 @@
+const DEFAULT_CONFIGS = {
+  development: {
+    host: '127.0.0.1',
+    port: 3000,
+    rateLimit: { windowMs: 60_000, max: 30 },
+  },
+  staging: {
+    host: '0.0.0.0',
+    port: 4000,
+    rateLimit: { windowMs: 60_000, max: 20 },
+  },
+  production: {
+    host: '0.0.0.0',
+    port: 8080,
+    rateLimit: { windowMs: 60_000, max: 15 },
+  },
+};
+
+function coerceEnv(value) {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.toLowerCase() : undefined;
+}
+
+function coerceHost(value, fallback) {
+  if (value == null) return fallback;
+  if (typeof value !== 'string') {
+    throw new Error('host must be a string');
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error('host must be a non-empty string');
+  }
+  return trimmed;
+}
+
+function coercePort(value, fallback) {
+  const candidate = value ?? fallback;
+  const number = typeof candidate === 'number' ? candidate : Number(candidate);
+  if (!Number.isFinite(number) || number < 0 || number > 65535) {
+    throw new Error('port must be between 0 and 65535');
+  }
+  return Math.trunc(number);
+}
+
+function coerceWindowMs(value, fallback) {
+  const candidate = value ?? fallback;
+  const number = typeof candidate === 'number' ? candidate : Number(candidate);
+  if (!Number.isFinite(number) || number <= 0) {
+    throw new Error('rate limit window must be a positive number');
+  }
+  return Math.trunc(number);
+}
+
+function coerceRateLimitMax(value, fallback) {
+  const candidate = value ?? fallback;
+  const number = typeof candidate === 'number' ? candidate : Number(candidate);
+  if (!Number.isFinite(number) || number <= 0) {
+    throw new Error('rate limit max must be a positive integer');
+  }
+  return Math.trunc(number);
+}
+
+function resolveBaseConfig(envKey) {
+  if (DEFAULT_CONFIGS[envKey]) {
+    return { env: envKey, base: DEFAULT_CONFIGS[envKey] };
+  }
+  return { env: 'development', base: DEFAULT_CONFIGS.development };
+}
+
+export function loadWebConfig(options = {}) {
+  const requestedEnv = coerceEnv(
+    options.env ?? process.env.JOBBOT_WEB_ENV ?? process.env.NODE_ENV ?? 'development',
+  );
+  const { env, base } = resolveBaseConfig(requestedEnv ?? 'development');
+
+  const host = coerceHost(
+    options.host ?? process.env.JOBBOT_WEB_HOST ?? base.host,
+    base.host,
+  );
+  const port = coercePort(options.port ?? process.env.JOBBOT_WEB_PORT, base.port);
+
+  const windowMs = coerceWindowMs(
+    options.rateLimit?.windowMs ?? process.env.JOBBOT_WEB_RATE_LIMIT_WINDOW_MS,
+    base.rateLimit.windowMs,
+  );
+  const max = coerceRateLimitMax(
+    options.rateLimit?.max ?? process.env.JOBBOT_WEB_RATE_LIMIT_MAX,
+    base.rateLimit.max,
+  );
+
+  const csrfHeaderName = coerceHost(
+    options.csrfHeaderName ?? process.env.JOBBOT_WEB_CSRF_HEADER ?? 'x-jobbot-csrf',
+    'x-jobbot-csrf',
+  ).toLowerCase();
+  const envCsrfToken =
+    process.env.JOBBOT_WEB_CSRF_TOKEN === undefined ? undefined : process.env.JOBBOT_WEB_CSRF_TOKEN;
+  const csrfTokenSource = options.csrfToken !== undefined ? options.csrfToken : envCsrfToken;
+  const csrfToken =
+    typeof csrfTokenSource === 'string' && csrfTokenSource.trim()
+      ? csrfTokenSource.trim()
+      : undefined;
+
+  const info = {
+    service: 'jobbot-web',
+    environment: env,
+  };
+  if (typeof options.version === 'string' && options.version.trim()) {
+    info.version = options.version.trim();
+  } else if (typeof process.env.JOBBOT_WEB_VERSION === 'string') {
+    const version = process.env.JOBBOT_WEB_VERSION.trim();
+    if (version) info.version = version;
+  }
+
+  return {
+    env,
+    host,
+    port,
+    rateLimit: { windowMs, max },
+    csrfHeaderName,
+    csrfToken,
+    info,
+  };
+}
+
+export function getDefaultWebConfig(env = 'development') {
+  const { base } = resolveBaseConfig(coerceEnv(env) ?? 'development');
+  return JSON.parse(JSON.stringify(base));
+}

--- a/test/web-config.test.js
+++ b/test/web-config.test.js
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const ORIGINAL_ENV = { ...process.env };
+
+function clearEnv(keys) {
+  for (const key of keys) {
+    if (ORIGINAL_ENV[key] === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = ORIGINAL_ENV[key];
+    }
+  }
+}
+
+describe('loadWebConfig', () => {
+  beforeEach(() => {
+    // Ensure tests do not inherit state from previous runs.
+    clearEnv([
+      'JOBBOT_WEB_ENV',
+      'JOBBOT_WEB_HOST',
+      'JOBBOT_WEB_PORT',
+      'JOBBOT_WEB_RATE_LIMIT_WINDOW_MS',
+      'JOBBOT_WEB_RATE_LIMIT_MAX',
+      'JOBBOT_WEB_CSRF_HEADER',
+      'JOBBOT_WEB_CSRF_TOKEN',
+    ]);
+  });
+
+  afterEach(() => {
+    clearEnv([
+      'JOBBOT_WEB_ENV',
+      'JOBBOT_WEB_HOST',
+      'JOBBOT_WEB_PORT',
+      'JOBBOT_WEB_RATE_LIMIT_WINDOW_MS',
+      'JOBBOT_WEB_RATE_LIMIT_MAX',
+      'JOBBOT_WEB_CSRF_HEADER',
+      'JOBBOT_WEB_CSRF_TOKEN',
+    ]);
+  });
+
+  it('provides development defaults when no overrides are present', async () => {
+    const { loadWebConfig } = await import('../src/web/config.js');
+    const config = loadWebConfig({ env: 'development' });
+
+    expect(config.env).toBe('development');
+    expect(config.host).toBe('127.0.0.1');
+    expect(config.port).toBe(3000);
+    expect(config.rateLimit).toEqual({ windowMs: 60000, max: 30 });
+    expect(config.csrfHeaderName).toBe('x-jobbot-csrf');
+    expect(config.info).toMatchObject({ service: 'jobbot-web', environment: 'development' });
+  });
+
+  it('exposes staging and production presets', async () => {
+    const { loadWebConfig } = await import('../src/web/config.js');
+    const staging = loadWebConfig({ env: 'staging' });
+    const production = loadWebConfig({ env: 'production' });
+
+    expect(staging.host).toBe('0.0.0.0');
+    expect(staging.port).toBe(4000);
+    expect(staging.rateLimit).toEqual({ windowMs: 60000, max: 20 });
+    expect(staging.info).toMatchObject({ environment: 'staging' });
+
+    expect(production.host).toBe('0.0.0.0');
+    expect(production.port).toBe(8080);
+    expect(production.rateLimit).toEqual({ windowMs: 60000, max: 15 });
+    expect(production.info).toMatchObject({ environment: 'production' });
+  });
+
+  it('accepts environment variables and explicit overrides', async () => {
+    process.env.JOBBOT_WEB_HOST = '10.0.0.5';
+    process.env.JOBBOT_WEB_PORT = '5123';
+    process.env.JOBBOT_WEB_RATE_LIMIT_WINDOW_MS = '120000';
+    process.env.JOBBOT_WEB_RATE_LIMIT_MAX = '9';
+    process.env.JOBBOT_WEB_CSRF_HEADER = 'x-test-csrf';
+
+    const { loadWebConfig } = await import('../src/web/config.js');
+    const config = loadWebConfig({ env: 'development', rateLimit: { max: 5 } });
+
+    expect(config.host).toBe('10.0.0.5');
+    expect(config.port).toBe(5123);
+    expect(config.rateLimit).toEqual({ windowMs: 120000, max: 5 });
+    expect(config.csrfHeaderName).toBe('x-test-csrf');
+
+    const overridden = loadWebConfig({
+      env: 'production',
+      host: '192.168.1.2',
+      port: 9090,
+      rateLimit: { windowMs: 30000, max: 7 },
+    });
+    expect(overridden.host).toBe('192.168.1.2');
+    expect(overridden.port).toBe(9090);
+    expect(overridden.rateLimit).toEqual({ windowMs: 30000, max: 7 });
+  });
+
+  it('throws when provided ports or rate limits are invalid', async () => {
+    const { loadWebConfig } = await import('../src/web/config.js');
+
+    expect(() =>
+      loadWebConfig({ env: 'development', port: -1 }),
+    ).toThrow(/port must be between 0 and 65535/i);
+    expect(() => loadWebConfig({ env: 'development', rateLimit: { windowMs: 0 } })).toThrow(
+      /rate limit window must be a positive number/i,
+    );
+    expect(() => loadWebConfig({ env: 'development', rateLimit: { max: 0 } })).toThrow(
+      /rate limit max must be a positive integer/i,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `loadWebConfig` to supply development, staging, and production presets plus override handling for the web server
- update `scripts/web-server.js` to consume the centralized config and expose new CLI flags while documenting the feature in README and platform support docs
- record progress in the web interface roadmap and add `test/web-config.test.js` to cover defaults, presets, overrides, and invalid inputs

## Testing
- npm run lint
- npm run test:ci


------
https://chatgpt.com/codex/tasks/task_e_68de046f0824832f8bcb516fe65d4f53