### PR TITLE
Implement Applications shortlist view for the web dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1639,12 +1639,16 @@ and failing checks so future endpoints can rely on the health contract when the
 web interface expands beyond the CLI wrappers.
 
 `GET /` renders an accessible status hub with hash-based navigation that keeps
-the active section and theme preference in sync across reloads. It surfaces the
-allow-listed CLI commands, roadmap links, and automated audits guarding the
-adapter while preserving WCAG AA guidance (landmarks, focus styles, skip links).
-[`test/web-server.test.js`](test/web-server.test.js) now exercises the router in
-addition to the theme toggle, and [`test/web-audits.test.js`](test/web-audits.test.js)
-continues to lock the accessibility and performance baselines.
+the active section and theme preference in sync across reloads. It now includes
+an **Applications** view that calls `POST /commands/shortlist-list` to stream
+shortlist entries through the CLI adapter, apply filters (`location`, `level`,
+`compensation`, tags), and paginate results client-side. The hub also surfaces
+the allow-listed CLI commands, roadmap links, and automated audits guarding the
+adapter while preserving WCAG AA guidance (landmarks, focus styles, skip
+links). [`test/web-server.test.js`](test/web-server.test.js) now exercises the
+router, shortlist view, and theme toggle, while
+[`test/web-audits.test.js`](test/web-audits.test.js) continues to lock the
+accessibility and performance baselines.
 
 Each routed section is wrapped in a reusable status panel that exposes ready,
 loading, and error slots. The client script attaches a `JobbotStatusHub` helper

--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -1385,7 +1385,7 @@ function formatDiscardArchive(archive) {
   return lines.join('\n');
 }
 
-async function cmdShortlistList(args) {
+export async function cmdShortlistList(args) {
   const asJson = args.includes('--json');
   const outPath = getFlag(args, '--out');
   const filteredArgs = [];

--- a/docs/web-interface-roadmap.md
+++ b/docs/web-interface-roadmap.md
@@ -192,6 +192,13 @@
 
 4. **Core Features**
    - Application list view with filtering and pagination backed by CLI `list` command.
+     _Implemented (2025-10-06):_ The status hub now exposes an Applications
+     route powered by `POST /commands/shortlist-list`, which reuses the CLI
+     schema, streams shortlist data, and paginates it client-side. Regression
+     coverage in [`test/web-server.test.js`](../test/web-server.test.js),
+     [`test/web-command-adapter.test.js`](../test/web-command-adapter.test.js),
+     and [`test/web-e2e.test.js`](../test/web-e2e.test.js) keeps the adapter,
+     HTML view, and CLI integration aligned.
    - Application detail view showing lifecycle timeline, notes, and attachments via CLI `show`.
    - Action panel enabling create/update status workflows mapped to CLI `create`/`update`.
    - Notification hooks for reminders, leveraging CLI scheduling or local system integration.


### PR DESCRIPTION
## Summary
- add an Applications route to the status hub with shortlist filters, paging controls, and async loading hooks wired to POST /commands/shortlist-list
- teach the web command adapter, schema normalizer, and command registry to validate shortlist-list payloads and shape CLI results into paginated items
- extend documentation to mark the shortlist view as shipped and cover the new regression tests around the UI and adapter

## Testing
- npm run lint
- npx vitest run test/web-server.test.js
- VITEST_MAX_THREADS=1 npm run test:ci *(fails: Vitest reports `Timeout calling "onTaskUpdate"` after all suites pass)*

------
https://chatgpt.com/codex/tasks/task_e_68e55d1a487c832f938c1bbd1a500d99