### PR TITLE
Add browser-first IndexedDB architecture contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 **jobbot3000** is a self-hosted, open-source job search copilot.
 
+The production web direction is browser-first: private application tracking data should live in user-owned IndexedDB, while the deployed server/container serves static assets and health endpoints. This is a planned architecture rather than a completed implementation; see [docs/browser-first-architecture.md](docs/browser-first-architecture.md) for the data contract and migration path.
+
 > [!WARNING]
 > The web interface is an experimental preview for local use only. Running production builds or
 > deploying to shared or cloud infrastructure can leak secrets, PII, and other sensitive data.
@@ -154,6 +156,7 @@ Run the snippet with `node example.js` after saving it to a file in the project 
 - [SECURITY.md](SECURITY.md) – security guidelines
 - [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) – prompt reference index
 - [docs/user-journeys.md](docs/user-journeys.md) – primary user journeys and flows
+- [docs/browser-first-architecture.md](docs/browser-first-architecture.md) – planned IndexedDB-first production web architecture and browser data contract
 - [docs/backup-restore-guide.md](docs/backup-restore-guide.md) – backup, restore, and verification
   steps
 - [docs/web-ux-guidelines.md](docs/web-ux-guidelines.md) – layout, typography, and interaction guardrails
@@ -161,8 +164,7 @@ Run the snippet with `node example.js` after saving it to a file in the project 
 
 ### Durable data export/import
 
-All recruiter outreach, contacts, and lifecycle events live in `data/opportunities.db` (SQLite via
-Drizzle ORM). Use the bundled scripts to back up or restore records:
+The current CLI/recruiter-ingest preview stores recruiter outreach, contacts, and lifecycle events in `data/opportunities.db` (SQLite via Drizzle ORM). The planned production web tracker will instead store private application data in browser-owned IndexedDB and use explicit JSON/NDJSON/CSV backup files; see [docs/browser-first-architecture.md](docs/browser-first-architecture.md). Use the bundled scripts to back up or restore the current CLI opportunity records:
 
 ```bash
 # Export every table as newline-delimited JSON

--- a/docs/browser-first-architecture.md
+++ b/docs/browser-first-architecture.md
@@ -1,0 +1,143 @@
+# Browser-first architecture and data contract
+
+jobbot3000 is moving toward a production web application where private job-search data belongs to
+the user and stays in the browser by default. This document defines the target architecture for that
+work. It is intentionally a contract and migration plan, not a claim that the current implementation
+is finished.
+
+## Principles
+
+- **IndexedDB is the source of truth for private application data.** Applications, contacts,
+  outreach, interviews, offers, notes, reminders, and private artifacts are stored in browser-owned
+  IndexedDB databases rather than server-side SQLite.
+- **The server does not own sensitive tracker state.** A deployed container serves static assets,
+  health endpoints, and optional public files. It must not persist applications, outreach messages,
+  interviews, offers, notes, imported spreadsheets, resumes, or private attachments.
+- **Offline-first behavior is required.** The app should load without network access after the first
+  visit, read and write tracker data locally, and queue only non-sensitive sync/export operations that
+  the user explicitly starts.
+- **Imports and exports are user-controlled backups.** JSON is the canonical full-fidelity backup
+  format. NDJSON is suitable for streaming and append-friendly tooling. CSV exists for compatibility
+  with the current spreadsheet workflow and may be lossy for normalized child records.
+- **No personal fixtures in git.** Tests and examples must use fake, anonymized companies, contacts,
+  and compensation data.
+
+## Deployment boundaries
+
+The production container should be safe to run as a static web app:
+
+```text
+Browser
+  ├─ IndexedDB: private applications, contacts, events, interviews, offers, notes, reminders
+  ├─ Cache Storage / service worker: versioned app shell and static assets
+  └─ Downloads/uploads: explicit user backup and restore files
+
+Container / static host
+  ├─ Static HTML, CSS, JS, images, and generated public documentation
+  ├─ Health/readiness endpoints for Docker, Kubernetes, and Sugarkube
+  └─ No server-side application database for private tracker data
+```
+
+This boundary differs from the current preview, which still includes Node/Express routes and a
+SQLite-backed opportunity repository for CLI-oriented recruiter outreach flows. Those pieces remain
+for compatibility while the browser repository is built behind a clearly named application model.
+
+## Data classes
+
+| Class                           | Examples                                                                                              | Storage expectation                                                       |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| App data                        | Application rows, contacts, outreach messages, lifecycle events, interviews, offers, notes, reminders | Private IndexedDB object stores                                           |
+| Optional public assets          | Logo, help text, sample empty-state content, generated documentation                                  | Static assets served by the container                                     |
+| Private user-imported artifacts | Spreadsheet imports, resumes, cover letters, take-home files, screenshots, PDFs                       | IndexedDB Blob records or user-managed files referenced by local metadata |
+
+Private imported artifacts must not be copied into the repo, bundled into production images, or
+uploaded to server endpoints unless a future feature makes that transfer explicit and opt-in.
+
+## Minimal normalized browser model
+
+The runtime contract lives in `src/domain/browserApplication.js`. Version 1 contains these stores:
+
+- `applications`: one row per target role, with company, role, current status, posting URL,
+  source, location, compensation summary, applied/closed timestamps, and notes.
+- `contacts`: recruiters, hiring managers, interviewers, and referrers linked to an application.
+- `outreachMessages`: inbound and outbound email, LinkedIn, phone, SMS, or other message records.
+- `lifecycleEvents`: append-only status history for auditability and funnel analytics.
+- `interviews`: recruiter screens, technical screens, onsite/loop interviews, and other scheduled
+  conversations.
+- `offers`: offer terms, deadlines, negotiation state, and acceptance/decline metadata.
+- `artifacts`: links or browser-local Blob references for postings, resumes, cover letters,
+  portfolios, take-homes, and other supporting files.
+- `reminders`: follow-up tasks with due and completion timestamps.
+- `settings`: local-only preferences such as schema version, locale, timezone, and default export
+  format.
+
+### Canonical lifecycle statuses
+
+The browser application tracker uses human workflow statuses that cover the current spreadsheet:
+
+| Display status    | Schema value       | Typical meaning                                           |
+| ----------------- | ------------------ | --------------------------------------------------------- |
+| Applied           | `applied`          | Application submitted or entered from historical tracking |
+| Outreach sent     | `outreach_sent`    | User contacted a recruiter, hiring manager, or referrer   |
+| Recruiter screen  | `recruiter_screen` | Recruiter or phone screen scheduled or completed          |
+| Technical screen  | `technical_screen` | Technical phone/video screen or take-home stage           |
+| Onsite / loop     | `onsite_loop`      | Final loop, onsite, or multi-interviewer stage            |
+| Offer             | `offer`            | Offer received or active negotiation underway             |
+| Accepted          | `accepted`         | Offer accepted                                            |
+| Rejected          | `rejected`         | Company rejected or process ended negatively              |
+| Withdrawn         | `withdrawn`        | User opted out                                            |
+| Closed / archived | `closed_archived`  | Historical, duplicate, stale, or archived record          |
+
+The older CLI opportunity lifecycle remains in `src/domain/opportunity.js` and is narrower because it
+models recruiter email ingestion and SQLite persistence. New browser code should depend on the
+browser application schema instead of overloading the CLI opportunity schema.
+
+## Backup and restore expectations
+
+- A full backup exports one JSON document matching `browserApplicationExportSchema`.
+- NDJSON exports should emit one validated record per line with type metadata when implemented.
+- CSV export should flatten application rows for spreadsheet review and include stable IDs so child
+  records can be joined from JSON/NDJSON backups.
+- Restore must validate schema versions before writing to IndexedDB and should run inside a single
+  migration transaction where the browser supports it.
+- The UI should explain that clearing browser storage deletes local tracker data unless the user has
+  exported a backup.
+
+## Offline-first behavior
+
+The production web app should use a service worker to cache the app shell and static assets. Once the
+app shell is available, users should be able to create, update, search, filter, import, and export job
+application data without network access. Health endpoints are for operators and orchestrators only;
+application CRUD must not depend on them.
+
+## Migration from current CSV and SQLite/NDJSON concepts
+
+The existing spreadsheet has 32 columns in a single wide row per opportunity. The normalized browser
+model splits those columns into parent application records and child stores. Exact importer field
+names will be implemented in a later PR, but the migration should follow this mapping:
+
+| Current CSV concept                                                                | Browser model target                                      |
+| ---------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| Company, role/title, job URL, source, location, remote flag                        | `applications`                                            |
+| Current status/stage/outcome                                                       | `applications.status` plus a `lifecycleEvents` row        |
+| Applied date, last updated, closed date                                            | `applications.appliedAt`, `updatedAt`, `closedAt`         |
+| Recruiter, hiring manager, referrer, interviewer names/emails/phones/profile links | `contacts`                                                |
+| Outreach date/channel/subject/body/follow-up notes                                 | `outreachMessages` and `reminders`                        |
+| Recruiter screen, technical screen, onsite dates, meeting links, prep notes        | `interviews`                                              |
+| Offer amount, equity, bonus, deadline, decision                                    | `offers` and terminal lifecycle status                    |
+| Resume, cover letter, posting snapshot, take-home, portfolio links                 | `artifacts`                                               |
+| Freeform notes and next action                                                     | `applications.notes`, `lifecycleEvents.note`, `reminders` |
+| Tags, preferences, import metadata                                                 | `applications.source`, future tag store, or `settings`    |
+
+SQLite/NDJSON exports from the current opportunity repository should be treated as import sources,
+not as the production browser database. Importers should create stable browser IDs, preserve original
+source IDs in metadata when needed, and avoid writing migrated private data anywhere under version
+control.
+
+## Implementation sequence
+
+1. Keep the CLI opportunity model and tests intact.
+2. Build an IndexedDB repository that consumes the browser schemas and performs versioned migrations.
+3. Add JSON, NDJSON, and CSV import/export around the browser model.
+4. Move UI tracker screens to the IndexedDB repository.
+5. Harden service worker, static deployment, health checks, Docker, Helm, and Sugarkube integration.

--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -1,0 +1,182 @@
+import { z } from "zod";
+
+export const browserApplicationLifecycleStatusSchema = z.enum([
+  "applied",
+  "outreach_sent",
+  "recruiter_screen",
+  "technical_screen",
+  "onsite_loop",
+  "offer",
+  "accepted",
+  "rejected",
+  "withdrawn",
+  "closed_archived",
+]);
+
+const isoDateTimeSchema = z.string().datetime();
+const optionalTrimmedStringSchema = z.string().trim().min(1).optional();
+const idSchema = z.string().trim().min(1);
+
+export const browserApplicationContactSchema = z.object({
+  id: idSchema,
+  applicationId: idSchema,
+  name: optionalTrimmedStringSchema,
+  role: optionalTrimmedStringSchema,
+  email: z.string().email().optional(),
+  phone: optionalTrimmedStringSchema,
+  profileUrl: z.string().url().optional(),
+  company: optionalTrimmedStringSchema,
+  notes: optionalTrimmedStringSchema,
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserApplicationOutreachMessageSchema = z.object({
+  id: idSchema,
+  applicationId: idSchema,
+  contactId: idSchema.optional(),
+  direction: z.enum(["inbound", "outbound"]),
+  channel: z.enum(["email", "linkedin", "phone", "sms", "other"]),
+  subject: optionalTrimmedStringSchema,
+  body: optionalTrimmedStringSchema,
+  sentAt: isoDateTimeSchema.optional(),
+  receivedAt: isoDateTimeSchema.optional(),
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserApplicationLifecycleEventSchema = z.object({
+  id: idSchema,
+  applicationId: idSchema,
+  status: browserApplicationLifecycleStatusSchema,
+  occurredAt: isoDateTimeSchema,
+  source: z.enum([
+    "manual",
+    "csv_import",
+    "json_import",
+    "ndjson_import",
+    "sqlite_migration",
+  ]),
+  note: optionalTrimmedStringSchema,
+  createdAt: isoDateTimeSchema,
+});
+
+export const browserApplicationInterviewSchema = z.object({
+  id: idSchema,
+  applicationId: idSchema,
+  contactIds: z.array(idSchema).default([]),
+  stage: z.enum([
+    "recruiter_screen",
+    "technical_screen",
+    "onsite_loop",
+    "other",
+  ]),
+  startsAt: isoDateTimeSchema,
+  endsAt: isoDateTimeSchema.optional(),
+  location: optionalTrimmedStringSchema,
+  meetingUrl: z.string().url().optional(),
+  preparationNotes: optionalTrimmedStringSchema,
+  outcome: z
+    .enum(["scheduled", "completed", "cancelled", "no_show"])
+    .default("scheduled"),
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserApplicationOfferSchema = z.object({
+  id: idSchema,
+  applicationId: idSchema,
+  status: z.enum([
+    "draft",
+    "received",
+    "negotiating",
+    "accepted",
+    "declined",
+    "expired",
+  ]),
+  baseSalaryMin: z.number().nonnegative().optional(),
+  baseSalaryMax: z.number().nonnegative().optional(),
+  currency: z.string().trim().length(3).optional(),
+  equity: optionalTrimmedStringSchema,
+  bonus: optionalTrimmedStringSchema,
+  deadlineAt: isoDateTimeSchema.optional(),
+  notes: optionalTrimmedStringSchema,
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserApplicationArtifactSchema = z.object({
+  id: idSchema,
+  applicationId: idSchema,
+  kind: z.enum([
+    "job_posting",
+    "resume",
+    "cover_letter",
+    "portfolio",
+    "take_home",
+    "link",
+    "other",
+  ]),
+  name: idSchema,
+  url: z.string().url().optional(),
+  blobKey: optionalTrimmedStringSchema,
+  mimeType: optionalTrimmedStringSchema,
+  private: z.boolean().default(true),
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserApplicationReminderSchema = z.object({
+  id: idSchema,
+  applicationId: idSchema,
+  contactId: idSchema.optional(),
+  dueAt: isoDateTimeSchema,
+  completedAt: isoDateTimeSchema.optional(),
+  summary: idSchema,
+  notes: optionalTrimmedStringSchema,
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserApplicationSettingsSchema = z.object({
+  id: z.literal("local"),
+  schemaVersion: z.number().int().positive(),
+  locale: optionalTrimmedStringSchema,
+  timezone: optionalTrimmedStringSchema,
+  defaultExportFormat: z.enum(["json", "ndjson", "csv"]).default("json"),
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserApplicationSchema = z.object({
+  id: idSchema,
+  company: idSchema,
+  role: idSchema,
+  status: browserApplicationLifecycleStatusSchema,
+  source: optionalTrimmedStringSchema,
+  postingUrl: z.string().url().optional(),
+  location: optionalTrimmedStringSchema,
+  remote: z.boolean().optional(),
+  compensationText: optionalTrimmedStringSchema,
+  appliedAt: isoDateTimeSchema.optional(),
+  closedAt: isoDateTimeSchema.optional(),
+  notes: optionalTrimmedStringSchema,
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserApplicationExportSchema = z.object({
+  schemaVersion: z.literal(1),
+  exportedAt: isoDateTimeSchema,
+  applications: z.array(browserApplicationSchema),
+  contacts: z.array(browserApplicationContactSchema).default([]),
+  outreachMessages: z
+    .array(browserApplicationOutreachMessageSchema)
+    .default([]),
+  lifecycleEvents: z.array(browserApplicationLifecycleEventSchema).default([]),
+  interviews: z.array(browserApplicationInterviewSchema).default([]),
+  offers: z.array(browserApplicationOfferSchema).default([]),
+  artifacts: z.array(browserApplicationArtifactSchema).default([]),
+  reminders: z.array(browserApplicationReminderSchema).default([]),
+  settings: browserApplicationSettingsSchema.optional(),
+});

--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -14,8 +14,9 @@ export const browserApplicationLifecycleStatusSchema = z.enum([
 ]);
 
 const isoDateTimeSchema = z.string().datetime();
-const optionalTrimmedStringSchema = z.string().trim().min(1).optional();
-const idSchema = z.string().trim().min(1);
+const requiredStringSchema = z.string().trim().min(1);
+const optionalTrimmedStringSchema = requiredStringSchema.optional();
+const idSchema = requiredStringSchema;
 
 export const browserApplicationContactSchema = z.object({
   id: idSchema,
@@ -83,27 +84,38 @@ export const browserApplicationInterviewSchema = z.object({
   updatedAt: isoDateTimeSchema,
 });
 
-export const browserApplicationOfferSchema = z.object({
-  id: idSchema,
-  applicationId: idSchema,
-  status: z.enum([
-    "draft",
-    "received",
-    "negotiating",
-    "accepted",
-    "declined",
-    "expired",
-  ]),
-  baseSalaryMin: z.number().nonnegative().optional(),
-  baseSalaryMax: z.number().nonnegative().optional(),
-  currency: z.string().trim().length(3).optional(),
-  equity: optionalTrimmedStringSchema,
-  bonus: optionalTrimmedStringSchema,
-  deadlineAt: isoDateTimeSchema.optional(),
-  notes: optionalTrimmedStringSchema,
-  createdAt: isoDateTimeSchema,
-  updatedAt: isoDateTimeSchema,
-});
+export const browserApplicationOfferSchema = z
+  .object({
+    id: idSchema,
+    applicationId: idSchema,
+    status: z.enum([
+      "draft",
+      "received",
+      "negotiating",
+      "accepted",
+      "declined",
+      "expired",
+    ]),
+    baseSalaryMin: z.number().nonnegative().optional(),
+    baseSalaryMax: z.number().nonnegative().optional(),
+    currency: z.string().trim().length(3).optional(),
+    equity: optionalTrimmedStringSchema,
+    bonus: optionalTrimmedStringSchema,
+    deadlineAt: isoDateTimeSchema.optional(),
+    notes: optionalTrimmedStringSchema,
+    createdAt: isoDateTimeSchema,
+    updatedAt: isoDateTimeSchema,
+  })
+  .refine(
+    ({ baseSalaryMin, baseSalaryMax }) =>
+      baseSalaryMin === undefined ||
+      baseSalaryMax === undefined ||
+      baseSalaryMin <= baseSalaryMax,
+    {
+      message: "baseSalaryMin must be less than or equal to baseSalaryMax",
+      path: ["baseSalaryMin"],
+    },
+  );
 
 export const browserApplicationArtifactSchema = z.object({
   id: idSchema,
@@ -117,7 +129,7 @@ export const browserApplicationArtifactSchema = z.object({
     "link",
     "other",
   ]),
-  name: idSchema,
+  name: requiredStringSchema,
   url: z.string().url().optional(),
   blobKey: optionalTrimmedStringSchema,
   mimeType: optionalTrimmedStringSchema,
@@ -132,7 +144,7 @@ export const browserApplicationReminderSchema = z.object({
   contactId: idSchema.optional(),
   dueAt: isoDateTimeSchema,
   completedAt: isoDateTimeSchema.optional(),
-  summary: idSchema,
+  summary: requiredStringSchema,
   notes: optionalTrimmedStringSchema,
   createdAt: isoDateTimeSchema,
   updatedAt: isoDateTimeSchema,
@@ -140,7 +152,7 @@ export const browserApplicationReminderSchema = z.object({
 
 export const browserApplicationSettingsSchema = z.object({
   id: z.literal("local"),
-  schemaVersion: z.number().int().positive(),
+  schemaVersion: z.literal(1),
   locale: optionalTrimmedStringSchema,
   timezone: optionalTrimmedStringSchema,
   defaultExportFormat: z.enum(["json", "ndjson", "csv"]).default("json"),
@@ -150,8 +162,8 @@ export const browserApplicationSettingsSchema = z.object({
 
 export const browserApplicationSchema = z.object({
   id: idSchema,
-  company: idSchema,
-  role: idSchema,
+  company: requiredStringSchema,
+  role: requiredStringSchema,
   status: browserApplicationLifecycleStatusSchema,
   source: optionalTrimmedStringSchema,
   postingUrl: z.string().url().optional(),
@@ -165,18 +177,130 @@ export const browserApplicationSchema = z.object({
   updatedAt: isoDateTimeSchema,
 });
 
-export const browserApplicationExportSchema = z.object({
-  schemaVersion: z.literal(1),
-  exportedAt: isoDateTimeSchema,
-  applications: z.array(browserApplicationSchema),
-  contacts: z.array(browserApplicationContactSchema).default([]),
-  outreachMessages: z
-    .array(browserApplicationOutreachMessageSchema)
-    .default([]),
-  lifecycleEvents: z.array(browserApplicationLifecycleEventSchema).default([]),
-  interviews: z.array(browserApplicationInterviewSchema).default([]),
-  offers: z.array(browserApplicationOfferSchema).default([]),
-  artifacts: z.array(browserApplicationArtifactSchema).default([]),
-  reminders: z.array(browserApplicationReminderSchema).default([]),
-  settings: browserApplicationSettingsSchema.optional(),
-});
+const addDuplicateIdIssues = (ctx, storeName, records) => {
+  const seen = new Set();
+
+  records.forEach(({ id }, index) => {
+    if (seen.has(id)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Duplicate ${storeName} id: ${id}`,
+        path: [storeName, index, "id"],
+      });
+      return;
+    }
+
+    seen.add(id);
+  });
+};
+
+const addApplicationReferenceIssues = (
+  ctx,
+  storeName,
+  records,
+  applicationIds,
+) => {
+  records.forEach(({ applicationId }, index) => {
+    if (!applicationIds.has(applicationId)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Unknown applicationId: ${applicationId}`,
+        path: [storeName, index, "applicationId"],
+      });
+    }
+  });
+};
+
+const addContactReferenceIssues = (ctx, storeName, records, contactIds) => {
+  records.forEach(({ contactId }, index) => {
+    if (contactId !== undefined && !contactIds.has(contactId)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Unknown contactId: ${contactId}`,
+        path: [storeName, index, "contactId"],
+      });
+    }
+  });
+};
+
+export const browserApplicationExportSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    exportedAt: isoDateTimeSchema,
+    applications: z.array(browserApplicationSchema),
+    contacts: z.array(browserApplicationContactSchema).default([]),
+    outreachMessages: z
+      .array(browserApplicationOutreachMessageSchema)
+      .default([]),
+    lifecycleEvents: z
+      .array(browserApplicationLifecycleEventSchema)
+      .default([]),
+    interviews: z.array(browserApplicationInterviewSchema).default([]),
+    offers: z.array(browserApplicationOfferSchema).default([]),
+    artifacts: z.array(browserApplicationArtifactSchema).default([]),
+    reminders: z.array(browserApplicationReminderSchema).default([]),
+    settings: browserApplicationSettingsSchema.optional(),
+  })
+  .superRefine((exportData, ctx) => {
+    const keyedStores = [
+      ["applications", exportData.applications],
+      ["contacts", exportData.contacts],
+      ["outreachMessages", exportData.outreachMessages],
+      ["lifecycleEvents", exportData.lifecycleEvents],
+      ["interviews", exportData.interviews],
+      ["offers", exportData.offers],
+      ["artifacts", exportData.artifacts],
+      ["reminders", exportData.reminders],
+    ];
+
+    keyedStores.forEach(([storeName, records]) => {
+      addDuplicateIdIssues(ctx, storeName, records);
+    });
+
+    const applicationIds = new Set(
+      exportData.applications.map((application) => application.id),
+    );
+    const contactIds = new Set(
+      exportData.contacts.map((contact) => contact.id),
+    );
+    const applicationScopedStores = [
+      ["contacts", exportData.contacts],
+      ["outreachMessages", exportData.outreachMessages],
+      ["lifecycleEvents", exportData.lifecycleEvents],
+      ["interviews", exportData.interviews],
+      ["offers", exportData.offers],
+      ["artifacts", exportData.artifacts],
+      ["reminders", exportData.reminders],
+    ];
+
+    applicationScopedStores.forEach(([storeName, records]) => {
+      addApplicationReferenceIssues(ctx, storeName, records, applicationIds);
+    });
+
+    addContactReferenceIssues(
+      ctx,
+      "outreachMessages",
+      exportData.outreachMessages,
+      contactIds,
+    );
+    addContactReferenceIssues(
+      ctx,
+      "reminders",
+      exportData.reminders,
+      contactIds,
+    );
+
+    exportData.interviews.forEach(
+      ({ contactIds: interviewContactIds }, index) => {
+        interviewContactIds.forEach((contactId, contactIndex) => {
+          if (!contactIds.has(contactId)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `Unknown contactId: ${contactId}`,
+              path: ["interviews", index, "contactIds", contactIndex],
+            });
+          }
+        });
+      },
+    );
+  });

--- a/src/domain/browserApplication.ts
+++ b/src/domain/browserApplication.ts
@@ -1,0 +1,69 @@
+import { z } from "zod";
+
+import {
+  browserApplicationArtifactSchema as runtimeBrowserApplicationArtifactSchema,
+  browserApplicationContactSchema as runtimeBrowserApplicationContactSchema,
+  browserApplicationExportSchema as runtimeBrowserApplicationExportSchema,
+  browserApplicationInterviewSchema as runtimeBrowserApplicationInterviewSchema,
+  browserApplicationLifecycleEventSchema as runtimeBrowserApplicationLifecycleEventSchema,
+  browserApplicationLifecycleStatusSchema as runtimeBrowserApplicationLifecycleStatusSchema,
+  browserApplicationOfferSchema as runtimeBrowserApplicationOfferSchema,
+  browserApplicationOutreachMessageSchema as runtimeBrowserApplicationOutreachMessageSchema,
+  browserApplicationReminderSchema as runtimeBrowserApplicationReminderSchema,
+  browserApplicationSchema as runtimeBrowserApplicationSchema,
+  browserApplicationSettingsSchema as runtimeBrowserApplicationSettingsSchema,
+} from "./browserApplication.js";
+
+export const browserApplicationArtifactSchema =
+  runtimeBrowserApplicationArtifactSchema;
+export const browserApplicationContactSchema =
+  runtimeBrowserApplicationContactSchema;
+export const browserApplicationExportSchema =
+  runtimeBrowserApplicationExportSchema;
+export const browserApplicationInterviewSchema =
+  runtimeBrowserApplicationInterviewSchema;
+export const browserApplicationLifecycleEventSchema =
+  runtimeBrowserApplicationLifecycleEventSchema;
+export const browserApplicationLifecycleStatusSchema =
+  runtimeBrowserApplicationLifecycleStatusSchema;
+export const browserApplicationOfferSchema =
+  runtimeBrowserApplicationOfferSchema;
+export const browserApplicationOutreachMessageSchema =
+  runtimeBrowserApplicationOutreachMessageSchema;
+export const browserApplicationReminderSchema =
+  runtimeBrowserApplicationReminderSchema;
+export const browserApplicationSchema = runtimeBrowserApplicationSchema;
+export const browserApplicationSettingsSchema =
+  runtimeBrowserApplicationSettingsSchema;
+
+export type BrowserApplicationLifecycleStatus = z.infer<
+  typeof browserApplicationLifecycleStatusSchema
+>;
+export type BrowserApplication = z.infer<typeof browserApplicationSchema>;
+export type BrowserApplicationContact = z.infer<
+  typeof browserApplicationContactSchema
+>;
+export type BrowserApplicationOutreachMessage = z.infer<
+  typeof browserApplicationOutreachMessageSchema
+>;
+export type BrowserApplicationLifecycleEvent = z.infer<
+  typeof browserApplicationLifecycleEventSchema
+>;
+export type BrowserApplicationInterview = z.infer<
+  typeof browserApplicationInterviewSchema
+>;
+export type BrowserApplicationOffer = z.infer<
+  typeof browserApplicationOfferSchema
+>;
+export type BrowserApplicationArtifact = z.infer<
+  typeof browserApplicationArtifactSchema
+>;
+export type BrowserApplicationReminder = z.infer<
+  typeof browserApplicationReminderSchema
+>;
+export type BrowserApplicationSettings = z.infer<
+  typeof browserApplicationSettingsSchema
+>;
+export type BrowserApplicationExport = z.infer<
+  typeof browserApplicationExportSchema
+>;

--- a/test/browser-application-schema.test.js
+++ b/test/browser-application-schema.test.js
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  browserApplicationExportSchema,
+  browserApplicationLifecycleStatusSchema,
+  browserApplicationSchema,
+} from "../src/domain/browserApplication.js";
+
+describe("browser application schemas", () => {
+  it("accepts the canonical lifecycle statuses for the IndexedDB model", () => {
+    expect(browserApplicationLifecycleStatusSchema.options).toEqual([
+      "applied",
+      "outreach_sent",
+      "recruiter_screen",
+      "technical_screen",
+      "onsite_loop",
+      "offer",
+      "accepted",
+      "rejected",
+      "withdrawn",
+      "closed_archived",
+    ]);
+  });
+
+  it("validates a normalized browser-local application export", () => {
+    const now = "2026-01-02T03:04:05.000Z";
+    const parsed = browserApplicationExportSchema.parse({
+      schemaVersion: 1,
+      exportedAt: now,
+      applications: [
+        {
+          id: "app_fake_001",
+          company: "Example Robotics",
+          role: "Staff Software Engineer",
+          status: "applied",
+          postingUrl: "https://example.test/jobs/staff-engineer",
+          appliedAt: now,
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+      contacts: [],
+      outreachMessages: [],
+      lifecycleEvents: [
+        {
+          id: "event_fake_001",
+          applicationId: "app_fake_001",
+          status: "applied",
+          occurredAt: now,
+          source: "manual",
+          createdAt: now,
+        },
+      ],
+    });
+
+    expect(parsed.applications[0].company).toBe("Example Robotics");
+    expect(parsed.lifecycleEvents[0].source).toBe("manual");
+  });
+
+  it("rejects malformed application URLs and statuses", () => {
+    const now = "2026-01-02T03:04:05.000Z";
+
+    expect(() =>
+      browserApplicationSchema.parse({
+        id: "app_fake_002",
+        company: "Example Health",
+        role: "Frontend Engineer",
+        status: "phone_screen_scheduled",
+        postingUrl: "not a url",
+        createdAt: now,
+        updatedAt: now,
+      }),
+    ).toThrow();
+  });
+});

--- a/test/browser-application-schema.test.js
+++ b/test/browser-application-schema.test.js
@@ -3,8 +3,59 @@ import { describe, expect, it } from "vitest";
 import {
   browserApplicationExportSchema,
   browserApplicationLifecycleStatusSchema,
+  browserApplicationOfferSchema,
   browserApplicationSchema,
+  browserApplicationSettingsSchema,
 } from "../src/domain/browserApplication.js";
+
+const now = "2026-01-02T03:04:05.000Z";
+
+const validApplication = {
+  id: "app_fake_001",
+  company: "Example Robotics",
+  role: "Staff Software Engineer",
+  status: "applied",
+  postingUrl: "https://example.test/jobs/staff-engineer",
+  appliedAt: now,
+  createdAt: now,
+  updatedAt: now,
+};
+
+const validExport = {
+  schemaVersion: 1,
+  exportedAt: now,
+  applications: [validApplication],
+  contacts: [
+    {
+      id: "contact_fake_001",
+      applicationId: "app_fake_001",
+      name: "Jordan Example",
+      createdAt: now,
+      updatedAt: now,
+    },
+  ],
+  outreachMessages: [
+    {
+      id: "message_fake_001",
+      applicationId: "app_fake_001",
+      contactId: "contact_fake_001",
+      direction: "outbound",
+      channel: "email",
+      createdAt: now,
+      updatedAt: now,
+    },
+  ],
+  lifecycleEvents: [
+    {
+      id: "event_fake_001",
+      applicationId: "app_fake_001",
+      status: "applied",
+      occurredAt: now,
+      source: "manual",
+      createdAt: now,
+    },
+  ],
+};
 
 describe("browser application schemas", () => {
   it("accepts the canonical lifecycle statuses for the IndexedDB model", () => {
@@ -23,53 +74,92 @@ describe("browser application schemas", () => {
   });
 
   it("validates a normalized browser-local application export", () => {
-    const now = "2026-01-02T03:04:05.000Z";
-    const parsed = browserApplicationExportSchema.parse({
-      schemaVersion: 1,
-      exportedAt: now,
-      applications: [
-        {
-          id: "app_fake_001",
-          company: "Example Robotics",
-          role: "Staff Software Engineer",
-          status: "applied",
-          postingUrl: "https://example.test/jobs/staff-engineer",
-          appliedAt: now,
-          createdAt: now,
-          updatedAt: now,
-        },
-      ],
-      contacts: [],
-      outreachMessages: [],
-      lifecycleEvents: [
-        {
-          id: "event_fake_001",
-          applicationId: "app_fake_001",
-          status: "applied",
-          occurredAt: now,
-          source: "manual",
-          createdAt: now,
-        },
-      ],
-    });
+    const parsed = browserApplicationExportSchema.parse(validExport);
 
     expect(parsed.applications[0].company).toBe("Example Robotics");
     expect(parsed.lifecycleEvents[0].source).toBe("manual");
+    expect(parsed.outreachMessages[0].contactId).toBe("contact_fake_001");
   });
 
-  it("rejects malformed application URLs and statuses", () => {
-    const now = "2026-01-02T03:04:05.000Z";
-
+  it("rejects malformed application statuses", () => {
     expect(() =>
       browserApplicationSchema.parse({
+        ...validApplication,
         id: "app_fake_002",
-        company: "Example Health",
-        role: "Frontend Engineer",
         status: "phone_screen_scheduled",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects malformed application URLs", () => {
+    expect(() =>
+      browserApplicationSchema.parse({
+        ...validApplication,
+        id: "app_fake_003",
         postingUrl: "not a url",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects inverted offer salary ranges", () => {
+    expect(() =>
+      browserApplicationOfferSchema.parse({
+        id: "offer_fake_001",
+        applicationId: "app_fake_001",
+        status: "received",
+        baseSalaryMin: 200000,
+        baseSalaryMax: 100000,
+        createdAt: now,
+        updatedAt: now,
+      }),
+    ).toThrow(/baseSalaryMin/);
+  });
+
+  it("pins settings schema version to the export schema version", () => {
+    expect(() =>
+      browserApplicationSettingsSchema.parse({
+        id: "local",
+        schemaVersion: 2,
         createdAt: now,
         updatedAt: now,
       }),
     ).toThrow();
+  });
+
+  it("rejects duplicate export keys", () => {
+    expect(() =>
+      browserApplicationExportSchema.parse({
+        ...validExport,
+        applications: [validApplication, { ...validApplication }],
+      }),
+    ).toThrow(/Duplicate applications id/);
+  });
+
+  it("rejects dangling application references", () => {
+    expect(() =>
+      browserApplicationExportSchema.parse({
+        ...validExport,
+        lifecycleEvents: [
+          {
+            ...validExport.lifecycleEvents[0],
+            applicationId: "app_missing_001",
+          },
+        ],
+      }),
+    ).toThrow(/Unknown applicationId/);
+  });
+
+  it("rejects dangling contact references", () => {
+    expect(() =>
+      browserApplicationExportSchema.parse({
+        ...validExport,
+        outreachMessages: [
+          {
+            ...validExport.outreachMessages[0],
+            contactId: "contact_missing_001",
+          },
+        ],
+      }),
+    ).toThrow(/Unknown contactId/);
   });
 });


### PR DESCRIPTION
### Motivation
- Establish the planned production web direction: make private application tracking browser-local (IndexedDB) and treat the server/container as a static asset/health endpoint host. 
- Provide a minimal normalized domain contract and runtime validation so future work can implement an IndexedDB repository, migrations, and import/export without changing the CLI opportunity model.

### Description
- Added `docs/browser-first-architecture.md` describing IndexedDB as the source of truth, offline-first behavior, deployment boundaries, backup/restore expectations, canonical lifecycle statuses, and a CSV/SQLite/NDJSON migration mapping. 
- Implemented runtime Zod schemas in `src/domain/browserApplication.js` for `applications`, `contacts`, `outreachMessages`, `lifecycleEvents`, `interviews`, `offers`, `artifacts`, `reminders`, `settings`, and the top-level `browserApplicationExportSchema` (versioned). 
- Added schema tests in `test/browser-application-schema.test.js` using anonymized fake records to validate statuses, export shape, and rejection of malformed inputs. 
- Updated `README.md` to announce the browser-first direction and link the new architecture doc; the existing CLI/SQLite export/import scripts remain unchanged and documented as import sources.

### Testing
- Ran formatting and style checks: `npm run format:check` reported pre-existing formatting warnings in unrelated files, while `npx prettier --check README.md docs/browser-first-architecture.md src/domain/browserApplication.js test/browser-application-schema.test.js` succeeded. 
- Ran static checks: `npm run lint` completed successfully. 
- Ran type checks: `npm run typecheck` completed successfully. 
- Ran the full test suite: `npm run test:ci` completed successfully (test run executed and passed). 
- Ran the repo secret scan: `git diff --cached | ./scripts/scan-secrets.py` ran on staged changes and reported no secrets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40ecf30c98832f899534609cd0c833)