### PR TITLE
Add custom calendar name flag for reminder ICS export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1571,8 +1571,9 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track reminders --json | jq '.sections[0]'
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot track reminders --ics reminders.ics --now 2025-03-06T00:00:00Z
 # Saved reminder calendar to /tmp/jobbot-data/reminders.ics
 # Import the ICS into your local calendar to receive native alerts for upcoming reminders
-# (past-due entries are omitted from the feed by design). The test suite locks in
-# the calendar escaping rules so commas, semicolons, and newlines survive import
+# (past-due entries are omitted from the feed by design). Add --calendar-name "Coaching Reminders"
+# to label the feed in calendar clients instead of the default "jobbot3000 Reminders" name. The
+# test suite locks in the calendar escaping rules so commas, semicolons, and newlines survive import
 # in native calendar clients.
 ```
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -165,7 +165,8 @@ aggressively to respect rate limits.
     also run `jobbot track reminders --ics <file>` to publish upcoming reminders as an iCalendar
     feed; the export omits past-due entries and preserves newline formatting (commas and semicolons
     are escaped to satisfy the iCalendar spec) so native calendar apps emit local notifications
-    without additional scripting.
+    without additional scripting. Pass `--calendar-name <label>` to override the default
+    "jobbot3000 Reminders" calendar title when subscribing multiple feeds.
 
 **Unhappy paths:** conflicting updates (e.g., two devices editing simultaneously) trigger a merge
 flow that preserves both sets of notes.

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -883,6 +883,40 @@ describe('jobbot CLI', () => {
     expect(ics).not.toContain('job-past-due');
   });
 
+  it('allows customizing the ICS calendar name with --calendar-name', () => {
+    runCli([
+      'track',
+      'log',
+      'job-calendar-name',
+      '--channel',
+      'call',
+      '--date',
+      '2025-03-05T10:00:00Z',
+      '--note',
+      'Prep talking points',
+      '--contact',
+      'Jamie Hiring Manager',
+      '--remind-at',
+      '2025-03-10T15:00:00Z',
+    ]);
+
+    const calendarPath = path.join(dataDir, 'custom-name.ics');
+    runCli([
+      'track',
+      'reminders',
+      '--ics',
+      calendarPath,
+      '--calendar-name',
+      'Coaching Reminders',
+      '--now',
+      '2025-03-06T00:00:00Z',
+    ]);
+
+    const ics = fs.readFileSync(calendarPath, 'utf8');
+    expect(ics).toContain('NAME:Coaching Reminders');
+    expect(ics).toContain('X-WR-CALNAME:Coaching Reminders');
+  });
+
   it('prints headings with (none) when reminders are filtered out', () => {
     runCli([
       'track',


### PR DESCRIPTION
## Summary
- allow `jobbot track reminders` to accept `--calendar-name` when exporting ICS feeds
- document the new flag in the README and journey notes
- cover calendar naming with a CLI regression test

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
https://chatgpt.com/codex/tasks/task_e_68e1b6f75d8c832fa8a7ed35657c8b32