### PR TITLE
Add /ready readiness endpoint with tests and docs

### DIFF
--- a/docs/web-api-reference.md
+++ b/docs/web-api-reference.md
@@ -63,6 +63,12 @@ for accessibility and performance audits.
 Returns a JSON payload describing service health, uptime, and individual check states. Responses use
 status code 200 when all checks pass and 503 when any check reports `status: "error"`.
 
+### GET /ready
+
+Returns a lightweight readiness payload with `status: "ready"`, uptime, and timestamp metadata so
+load balancers can confirm the server is accepting requests. Regression coverage in
+[`test/web-server.test.js`](../test/web-server.test.js) validates the response contract.
+
 ### POST /sessions/revoke
 
 Invalidates the caller's active session and returns a fresh identifier. Requests must include the

--- a/docs/web-operational-playbook.md
+++ b/docs/web-operational-playbook.md
@@ -10,6 +10,8 @@ expectations so on-call engineers can keep the CLI bridge healthy.
   address, CSRF header, token, and any configured auth scheme on boot.
 - Confirm `/health` returns `status: "ok"` before routing traffic. The endpoint
   aggregates custom checks passed to `startWebServer({ healthChecks })`.
+- Use `/ready` for lightweight load-balancer readiness checks; it returns
+  `status: "ready"` once the server is accepting requests.
 - Visit `GET /` to load the status hub. The overview panel highlights rate
   limiting, CSRF, and auth guardrails. Hash-based navigation keeps the page
   static for local deployments.
@@ -50,7 +52,12 @@ discoverable.
    `error` and return HTTP 503. Regression coverage in
    [`test/web-health-checks.test.js`](../test/web-health-checks.test.js)
    exercises both probes so outages surface immediately.
-3. **Audit scores** – `src/web/audits.js` exposes axe-core and performance
+3. **Readiness checks** – `/ready` offers a lightweight probe that reports
+   `status: "ready"` with uptime metadata. Use it for load balancers that need a
+   fast signal without running the heavier `/health` checks. Coverage in
+   [`test/web-server.test.js`](../test/web-server.test.js) locks the response
+   shape.
+4. **Audit scores** – `src/web/audits.js` exposes axe-core and performance
    audits. Schedule them in CI or cron jobs to catch regressions between
    releases.
 

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -6650,6 +6650,17 @@ function buildHealthResponse({ info, uptime, timestamp, checks }) {
   return payload;
 }
 
+function buildReadyResponse({ info, uptime, timestamp }) {
+  const payload = {
+    status: "ready",
+    uptime,
+    timestamp,
+  };
+  if (info.service) payload.service = info.service;
+  if (info.version) payload.version = info.version;
+  return payload;
+}
+
 function isPlainObject(value) {
   if (!value || typeof value !== "object") return false;
   const prototype = Object.getPrototypeOf(value);
@@ -7989,6 +8000,17 @@ export function createWebApp({
     });
     const statusCode = payload.status === "error" ? 503 : 200;
     res.status(statusCode).json(payload);
+  });
+
+  app.get("/ready", (req, res) => {
+    const timestamp = new Date().toISOString();
+    const uptime = process.uptime();
+    const payload = buildReadyResponse({
+      info: normalizedInfo,
+      uptime,
+      timestamp,
+    });
+    res.status(200).json(payload);
   });
 
   app.post("/sessions/revoke", jsonParser, (req, res) => {

--- a/test/web-server.test.js
+++ b/test/web-server.test.js
@@ -383,6 +383,26 @@ describe("web server health endpoint", () => {
   });
 });
 
+describe("web server readiness endpoint", () => {
+  it("reports ready status with uptime metadata", async () => {
+    const server = await startServer({
+      info: { service: "jobbot-web", version: "0.1.0-test" },
+    });
+
+    const response = await fetch(`${server.url}/ready`);
+    expect(response.status).toBe(200);
+    const payload = await response.json();
+    expect(payload).toMatchObject({
+      status: "ready",
+      service: "jobbot-web",
+      version: "0.1.0-test",
+    });
+    expect(typeof payload.uptime).toBe("number");
+    expect(payload.uptime).toBeGreaterThanOrEqual(0);
+    expect(new Date(payload.timestamp).toString()).not.toBe("Invalid Date");
+  });
+});
+
 describe("web server status page", () => {
   it("exposes a theme toggle that persists the preferred mode", async () => {
     const server = await startServer();


### PR DESCRIPTION
### Motivation
- Provide a lightweight readiness probe for load balancers that does not run the full `/health` checks. 
- Roadmap and operational docs referenced readiness as a separate signal and the server previously lacked an explicit `/ready` endpoint. 
- This is a small, self-contained enhancement that unlocks safer orchestration and CI readiness checks. 
- Keep the change minimal: an endpoint, a payload builder, a test, and doc updates.

### Description
- Add `buildReadyResponse` and a `GET /ready` route to `src/web/server.js` that returns `{ status: "ready", uptime, timestamp, ...info }`.
- Add a test covering the readiness endpoint in `test/web-server.test.js` that asserts `200` status and the payload shape. 
- Document the new endpoint in `docs/web-api-reference.md` and note readiness usage in `docs/web-operational-playbook.md`.
- Modified files: `src/web/server.js`, `test/web-server.test.js`, `docs/web-api-reference.md`, and `docs/web-operational-playbook.md`.

### Testing
- Ran `npm run lint` which completed successfully. 
- Ran `npm run test:ci` which exercised the full suite but failed due to a PERF threshold in `test/scoring.resume.perf.test.js` (measured 227ms vs threshold 200ms). 
- Verified the new readiness test passes in isolation with `npx vitest test/scoring.resume.perf.test.js` and the added `test/web-server.test.js` run as part of the suite; local targeted runs passed. 
- Ran the secret scan `git diff --cached | ./scripts/scan-secrets.py` against staged changes and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696096e51130832f95443e56f4706026)