### PR TITLE
Add analytics export redaction controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1070,6 +1070,9 @@ JOBBOT_DATA_DIR=$DATA_DIR npx jobbot analytics export --out analytics.json
 #   "referral": 1
 # }
 
+JOBBOT_DATA_DIR=$DATA_DIR npx jobbot analytics export --redact --out analytics-redacted.json
+# Saved analytics snapshot to /tmp/jobbot-cli-XXXX/analytics-redacted.json
+
 JOBBOT_DATA_DIR=$DATA_DIR npx jobbot analytics compensation
 # Compensation summary (3 parsed of 4 entries; 1 unparsed)
 # - $ — 1 job
@@ -1114,6 +1117,11 @@ runs and interview sessions exist across the data directory without revealing th
 giving the recommender a privacy-preserving signal about tailoring and rehearsal momentum. Legacy
 deliverable folders that store files directly under a job directory are counted as a single run so
 older tailoring archives stay visible in the activity totals.
+
+The snapshot's `companies` array summarizes tracked jobs per company, including stage counts, outreach
+activity, and how many outreach-only records still await status updates. Pass `--redact` to `jobbot
+analytics export` to replace company names with anonymized labels before sharing the report externally;
+the CLI flag mirrors the web dashboard's **Redact company** toggle.
 
 When outreach events exist without a matching lifecycle status, the report now prints a
 `Missing data: …` line listing the affected job IDs so you can backfill outcomes quickly.

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -1515,7 +1515,8 @@ async function cmdAnalyticsFunnel(args) {
 
 async function cmdAnalyticsExport(args) {
   const output = getFlag(args, '--out');
-  const snapshot = await exportAnalyticsSnapshot();
+  const redact = args.includes('--redact');
+  const snapshot = await exportAnalyticsSnapshot({ redactCompanies: redact });
   const payload = `${JSON.stringify(snapshot, null, 2)}\n`;
   if (output) {
     const resolved = path.resolve(process.cwd(), output);

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -346,6 +346,8 @@ jobbot3000.
 4. Schedule periodic exports via `jobbot schedule run --config configs/analytics.yml` to ensure
    analytics stay current.
 5. Share sanitized aggregates through `jobbot analytics export --out share/analytics.csv`.
+   Include `--redact` when you need to anonymize company names in the exported `companies` summary
+   before circulating metrics outside the immediate team.
 
 ### Web flow
 


### PR DESCRIPTION
## Summary
- confirmed docs/user-journeys.md outlined a future CLI `--redact` option for analytics exports and implemented it by wiring a redaction flag through the CLI and analytics snapshot generator
- extend analytics snapshots with a per-company summary that can be anonymized, reusing job snapshots and status metadata while sanitizing the output for sharing
- document the new workflows in the README and user journeys so contributors know how to share redacted exports

## Testing
- npm run lint
- npm run test:ci

------
https://chatgpt.com/codex/tasks/task_e_68e4c33b5b24832f97941278438f8016