### PR TITLE
Define browser-first application data contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@
 **jobbot3000** is a self-hosted, open-source job search copilot.
 
 > [!WARNING]
-> The web interface is an experimental preview for local use only. Running production builds or
-> deploying to shared or cloud infrastructure can leak secrets, PII, and other sensitive data.
-> Operate on trusted hardware while we implement hardened authentication, storage, and network
-> isolation. Track the hardening plan in [docs/web-security-roadmap.md](docs/web-security-roadmap.md).
+> The current web interface is still an experimental preview for local use only. The production
+> direction is a browser-first static web app where private job-search data lives in IndexedDB, not
+> on a server-side SQLite database. Do not deploy the current preview to shared or cloud
+> infrastructure with sensitive data. Track the target architecture in
+> [docs/browser-first-architecture.md](docs/browser-first-architecture.md) and the hardening plan in
+> [docs/web-security-roadmap.md](docs/web-security-roadmap.md).
 
 ## Quickstart
 
@@ -153,6 +155,8 @@ Run the snippet with `node example.js` after saving it to a file in the project 
 - [DESIGN.md](DESIGN.md) – architecture details and roadmap
 - [SECURITY.md](SECURITY.md) – security guidelines
 - [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) – prompt reference index
+- [docs/browser-first-architecture.md](docs/browser-first-architecture.md) – target IndexedDB-first
+  production web architecture and normalized browser data contract
 - [docs/user-journeys.md](docs/user-journeys.md) – primary user journeys and flows
 - [docs/backup-restore-guide.md](docs/backup-restore-guide.md) – backup, restore, and verification
   steps
@@ -161,8 +165,11 @@ Run the snippet with `node example.js` after saving it to a file in the project 
 
 ### Durable data export/import
 
-All recruiter outreach, contacts, and lifecycle events live in `data/opportunities.db` (SQLite via
-Drizzle ORM). Use the bundled scripts to back up or restore records:
+Today, CLI recruiter outreach, contacts, and lifecycle events live in `data/opportunities.db`
+(SQLite via Drizzle ORM). This remains the supported local CLI backup path while the production web
+app moves toward IndexedDB as described in
+[docs/browser-first-architecture.md](docs/browser-first-architecture.md). Use the bundled scripts to
+back up or restore current CLI records:
 
 ```bash
 # Export every table as newline-delimited JSON

--- a/docs/browser-first-architecture.md
+++ b/docs/browser-first-architecture.md
@@ -1,0 +1,149 @@
+# Browser-first architecture and data contract
+
+jobbot3000 is moving toward a production web application where the browser owns private job-search
+records. The existing CLI, SQLite opportunity repository, and NDJSON backup scripts remain supported
+while the browser implementation is built, but they are not the target persistence boundary for the
+production web app.
+
+## Principles
+
+- **IndexedDB is the source of truth for user data.** Applications, contacts, outreach, interviews,
+  offers, notes, reminders, and private artifacts are stored in an IndexedDB database in the user's
+  browser profile.
+- **The server does not own sensitive application data.** A production container serves static assets,
+  cacheable public files, and health endpoints only. It must not persist applications, outreach
+  messages, interviews, offers, notes, reminders, or imported private files on the server filesystem.
+- **Browser-local by default.** The app must work without a hosted API account. Sync, if ever added,
+  must be opt-in and layered on top of the browser repository instead of replacing it.
+- **Portable backups.** Users must be able to export, inspect, and restore their data without trusting
+  a server database.
+
+## Deployment boundaries
+
+| Boundary                        | Examples                                                                          | Persistence expectation                                                                          |
+| ------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Static application assets       | HTML, CSS, JS bundles, icons, public docs                                         | Served by the container or any static host. Cacheable and safe to rebuild.                       |
+| Health and metadata endpoints   | `/healthz`, `/readyz`, build/version JSON                                         | No private user records. May expose operational status only.                                     |
+| Browser app data                | Applications, contacts, lifecycle events, interviews, offers, reminders, settings | IndexedDB in the user's browser profile. Export/restore is user initiated.                       |
+| Optional public assets          | Public job posting snapshots, sample anonymized fixtures, screenshots             | May ship with the app when they contain no personal data or secrets.                             |
+| Private user-imported artifacts | Resumes, cover letters, recruiter emails, transcripts, offer PDFs                 | Browser-private Blob records or user-held links. Never uploaded to the static server by default. |
+
+This split allows GHCR images, Helm charts, and Sugarkube deployments to remain simple: the runtime
+container can be replaced freely because it has no authoritative application database.
+
+## Minimal normalized browser model
+
+Runtime schemas for this contract live in `src/domain/browserApplication.js`, with TypeScript aliases
+in `src/domain/browserApplication.ts`. They intentionally sit beside the current
+`src/domain/opportunity.*` model instead of replacing it. The opportunity model describes the present
+CLI/SQLite recruiter-ingest flow; the browser application model describes the target IndexedDB shape.
+
+### Stores
+
+- `applications` — one row per role/company application. Includes company, role title, canonical
+  lifecycle status, posting URL, source, priority, tags, notes, and timestamps.
+- `contacts` — recruiters, hiring managers, referrals, and interviewers. Contacts may be global or
+  linked to an application.
+- `outreachMessages` — inbound and outbound messages by channel, optionally linked to contacts.
+- `lifecycleEvents` — append-only status changes, notes, imports, exports, reminders, and artifact
+  events for auditability.
+- `interviews` — scheduled or completed interviews with stage, contact links, meeting details, and
+  outcomes.
+- `offers` — offer records, compensation fields, deadlines, negotiation notes, and final state.
+- `artifactLinks` — metadata for URLs or browser-private Blob identifiers. The metadata is separate
+  from private imported files so exports can choose whether to include large artifacts.
+- `reminders` — follow-ups and due dates linked to applications or contacts.
+- `settings` — schema version, locale, timezone, and preferred export format.
+
+### Canonical lifecycle statuses
+
+These statuses cover the current spreadsheet workflow while keeping the UI vocabulary simple:
+
+1. `Applied`
+2. `Outreach sent`
+3. `Recruiter screen`
+4. `Technical screen`
+5. `Onsite / loop`
+6. `Offer`
+7. `Accepted`
+8. `Rejected`
+9. `Withdrawn`
+10. `Closed / archived`
+
+Lifecycle status belongs on the `applications` record for fast list rendering. Every change should
+also create a `lifecycleEvents` record so imports, restores, and analytics can reconstruct history.
+
+## IndexedDB repository expectations
+
+The future browser repository should create one database, for example `jobbot3000`, with versioned
+object stores matching the normalized model above. Migrations must be deterministic and idempotent:
+
+1. Create missing stores and indexes.
+2. Backfill derived fields from older records.
+3. Never drop user data without exporting a recovery copy first.
+4. Record the active `schemaVersion` in `settings` and in full-database exports.
+
+Suggested indexes include application status, company, updated time, contact email, message
+application ID, event application ID, interview start time, offer application ID, and reminder due
+time.
+
+## Offline-first behavior
+
+- The shell and last successful static assets should be service-worker cacheable.
+- Reads and writes go to IndexedDB first and must not require network access.
+- Health endpoints are operational hints, not application dependencies.
+- Import, export, search, filtering, and reminders should continue offline when browser APIs permit.
+- Conflicts are local-first: a restore or import should preview changes before merging into existing
+  IndexedDB stores.
+
+## Backup and restore
+
+The production browser app should support these user-initiated formats:
+
+- **JSON** for full-fidelity backups that include `schemaVersion` and all normalized stores.
+- **NDJSON** for streaming backups and compatibility with the current CLI import/export mental model.
+- **CSV** for spreadsheet interoperability. CSV is a view over normalized records, not the canonical
+  storage format.
+
+Exports should let users choose whether to include private Blob artifacts. Restores should validate
+with the runtime schemas before writing to IndexedDB and should preserve rejected rows for download so
+users can repair bad imports.
+
+## Migration from CSV, SQLite, and NDJSON
+
+The existing SQLite-backed opportunities and NDJSON scripts remain useful transitional tooling. The
+browser import path should normalize both current opportunity exports and the 32-column spreadsheet
+into the stores above.
+
+### 32-column CSV mapping notes
+
+The spreadsheet is treated as a denormalized application row. Exact headers can vary, so importers
+should use header aliases and show an unmapped-column preview.
+
+| CSV concept                                         | Browser destination                                                                       |
+| --------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| Company, organization, employer                     | `applications.company`                                                                    |
+| Role, title, position                               | `applications.roleTitle`                                                                  |
+| Status, stage, outcome                              | `applications.status` plus a `lifecycleEvents` status change                              |
+| Applied date                                        | `applications.appliedAt` and an `Applied` lifecycle event                                 |
+| Source, job board, referral source                  | `applications.source`                                                                     |
+| Job posting URL                                     | `applications.postingUrl` and optionally an `artifactLinks` record with kind `posting`    |
+| Location, remote/hybrid notes                       | `applications.location` or `applications.notes` when unstructured                         |
+| Compensation, salary, equity notes                  | `applications.compensation`; offer-specific values move to `offers` when present          |
+| Recruiter or contact name/email/phone               | `contacts` linked to the application                                                      |
+| Outreach date, follow-up date, message subject/body | `outreachMessages` and `reminders`                                                        |
+| Screen, technical, onsite, loop dates               | `interviews` with matching stage values                                                   |
+| Offer details, deadline, decision                   | `offers` plus application status updates                                                  |
+| Resume, cover letter, portfolio, artifact links     | `artifactLinks`; imported files become browser-private Blobs                              |
+| Notes, next steps, risks                            | `applications.notes`, `lifecycleEvents`, and `reminders` depending on date/actionability  |
+| Tags, priority, rating                              | `applications.tags` and `applications.priority` when supported                            |
+| Unknown or custom columns                           | Preserve in `lifecycleEvents.metadata` during import until the user maps or discards them |
+
+SQLite `opportunities` map most directly to `applications`, `contacts`, `outreachMessages`, and
+`lifecycleEvents`. NDJSON exports should be transformed record-by-record into the same stores, then
+validated before commit.
+
+## Non-goals for this PR
+
+This document and the schema module define the target contract only. They do not replace the current
+CLI, rewrite the web UI, implement IndexedDB persistence, or remove SQLite opportunity storage.

--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -1,0 +1,178 @@
+import { z } from "zod";
+
+export const browserApplicationLifecycleStatusSchema = z.enum([
+  "Applied",
+  "Outreach sent",
+  "Recruiter screen",
+  "Technical screen",
+  "Onsite / loop",
+  "Offer",
+  "Accepted",
+  "Rejected",
+  "Withdrawn",
+  "Closed / archived",
+]);
+
+export const browserApplicationIdSchema = z.string().min(1);
+export const isoDateTimeSchema = z.string().datetime({ offset: true });
+
+const optionalTrimmedStringSchema = z.string().trim().min(1).optional();
+
+export const browserContactSchema = z.object({
+  id: browserApplicationIdSchema,
+  applicationId: browserApplicationIdSchema.optional(),
+  fullName: optionalTrimmedStringSchema,
+  email: z.string().email().optional(),
+  phone: optionalTrimmedStringSchema,
+  company: optionalTrimmedStringSchema,
+  title: optionalTrimmedStringSchema,
+  source: optionalTrimmedStringSchema,
+  notes: optionalTrimmedStringSchema,
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserApplicationSchema = z.object({
+  id: browserApplicationIdSchema,
+  company: z.string().trim().min(1),
+  roleTitle: z.string().trim().min(1),
+  status: browserApplicationLifecycleStatusSchema,
+  source: optionalTrimmedStringSchema,
+  postingUrl: z.string().url().optional(),
+  location: optionalTrimmedStringSchema,
+  compensation: optionalTrimmedStringSchema,
+  priority: z.enum(["low", "medium", "high"]).default("medium"),
+  tags: z.array(z.string().trim().min(1)).default([]),
+  notes: optionalTrimmedStringSchema,
+  appliedAt: isoDateTimeSchema.optional(),
+  archivedAt: isoDateTimeSchema.optional(),
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserOutreachMessageSchema = z.object({
+  id: browserApplicationIdSchema,
+  applicationId: browserApplicationIdSchema,
+  contactId: browserApplicationIdSchema.optional(),
+  channel: z.enum(["email", "linkedin", "phone", "in-person", "other"]),
+  direction: z.enum(["inbound", "outbound"]),
+  subject: optionalTrimmedStringSchema,
+  body: optionalTrimmedStringSchema,
+  sentAt: isoDateTimeSchema.optional(),
+  receivedAt: isoDateTimeSchema.optional(),
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserLifecycleEventSchema = z.object({
+  id: browserApplicationIdSchema,
+  applicationId: browserApplicationIdSchema,
+  type: z.enum([
+    "status_change",
+    "note",
+    "import",
+    "export",
+    "reminder",
+    "artifact",
+  ]),
+  status: browserApplicationLifecycleStatusSchema.optional(),
+  occurredAt: isoDateTimeSchema,
+  note: optionalTrimmedStringSchema,
+  metadata: z.record(z.unknown()).default({}),
+});
+
+export const browserInterviewSchema = z.object({
+  id: browserApplicationIdSchema,
+  applicationId: browserApplicationIdSchema,
+  contactIds: z.array(browserApplicationIdSchema).default([]),
+  stage: z.enum([
+    "recruiter",
+    "technical",
+    "onsite",
+    "hiring-manager",
+    "other",
+  ]),
+  startsAt: isoDateTimeSchema,
+  endsAt: isoDateTimeSchema.optional(),
+  location: optionalTrimmedStringSchema,
+  meetingUrl: z.string().url().optional(),
+  notes: optionalTrimmedStringSchema,
+  outcome: z
+    .enum(["pending", "passed", "rejected", "cancelled"])
+    .default("pending"),
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserOfferSchema = z.object({
+  id: browserApplicationIdSchema,
+  applicationId: browserApplicationIdSchema,
+  status: z.enum([
+    "draft",
+    "received",
+    "negotiating",
+    "accepted",
+    "declined",
+    "expired",
+  ]),
+  baseSalary: z.number().nonnegative().optional(),
+  currency: z.string().length(3).default("USD"),
+  equity: optionalTrimmedStringSchema,
+  bonus: optionalTrimmedStringSchema,
+  deadlineAt: isoDateTimeSchema.optional(),
+  notes: optionalTrimmedStringSchema,
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserArtifactLinkSchema = z.object({
+  id: browserApplicationIdSchema,
+  applicationId: browserApplicationIdSchema.optional(),
+  kind: z.enum([
+    "posting",
+    "resume",
+    "cover-letter",
+    "portfolio",
+    "note",
+    "other",
+  ]),
+  label: z.string().trim().min(1),
+  url: z.string().url().optional(),
+  privateBlobId: browserApplicationIdSchema.optional(),
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserReminderSchema = z.object({
+  id: browserApplicationIdSchema,
+  applicationId: browserApplicationIdSchema.optional(),
+  contactId: browserApplicationIdSchema.optional(),
+  dueAt: isoDateTimeSchema,
+  title: z.string().trim().min(1),
+  completedAt: isoDateTimeSchema.optional(),
+  notes: optionalTrimmedStringSchema,
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserSettingsSchema = z.object({
+  id: z.literal("settings"),
+  schemaVersion: z.literal(1),
+  locale: z.string().default("en-US"),
+  timezone: z.string().default("UTC"),
+  defaultExportFormat: z.enum(["json", "ndjson", "csv"]).default("json"),
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserApplicationDatabaseSchema = z.object({
+  schemaVersion: z.literal(1),
+  applications: z.array(browserApplicationSchema).default([]),
+  contacts: z.array(browserContactSchema).default([]),
+  outreachMessages: z.array(browserOutreachMessageSchema).default([]),
+  lifecycleEvents: z.array(browserLifecycleEventSchema).default([]),
+  interviews: z.array(browserInterviewSchema).default([]),
+  offers: z.array(browserOfferSchema).default([]),
+  artifactLinks: z.array(browserArtifactLinkSchema).default([]),
+  reminders: z.array(browserReminderSchema).default([]),
+  settings: browserSettingsSchema,
+});

--- a/src/domain/browserApplication.ts
+++ b/src/domain/browserApplication.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+
+import {
+  browserApplicationDatabaseSchema as runtimeBrowserApplicationDatabaseSchema,
+  browserApplicationLifecycleStatusSchema as runtimeBrowserApplicationLifecycleStatusSchema,
+  browserApplicationSchema as runtimeBrowserApplicationSchema,
+  browserArtifactLinkSchema as runtimeBrowserArtifactLinkSchema,
+  browserContactSchema as runtimeBrowserContactSchema,
+  browserInterviewSchema as runtimeBrowserInterviewSchema,
+  browserLifecycleEventSchema as runtimeBrowserLifecycleEventSchema,
+  browserOfferSchema as runtimeBrowserOfferSchema,
+  browserOutreachMessageSchema as runtimeBrowserOutreachMessageSchema,
+  browserReminderSchema as runtimeBrowserReminderSchema,
+  browserSettingsSchema as runtimeBrowserSettingsSchema,
+} from "./browserApplication.js";
+
+export const browserApplicationDatabaseSchema =
+  runtimeBrowserApplicationDatabaseSchema;
+export const browserApplicationLifecycleStatusSchema =
+  runtimeBrowserApplicationLifecycleStatusSchema;
+export const browserApplicationSchema = runtimeBrowserApplicationSchema;
+export const browserArtifactLinkSchema = runtimeBrowserArtifactLinkSchema;
+export const browserContactSchema = runtimeBrowserContactSchema;
+export const browserInterviewSchema = runtimeBrowserInterviewSchema;
+export const browserLifecycleEventSchema = runtimeBrowserLifecycleEventSchema;
+export const browserOfferSchema = runtimeBrowserOfferSchema;
+export const browserOutreachMessageSchema = runtimeBrowserOutreachMessageSchema;
+export const browserReminderSchema = runtimeBrowserReminderSchema;
+export const browserSettingsSchema = runtimeBrowserSettingsSchema;
+
+export type BrowserApplicationLifecycleStatus = z.infer<
+  typeof browserApplicationLifecycleStatusSchema
+>;
+export type BrowserApplication = z.infer<typeof browserApplicationSchema>;
+export type BrowserContact = z.infer<typeof browserContactSchema>;
+export type BrowserOutreachMessage = z.infer<
+  typeof browserOutreachMessageSchema
+>;
+export type BrowserLifecycleEvent = z.infer<typeof browserLifecycleEventSchema>;
+export type BrowserInterview = z.infer<typeof browserInterviewSchema>;
+export type BrowserOffer = z.infer<typeof browserOfferSchema>;
+export type BrowserArtifactLink = z.infer<typeof browserArtifactLinkSchema>;
+export type BrowserReminder = z.infer<typeof browserReminderSchema>;
+export type BrowserSettings = z.infer<typeof browserSettingsSchema>;
+export type BrowserApplicationDatabase = z.infer<
+  typeof browserApplicationDatabaseSchema
+>;

--- a/test/browser-application-schema.test.js
+++ b/test/browser-application-schema.test.js
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  browserApplicationDatabaseSchema,
+  browserApplicationLifecycleStatusSchema,
+} from "../src/domain/browserApplication.js";
+
+const now = "2026-01-02T03:04:05.000Z";
+
+describe("browser application data contract", () => {
+  it("accepts the canonical lifecycle statuses used by the browser model", () => {
+    expect(browserApplicationLifecycleStatusSchema.options).toEqual([
+      "Applied",
+      "Outreach sent",
+      "Recruiter screen",
+      "Technical screen",
+      "Onsite / loop",
+      "Offer",
+      "Accepted",
+      "Rejected",
+      "Withdrawn",
+      "Closed / archived",
+    ]);
+  });
+
+  it("validates a normalized browser-owned application database export", () => {
+    const parsed = browserApplicationDatabaseSchema.parse({
+      schemaVersion: 1,
+      applications: [
+        {
+          id: "app-1",
+          company: "Example Co",
+          roleTitle: "Staff Engineer",
+          status: "Recruiter screen",
+          postingUrl: "https://example.com/jobs/staff-engineer",
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+      contacts: [
+        {
+          id: "contact-1",
+          applicationId: "app-1",
+          fullName: "Anonymized Recruiter",
+          email: "recruiter@example.com",
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+      outreachMessages: [],
+      lifecycleEvents: [
+        {
+          id: "event-1",
+          applicationId: "app-1",
+          type: "status_change",
+          status: "Recruiter screen",
+          occurredAt: now,
+        },
+      ],
+      interviews: [],
+      offers: [],
+      artifactLinks: [],
+      reminders: [],
+      settings: {
+        id: "settings",
+        schemaVersion: 1,
+        updatedAt: now,
+      },
+    });
+
+    expect(parsed.applications[0]).toMatchObject({
+      priority: "medium",
+      tags: [],
+    });
+    expect(parsed.lifecycleEvents[0].metadata).toEqual({});
+    expect(parsed.settings.defaultExportFormat).toBe("json");
+  });
+});

--- a/test/browser-first-architecture-doc.test.js
+++ b/test/browser-first-architecture-doc.test.js
@@ -1,0 +1,20 @@
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+import { describe, expect, it } from "vitest";
+
+const DOC_PATH = resolve("docs/browser-first-architecture.md");
+
+describe("browser-first architecture documentation", () => {
+  it("documents IndexedDB ownership, deployment boundaries, and migration notes", () => {
+    expect(existsSync(DOC_PATH)).toBe(true);
+
+    const contents = readFileSync(DOC_PATH, "utf8");
+
+    expect(contents).toMatch(/IndexedDB is the source of truth/);
+    expect(contents).toMatch(/server does not own sensitive application data/);
+    expect(contents).toMatch(/Offline-first behavior/);
+    expect(contents).toMatch(/Backup and restore/);
+    expect(contents).toMatch(/32-column CSV mapping notes/);
+    expect(contents).toMatch(/src\/domain\/browserApplication\.js/);
+  });
+});


### PR DESCRIPTION
### Motivation
- Establish a clear browser-first production architecture that treats IndexedDB as the source of truth for all private job-search records and keeps the server/container stateless. 
- Provide a normalized, runtime-validated browser data contract so future IndexedDB persistence, migrations, and import/export tooling have a canonical shape to implement against.

### Description
- Add `docs/browser-first-architecture.md` describing IndexedDB ownership, deployment boundaries, offline-first behavior, backup/restore formats, and CSV/SQLite/NDJSON migration notes. 
- Introduce Zod runtime schemas in `src/domain/browserApplication.js` and TypeScript re-exports in `src/domain/browserApplication.ts` that define applications, contacts, outreach messages, lifecycle events, interviews, offers, artifact links, reminders, and settings. 
- Update `README.md` to reference the new browser-first architecture doc and clarify that the current web preview is still local/experimental. 
- Add tests `test/browser-application-schema.test.js` and `test/browser-first-architecture-doc.test.js` that validate the schema and the presence/content of the architecture document.

### Testing
- Ran `npm run lint` and it completed successfully. 
- Ran `npm run typecheck` (`tsc -p tsconfig.json`) and it completed successfully. 
- Ran `npm run test:ci` and the CI test suite completed successfully (all tests passed). 
- Ran a focused formatting check with `npx prettier --check README.md docs/browser-first-architecture.md src/domain/browserApplication.js src/domain/browserApplication.ts test/browser-application-schema.test.js test/browser-first-architecture-doc.test.js` and the affected files passed Prettier formatting. 
- Note: a repository-wide `npm run format:check` still reports pre-existing Prettier warnings in unrelated files; this PR only formats and validates the newly added/modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40ecfff9e8832faf82c860554d3c9b)