### PR TITLE
Add intake confidence tracking to intake record flows

### DIFF
--- a/docs/user-journeys.md
+++ b/docs/user-journeys.md
@@ -89,7 +89,10 @@ jobbot3000.
    Pass any readable resume path to `--profile` (even outside `JOBBOT_DATA_DIR`); the CLI echoes the
    resolved location in its output. Optionally add `--json` to feed automated review tools.
 2. Iterate through prompts using `jobbot intake record --question <text>`; the command accepts
-   `--answer`, `--tags`, and `--confidence` so the assistant can track certainty.
+   `--answer`, `--tags`, and `--confidence <0-1>` so the assistant can track certainty.
+   Regression coverage in [`test/cli.test.js`](../test/cli.test.js) and
+   [`test/intake.test.js`](../test/intake.test.js) verifies confidence values are persisted and
+   surfaced in list output.
 3. Use `jobbot intake record --question <text> --skip --reason <text>` when the candidate defers a question.
    Skip reasons persist in `jobbot intake list` output (including `--json` exports) so follow-up
    runs know why a prompt was deferred. Redaction with `--redact` masks skip reasons containing

--- a/docs/web-api-reference.md
+++ b/docs/web-api-reference.md
@@ -220,9 +220,9 @@ The following command endpoints are available. Each one maps directly to a CLI h
   `intake-resume`. Responses return `{ "draft": { ... } }` so the UI can immediately reflect the
   persisted draft contents.
 - `POST /commands/intake-record` → `jobbot intake record`: Record a new interview question response
-  with optional tags, notes, and timestamps, supporting both answered and skipped prompts. Skipped
-  prompts may include a `reason` that is stored and returned as `skip_reason` for downstream list
-  and export responses; sensitive reasons are sanitized alongside answers and notes.
+  with optional tags, notes, confidence (0–1), and timestamps, supporting both answered and skipped
+  prompts. Skipped prompts may include a `reason` that is stored and returned as `skip_reason` for
+  downstream list and export responses; sensitive reasons are sanitized alongside answers and notes.
 - `POST /commands/intake-resume` → `jobbot intake resume`: Retrieve the most recent intake draft for
   the active client, including the saved question, answer, notes, tags, and timestamps with control
   characters stripped. Responses return `{ "draft": null }` when no draft is present so callers can

--- a/src/web/command-adapter.js
+++ b/src/web/command-adapter.js
@@ -1568,7 +1568,7 @@ export function createCommandAdapter(options = {}) {
 
   async function intakeRecordCommand(options = {}) {
     const cli = injectedCli;
-    const { question, answer, skipped, askedAt, tags, notes, skipReason } =
+    const { question, answer, skipped, askedAt, tags, notes, skipReason, confidence } =
       normalizeIntakeRecordRequest(options);
 
     if (cli && typeof cli.cmdIntakeRecord === "function") {
@@ -1584,6 +1584,7 @@ export function createCommandAdapter(options = {}) {
       if (askedAt) args.push("--asked-at", askedAt);
       if (tags) args.push("--tags", tags);
       if (notes) args.push("--notes", notes);
+      if (confidence !== undefined) args.push("--confidence", String(confidence));
 
       const { result, stdout, stderr } = await captureConsole(() =>
         cli.cmdIntakeRecord(args),
@@ -1606,6 +1607,7 @@ export function createCommandAdapter(options = {}) {
     if (tags) payload.tags = tags;
     if (notes) payload.notes = notes;
     if (skipReason) payload.skipReason = skipReason;
+    if (confidence !== undefined) payload.confidence = confidence;
 
     const entry = await recordIntakeResponse(payload);
     const sanitized = sanitizeOutputValue(entry, { key: "data" });

--- a/src/web/schemas.js
+++ b/src/web/schemas.js
@@ -148,6 +148,15 @@ function assertPositiveNumber(value, name) {
   return numberValue;
 }
 
+function assertConfidence(value) {
+  const numberValue = coerceNumber(value);
+  if (numberValue === undefined) return undefined;
+  if (numberValue < 0 || numberValue > 1) {
+    throw new Error('confidence must be between 0 and 1');
+  }
+  return Number(numberValue.toFixed(4));
+}
+
 function normalizeFormat(value) {
   const normalized = normalizeString(value)?.toLowerCase() ?? 'markdown';
   if (!SUPPORTED_FORMATS.includes(normalized)) {
@@ -548,6 +557,7 @@ export function normalizeIntakeRecordRequest(options = {}) {
     'tags',
     'notes',
     'reason',
+    'confidence',
   ]);
   const extra = Object.keys(options).filter(key => !allowedKeys.has(key));
   if (extra.length > 0) {
@@ -578,12 +588,14 @@ export function normalizeIntakeRecordRequest(options = {}) {
 
   const tags = normalizeString(options.tags);
   const notes = normalizeString(options.notes);
+  const confidence = assertConfidence(options.confidence);
 
   const request = { question, skipped };
   if (answer) request.answer = answer;
   if (askedAt) request.askedAt = askedAt;
   if (tags) request.tags = tags;
   if (notes) request.notes = notes;
+  if (confidence !== undefined) request.confidence = confidence;
   const reason = normalizeString(options.reason);
   if (reason && !skipped) {
     throw new Error('reason requires skipped: true');

--- a/src/web/schemas.js
+++ b/src/web/schemas.js
@@ -595,7 +595,12 @@ export function normalizeIntakeRecordRequest(options = {}) {
   if (askedAt) request.askedAt = askedAt;
   if (tags) request.tags = tags;
   if (notes) request.notes = notes;
-  if (confidence !== undefined) request.confidence = confidence;
+  if (confidence !== undefined) {
+    if (skipped) {
+      throw new Error('confidence is only supported for answered intake responses');
+    }
+    request.confidence = confidence;
+  }
   const reason = normalizeString(options.reason);
   if (reason && !skipped) {
     throw new Error('reason requires skipped: true');

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -2107,6 +2107,26 @@ describe('jobbot CLI', () => {
     });
   });
 
+  it('captures intake confidence scores when recording responses', () => {
+    const output = runCli([
+      'intake',
+      'record',
+      '--question',
+      'How confident are you in your onboarding story?',
+      '--answer',
+      'Confident after recent role.',
+      '--confidence',
+      '0.82',
+    ]);
+    expect(output.trim()).toMatch(/^Recorded intake response /);
+
+    const list = runCli(['intake', 'list']);
+    expect(list).toContain('Confidence: 0.82');
+
+    const payload = JSON.parse(runCli(['intake', 'list', '--json']));
+    expect(payload.responses[0].confidence).toBe(0.82);
+  });
+
   it('records skipped intake prompts for later follow-up', () => {
     const output = runCli([
       'intake',

--- a/test/intake.test.js
+++ b/test/intake.test.js
@@ -99,6 +99,18 @@ describe('intake responses', () => {
     expect(raw.responses[0].confidence).toBe(0.72);
   });
 
+  it('rejects confidence when skipping a response', async () => {
+    const { recordIntakeResponse } = await import('../src/intake.js');
+
+    await expect(
+      recordIntakeResponse({
+        question: 'What is your salary range?',
+        skipped: true,
+        confidence: 0.3,
+      }),
+    ).rejects.toThrow('confidence is only supported for answered intake responses');
+  });
+
   it('returns intake history in insertion order', async () => {
     const { recordIntakeResponse, getIntakeResponses } = await import('../src/intake.js');
 

--- a/test/intake.test.js
+++ b/test/intake.test.js
@@ -78,6 +78,27 @@ describe('intake responses', () => {
     ).rejects.toThrow(/answer is required/);
   });
 
+  it('records confidence scores alongside intake responses', async () => {
+    const fs = await import('node:fs/promises');
+    const { recordIntakeResponse, getIntakeResponses } = await import('../src/intake.js');
+
+    const entry = await recordIntakeResponse({
+      question: 'How confident are you in your leadership story?',
+      answer: 'Confident after recent project delivery.',
+      confidence: 0.72,
+    });
+
+    expect(entry.confidence).toBe(0.72);
+
+    const responses = await getIntakeResponses();
+    expect(responses[0].confidence).toBe(0.72);
+
+    const raw = JSON.parse(
+      await fs.readFile(path.join(dataDir, 'profile', 'intake.json'), 'utf8')
+    );
+    expect(raw.responses[0].confidence).toBe(0.72);
+  });
+
   it('returns intake history in insertion order', async () => {
     const { recordIntakeResponse, getIntakeResponses } = await import('../src/intake.js');
 

--- a/test/web-command-adapter.test.js
+++ b/test/web-command-adapter.test.js
@@ -1206,6 +1206,8 @@ describe('createCommandAdapter', () => {
           'Mission alignment',
           '--tags',
           'motivation,values',
+          '--confidence',
+          '0.64',
         ]);
         console.log(
           JSON.stringify({
@@ -1216,6 +1218,7 @@ describe('createCommandAdapter', () => {
             recorded_at: '2025-03-05T14:00:00.000Z',
             status: 'answered',
             tags: ['motivation', 'values'],
+            confidence: 0.64,
           }),
         );
       }),
@@ -1226,6 +1229,7 @@ describe('createCommandAdapter', () => {
       question: 'Why this role?',
       answer: 'Mission alignment',
       tags: 'motivation,values',
+      confidence: 0.64,
     });
 
     expect(cli.cmdIntakeRecord).toHaveBeenCalledTimes(1);
@@ -1239,6 +1243,7 @@ describe('createCommandAdapter', () => {
       answer: 'Mission alignment',
       status: 'answered',
       tags: ['motivation', 'values'],
+      confidence: 0.64,
     });
   });
 

--- a/test/web-schemas.test.js
+++ b/test/web-schemas.test.js
@@ -345,6 +345,16 @@ describe('web request schemas', () => {
       ).toThrow('confidence must be between 0 and 1');
     });
 
+    it('throws when confidence is provided for a skipped prompt', () => {
+      expect(() =>
+        normalizeIntakeRecordRequest({
+          question: 'Tell me about your manager',
+          skipped: true,
+          confidence: 0.4,
+        }),
+      ).toThrow('confidence is only supported for answered intake responses');
+    });
+
     it('throws when reason is provided without skipping', () => {
       expect(() =>
         normalizeIntakeRecordRequest({

--- a/test/web-schemas.test.js
+++ b/test/web-schemas.test.js
@@ -284,6 +284,21 @@ describe('web request schemas', () => {
       });
     });
 
+    it('accepts confidence scores between 0 and 1', () => {
+      const options = normalizeIntakeRecordRequest({
+        question: 'How confident are you?',
+        answer: 'High confidence',
+        confidence: 0.85,
+      });
+
+      expect(options).toEqual({
+        question: 'How confident are you?',
+        answer: 'High confidence',
+        skipped: false,
+        confidence: 0.85,
+      });
+    });
+
     it('allows skipped prompts without an answer', () => {
       const options = normalizeIntakeRecordRequest({
         question: 'Compensation expectations?',
@@ -318,6 +333,16 @@ describe('web request schemas', () => {
           askedAt: 'not-a-date',
         }),
       ).toThrow('askedAt must be a valid ISO-8601 timestamp');
+    });
+
+    it('throws when confidence is outside the 0-1 range', () => {
+      expect(() =>
+        normalizeIntakeRecordRequest({
+          question: 'Test',
+          answer: 'Answer',
+          confidence: 1.2,
+        }),
+      ).toThrow('confidence must be between 0 and 1');
     });
 
     it('throws when reason is provided without skipping', () => {


### PR DESCRIPTION
### Motivation

- Ship documented-but-unshipped `--confidence` support for intake responses so intake answers can carry a certainty score. 
- The change is small and self-contained because intake responses already persist structured metadata and list output can surface an extra numeric field.
- Ensure both CLI and web surfaces accept, validate, and propagate confidence values to avoid drift between interfaces.
- Add regression tests to lock the request/response shapes and storage contract for confidence values.

### Description

- Add `normalizeConfidence` and wire strict validation/persistence of `confidence` in `src/intake.js`, and refuse `confidence` for skipped responses. 
- Extend the CLI `intake record` flow in `bin/jobbot.js` to accept `--confidence <0-1>`, validate it, include it in the stored payload, and display it in `intake list` output.
- Update web input validation in `src/web/schemas.js` and forward the `confidence` field through `src/web/command-adapter.js` so web endpoints accept and pass confidence to the CLI adapter.
- Update docs (`docs/user-journeys.md`, `docs/web-api-reference.md`) and add tests covering module persistence, CLI round-trips, schema validation, and adapter behavior (`test/intake.test.js`, `test/cli.test.js`, `test/web-schemas.test.js`, `test/web-command-adapter.test.js`).

### Testing

- Ran `npm run lint` and `npm run test:ci` and the full test suite completed successfully (`931 tests passed` in the CI run). 
- Executed `git diff --cached | ./scripts/scan-secrets.py` as a pre-push secret scan and it reported no findings. 
- Performed TypeScript check via the repo `typecheck` hook and it passed (`tsc -p tsconfig.json`).
- Added and ran targeted Vitest suites exercising the intake persistence, CLI display, web schema validation, and adapter plumbing and they all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696096e51130832f95443e56f4706026)