### PR TITLE
Remove PR Reaper references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![CI](https://img.shields.io/github/actions/workflow/status/futuroptimist/jobbot3000/.github/workflows/ci.yml?label=ci)](https://github.com/futuroptimist/jobbot3000/actions/workflows/ci.yml)
 [![CodeQL](https://img.shields.io/github/actions/workflow/status/futuroptimist/jobbot3000/.github/workflows/codeql.yml?label=codeql)](https://github.com/futuroptimist/jobbot3000/actions/workflows/codeql.yml)
-[![PR Reaper](https://img.shields.io/github/actions/workflow/status/futuroptimist/jobbot3000/.github/workflows/pr-reaper.yml?label=pr%20reaper)](https://github.com/futuroptimist/jobbot3000/actions/workflows/pr-reaper.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](#license)
 
 **jobbot3000** is a self-hosted, open-source job search copilot.

--- a/docs/prompts/codex/ci.md
+++ b/docs/prompts/codex/ci.md
@@ -22,7 +22,7 @@ CONTEXT:
 - Follow [README.md](../../../README.md); see the
   [AGENTS spec](https://agentsmd.net/AGENTS.md) for instruction semantics.
 - Review [.github/workflows](../../../.github/workflows) to understand active automation
-  (e.g., `ci.yml`, `codeql.yml`, `pr-reaper.yml`).
+  (e.g., `ci.yml`, `codeql.yml`).
 - When touching `ci.yml`, preserve the Node 20 toolchain, npm cache, and required steps:
   `npm ci`, `npm run lint`, `npm run test:ci`, and
 - Aim for 100% patch coverage to minimize regressions and surprises.


### PR DESCRIPTION
## Summary
- remove the PR Reaper badge from the README
- update the CI prompt docs to only cite active workflows

## Testing
- n/a (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e1aad4f50c832fba7a36710da3c92f