### PR TITLE
🛠️ : – Fix future-dated documentation references

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,4 +119,4 @@ New contributors can follow this checklist to ramp up quickly:
 4. Run `npm run lint` and `npm run test:ci` before committing changes.
 5. Use the fixtures in `test/fixtures/` when writing new ingestion or resume parsing tests.
 
-_Last updated: 2025-10-08._
+_Last updated: 2025-09-24._

--- a/docs/simplification_suggestions.md
+++ b/docs/simplification_suggestions.md
@@ -10,11 +10,11 @@ New contributors must infer relationships by reading files such as
 [`src/analytics.js`](../src/analytics.js). Creating a lightweight architecture map would shorten
 onboarding and highlight reuse opportunities.
 
-_Update (2025-10-08):_ [`docs/architecture.md`](architecture.md) now documents the high-level
+_Update (2025-09-24):_ [`docs/architecture.md`](architecture.md) now documents the high-level
 module graph, data directories, and onboarding checklist linked from the README so new contributors
 can ramp without spelunking through individual files first.
 
-_Update (2025-11-10):_ The host queue helper in [`src/fetch.js`](../src/fetch.js) now links directly
+_Update (2025-09-28):_ The host queue helper in [`src/fetch.js`](../src/fetch.js) now links directly
 to the architecture map so engineers debugging rate limits can jump from the code to the onboarding
 diagram immediately.
 
@@ -34,17 +34,17 @@ Multiple files implement vendor-specific logic (`src/ashby.js`, `src/greenhouse.
 normalizing jobs, yet the calling conventions vary. A shared interface would remove repetitive
 boilerplate and clarify extension points.
 
-_Update (2025-10-06):_ `src/adapters/job-source.js` now defines the shared
+_Update (2025-09-24):_ `src/adapters/job-source.js` now defines the shared
 `JobSourceAdapter` contract. Each connector exports a provider-specific adapter that implements
 `listOpenings`, `normalizeJob`, and `toApplicationEvent`, and the ingestion flows have been wired to
 use those adapters directly.
 
-_Update (2025-10-21):_ `src/jobs/adapters/common.js` centralizes adapter helpers so connectors share
+_Update (2025-09-24):_ `src/jobs/adapters/common.js` centralizes adapter helpers so connectors share
 rate-limit resolution, pagination, and snapshot normalization. Coverage in
 `test/jobs-adapters-common.test.js` keeps the rate-limit override, paginated fetcher, and snapshot
 metadata aligned across providers.
 
-_Update (2025-11-12):_ [`docs/job-source-adapters-guide.md`](job-source-adapters-guide.md) now
+_Update (2025-09-28):_ [`docs/job-source-adapters-guide.md`](job-source-adapters-guide.md) now
 documents the `JobSourceAdapter` contract, quick-start checklist, and regression tests for new
 providers so contributors can ship connectors without spelunking through existing modules.
 
@@ -63,18 +63,18 @@ scoring are spread across [`src/profile.js`](../src/profile.js), [`src/scoring.j
 and [`src/application-events.js`](../src/application-events.js). Splitting the pipeline into distinct
 stages would make it easier to reason about transformations.
 
-_Update (2025-10-17):_ [`src/pipeline/resume-pipeline.js`](../src/pipeline/resume-pipeline.js)
+_Update (2025-09-24):_ [`src/pipeline/resume-pipeline.js`](../src/pipeline/resume-pipeline.js)
 introduces a typed, stage-driven resume pipeline. The new
 [`test/resume-pipeline.test.js`](../test/resume-pipeline.test.js) table-drives markdown and text
 fixtures through the pipeline, asserting each stage's output (source metadata, ATS warnings,
 ambiguity heuristics, and confidence metrics) so future refactors can extend the stages with
 confidence.
 
-_Update (2025-10-26):_ [`docs/resume-pipeline-guide.md`](resume-pipeline-guide.md) now documents how
+_Update (2025-09-26):_ [`docs/resume-pipeline-guide.md`](resume-pipeline-guide.md) now documents how
 to insert new stages, mutate the shared context safely, and extend the pipeline's regression suite so
 contributors can grow the enrichment flow without spelunking through implementation details.
 
-_Update (2025-11-18):_ The resume pipeline now includes an explicit `normalize` stage that organizes
+_Update (2025-09-28):_ The resume pipeline now includes an explicit `normalize` stage that organizes
 plain-text resumes into canonical sections (`experience`, `skills`, `projects`, and a `body`
 fallback), counts trimmed lines and words, and exposes the summary via
 `context.normalizedResume`/`normalized` for downstream enrichment.
@@ -104,11 +104,11 @@ would cut coordination overhead.
   that `docs/prompt-docs-summary.md` only references existing files. The chore coverage lives in
   `test/chore-prompts.test.js`, which gives the spellcheck up to 20 seconds on CI to absorb
   occasional npm start-up slowness.
-- _Update (2025-10-30):_ `npm run chore:prompts` also validates relative Markdown links within
+- _Update (2025-09-26):_ `npm run chore:prompts` also validates relative Markdown links within
   `docs/prompts/**`. The expanded suite in [`test/chore-prompts.test.js`](../test/chore-prompts.test.js)
   now creates a throwaway prompt doc with a broken link and expects the chore to fail with a "Broken
   Markdown links" error, keeping the prompt catalog discoverable.
-- _Update (2025-11-04):_ The prompts chore now enforces Prettier formatting for changed prompt docs
+- _Update (2025-09-26):_ The prompts chore now enforces Prettier formatting for changed prompt docs
   (pass `--write`/`--fix` and `--all` to auto-format the entire catalog) so headings, lists, and
   tables stay consistent across the catalog.
 - `npm run chore:reminders` prints the catalog as either a human-readable digest or JSON (pass
@@ -123,18 +123,18 @@ expose powerful primitives (custom retry queues, sentence parsing) but require c
 intricate details. Introducing thin wrappers would preserve flexibility while providing ergonomic
 entry points.
 
-_Update (2025-10-12):_ [`src/services/http.js`](../src/services/http.js) now exposes a
+_Update (2025-09-24):_ [`src/services/http.js`](../src/services/http.js) now exposes a
 `createHttpClient` helper that centralizes rate limits, default headers, and request timeouts for
 ATS connectors. Tests in [`test/services-http.test.js`](../test/services-http.test.js) cover header
 merging, rate-limit propagation, and timeout behavior.
 
-_Update (2025-10-14):_ [`src/sentence-extractor.js`](../src/sentence-extractor.js) implements a
+_Update (2025-09-24):_ [`src/sentence-extractor.js`](../src/sentence-extractor.js) implements a
 reusable `SentenceExtractor` iterator with `next()` and `reset()` methods that powers
 [`summarize`](../src/index.js). Coverage in
 [`test/sentence-extractor.test.js`](../test/sentence-extractor.test.js) exercises sequential
 extraction, iterator resets, and decimal-number safety.
 
-_Update (2025-10-15):_ The README now ships a runnable `createHttpClient` example, and the helper's
+_Update (2025-09-24):_ The README now ships a runnable `createHttpClient` example, and the helper's
 JSDoc includes the same snippet so connectors can copy/paste the pattern without spelunking through
 tests.
 

--- a/docs/web-interface-roadmap.md
+++ b/docs/web-interface-roadmap.md
@@ -59,7 +59,7 @@
   rely on backend for persistence.
 - **Observability**: Structured logging (pino/winston) capturing command, duration, exit codes, and
   correlation IDs; expose health and readiness probes.
-  _Implemented (2025-11-27):_ [`src/web/command-adapter.js`](../src/web/command-adapter.js)
+  _Implemented (2025-09-29):_ [`src/web/command-adapter.js`](../src/web/command-adapter.js)
   now emits JSON-friendly telemetry for each CLI invocation, including the
   command name, correlation ID, duration, and synthesized exit code. Regression
   coverage in [`test/web-command-adapter.test.js`](../test/web-command-adapter.test.js)
@@ -73,7 +73,7 @@
 - Validate payloads with a shared schema library (e.g., Zod) on both frontend and backend to ensure
   alignment.
 - Avoid shell invocation; use `spawn`/`execFile` with explicit argument arrays.
-  _Implemented (2025-12-06):_ [`src/web/command-adapter.js`](../src/web/command-adapter.js)
+  _Implemented (2025-09-30):_ [`src/web/command-adapter.js`](../src/web/command-adapter.js)
   now executes CLI commands via `child_process.spawn` with `shell: false`,
   `windowsHide: true`, and explicit argument arrays. The adapter streams
   stdout/stderr, rejects on non-zero exit codes, and surfaces correlation IDs
@@ -82,7 +82,7 @@
   verifies the secure spawn configuration and error propagation when the CLI
   process fails.
 - Apply rate limiting and CSRF defenses even in local deployments to simplify production hardening.
-  _Implemented (2025-12-11):_ [`src/web/server.js`](../src/web/server.js) now enforces a
+  _Implemented (2025-09-30):_ [`src/web/server.js`](../src/web/server.js) now enforces a
   startup-provided CSRF header and in-memory per-client rate limiting on
   `POST /commands`. Coverage in [`test/web-server.test.js`](../test/web-server.test.js)
   verifies 403 responses for missing tokens and 429 responses once
@@ -100,8 +100,8 @@
 - Create reusable components (buttons, tables, timeline, status badges) adhering to the token system.
 - Provide responsive layouts using a grid/flex approach; ensure minimum touch target sizes for mobile.
 - Integrate a global keyboard navigation layer and focus outlines for accessibility.
-- Offer optional light theme toggle for future parity, but prioritize dark mode for initial release.
-  _Implemented (2026-01-15):_ The status page served by
+  - Offer optional light theme toggle for future parity, but prioritize dark mode for initial release.
+    _Implemented (2025-10-04):_ The status page served by
   [`startWebServer`](../src/web/server.js) now exposes an accessible light/dark
   theme toggle that persists the user's preference in `localStorage` and
   honors `prefers-color-scheme`. Coverage in
@@ -113,11 +113,11 @@
 
 1. **Foundations**
    - Scaffold backend Express app with health check endpoint.
-     _Implemented (2025-11-23):_ [`src/web/server.js`](../src/web/server.js) now exposes an Express
+    _Implemented (2025-09-28):_ [`src/web/server.js`](../src/web/server.js) now exposes an Express
      app with a `/health` route that aggregates pluggable status checks. Start the backend with
      `npm run web:server` to serve the health endpoint locally while wiring additional adapters.
   - Build command adapter with a mocked CLI module and comprehensive tests.
-    _Implemented (2025-11-24):_ [`src/web/command-adapter.js`](../src/web/command-adapter.js)
+    _Implemented (2025-09-29):_ [`src/web/command-adapter.js`](../src/web/command-adapter.js)
     now exposes `createCommandAdapter`, which wraps CLI command handlers, captures
     stdout/stderr output, and normalizes arguments for summarize/match calls.
    Regression coverage in
@@ -125,7 +125,7 @@
     uses mocked CLI functions to assert argument shaping, JSON parsing, and
     error translation so future endpoints can reuse the adapter safely.
    - Establish shared TypeScript types and validation schemas.
-     _Implemented (2025-11-25):_ [`src/web/schemas.js`](../src/web/schemas.js)
+     _Implemented (2025-09-29):_ [`src/web/schemas.js`](../src/web/schemas.js)
      now defines shared request types for summarize and match calls, enforcing
      supported formats and numeric constraints before CLI execution. Regression
      coverage in
@@ -137,7 +137,7 @@
 
 2. **CLI Integration Layer**
   - Implement real CLI invocations behind feature flags.
-    _Implemented (2025-12-30):_ [`src/web/command-adapter.js`](../src/web/command-adapter.js)
+    _Implemented (2025-10-02):_ [`src/web/command-adapter.js`](../src/web/command-adapter.js)
     now requires setting `JOBBOT_WEB_ENABLE_NATIVE_CLI=1` (or passing
     `enableNativeCli: true` to [`startWebServer`](../src/web/server.js))
     before spawning the CLI. Otherwise callers must inject a mocked
@@ -145,19 +145,19 @@
     [`test/web-command-adapter.test.js`](../test/web-command-adapter.test.js)
     asserts native execution stays gated behind the feature flag.
    - Add structured logging, metrics, and error handling utilities.
-     _Implemented (2025-12-20):_ [`src/web/server.js`](../src/web/server.js)
+     _Implemented (2025-10-01):_ [`src/web/server.js`](../src/web/server.js)
      now emits structured `web.command` telemetry for every command request,
      capturing durations, sanitized stdout/stderr lengths, and correlation IDs.
      The regression coverage in
      [`test/web-server.test.js`](../test/web-server.test.js) asserts both
      success and failure logs remain wired without leaking sensitive fields.
   - Write integration tests that execute representative CLI commands in a sandboxed environment.
-    _Implemented (2025-12-22):_ [`test/web-server-integration.test.js`](../test/web-server-integration.test.js)
+    _Implemented (2025-10-02):_ [`test/web-server-integration.test.js`](../test/web-server-integration.test.js)
     now boots the Express server with the real command adapter, calls the `match`
     endpoint against sandboxed resume and job fixtures, verifies sanitized JSON
     responses, and asserts job snapshots land inside the temporary
     `JOBBOT_DATA_DIR` so web requests never escape their test environment.
-   _Update (2025-11-30):_ The Express app now exposes `POST /commands/:command`, which validates
+   _Update (2025-09-29):_ The Express app now exposes `POST /commands/:command`, which validates
    requests against an allow-listed schema before delegating to the CLI via
    `createCommandAdapter`. Coverage in
    [`test/web-server.test.js`](../test/web-server.test.js) locks the sanitized payloads and error
@@ -166,7 +166,7 @@
 3. **Frontend Shell**
    - Set up routing, layout, and theme providers.
   - Implement authentication stubs if future remote deployment is anticipated.
-    _Implemented (2025-12-13):_ [`src/web/server.js`](../src/web/server.js)
+    _Implemented (2025-10-02):_ [`src/web/server.js`](../src/web/server.js)
     now enforces configurable static authorization tokens for
     `/commands/:command` requests when `startWebServer` receives `auth`
     options or the `JOBBOT_WEB_AUTH_TOKENS` environment variable. Callers
@@ -181,7 +181,7 @@
    - Application detail view showing lifecycle timeline, notes, and attachments via CLI `show`.
    - Action panel enabling create/update status workflows mapped to CLI `create`/`update`.
    - Notification hooks for reminders, leveraging CLI scheduling or local system integration.
-     _Implemented (2025-12-31):_ [`bin/jobbot.js`](../bin/jobbot.js) now supports
+     _Implemented (2025-10-04):_ [`bin/jobbot.js`](../bin/jobbot.js) now supports
      `jobbot track reminders --ics <file>`, wiring the upcoming reminders feed into
      [`createReminderCalendar`](../src/reminders-calendar.js) so contributors can
      subscribe via native calendar apps. Coverage in
@@ -196,7 +196,7 @@
    - Contract tests ensuring backend responses align with CLI output fixtures.
    - End-to-end tests (Playwright/Cypress) simulating user flows with mocked CLI responses.
   - Accessibility audits (axe-core) and performance benchmarks (Lighthouse).
-    _Implemented (2025-12-19):_ [`src/web/audits.js`](../src/web/audits.js)
+    _Implemented (2025-10-02):_ [`src/web/audits.js`](../src/web/audits.js)
     now runs axe-core against the status page while translating
     Lighthouse scoring formulas to real HTTP timings. The regression
     suite in [`test/web-audits.test.js`](../test/web-audits.test.js)
@@ -206,7 +206,7 @@
 6. **Hardening and Packaging**
    - Implement rate limiting, input sanitization, and CSRF tokens.
    - Add configuration for local, staging, and production environments.
-     _Implemented (2025-12-18):_ [`src/web/config.js`](../src/web/config.js)
+     _Implemented (2025-10-02):_ [`src/web/config.js`](../src/web/config.js)
      centralizes environment presets (development/staging/production) and
      powers `scripts/web-server.js` so the CLI picks up consistent hosts,
      ports, and rate limits per tier. Regression coverage in
@@ -240,7 +240,7 @@
 - [x] Secure process spawning without shell interpolation (speech commands now
   tokenize templates and spawn without `shell: true`; see `test/speech.test.js`)
 - [x] Input sanitization and output redaction
-  _Implemented (2025-12-09):_ [`src/web/command-adapter.js`](../src/web/command-adapter.js)
+  _Implemented (2025-09-30):_ [`src/web/command-adapter.js`](../src/web/command-adapter.js)
   now strips control characters and redacts secret-like values before
   returning CLI output. The web server sanitizes successful payloads and
   error responses to shield clients from leaked credentials. Regression
@@ -249,18 +249,18 @@
   that stdout/stderr, parsed JSON, and adapter return values all receive
   consistent redaction.
 - [x] Logging with redacted secrets and trace IDs
-  _Implemented (2025-12-05):_ [`src/web/command-adapter.js`](../src/web/command-adapter.js)
+  _Implemented (2025-09-30):_ [`src/web/command-adapter.js`](../src/web/command-adapter.js)
   now redacts secret-like values before emitting telemetry, attaches a `traceId`
   to each invocation, and [`test/web-command-adapter.test.js`](../test/web-command-adapter.test.js)
   plus [`test/web-server.test.js`](../test/web-server.test.js) assert the sanitized
   logs and identifiers propagate to API clients.
 - [x] Automated tests spanning unit → e2e layers
-  _Implemented (2025-12-15):_ [`test/web-e2e.test.js`](../test/web-e2e.test.js)
+  _Implemented (2025-10-01):_ [`test/web-e2e.test.js`](../test/web-e2e.test.js)
   exercises `POST /commands/summarize` end to end against the CLI-backed
   adapter, asserting the HTTP stack, schema validation, and sanitized payloads
   round-trip real job text without mocks.
 - [x] Accessibility and performance audits
-  _Implemented (2025-12-19):_ The homepage served by
+  _Implemented (2025-10-02):_ The homepage served by
   [`startWebServer`](../src/web/server.js) now exposes a WCAG-compliant
   status page. [`src/web/audits.js`](../src/web/audits.js) and
   [`test/web-audits.test.js`](../test/web-audits.test.js) run axe-core and
@@ -269,7 +269,7 @@
 - [x] Deployment artifacts and environment parity *(configuration presets
   shipped via [`src/web/config.js`](../src/web/config.js); container images
   now ship with the repository)*
-  _Implemented (2025-12-30):_ [`Dockerfile`](../Dockerfile) and
+  _Implemented (2025-10-02):_ [`Dockerfile`](../Dockerfile) and
   [`docker-compose.web.yml`](../docker-compose.web.yml) now build the web
   server with production defaults, mount `/data`, and bind to
   `0.0.0.0`. Regression coverage in

--- a/test/jobs-adapters-common.test.js
+++ b/test/jobs-adapters-common.test.js
@@ -36,7 +36,7 @@ describe('adapter common utilities', () => {
       raw: 'Raw text',
       parsed: { title: 'Example' },
       headers: { 'User-Agent': 'jobbot3000-tests' },
-      fetchedAt: '2025-10-20T12:00:00Z',
+      fetchedAt: '2025-09-24T12:00:00Z',
     });
 
     expect(snapshot).toMatchObject({
@@ -44,7 +44,7 @@ describe('adapter common utilities', () => {
       parsed: { title: 'Example' },
       source: { type: 'example', value: 'https://jobs.example.com/posting/123' },
       requestHeaders: { 'User-Agent': 'jobbot3000-tests' },
-      fetchedAt: '2025-10-20T12:00:00Z',
+      fetchedAt: '2025-09-24T12:00:00Z',
     });
     expect(snapshot.id).toBe(
       jobIdFromSource({ provider: 'example', url: 'https://jobs.example.com/posting/123' }),


### PR DESCRIPTION
what: align roadmap/docs dates with blame-derived actual timestamps.
why: remove hallucinated future references beyond 2025-10-05.
how to test: no automated tests run (docs/test fixture updates only).


------
https://chatgpt.com/codex/tasks/task_e_68e35b68c678832f8d6f8e9e7b9bfffa