### PR TITLE
Add deployment Docker assets for web server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# syntax=docker/dockerfile:1.7
+FROM node:20-slim AS base
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+FROM node:20-slim AS runtime
+ENV NODE_ENV=production
+WORKDIR /app
+COPY --from=base /app/node_modules ./node_modules
+COPY package.json package-lock.json ./
+COPY bin ./bin
+COPY src ./src
+COPY scripts ./scripts
+COPY docs ./docs
+RUN mkdir -p /data && chown node:node /data
+EXPOSE 3000
+VOLUME ["/data"]
+USER node
+CMD ["node", "scripts/web-server.js", "--env", "production", "--host", "0.0.0.0"]

--- a/docker-compose.web.yml
+++ b/docker-compose.web.yml
@@ -1,0 +1,23 @@
+version: "3.9"
+services:
+  web:
+    image: jobbot3000-web:latest
+    build:
+      context: .
+      target: runtime
+    environment:
+      - JOBBOT_WEB_ENV=production
+      - JOBBOT_WEB_HOST=0.0.0.0
+      - JOBBOT_WEB_PORT=3000
+      - JOBBOT_DATA_DIR=/data
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./data:/data
+    command:
+      - node
+      - scripts/web-server.js
+      - --env
+      - production
+      - --host
+      - 0.0.0.0

--- a/docs/web-interface-roadmap.md
+++ b/docs/web-interface-roadmap.md
@@ -230,9 +230,15 @@
   adapter, asserting the HTTP stack, schema validation, and sanitized payloads
   round-trip real job text without mocks.
 - [ ] Accessibility and performance audits
-- [ ] Deployment artifacts and environment parity *(configuration presets
+- [x] Deployment artifacts and environment parity *(configuration presets
   shipped via [`src/web/config.js`](../src/web/config.js); container images
-  remain outstanding)*
+  now ship with the repository)*
+  _Implemented (2025-12-30):_ [`Dockerfile`](../Dockerfile) and
+  [`docker-compose.web.yml`](../docker-compose.web.yml) now build the web
+  server with production defaults, mount `/data`, and bind to
+  `0.0.0.0`. Regression coverage in
+  [`test/web-deployment.test.js`](../test/web-deployment.test.js) keeps the
+  artifacts present and pinned to the hardened entrypoint.
 
 ## Roadmap Timeline (Quarterly)
 

--- a/test/web-deployment.test.js
+++ b/test/web-deployment.test.js
@@ -1,0 +1,23 @@
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+import { describe, it, expect } from 'vitest';
+
+const repoRoot = path.resolve(__dirname, '..');
+
+describe('web deployment artifacts', () => {
+  it('ships a Dockerfile for the web server', async () => {
+    const dockerfilePath = path.join(repoRoot, 'Dockerfile');
+    const dockerfile = await readFile(dockerfilePath, 'utf8');
+    expect(dockerfile).toContain('FROM node:20-slim AS base');
+    expect(dockerfile).toContain('npm ci --omit=dev');
+    expect(dockerfile).toContain('CMD ["node", "scripts/web-server.js"');
+  });
+
+  it('provides a docker-compose definition wiring the web server defaults', async () => {
+    const composePath = path.join(repoRoot, 'docker-compose.web.yml');
+    const compose = await readFile(composePath, 'utf8');
+    expect(compose).toContain('services:');
+    expect(compose).toContain('JOBBOT_WEB_ENV=production');
+    expect(compose).toContain('JOBBOT_DATA_DIR=/data');
+  });
+});

--- a/test/web-deployment.test.js
+++ b/test/web-deployment.test.js
@@ -1,7 +1,9 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { readFile } from 'node:fs/promises';
 import { describe, it, expect } from 'vitest';
 
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 
 describe('web deployment artifacts', () => {


### PR DESCRIPTION
## Summary
- add a multi-stage Dockerfile and docker-compose.web.yml to run the web server with production defaults
- add Vitest coverage that locks the Dockerfile and compose wiring to the hardened entrypoint
- mark the deployment artifacts checklist item in the web interface roadmap as implemented with test references

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68dec1a22954832fa75c14c0dfeac2c3