### PR TITLE
Add scheduler outage status tracking and status hub warning banner

### DIFF
--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -524,6 +524,12 @@ call scheduled"`.
   tables when the chart generator crashes.
 - Scheduler outages notify maintainers via local notifications and mark dashboards with a warning
   banner until resolved.
+  _Implemented (2026-01-09):_ `buildScheduledTasks` now records scheduler status snapshots and
+  writes `.eml` notifications to the local outbox whenever a task fails. The status hub reads the
+  snapshot and renders a warning banner until the next successful run clears the outage state.
+  Regression coverage in [`test/schedule-config.test.js`](../test/schedule-config.test.js) and
+  [`test/web-scheduler-status.test.js`](../test/web-scheduler-status.test.js) keeps the CLI
+  notifier and dashboard banner aligned.
 
 ## Journey 5: Background ingestion to notifications
 

--- a/test/listings.e2e.test.js
+++ b/test/listings.e2e.test.js
@@ -8,18 +8,22 @@ const greenhouseAdapterMock = {
   listOpenings: vi.fn(),
   normalizeJob: vi.fn(),
 };
+const ingestGreenhouseBoardMock = vi.fn();
 
 vi.mock('../src/greenhouse.js', () => ({
   greenhouseAdapter: greenhouseAdapterMock,
+  ingestGreenhouseBoard: ingestGreenhouseBoardMock,
 }));
 
 const leverAdapterMock = {
   listOpenings: vi.fn(),
   normalizeJob: vi.fn(),
 };
+const ingestLeverBoardMock = vi.fn();
 
 vi.mock('../src/lever.js', () => ({
   leverAdapter: leverAdapterMock,
+  ingestLeverBoard: ingestLeverBoardMock,
 }));
 
 const shortlistMock = {

--- a/test/web-scheduler-status.test.js
+++ b/test/web-scheduler-status.test.js
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+import { startWebServer } from '../src/web/server.js';
+
+let dataDir;
+const activeServers = [];
+
+async function bootServer() {
+  const server = await startWebServer({
+    host: '127.0.0.1',
+    port: 0,
+    csrfToken: 'scheduler-status-token',
+    commandAdapterOptions: {
+      env: { ...process.env, JOBBOT_DATA_DIR: dataDir },
+    },
+  });
+  activeServers.push(server);
+  return server;
+}
+
+describe('web scheduler status banner', () => {
+  const originalDataDir = process.env.JOBBOT_DATA_DIR;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'jobbot-web-scheduler-'));
+    process.env.JOBBOT_DATA_DIR = dataDir;
+  });
+
+  afterEach(async () => {
+    while (activeServers.length > 0) {
+      const server = activeServers.pop();
+      await server.close();
+    }
+    if (dataDir) {
+      await fs.rm(dataDir, { recursive: true, force: true });
+      dataDir = undefined;
+    }
+    if (originalDataDir === undefined) {
+      delete process.env.JOBBOT_DATA_DIR;
+    } else {
+      process.env.JOBBOT_DATA_DIR = originalDataDir;
+    }
+  });
+
+  it('renders a scheduler warning banner when outages are recorded', async () => {
+    const statusPath = path.join(dataDir, 'scheduler', 'status.json');
+    await fs.mkdir(path.dirname(statusPath), { recursive: true });
+    await fs.writeFile(
+      statusPath,
+      `${JSON.stringify(
+        {
+          status: 'error',
+          lastErrorAt: '2025-02-01T00:00:00.000Z',
+          lastErrorTask: 'greenhouse-hourly',
+          lastErrorMessage: 'Greenhouse offline',
+        },
+        null,
+        2,
+      )}\n`,
+      'utf8',
+    );
+
+    const server = await bootServer();
+    const response = await fetch(`${server.url}/`);
+    const html = await response.text();
+
+    expect(html).toContain('Scheduler outage detected');
+    expect(html).toContain('greenhouse-hourly');
+    expect(html).toContain('Greenhouse offline');
+  });
+});


### PR DESCRIPTION
### Motivation
- Surface scheduler failure modes in the UI and provide local, auditable notifications so operators see and triage outages faster.
- Persist a compact status snapshot and a local `.eml` notification whenever scheduled tasks fail so on-call workflows have a durable artifact.
- Keep the status hub and scheduler docs in sync by removing a documented-but-unshipped behavior gap around scheduler outages.
- Add regression coverage that exercises the new failure and recovery paths so the guardrail remains enforced.

### Description
- Record scheduler status snapshots and write local outage emails by adding status helpers and a `createSchedulerStatusReporter` to `src/schedule.js`, and wire `reportSuccess`/`reportError` into `buildScheduledTasks`.
- Expose `readSchedulerStatus` and have the web status hub call it to render a persistent warning banner when `status === "error"` in `src/web/server.js`, plus a small UI/CSS tweak for the banner.
- Add/update tests: extended `test/schedule-config.test.js` to cover outage recording and resolution, added `test/web-scheduler-status.test.js` to assert the banner renders, and adjusted `test/listings.e2e.test.js` mocks to accommodate module shape changes.
- Update documentation `docs/user-journeys.md` to reflect the shipped behavior and added a lightweight E2E test to keep docs and behavior aligned.

### Testing
- Ran `npm run lint` and it completed successfully with no lint errors.
- Ran `npm run test:ci` (Vitest full CI run) and the test suite completed: all test files passed and the suite exited with success (final run: 133 test files, 929 tests passed).
- Scanned staged changes for secrets with `git diff --cached | ./scripts/scan-secrets.py` and no secrets were detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696096e51130832f95443e56f4706026)