### PR TITLE
🛡️ : tamper-evident audit logging

### DIFF
--- a/bin/jobbot.js
+++ b/bin/jobbot.js
@@ -144,9 +144,16 @@ const rawAuditRetention =
     ? process.env.JOBBOT_AUDIT_RETENTION_DAYS.trim()
     : '';
 const parsedAuditRetention = Number.parseInt(rawAuditRetention, 10);
+const rawAuditIntegrityKey =
+  typeof process.env.JOBBOT_AUDIT_INTEGRITY_KEY === 'string'
+    ? process.env.JOBBOT_AUDIT_INTEGRITY_KEY.trim()
+    : '';
 const cliAuditLoggerOptions = { logPath: cliAuditLogPath };
 if (Number.isFinite(parsedAuditRetention) && parsedAuditRetention > 0) {
   cliAuditLoggerOptions.retentionDays = parsedAuditRetention;
+}
+if (rawAuditIntegrityKey) {
+  cliAuditLoggerOptions.integrityKey = rawAuditIntegrityKey;
 }
 
 let cliAuditLogger = null;

--- a/docs/web-security-roadmap.md
+++ b/docs/web-security-roadmap.md
@@ -60,6 +60,12 @@
      directives.
 4. **Observability and alerting**
    - Stream audit logs to a tamper-resistant store.
+     _Implemented (2025-12-01):_ The shared audit logger now chains entries with HMAC
+     signatures derived from `JOBBOT_AUDIT_INTEGRITY_KEY` and refuses to append when history
+     has been modified. Both the CLI and web server reuse the integrity key plumbing so
+     operators can enable tamper-evident audit storage across deployments. Regression coverage
+     in [`test/audit-log-integrity.test.js`](../test/audit-log-integrity.test.js) verifies the
+     hash-chain metadata and the failure path when log entries are altered.
    - Emit security telemetry for failed logins, rate limiting events, and suspicious traffic.
      _Implemented (2025-10-20):_ `createWebApp` now emits `web.security`
      telemetry for authorization failures, CSRF mismatches, malformed payloads,

--- a/src/shared/config/manifest.js
+++ b/src/shared/config/manifest.js
@@ -340,10 +340,11 @@ export function loadConfig(options = {}) {
 
   const normalizedIntegrityKey = (() => {
     const rawIntegrityKey = options.audit?.integrityKey ?? env.JOBBOT_AUDIT_INTEGRITY_KEY;
-    if (rawIntegrityKey == null) return '';
+    if (rawIntegrityKey == null) return null;
     const stringValue =
       typeof rawIntegrityKey === 'string' ? rawIntegrityKey : rawIntegrityKey.toString();
-    return stringValue.trim();
+    const trimmed = stringValue.trim();
+    return trimmed ? trimmed : null;
   })();
 
   const audit = {
@@ -352,7 +353,7 @@ export function loadConfig(options = {}) {
       options.audit?.retentionDays ?? env.JOBBOT_AUDIT_RETENTION_DAYS,
       30,
     ),
-    ...(normalizedIntegrityKey ? { integrityKey: normalizedIntegrityKey } : {}),
+    ...(normalizedIntegrityKey !== null ? { integrityKey: normalizedIntegrityKey } : {}),
   };
 
   const auth = (() => {

--- a/src/shared/config/manifest.js
+++ b/src/shared/config/manifest.js
@@ -338,19 +338,21 @@ export function loadConfig(options = {}) {
     },
   };
 
+  const normalizedIntegrityKey = (() => {
+    const rawIntegrityKey = options.audit?.integrityKey ?? env.JOBBOT_AUDIT_INTEGRITY_KEY;
+    if (rawIntegrityKey == null) return '';
+    const stringValue =
+      typeof rawIntegrityKey === 'string' ? rawIntegrityKey : rawIntegrityKey.toString();
+    return stringValue.trim();
+  })();
+
   const audit = {
     logPath: options.audit?.logPath ?? env.JOBBOT_AUDIT_LOG ?? 'data/audit/audit-log.jsonl',
     retentionDays: numberFromEnv(
       options.audit?.retentionDays ?? env.JOBBOT_AUDIT_RETENTION_DAYS,
       30,
     ),
-    ...(options.audit?.integrityKey || env.JOBBOT_AUDIT_INTEGRITY_KEY
-      ? {
-          integrityKey:
-            (options.audit?.integrityKey ?? env.JOBBOT_AUDIT_INTEGRITY_KEY)?.toString().trim() ||
-            undefined,
-        }
-      : {}),
+    ...(normalizedIntegrityKey ? { integrityKey: normalizedIntegrityKey } : {}),
   };
 
   const auth = (() => {

--- a/src/shared/config/manifest.js
+++ b/src/shared/config/manifest.js
@@ -145,6 +145,7 @@ const ConfigSchema = z.object({
   audit: z.object({
     logPath: z.string().min(1).default('data/audit/audit-log.jsonl'),
     retentionDays: z.number().int().positive().default(30),
+    integrityKey: z.string().min(1).optional(),
   }),
   features: z.object({
     scraping: z.object({
@@ -343,6 +344,13 @@ export function loadConfig(options = {}) {
       options.audit?.retentionDays ?? env.JOBBOT_AUDIT_RETENTION_DAYS,
       30,
     ),
+    ...(options.audit?.integrityKey || env.JOBBOT_AUDIT_INTEGRITY_KEY
+      ? {
+          integrityKey:
+            (options.audit?.integrityKey ?? env.JOBBOT_AUDIT_INTEGRITY_KEY)?.toString().trim() ||
+            undefined,
+        }
+      : {}),
   };
 
   const auth = (() => {

--- a/src/shared/security/audit-log.js
+++ b/src/shared/security/audit-log.js
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
+import { createHmac } from 'node:crypto';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const lastRetentionRun = new Map();
@@ -7,58 +8,173 @@ const lastRetentionRun = new Map();
 /**
  * @param {string} logPath
  * @param {number} retentionDays
- * @returns {Promise<void>}
+ * @returns {Promise<boolean>}
  */
 async function enforceRetention(logPath, retentionDays) {
-  if (!Number.isFinite(retentionDays) || retentionDays <= 0) return;
+  if (!Number.isFinite(retentionDays) || retentionDays <= 0) return false;
   const absolute = path.resolve(logPath);
   const now = Date.now();
   const last = lastRetentionRun.get(absolute) || 0;
   if (now - last < DAY_MS) {
-    return;
+    return false;
   }
   lastRetentionRun.set(absolute, now);
   try {
     const stats = await fs.stat(absolute);
     if (now - stats.mtimeMs <= retentionDays * DAY_MS) {
-      return;
+      return false;
     }
     const timestamp = new Date(stats.mtime).toISOString().replace(/[:]/g, '-');
     const archiveName = `${absolute}.${timestamp}.bak`;
     await fs.rename(absolute, archiveName);
+    return true;
   } catch (error) {
-    if (error && error.code === 'ENOENT') return;
+    if (error && error.code === 'ENOENT') return false;
     throw error;
   }
 }
 
+function stableStringify(value) {
+  return JSON.stringify(value, (key, val) => {
+    if (!val || typeof val !== 'object' || Array.isArray(val)) return val;
+    return Object.keys(val)
+      .sort()
+      .reduce((acc, current) => {
+        acc[current] = val[current];
+        return acc;
+      }, {});
+  });
+}
+
+function computeIntegrityHash(entry, integrityKey) {
+  const payload = stableStringify(entry);
+  return createHmac('sha256', integrityKey).update(payload).digest('hex');
+}
+
+async function verifyExistingLog(logPath, integrityKey) {
+  let previousHash = null;
+  let lineNumber = 0;
+
+  try {
+    const raw = await fs.readFile(logPath, 'utf8');
+    const lines = raw
+      .split('\n')
+      .map(line => line.trim())
+      .filter(Boolean);
+    for (const line of lines) {
+      lineNumber += 1;
+      let entry;
+      try {
+        entry = JSON.parse(line);
+      } catch (error) {
+        const reason = error?.message ?? 'unknown error';
+        throw new Error(
+          `Audit log integrity check failed on line ${lineNumber}: invalid JSON (${reason})`,
+        );
+      }
+      const recordedHash = entry.hash;
+      const recordedPrevHash = entry.prevHash ?? null;
+      if (recordedPrevHash !== previousHash) {
+        throw new Error(
+          `Audit log integrity check failed on line ${lineNumber}: unexpected prevHash value`,
+        );
+      }
+      if (!recordedHash) {
+        throw new Error(
+          `Audit log integrity check failed on line ${lineNumber}: missing hash value`,
+        );
+      }
+      const rest = { ...entry };
+      delete rest.hash;
+      const expectedHash = computeIntegrityHash(rest, integrityKey);
+      if (expectedHash !== recordedHash) {
+        throw new Error(
+          `Audit log integrity check failed on line ${lineNumber}: hash mismatch`,
+        );
+      }
+      previousHash = recordedHash;
+    }
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      return { lastHash: null, lines: 0 };
+    }
+    throw error;
+  }
+
+  return { lastHash: previousHash, lines: lineNumber };
+}
+
 /**
- * @typedef {{ logPath: string, retentionDays?: number }} AuditLoggerOptions
+ * @typedef {{ logPath: string, retentionDays?: number, integrityKey?: string }} AuditLoggerOptions
  */
 
 /**
  * @param {AuditLoggerOptions} [options]
  */
 export function createAuditLogger(options) {
-  const { logPath, retentionDays = 30 } = /** @type {AuditLoggerOptions} */ (options ?? {});
+  const { logPath, retentionDays = 30, integrityKey } =
+    /** @type {AuditLoggerOptions} */ (options ?? {});
   if (!logPath) {
     throw new Error('audit log path is required');
   }
   const absolute = path.resolve(logPath);
+  const trimmedIntegrityKey =
+    typeof integrityKey === 'string' && integrityKey.trim() ? integrityKey.trim() : null;
+  let chainHead = null;
+  /** @type {Promise<unknown>} */
+  let writeChain = Promise.resolve();
 
   return {
+    /**
+     * @param {Record<string, unknown>} event
+     * @returns {Promise<Record<string, unknown>>}
+     */
     async record(event) {
       if (!event || typeof event !== 'object') {
         throw new Error('audit event must be an object');
       }
-      const entry = {
-        ...event,
-        timestamp: new Date().toISOString(),
+
+      const performWrite = async () => {
+        const rotated = await enforceRetention(absolute, retentionDays);
+        if (rotated) {
+          chainHead = null;
+        }
+        if (trimmedIntegrityKey) {
+          const { lastHash } = await verifyExistingLog(absolute, trimmedIntegrityKey);
+          chainHead = lastHash;
+        }
+
+        const baseEntry = Object.fromEntries(
+          Object.entries({
+            ...event,
+            timestamp: new Date().toISOString(),
+          }).filter(([, value]) => value !== undefined),
+        );
+
+        let entryToPersist = baseEntry;
+        if (trimmedIntegrityKey) {
+          const prevHash = chainHead;
+          const entryForHash = { ...baseEntry, prevHash };
+          const hash = computeIntegrityHash(entryForHash, trimmedIntegrityKey);
+          entryToPersist = { ...entryForHash, hash };
+          chainHead = hash;
+        }
+
+        await fs.mkdir(path.dirname(absolute), { recursive: true });
+        await fs.appendFile(absolute, `${JSON.stringify(entryToPersist)}\n`, 'utf8');
+        return entryToPersist;
       };
-      await fs.mkdir(path.dirname(absolute), { recursive: true });
-      await enforceRetention(absolute, retentionDays);
-      await fs.appendFile(absolute, `${JSON.stringify(entry)}\n`, 'utf8');
-      return entry;
+
+      const pendingWrite = writeChain.then(performWrite, performWrite);
+      writeChain = pendingWrite.catch(() => {});
+      return pendingWrite;
+    },
+
+    async verify() {
+      if (!trimmedIntegrityKey) {
+        throw new Error('audit log integrity requires an integrityKey option');
+      }
+      return verifyExistingLog(absolute, trimmedIntegrityKey);
     },
   };
 }

--- a/test/audit-log-integrity.test.js
+++ b/test/audit-log-integrity.test.js
@@ -92,6 +92,14 @@ describe('tamper-resistant audit log', () => {
     await expect(logger.verify()).rejects.toThrow(/integrityKey/i);
   });
 
+  it('rejects verification with an incorrect integrity key', async () => {
+    const logger = createAuditLogger({ logPath, integrityKey: 'secret-key' });
+    await logger.record({ action: 'first', actor: 'cli' });
+
+    const verifier = createAuditLogger({ logPath, integrityKey: 'other-key' });
+    await expect(verifier.verify()).rejects.toThrow(/integrity/i);
+  });
+
   it('fails verification when history has been tampered', async () => {
     const logger = createAuditLogger({ logPath, integrityKey: 'secret-key' });
     await logger.record({ action: 'first', actor: 'cli' });

--- a/test/audit-log-integrity.test.js
+++ b/test/audit-log-integrity.test.js
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createAuditLogger } from '../src/shared/security/audit-log.js';
+
+async function readAuditEntries(logPath) {
+  const raw = await fs.readFile(logPath, 'utf8');
+  return raw
+    .split('\n')
+    .map(line => line.trim())
+    .filter(Boolean)
+    .map(line => JSON.parse(line));
+}
+
+describe('tamper-resistant audit log', () => {
+  let tmpDir;
+  let logPath;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-audit-log-'));
+    logPath = path.join(tmpDir, 'audit.log');
+  });
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+      tmpDir = undefined;
+      logPath = undefined;
+    }
+  });
+
+  it('hash-chains audit entries when an integrity key is configured', async () => {
+    const logger = createAuditLogger({ logPath, integrityKey: 'secret-key' });
+    await logger.record({ action: 'first', actor: 'cli' });
+    await logger.record({ action: 'second', actor: 'cli' });
+
+    const entries = await readAuditEntries(logPath);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      action: 'first',
+      hash: expect.any(String),
+    });
+    expect(entries[0].prevHash ?? null).toBeNull();
+    expect(entries[1]).toMatchObject({
+      action: 'second',
+      prevHash: entries[0].hash,
+      hash: expect.any(String),
+    });
+
+    const verifyingLogger = createAuditLogger({
+      logPath,
+      integrityKey: 'secret-key',
+    });
+    await verifyingLogger.record({ action: 'third', actor: 'cli' });
+
+    const refreshed = await readAuditEntries(logPath);
+    expect(refreshed[2].prevHash).toBe(refreshed[1].hash);
+  });
+
+  it('rejects tampered history before appending new entries', async () => {
+    const logger = createAuditLogger({ logPath, integrityKey: 'secret-key' });
+    await logger.record({ action: 'legit', actor: 'cli' });
+
+    const [first] = await readAuditEntries(logPath);
+    const tampered = { ...first, actor: 'intruder' };
+    await fs.writeFile(logPath, `${JSON.stringify(tampered)}\n`, 'utf8');
+
+    await expect(
+      logger.record({ action: 'next', actor: 'cli' }),
+    ).rejects.toThrow(/integrity/i);
+  });
+});

--- a/test/cli-audit-exports.test.js
+++ b/test/cli-audit-exports.test.js
@@ -47,6 +47,7 @@ async function readAuditEntries(logPath) {
 
 const originalAuditLogPath = process.env.JOBBOT_AUDIT_LOG;
 const originalAuditRetention = process.env.JOBBOT_AUDIT_RETENTION_DAYS;
+const originalAuditIntegrityKey = process.env.JOBBOT_AUDIT_INTEGRITY_KEY;
 let tmpDir;
 
 beforeEach(async () => {
@@ -60,6 +61,7 @@ beforeEach(async () => {
   tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-cli-audit-'));
   process.env.JOBBOT_AUDIT_LOG = path.join(tmpDir, 'audit.log');
   delete process.env.JOBBOT_AUDIT_RETENTION_DAYS;
+  delete process.env.JOBBOT_AUDIT_INTEGRITY_KEY;
 });
 
 afterEach(async () => {
@@ -76,6 +78,11 @@ afterEach(async () => {
     delete process.env.JOBBOT_AUDIT_RETENTION_DAYS;
   } else {
     process.env.JOBBOT_AUDIT_RETENTION_DAYS = originalAuditRetention;
+  }
+  if (originalAuditIntegrityKey === undefined) {
+    delete process.env.JOBBOT_AUDIT_INTEGRITY_KEY;
+  } else {
+    process.env.JOBBOT_AUDIT_INTEGRITY_KEY = originalAuditIntegrityKey;
   }
 });
 

--- a/test/web-config.test.js
+++ b/test/web-config.test.js
@@ -164,6 +164,15 @@ describe('loadWebConfig', () => {
     ]);
   });
 
+  it('ignores empty or whitespace-only audit integrity keys', async () => {
+    process.env.JOBBOT_AUDIT_INTEGRITY_KEY = '   ';
+
+    const { loadWebConfig } = await import('../src/web/config.js');
+    const config = await loadWebConfig({ env: 'development' });
+
+    expect(config.audit.integrityKey).toBeUndefined();
+  });
+
   it('parses numeric trust proxy hop counts before boolean normalization', async () => {
     process.env.JOBBOT_WEB_TRUST_PROXY = '1';
 

--- a/test/web-config.test.js
+++ b/test/web-config.test.js
@@ -36,6 +36,7 @@ describe('loadWebConfig', () => {
       'JOBBOT_HTTP_CIRCUIT_BREAKER_THRESHOLD',
       'JOBBOT_HTTP_CIRCUIT_BREAKER_RESET_MS',
       'JOBBOT_WEB_PLUGINS',
+      'JOBBOT_AUDIT_INTEGRITY_KEY',
       'JOBBOT_GREENHOUSE_TOKEN',
       'JOBBOT_LEVER_API_TOKEN',
       'JOBBOT_SMARTRECRUITERS_TOKEN',
@@ -69,6 +70,7 @@ describe('loadWebConfig', () => {
       'JOBBOT_HTTP_CIRCUIT_BREAKER_THRESHOLD',
       'JOBBOT_HTTP_CIRCUIT_BREAKER_RESET_MS',
       'JOBBOT_WEB_PLUGINS',
+      'JOBBOT_AUDIT_INTEGRITY_KEY',
       'JOBBOT_GREENHOUSE_TOKEN',
       'JOBBOT_LEVER_API_TOKEN',
       'JOBBOT_SMARTRECRUITERS_TOKEN',
@@ -127,6 +129,7 @@ describe('loadWebConfig', () => {
     process.env.JOBBOT_FEATURE_SCRAPING_MOCKS = 'true';
     process.env.JOBBOT_HTTP_MAX_RETRIES = '4';
     process.env.JOBBOT_HTTP_CIRCUIT_BREAKER_THRESHOLD = '6';
+    process.env.JOBBOT_AUDIT_INTEGRITY_KEY = 'audit-secret';
 
     const { loadWebConfig } = await import('../src/web/config.js');
     const config = await loadWebConfig({ env: 'development', rateLimit: { max: 5 } });
@@ -138,6 +141,7 @@ describe('loadWebConfig', () => {
     expect(config.features.scraping.useMocks).toBe(true);
     expect(config.features.httpClient.maxRetries).toBe(4);
     expect(config.features.httpClient.circuitBreakerThreshold).toBe(6);
+    expect(config.audit.integrityKey).toBe('audit-secret');
     expect(config.missingSecrets).toEqual([]);
     expect(config.trustProxy).toBe(true);
 


### PR DESCRIPTION
What:
- add HMAC hash chaining with integrity verification to audit logs
- expose audit integrity key config/env wiring in CLI and manifest
- document the tamper-resistant audit log milestone and add regression

Why:
- fulfill the security roadmap item for tamper-resistant audit logs

How to test:
- npm run lint
- npm run test:ci

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950f2aac588832f919e8944aabada46)