### PR TITLE
Add static authorization guard to the web command endpoint

### DIFF
--- a/docs/web-interface-roadmap.md
+++ b/docs/web-interface-roadmap.md
@@ -158,7 +158,15 @@
 
 3. **Frontend Shell**
    - Set up routing, layout, and theme providers.
-   - Implement authentication stubs if future remote deployment is anticipated.
+  - Implement authentication stubs if future remote deployment is anticipated.
+    _Implemented (2025-12-13):_ [`src/web/server.js`](../src/web/server.js)
+    now enforces configurable static authorization tokens for
+    `/commands/:command` requests when `startWebServer` receives `auth`
+    options or the `JOBBOT_WEB_AUTH_TOKENS` environment variable. Callers
+    can override the header name and scheme (including scheme-less API
+    keys), and unauthorized requests receive 401 responses. Coverage in
+    [`test/web-server.test.js`](../test/web-server.test.js) exercises the
+    missing-token guard, Bearer token flow, and custom header handling.
    - Create base components and loading/error states.
 
 4. **Core Features**


### PR DESCRIPTION
## Summary
- closed the "Implement authentication stubs" roadmap item by requiring configurable auth tokens on `/commands/:command`
- added start-up wiring for token sources (options or `JOBBOT_WEB_AUTH_TOKENS`) and surfaced header metadata from `startWebServer`
- documented the shipped behavior in the web interface roadmap alongside regression coverage

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

## Test matrix
| Scenario | Coverage |
| --- | --- |
| Missing or malformed auth token returns 401 | `test/web-server.test.js` "requires a valid authorization token when configured" |
| Valid Bearer token executes command | Same test |
| Custom header without scheme succeeds | `test/web-server.test.js` "supports custom authorization headers without schemes" |


------
https://chatgpt.com/codex/tasks/task_e_68dec1a22954832fa75c14c0dfeac2c3