### PR TITLE
Add reusable status panels to the web status hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1614,11 +1614,40 @@ extended by passing custom check functions to
 and failing checks so future endpoints can rely on the health contract when the
 web interface expands beyond the CLI wrappers.
 
-`GET /` renders an accessible status page that surfaces the allow-listed CLI
-commands, links to roadmap docs, and summarizes the automated audits guarding
-the adapter. The markup follows WCAG AA guidance (landmarks, focus styles, skip
-links) and doubles as the fixture for the new `axe-core` and Lighthouse checks
-exercised in [`test/web-audits.test.js`](test/web-audits.test.js).
+`GET /` renders an accessible status hub with hash-based navigation that keeps
+the active section and theme preference in sync across reloads. It surfaces the
+allow-listed CLI commands, roadmap links, and automated audits guarding the
+adapter while preserving WCAG AA guidance (landmarks, focus styles, skip links).
+[`test/web-server.test.js`](test/web-server.test.js) now exercises the router in
+addition to the theme toggle, and [`test/web-audits.test.js`](test/web-audits.test.js)
+continues to lock the accessibility and performance baselines.
+
+Each routed section is wrapped in a reusable status panel that exposes ready,
+loading, and error slots. The client script attaches a `JobbotStatusHub` helper
+alongside a `jobbot:status-panels-ready` event so future integrations can flip
+panels while async data streams in from the CLI. Use the helper to provide
+optimistic feedback and descriptive error fallbacks:
+
+```js
+document.addEventListener('jobbot:status-panels-ready', () => {
+  window.JobbotStatusHub.setPanelState('commands', 'loading');
+
+  fetch('/commands/summarize')
+    .then(response => response.json())
+    .then(() => {
+      window.JobbotStatusHub.setPanelState('commands', 'ready');
+    })
+    .catch(error => {
+      window.JobbotStatusHub.setPanelState('commands', 'error', {
+        message: `Command bridge failed: ${error.message}`,
+      });
+    });
+});
+```
+
+[`test/web-server.test.js`](test/web-server.test.js) locks the DOM transitions,
+API surface, and error messaging so future UI changes preserve the loading and
+failure affordances.
 
 Environment presets now live in
 [`loadWebConfig`](src/web/config.js), which provides development, staging, and

--- a/docs/web-interface-roadmap.md
+++ b/docs/web-interface-roadmap.md
@@ -164,7 +164,13 @@
    handling so future endpoints inherit the same guardrails.
 
 3. **Frontend Shell**
-   - Set up routing, layout, and theme providers.
+  - Set up routing, layout, and theme providers.
+    _Implemented (2025-10-05):_ The status hub served by
+    [`startWebServer`](../src/web/server.js) now includes a hash-based router that
+    persists the active section and theme toggle across reloads. Regression
+    coverage in [`test/web-server.test.js`](../test/web-server.test.js) drives the
+    router through navigation events to ensure the stored route, `aria-current`
+    markers, and section visibility stay in sync.
   - Implement authentication stubs if future remote deployment is anticipated.
     _Implemented (2025-10-02):_ [`src/web/server.js`](../src/web/server.js)
     now enforces configurable static authorization tokens for
@@ -175,6 +181,14 @@
     [`test/web-server.test.js`](../test/web-server.test.js) exercises the
     missing-token guard, Bearer token flow, and custom header handling.
    - Create base components and loading/error states.
+     _Implemented (2025-10-05):_ The status hub wraps the Commands and Audits
+     sections in reusable status panels with ready/loading/error slots. The
+     client script now exposes a `JobbotStatusHub` helper and fires a
+     `jobbot:status-panels-ready` event so asynchronous CLI data loaders can
+     flip between skeleton, success, and descriptive failure states. Regression
+     coverage in [`test/web-server.test.js`](../test/web-server.test.js)
+     exercises the API surface and DOM transitions to keep the affordances
+     stable.
 
 4. **Core Features**
    - Application list view with filtering and pagination backed by CLI `list` command.


### PR DESCRIPTION
## Summary
- Inventoried `docs/web-interface-roadmap.md` and found the "Create base components and loading/error states" roadmap item was still open while neighboring tasks were already shipped, making it a good single-PR target.
- Wrapped the commands and audits sections in reusable status panels, exposed the `JobbotStatusHub` helper, and dispatched a `jobbot:status-panels-ready` event so async loaders can flip between ready, loading, and error affordances. Updated styles and scripts to manage panel state, persistence, and accessibility.
- Documented the panel API in the README and marked the roadmap entry as implemented. Added regression coverage to `test/web-server.test.js` to lock the DOM transitions and API surface.

## Testing
- `npm run lint`
- `npx vitest run test/web-server.test.js`
- `npm run test:ci` *(fails: Vitest worker timed out while reporting task updates; all tests passed before the infrastructure error)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c33b5b24832f97941278438f8016