### PR TITLE
Add intake redaction export support

### DIFF
--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -1006,8 +1006,11 @@ async function cmdIntakeRecord(args) {
 async function cmdIntakeList(args) {
   const asJson = args.includes('--json');
   const skippedOnly = args.includes('--skipped-only');
-  const filters = skippedOnly ? { status: 'skipped' } : undefined;
-  const entries = await getIntakeResponses(filters);
+  const redact = args.includes('--redact');
+  const options = {};
+  if (skippedOnly) options.status = 'skipped';
+  if (redact) options.redact = true;
+  const entries = await getIntakeResponses(options);
   if (asJson) {
     console.log(JSON.stringify({ responses: entries }, null, 2));
     return;
@@ -1071,13 +1074,40 @@ async function cmdIntakePlan(args) {
   console.log(formatIntakePlan(plan, resumePath));
 }
 
+async function cmdIntakeExport(args) {
+  const outSpecified = args.includes('--out');
+  const outPath = getFlag(args, '--out');
+  if (outSpecified && !outPath) {
+    console.error(
+      'Usage: jobbot intake export [--out <path>] [--json] [--redact]',
+    );
+    process.exit(2);
+  }
+  const redact = args.includes('--redact');
+  const emitJson = args.includes('--json') || !outPath;
+  const entries = await getIntakeResponses({ redact });
+  const payload = { responses: entries };
+
+  if (outPath) {
+    const resolved = path.resolve(process.cwd(), outPath);
+    await fs.promises.mkdir(path.dirname(resolved), { recursive: true });
+    await fs.promises.writeFile(resolved, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+    console.log(`Saved intake export to ${resolved}`);
+  }
+
+  if (emitJson) {
+    console.log(JSON.stringify(payload, null, 2));
+  }
+}
+
 async function cmdIntake(args) {
   const sub = args[0];
   if (sub === 'record') return cmdIntakeRecord(args.slice(1));
   if (sub === 'list') return cmdIntakeList(args.slice(1));
   if (sub === 'bullets') return cmdIntakeBullets(args.slice(1));
   if (sub === 'plan') return cmdIntakePlan(args.slice(1));
-  console.error('Usage: jobbot intake <record|list|bullets|plan> ...');
+  if (sub === 'export') return cmdIntakeExport(args.slice(1));
+  console.error('Usage: jobbot intake <record|list|bullets|plan|export> ...');
   process.exit(2);
 }
 

--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -83,7 +83,9 @@ jobbot3000.
 4. Summarize collected insights with `jobbot intake bullets --tag strengths --json` and merge them
    into the profile via `jobbot profile merge intake` once the candidate confirms accuracy.
 5. Export the session transcript with `jobbot intake export --out data/profile/intake-<date>.json`
-   for regression testing and audit trails.
+   for regression testing and audit trails. Pass `--redact` to mask compensation, visa, and other
+   sensitive answers in the exported JSON. This lets teammates review structure without seeing
+   private values.
 
 ### Web flow
 
@@ -110,7 +112,8 @@ jobbot3000.
 - Conflicting answers (e.g., contradictory location preferences) trigger conflict resolution prompts
   requiring the user to pick a canonical value before continuing.
 - Sensitive questions (compensation, visa) respect redaction flags; the UI and CLI both mask stored
-  values when `--redact` is active so tests can confirm privacy compliance.
+  values when `--redact` is active so tests can confirm privacy compliance. CLI listings and exports
+  replace answers/notes with `[redacted]` while preserving metadata for downstream automation.
 
 ### Failure modes & alerts
 


### PR DESCRIPTION
## Summary
- add redaction-aware intake response masking and export CLI command
- extend intake listing to respect --redact and document the shipped flow
- cover new behaviour with CLI/unit tests around masking and exports

## Testing
- npm run lint
- npm run test:ci *(fails: Vitest reported Timeout calling "onTaskUpdate" after all tests passed)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c33b5b24832f97941278438f8016