### PR TITLE
Enforce JSON content type for command endpoints

### DIFF
--- a/docs/web-api-reference.md
+++ b/docs/web-api-reference.md
@@ -15,6 +15,9 @@ The web server listens on the host/port returned by
   (defaults to `x-jobbot-csrf`).
 - When `startWebServer` is configured with `auth`, clients must also supply the configured
   authorization header. Bearer tokens are required when `requireScheme` is enabled.
+- `POST /commands/:command` requires `Content-Type: application/json` (or another `*/json`
+  media type). Requests with other content types receive 415 responses so validators run against
+  normalized JSON payloads.
 - Tokens can include role assignments. Viewer roles unlock read-only commands while editor (or
   admin) roles are required for mutations such as `track-record`, `listings-ingest`, and
   `listings-archive`. Requests without the needed roles receive 403 responses and are recorded in the

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -7172,6 +7172,13 @@ export function createWebApp({
         return;
       }
 
+      if (!req.is(["application/json", "*/json"])) {
+        res
+          .status(415)
+          .json({ error: "Content-Type must be application/json" });
+        return;
+      }
+
       const started = performance.now();
       const clientIp = req.ip || req.socket?.remoteAddress || undefined;
       const userAgent = req.get("user-agent");

--- a/test/web-server.test.js
+++ b/test/web-server.test.js
@@ -2935,6 +2935,24 @@ describe("web server command endpoint", () => {
     expect(payload).toBe("API_KEY=***");
   });
 
+  it("rejects command requests without an application/json content type", async () => {
+    const commandAdapter = {
+      summarize: vi.fn(),
+    };
+
+    const server = await startServer({ commandAdapter });
+    const response = await fetch(`${server.url}/commands/summarize`, {
+      method: "POST",
+      headers: buildCommandHeaders(server, { "content-type": "text/plain" }),
+      body: JSON.stringify({ input: "job.txt" }),
+    });
+
+    expect(response.status).toBe(415);
+    const payload = await response.json();
+    expect(payload.error).toMatch(/content-type must be application\/json/i);
+    expect(commandAdapter.summarize).not.toHaveBeenCalled();
+  });
+
   it("rejects command requests without a valid CSRF token", async () => {
     const commandAdapter = {
       summarize: vi.fn(),


### PR DESCRIPTION
## Summary
- reject non-JSON command requests with a 415 response so only sanitized JSON payloads reach adapters
- document the JSON-only requirement for POST /commands endpoints in the web API reference
- add regression coverage to ensure non-JSON content types are blocked before dispatching commands

## Testing
- npm run lint
- npm run test:ci
- git diff --cached | ./scripts/scan-secrets.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69281eb68c38832f97840e2598376bc8)