### PR TITLE
✅ : – Drop empty payload history fields

### DIFF
--- a/docs/web-api-reference.md
+++ b/docs/web-api-reference.md
@@ -60,9 +60,10 @@ cookie for subsequent requests.
 ### GET /commands/payloads/recent
 
 Returns the sanitized payload history for the current client. Entries mirror the payloads supplied to
-recent `/commands/:command` requests after control characters are stripped, keys trimmed, and empty
-values removed. Timestamps include up to 750ms of forward or backward jitter to reduce
-correlation value in the unlikely event encrypted history is exposed. The response shape is:
+recent `/commands/:command` requests after control characters are stripped, keys trimmed, empty
+collections removed, and blank fields discarded. Timestamps include up to 750ms of forward or
+backward jitter to reduce correlation value in the unlikely event encrypted history is exposed. The
+response shape is:
 
 ```jsonc
 {

--- a/src/web/client-payload-store.js
+++ b/src/web/client-payload-store.js
@@ -52,6 +52,9 @@ function sanitizeValue(value) {
     const entries = value
       .map((entry) => sanitizeValue(entry))
       .filter((entry) => entry !== undefined);
+    if (entries.length === 0) {
+      return undefined;
+    }
     return entries;
   }
   if (typeof value === "number" || typeof value === "boolean") {
@@ -65,6 +68,9 @@ function sanitizeValue(value) {
       const sanitizedEntry = sanitizeValue(value[key]);
       if (sanitizedEntry === undefined) continue;
       sanitized[normalizedKey] = sanitizedEntry;
+    }
+    if (Object.keys(sanitized).length === 0) {
+      return undefined;
     }
     return sanitized;
   }

--- a/test/client-payload-store.test.js
+++ b/test/client-payload-store.test.js
@@ -102,4 +102,42 @@ describe("createClientPayloadStore", () => {
       },
     ]);
   });
+
+  it("drops empty collections and whitespace-only keys when sanitizing payloads", () => {
+    const store = createClientPayloadStore();
+
+    const entry = store.record("client-a", "summarize", {
+      " input ": "  Candidate summary  ",
+      notes: [],
+      tags: ["priority", "  ", "\u0000"],
+      meta: {
+        " label ": "  Keep me  ",
+        " \t ": "ignored",
+        blank: "   ",
+        nestedEmpty: {},
+      },
+    });
+
+    expect(entry).toEqual({
+      command: "summarize",
+      payload: {
+        input: "Candidate summary",
+        tags: ["priority"],
+        meta: { label: "Keep me" },
+      },
+      timestamp: expect.any(String),
+    });
+
+    expect(store.getRecent("client-a")).toEqual([
+      {
+        command: "summarize",
+        payload: {
+          input: "Candidate summary",
+          tags: ["priority"],
+          meta: { label: "Keep me" },
+        },
+        timestamp: entry?.timestamp,
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
what: Drop empty collections from payload history and document the
behavior.
why: Payload history docs promised empty values would be removed; the
sanitizer now enforces it and tests cover the contract.
how to test: npm run lint; npm run test:ci.
Refs: #none

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69281eb68c38832f97840e2598376bc8)