### PR TITLE
🔒 Require auth for remote web command mode

### DIFF
--- a/src/web/server.js
+++ b/src/web/server.js
@@ -8852,6 +8852,12 @@ export function startWebServer(options = {}) {
     }
   }
   const normalizedAuth = normalizeAuthOptions(authConfig);
+  if (allowRemote && !isLoopbackHost(host) && !normalizedAuth) {
+    throw new Error(
+      "Remote web command access requires authentication; configure JOBBOT_WEB_AUTH_TOKENS " +
+        "or pass auth tokens when allowRemoteAccess is enabled.",
+    );
+  }
   const commandEvents = new EventEmitter();
   const normalizedLogTransport = normalizeLogTransport(providedLogTransport, {
     host,

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -8855,7 +8855,7 @@ export function startWebServer(options = {}) {
   if (allowRemote && !isLoopbackHost(host) && !normalizedAuth) {
     throw new Error(
       "Remote web command access requires authentication; configure JOBBOT_WEB_AUTH_TOKENS " +
-        "or pass auth tokens when allowRemoteAccess is enabled.",
+        "or JOBBOT_WEB_AUTH_TOKEN, or pass auth tokens when allowRemoteAccess is enabled.",
     );
   }
   const commandEvents = new EventEmitter();

--- a/test/web-log-transport.test.js
+++ b/test/web-log-transport.test.js
@@ -23,6 +23,7 @@ describe('web server log transport', () => {
         host: '0.0.0.0',
         port: 0,
         allowRemoteAccess: true,
+        auth: { tokens: ['log-transport-token'] },
         csrfToken: 'log-transport-csrf',
         commandAdapter: {},
         logTransport,

--- a/test/web-server-host-guard.test.js
+++ b/test/web-server-host-guard.test.js
@@ -30,6 +30,7 @@ describe('web server host guard', () => {
     const server = await startWebServer({
       host: '0.0.0.0',
       port: 0,
+      auth: { tokens: ['host-guard-token'] },
       csrfToken: 'host-guard-csrf',
       commandAdapter: {},
     });
@@ -42,6 +43,7 @@ describe('web server host guard', () => {
     const server = await startWebServer({
       host: '0.0.0.0',
       port: 0,
+      auth: { tokens: ['host-guard-env-token'] },
       csrfToken: 'host-guard-csrf',
       commandAdapter: {},
     });

--- a/test/web-server-remote-access.test.js
+++ b/test/web-server-remote-access.test.js
@@ -56,6 +56,7 @@ describe('web server remote access guard', () => {
       host: '0.0.0.0',
       port: 0,
       allowRemoteAccess: true,
+      auth: { tokens: ['remote-guard-token'] },
       audit: { logPath: path.join(tempDir, 'audit.jsonl') },
       csrfToken: 'remote-guard-csrf',
       commandAdapter: {},
@@ -96,6 +97,7 @@ describe('web server remote access guard', () => {
     server = await startWebServer({
       host: '0.0.0.0',
       port: 0,
+      auth: { tokens: ['remote-env-token'] },
       audit: { logPath: path.join(tempDir, 'audit.jsonl') },
       csrfToken: 'remote-guard-csrf',
       commandAdapter: {},

--- a/test/web-server.test.js
+++ b/test/web-server.test.js
@@ -381,6 +381,27 @@ describe("web server health endpoint", () => {
       process.env.JOBBOT_WEB_ALLOW_REMOTE = originalEnv;
     }
   });
+
+  it("requires auth when remote-access mode is enabled", async () => {
+    const { startWebServer } = await import("../src/web/server.js");
+
+    expect(() =>
+      startWebServer({ host: "0.0.0.0", allowRemoteAccess: true }),
+    ).toThrow(/requires authentication/i);
+  });
+
+  it("allows remote-access mode when auth tokens are configured", async () => {
+    const { startWebServer } = await import("../src/web/server.js");
+    const server = await startWebServer({
+      host: "0.0.0.0",
+      port: 0,
+      allowRemoteAccess: true,
+      csrfToken: "test-csrf-token",
+      auth: { tokens: ["remote-token"] },
+    });
+    activeServers.push(server);
+    expect(server.url).toMatch(/^http:\/\/0\.0\.0\.0:/);
+  });
 });
 
 describe("web server readiness endpoint", () => {

--- a/test/web-server.test.js
+++ b/test/web-server.test.js
@@ -384,10 +384,29 @@ describe("web server health endpoint", () => {
 
   it("requires auth when remote-access mode is enabled", async () => {
     const { startWebServer } = await import("../src/web/server.js");
+    const originalAuthTokens = process.env.JOBBOT_WEB_AUTH_TOKENS;
+    const originalAuthToken = process.env.JOBBOT_WEB_AUTH_TOKEN;
 
-    expect(() =>
-      startWebServer({ host: "0.0.0.0", allowRemoteAccess: true }),
-    ).toThrow(/requires authentication/i);
+    delete process.env.JOBBOT_WEB_AUTH_TOKENS;
+    delete process.env.JOBBOT_WEB_AUTH_TOKEN;
+
+    try {
+      expect(() =>
+        startWebServer({ host: "0.0.0.0", allowRemoteAccess: true }),
+      ).toThrow(/requires authentication/i);
+    } finally {
+      if (originalAuthTokens === undefined) {
+        delete process.env.JOBBOT_WEB_AUTH_TOKENS;
+      } else {
+        process.env.JOBBOT_WEB_AUTH_TOKENS = originalAuthTokens;
+      }
+
+      if (originalAuthToken === undefined) {
+        delete process.env.JOBBOT_WEB_AUTH_TOKEN;
+      } else {
+        process.env.JOBBOT_WEB_AUTH_TOKEN = originalAuthToken;
+      }
+    }
   });
 
   it("allows remote-access mode when auth tokens are configured", async () => {


### PR DESCRIPTION
### Motivation

- Prevent unauthenticated remote invocation of CLI commands (and potential local file disclosure) when the web server is bound to a non-loopback host with remote access enabled.

### Description

- Add a runtime check in `startWebServer` to throw if `allowRemoteAccess` is true and the host is non-loopback while no authentication configuration is present, preserving local loopback behavior (`src/web/server.js`).
- Add regression tests that assert startup fails when remote-access is enabled without auth and succeeds when auth tokens are provided (`test/web-server.test.js`).

### Testing

- Ran `npm run lint` which completed successfully.
- Ran targeted tests with `npx vitest` / `npm run test:ci` for the new cases and related startup checks and they passed.
- Ran `npm run test:ci` for a small test subset used during verification and observed successful results for the modified scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8d4f71180832f8af027b9002023b1)