### PR TITLE
Add web operations playbook and link it from the status hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -1642,6 +1642,9 @@ web interface expands beyond the CLI wrappers.
 the active section and theme preference in sync across reloads. It surfaces the
 allow-listed CLI commands, roadmap links, and automated audits guarding the
 adapter while preserving WCAG AA guidance (landmarks, focus styles, skip links).
+The “Helpful references” card now links directly to the repository, README,
+web roadmap, and the new [web operations playbook](docs/web-operational-playbook.md)
+so on-call responders can jump from the dashboard to runbooks in one click.
 [`test/web-server.test.js`](test/web-server.test.js) now exercises the router in
 addition to the theme toggle, and [`test/web-audits.test.js`](test/web-audits.test.js)
 continues to lock the accessibility and performance baselines.

--- a/docs/web-interface-roadmap.md
+++ b/docs/web-interface-roadmap.md
@@ -227,7 +227,12 @@
      [`test/web-config.test.js`](../test/web-config.test.js) locks the
      defaults and override semantics in place.
    - Provide Dockerfile and docker-compose for reproducible deployment.
-   - Document operational playbooks (monitoring, alerting, on-call runbooks).
+  - Document operational playbooks (monitoring, alerting, on-call runbooks).
+    _Implemented (2025-10-05):_ [`docs/web-operational-playbook.md`](web-operational-playbook.md)
+    now captures the on-call checklist, guardrails, and incident response
+    steps for the Express adapter. The status hub links to the playbook and
+    [`test/web-server.test.js`](../test/web-server.test.js) asserts the link
+    remains visible so future UI updates keep the operations guidance handy.
 
 7. **Release Prep**
    - Finalize documentation (README updates, API reference, UX guidelines).

--- a/docs/web-operational-playbook.md
+++ b/docs/web-operational-playbook.md
@@ -1,0 +1,83 @@
+# Web Operations Playbook
+
+This playbook documents the day-to-day operations for the jobbot3000 web
+adapter. It captures readiness checks, incident workflows, and monitoring
+expectations so on-call engineers can keep the CLI bridge healthy.
+
+## Quick start
+
+- Start the server locally with `npm run web:server`. The CLI prints the bind
+  address, CSRF header, token, and any configured auth scheme on boot.
+- Confirm `/health` returns `status: "ok"` before routing traffic. The endpoint
+  aggregates custom checks passed to `startWebServer({ healthChecks })`.
+- Visit `GET /` to load the status hub. The overview panel highlights rate
+  limiting, CSRF, and auth guardrails. Hash-based navigation keeps the page
+  static for local deployments.
+
+The status page now links directly to this playbook from the “Helpful
+references” card. [`test/web-server.test.js`](../test/web-server.test.js)
+verifies that the link renders so future UI tweaks keep the on-call checklist
+discoverable.
+
+## Operational guardrails
+
+| Control | Location | Notes |
+| --- | --- | --- |
+| Rate limiting | `createInMemoryRateLimiter` in [`src/web/server.js`](../src/web/server.js) | Defaults to 30 requests/min per client. Tune via `startWebServer({ rateLimit })` or `JOBBOT_WEB_RATE_LIMIT_*` env vars. |
+| CSRF protection | `normalizeCsrfOptions` in [`src/web/server.js`](../src/web/server.js) | Start the server with `csrfToken` (or env vars). Clients must send the matching header on every POST. |
+| Authentication | `normalizeAuthOptions` in [`src/web/server.js`](../src/web/server.js) | Provide tokens or header overrides to require API keys. 401 responses include `WWW-Authenticate` when schemes are enforced. |
+| Output sanitization | [`src/web/command-adapter.js`](../src/web/command-adapter.js) | Redacts secret-like tokens from stdout/stderr/data payloads before returning to clients. |
+
+## Monitoring checklist
+
+1. **Access logs** – Enable structured logging by passing a logger with `info`,
+   `warn`, and `error` methods to `startWebServer`. Command invocations log
+   duration, status, and correlation IDs.
+2. **Health checks** – Add `run()` functions that verify downstream resources
+   (CLI availability, data directories). Failing checks flip the aggregated
+   status to `error` and return HTTP 503.
+3. **Audit scores** – `src/web/audits.js` exposes axe-core and performance
+   audits. Schedule them in CI or cron jobs to catch regressions between
+   releases.
+
+## Incident response
+
+1. Capture the failing request (command name, correlation ID, payload summary).
+2. Inspect logs for sanitized stdout/stderr and rate-limit counters.
+3. Retry locally with `npm run web:server -- --env development` to reproduce.
+4. When the CLI fails, replay the command directly via `npx jobbot …` using the
+   sanitized payload written to the logs.
+5. Update health checks if the incident revealed missing coverage.
+
+## Maintenance routines
+
+- Rotate auth tokens and CSRF secrets after every deployment or personnel
+  change.
+- Review rate-limit budgets quarterly to match observed traffic.
+- Regenerate docs or screenshots after UI updates so the playbook stays current.
+- Run `npm run lint` and `npm run test:ci` before releasing configuration
+  changes. The Vitest suite exercises routing, auth, and telemetry paths.
+
+## Useful commands
+
+```bash
+# Start the server with custom tokens and rate limits
+JOBBOT_WEB_CSRF_TOKEN=$(openssl rand -hex 16) \
+JOBBOT_WEB_AUTH_TOKENS=token123,token456 \
+JOBBOT_WEB_RATE_LIMIT_MAX=20 \
+npm run web:server -- --port 4000
+
+# Hit the health endpoint and pretty-print the response
+curl -s http://127.0.0.1:4000/health | jq
+
+# Exercise an allow-listed CLI command via the adapter
+curl -s \
+  -H "Content-Type: application/json" \
+  -H "${JOBBOT_WEB_CSRF_HEADER:-X-Jobbot-Csrf}: $JOBBOT_WEB_CSRF_TOKEN" \
+  -H "Authorization: Bearer token123" \
+  -d '{"input":"job.txt"}' \
+  http://127.0.0.1:4000/commands/summarize | jq
+```
+
+Keep this document close to the deployment manifests so responders know where
+rate limits, secrets, and guardrails live before incidents occur.

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -362,6 +362,7 @@ export function createWebApp({
     const repoUrl = 'https://github.com/jobbot3000/jobbot3000';
     const readmeUrl = `${repoUrl}/blob/main/README.md`;
     const roadmapUrl = `${repoUrl}/blob/main/docs/web-interface-roadmap.md`;
+    const operationsUrl = `${repoUrl}/blob/main/docs/web-operational-playbook.md`;
 
     res.set('Content-Type', 'text/html; charset=utf-8');
     res.send(`<!doctype html>
@@ -705,6 +706,7 @@ export function createWebApp({
                     <li><a href="${repoUrl}">Repository</a></li>
                     <li><a href="${readmeUrl}">README</a></li>
                     <li><a href="${roadmapUrl}">Web interface roadmap</a></li>
+                    <li><a href="${operationsUrl}">Operations playbook</a></li>
                   </ul>
                 </nav>
               </article>

--- a/test/web-server.test.js
+++ b/test/web-server.test.js
@@ -136,6 +136,21 @@ describe('web server status page', () => {
     expect(html).toMatch(/prefers-color-scheme/);
   });
 
+  it('links to the web operations playbook for on-call guidance', async () => {
+    const server = await startServer();
+
+    const response = await fetch(`${server.url}/`);
+    expect(response.status).toBe(200);
+    const html = await response.text();
+
+    const dom = new JSDOM(html);
+    const operationsLink = dom.window.document.querySelector(
+      'nav[aria-label="Documentation links"] a[href$="docs/web-operational-playbook.md"]',
+    );
+
+    expect(operationsLink?.textContent).toMatch(/Operations playbook/i);
+  });
+
   it('supports hash-based navigation between status sections', async () => {
     const server = await startServer();
 


### PR DESCRIPTION
## Summary
- inventoried future-work notes and closed the "Document operational playbooks" item in `docs/web-interface-roadmap.md`
- add a dedicated web operations playbook that captures guardrails, monitoring, and incident response guidance
- expose the playbook through the status hub references card and note the new link in the README with regression coverage

## Testing
- npm run lint
- npm run test:ci -- web-server.test.js
- npm run test:ci *(fails: Vitest worker RPC timeout in this environment after the CLI suite completes; retry with higher RPC timeout or run in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68e55d1a487c832f938c1bbd1a500d99