### PR TITLE
Add blockers alias to match payload and build log summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,10 +482,13 @@ the flag is supplied. JSON payloads also include `skills_hit` and `skills_gap` a
 matched/missing sections so downstream tools can treat them as normalized competency buckets without
 having to re-scan Markdown output. A `must_haves_missed` array lists missing requirements flagged as
 blockers (for example, entries containing 'must have', 'required', or specific clearance language)
-so downstream tooling can highlight hard-stops without re-parsing the text. A `keyword_overlap` array
-surfaces the lower-cased tokens and synonym phrases that triggered a match so follow-up tooling can
-see which concrete words or abbreviations aligned without recomputing overlaps. The list is capped
-at 12 entries and cached per resume/requirement pairing to keep repeated evaluations (like multi-job
+so downstream tooling can highlight hard-stops without re-parsing the text. The payload also mirrors
+those entries in a `blockers` array so deliverable logs and integrations can count must-haves without
+recomputing heuristics. Regression coverage in [`test/match.test.js`](test/match.test.js) and
+[`test/cli.test.js`](test/cli.test.js) keeps the alias and build-log summary aligned. A `keyword_overlap`
+array surfaces the lower-cased tokens and synonym phrases that triggered a match so follow-up tooling can
+see which concrete words or abbreviations aligned without recomputing overlaps. The list is capped at 12
+entries and cached per resume/requirement pairing to keep repeated evaluations (like multi-job
 comparisons) fast. Extremely large resumes (more than 5,000 unique tokens) skip overlap extraction to
 preserve cold-start latency targets.
 

--- a/src/match.js
+++ b/src/match.js
@@ -42,6 +42,7 @@ export function matchResumeToJob(resumeText, jobInput, options = {}) {
     resumeText,
     requirements,
   );
+  const blockers = Array.isArray(must_haves_missed) ? must_haves_missed.slice() : [];
 
   const payload = {
     ...parsedJob,
@@ -52,6 +53,7 @@ export function matchResumeToJob(resumeText, jobInput, options = {}) {
     skills_hit: matched,
     skills_gap: missing,
     must_haves_missed,
+    blockers,
     keyword_overlap,
     evidence,
   };

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -2202,7 +2202,12 @@ describe('jobbot CLI', () => {
         company: 'ExampleCorp',
         location: 'Remote',
         summary: 'Keep Node.js infrastructure reliable while expanding Terraform coverage.',
-        requirements: ['Node.js experience', 'Terraform automation', 'Clear communication'],
+        requirements: [
+          'Node.js experience',
+          'Terraform automation',
+          'Clear communication',
+          'Security clearance required',
+        ],
       },
       source: { type: 'url', value: jobSource, headers: {} },
     };
@@ -2265,12 +2270,14 @@ describe('jobbot CLI', () => {
       locale: 'en',
       matched_count: matchJson.matched.length,
       missing_count: matchJson.missing.length,
+      blockers_count: matchJson.blockers.length,
     });
     expect(typeof buildLog.match_summary.score).toBe('number');
     expect(matchJson.title).toBe('Platform Engineer');
     expect(matchJson.company).toBe('ExampleCorp');
     expect(matchJson.matched).toContain('Node.js experience');
     expect(matchJson.matched).toContain('Terraform automation');
+    expect(matchJson.blockers).toEqual(['Security clearance required']);
 
     const matchMarkdown = fs.readFileSync(path.join(runDir, 'match.md'), 'utf8');
     expect(matchMarkdown).toContain('# Platform Engineer');

--- a/test/match.test.js
+++ b/test/match.test.js
@@ -32,6 +32,7 @@ describe('matchResumeToJob', () => {
       matched: ['Experience with Node.js', 'Terraform proficiency'],
       missing: ['Must have Kubernetes certification'],
       must_haves_missed: ['Must have Kubernetes certification'],
+      blockers: ['Must have Kubernetes certification'],
     });
 
     expect(result.skills_hit).toEqual(result.matched);


### PR DESCRIPTION
## Summary
- inventory: README documents build.json blocker counts, but match payload lacked a blockers array so the summary stayed at zero
- expose a blockers alias on match payloads and propagate the count into tailor build logs
- document the alias and extend match/CLI tests to keep blockers and build summaries aligned

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68df7e01f528832fba0a3dfabca0bd16