### PR TITLE
Add web security roadmap maintenance chore

### DIFF
--- a/docs/chore-catalog.md
+++ b/docs/chore-catalog.md
@@ -12,6 +12,7 @@ stays accurate.
 | Pre-push sweep (lint, tests, secret scan) | All contributors | Before pushing branches or opening a pull request | `npm run chore:prepush` |
 | Secret scan before push | All contributors | Before every commit and prior to opening a pull request | `git diff --cached \| ./scripts/scan-secrets.py` |
 | Prompt docs audit | Prompt Docs maintainers | Whenever prompt documentation changes or monthly during content reviews | `npm run chore:prompts`<br>`npm run chore:prompts --write` _(when auto-fixing formatting)_ |
+| Web security roadmap sync | Security leads | Monthly | Review [docs/web-security-roadmap.md](docs/web-security-roadmap.md)<br>`npm run security:risk-assessment`<br>`npx vitest run test/web-security-roadmap-doc.test.js` |
 
 ## How to use this catalog
 

--- a/docs/web-security-roadmap.md
+++ b/docs/web-security-roadmap.md
@@ -181,7 +181,8 @@
 ## How to contribute
 
 - Pick a milestone above and open an RFC in `docs/architecture-decisions/` describing the approach.
-- Add implementation tasks to `docs/chore-catalog.md` so the roadmap stays discoverable.
+- Keep the `docs/chore-catalog.md` entry for the web security roadmap up to date so the
+  recurring sync remains discoverable.
 - Keep `docs/web-interface-roadmap.md` and this file in sync as features ship or priorities change.
 
 Until these items are finished the web UI must **not** be exposed to the public internet. Treat every

--- a/test/chore-catalog.test.js
+++ b/test/chore-catalog.test.js
@@ -27,4 +27,12 @@ describe('chore catalog documentation', () => {
     expect(packageJson.scripts['chore:prepush']).toMatch(/npm run test:ci/);
     expect(packageJson.scripts['chore:prepush']).toMatch(secretScanPattern);
   });
+
+  it('surfaces the web security roadmap upkeep routine', () => {
+    const contents = fs.readFileSync(CATALOG_PATH, 'utf8');
+    expect(contents).toMatch(/Web security roadmap/i);
+    expect(contents).toContain('docs/web-security-roadmap.md');
+    expect(contents).toMatch(/test\/web-security-roadmap-doc\.test\.js/);
+    expect(contents).toMatch(/npm run security:risk-assessment/);
+  });
 });


### PR DESCRIPTION
## Summary
- add regression coverage to ensure the chore catalog surfaces the web security roadmap upkeep routine
- document the monthly web security roadmap sync chore with links and commands
- update the roadmap contribution notes to reference the new catalog entry

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69281eb68c38832f97840e2598376bc8)