### PR TITLE
Add browser-first architecture contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@
 **jobbot3000** is a self-hosted, open-source job search copilot.
 
 > [!WARNING]
-> The web interface is an experimental preview for local use only. Running production builds or
-> deploying to shared or cloud infrastructure can leak secrets, PII, and other sensitive data.
-> Operate on trusted hardware while we implement hardened authentication, storage, and network
-> isolation. Track the hardening plan in [docs/web-security-roadmap.md](docs/web-security-roadmap.md).
+> The current web interface is an experimental preview for local use only. Running this preview on
+> shared or cloud infrastructure can leak secrets, PII, and other sensitive data. The intended
+> production direction is a browser-first static app where private job-search data is stored in
+> IndexedDB instead of server-side SQLite; see
+> [docs/browser-first-architecture.md](docs/browser-first-architecture.md) for the target contract and
+> [docs/web-security-roadmap.md](docs/web-security-roadmap.md) for hardening work.
 
 ## Quickstart
 
@@ -154,6 +156,7 @@ Run the snippet with `node example.js` after saving it to a file in the project 
 - [SECURITY.md](SECURITY.md) – security guidelines
 - [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) – prompt reference index
 - [docs/user-journeys.md](docs/user-journeys.md) – primary user journeys and flows
+- [docs/browser-first-architecture.md](docs/browser-first-architecture.md) – target IndexedDB-first web architecture and normalized browser data contract
 - [docs/backup-restore-guide.md](docs/backup-restore-guide.md) – backup, restore, and verification
   steps
 - [docs/web-ux-guidelines.md](docs/web-ux-guidelines.md) – layout, typography, and interaction guardrails
@@ -161,8 +164,10 @@ Run the snippet with `node example.js` after saving it to a file in the project 
 
 ### Durable data export/import
 
-All recruiter outreach, contacts, and lifecycle events live in `data/opportunities.db` (SQLite via
-Drizzle ORM). Use the bundled scripts to back up or restore records:
+Today, the CLI/local preview stores recruiter outreach, contacts, and lifecycle events in
+`data/opportunities.db` (SQLite via Drizzle ORM). The production web direction is IndexedDB-first and
+browser-local; the SQLite store remains a migration source rather than the future web source of truth.
+Use the bundled scripts to back up or restore current CLI records:
 
 ```bash
 # Export every table as newline-delimited JSON

--- a/docs/browser-first-architecture.md
+++ b/docs/browser-first-architecture.md
@@ -1,0 +1,158 @@
+# Browser-first production architecture
+
+jobbot3000's production web direction is a static, offline-capable application where private job-search
+records belong to the browser, not to the web server. The current CLI, Express preview, SQLite
+opportunity repository, and CSV/NDJSON concepts stay available while the browser implementation is
+built in small PRs. This document defines the target boundary and the minimal data contract that later
+IndexedDB, import/export, and UI work should implement.
+
+## Principles
+
+- **IndexedDB is the source of truth for user-owned data.** Applications, contacts, outreach,
+  interviews, offers, reminders, notes, imported files, and user settings are persisted in the
+  browser profile that created or imported them.
+- **The server does not own private application state.** A production container should serve static
+  assets, health endpoints, and optional public metadata only. It must not persist applications,
+  outreach messages, interviews, offers, notes, private artifacts, or imported spreadsheet rows.
+- **Offline-first is the default.** The installed or loaded web app should read and write IndexedDB
+  without requiring a live network connection after assets are cached. Network failures may block new
+  asset downloads, but they must not block reviewing or editing already-local job-search records.
+- **Portable backups are explicit user actions.** Because IndexedDB is browser-local, users need
+  first-class JSON, NDJSON, and CSV export/import flows for device migration, disaster recovery, and
+  spreadsheet interoperability.
+- **No real personal job-search data belongs in git.** Tests and examples must use anonymized fake
+  companies, people, URLs, and messages.
+
+## Deployment boundary
+
+The production web deployment is intentionally boring:
+
+1. A container or static host serves the compiled HTML, CSS, JavaScript, service worker, manifest,
+   icons, and public documentation/assets.
+2. Health endpoints report whether the static service is alive for orchestrators such as Docker,
+   Kubernetes, and Sugarkube.
+3. The browser initializes the repository against IndexedDB and runs migrations locally.
+4. All sensitive reads and writes happen inside the browser. No API endpoint receives the canonical
+   application database.
+
+This differs from the current preview, where `scripts/web-server.js` starts an Express app that can
+invoke CLI workflows and read local data stores. That preview remains useful during the transition,
+but production static hosting should narrow the server role to asset delivery and health checks.
+
+## Data classes
+
+| Class                           | Examples                                                                                      | Production storage                                                         |
+| ------------------------------- | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
+| App data                        | Applications, contacts, lifecycle events, outreach, interviews, offers, reminders, settings   | IndexedDB object stores                                                    |
+| Optional public assets          | App shell, styles, static screenshots, public docs, provider logos if licensed                | Static container/image assets                                              |
+| Private user-imported artifacts | Resumes, cover letters, pasted recruiter emails, job descriptions, notes, spreadsheet imports | IndexedDB records or browser-managed private blobs referenced by IndexedDB |
+
+Private artifacts should be referenced by stable local IDs such as `privateBlobRef`. If later browser
+APIs store large blobs outside an object store, the IndexedDB record remains the index and export
+manifest source.
+
+## Minimal normalized browser model
+
+Runtime validators live in `src/domain/browser-application.js`. They intentionally do not replace the
+existing CLI opportunity schemas in `src/domain/opportunity.js`; instead, they describe the
+browser-owned model that future IndexedDB repositories will validate at the storage boundary.
+
+### Object stores
+
+- **applications** — one row per company/role pursuit with the current canonical lifecycle status,
+  job URL, source, location, compensation summary, and notes.
+- **contacts** — recruiters, hiring managers, referrals, and interviewers. Contacts can be linked to
+  an application or kept as reusable address-book records.
+- **outreachMessages** — inbound and outbound communication with direction, channel, subject/body,
+  timestamps, and contact/application links.
+- **lifecycleEvents** — immutable status/history entries used to reconstruct the timeline and explain
+  how an application reached its current state.
+- **interviews** — scheduled or completed recruiter screens, technical screens, onsites/loops, and
+  other meetings.
+- **offers** — offer packets, negotiation state, deadlines, compensation summary, and outcome.
+- **artifacts** — links or private browser-local references for resumes, cover letters, job postings,
+  portfolios, notes, and related files.
+- **reminders** — follow-ups and tasks with due/completed/snoozed timestamps.
+- **settings** — local preferences, schema version, import behavior, timezone, and non-secret UI
+  defaults.
+
+All stores include stable IDs, `createdAt`, and `updatedAt` timestamps where applicable. Records may
+carry a `metadata` object for importer provenance and forward-compatible annotations, but UI features
+should prefer typed fields before adding metadata keys.
+
+## Canonical lifecycle statuses
+
+The browser model uses stable slugs with display labels:
+
+| Slug               | Label             | Typical meaning                                                    |
+| ------------------ | ----------------- | ------------------------------------------------------------------ |
+| `applied`          | Applied           | Application submitted or logged from a spreadsheet                 |
+| `outreach_sent`    | Outreach sent     | User sent or received outreach before a formal screen              |
+| `recruiter_screen` | Recruiter screen  | Recruiter/HR phone or video screen                                 |
+| `technical_screen` | Technical screen  | Coding, system design, portfolio, or hiring-manager technical step |
+| `onsite_loop`      | Onsite / loop     | Final loop, virtual onsite, panel, or multi-interview round        |
+| `offer`            | Offer             | Offer received and not yet accepted/declined                       |
+| `accepted`         | Accepted          | Accepted offer / hired outcome                                     |
+| `rejected`         | Rejected          | Company rejected or passed                                         |
+| `withdrawn`        | Withdrawn         | User withdrew or declined to continue before an offer decision     |
+| `closed_archived`  | Closed / archived | Historical record that should stay out of active workflows         |
+
+Current CLI statuses map into these statuses during import rather than changing CLI behavior in this
+PR. For example, `screening` maps to `recruiter_screen`, `onsite` maps to `onsite_loop`, `offer` maps
+to `offer`, `accepted`/`acceptance`/`hired` map to `accepted`, and `no_response` can import as
+`applied` or `closed_archived` depending on archive flags and dates.
+
+## Backup and restore expectations
+
+- **Full backup:** Export all object stores plus schema version and export timestamp as JSON. This is
+  the preferred restore format because it preserves normalized relationships.
+- **Streaming backup:** Export NDJSON where each line identifies the store and record. This supports
+  large datasets and easier command-line inspection without loading the entire backup into memory.
+- **Spreadsheet bridge:** Export CSV views for applications and timelines so users can audit data in a
+  spreadsheet. CSV is an interoperability view, not the canonical database.
+- **Restore:** Importers validate every row through the runtime schemas, present duplicates/conflicts,
+  and then write to IndexedDB inside a migration-aware transaction.
+
+Users are responsible for storing exported backups somewhere durable. The app should remind users that
+clearing browser storage, changing browser profiles, or using aggressive privacy settings can remove
+local data unless an export exists.
+
+## Offline-first behavior
+
+A future service worker should cache the app shell and static assets. IndexedDB reads and writes should
+continue when offline, and import/export should operate entirely in the browser. Features that need
+external job boards, AI providers, or CLI integrations must be optional enhancements that fail closed
+with clear messaging and never block access to existing local records.
+
+## Migration path from CSV, SQLite, and NDJSON
+
+### Existing 32-column CSV
+
+The current spreadsheet is treated as a denormalized import source. The importer should let users map
+columns, but the default 32-column profile should split data as follows:
+
+| CSV column family                                                                            | Browser target                                                          |
+| -------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| Company, role/title, job URL, source, location, compensation, priority, tags, freeform notes | `applications` typed fields plus `metadata` for importer-only values    |
+| Status, stage, outcome, applied date, last update date, archived flag                        | `applications.status`, `applications.archivedAt`, and `lifecycleEvents` |
+| Recruiter/contact names, emails, phone numbers, LinkedIn/profile URLs                        | `contacts` linked to the application                                    |
+| Outreach dates, follow-up dates, message snippets, response notes                            | `outreachMessages` and `reminders`                                      |
+| Interview dates, interview type/stage, interviewer names, meeting links, feedback notes      | `interviews`, `contacts`, and timeline `lifecycleEvents`                |
+| Offer deadline, compensation details, negotiation notes, accepted/rejected decision          | `offers` and terminal lifecycle status                                  |
+| Resume, cover letter, portfolio, job description, or other file/link columns                 | `artifacts` with `url` or `privateBlobRef`                              |
+| Columns without a normalized destination                                                     | `metadata.importedColumns` so no user-entered value is silently dropped |
+
+The importer should preserve raw source headers and row numbers in metadata for auditability, but it
+must not commit any real spreadsheet content to fixtures or documentation.
+
+### SQLite opportunity repository
+
+The existing SQLite-backed opportunity model remains a CLI/local preview store. Browser migration code
+should read exported opportunities and normalize them into applications, contacts, outreach messages,
+and lifecycle events. It should not make the server database authoritative for the web app.
+
+### NDJSON
+
+NDJSON remains a useful interchange format. Browser exports should include store names and schema
+versions per line so future CLI tools can transform or inspect backups without owning the production
+source of truth.

--- a/src/domain/browser-application.js
+++ b/src/domain/browser-application.js
@@ -1,0 +1,183 @@
+import { z } from "zod";
+
+export const browserLifecycleStatusValues = [
+  "applied",
+  "outreach_sent",
+  "recruiter_screen",
+  "technical_screen",
+  "onsite_loop",
+  "offer",
+  "accepted",
+  "rejected",
+  "withdrawn",
+  "closed_archived",
+];
+
+export const browserLifecycleStatusLabels = {
+  applied: "Applied",
+  outreach_sent: "Outreach sent",
+  recruiter_screen: "Recruiter screen",
+  technical_screen: "Technical screen",
+  onsite_loop: "Onsite / loop",
+  offer: "Offer",
+  accepted: "Accepted",
+  rejected: "Rejected",
+  withdrawn: "Withdrawn",
+  closed_archived: "Closed / archived",
+};
+
+export const browserLifecycleStatusSchema = z.enum(
+  browserLifecycleStatusValues,
+);
+
+const idSchema = z.string().min(1);
+const dateTimeSchema = z.string().datetime();
+const optionalUrlSchema = z.string().url().optional();
+const metadataSchema = z.record(z.unknown()).default({});
+
+const baseRecordSchema = z.object({
+  id: idSchema,
+  createdAt: dateTimeSchema,
+  updatedAt: dateTimeSchema,
+});
+
+export const browserApplicationSchema = baseRecordSchema.extend({
+  company: z.string().min(1),
+  role: z.string().min(1),
+  status: browserLifecycleStatusSchema,
+  source: z.string().optional(),
+  jobUrl: optionalUrlSchema,
+  location: z.string().optional(),
+  compensation: z.string().optional(),
+  notes: z.string().optional(),
+  archivedAt: dateTimeSchema.optional(),
+  metadata: metadataSchema,
+});
+
+export const browserContactSchema = baseRecordSchema.extend({
+  applicationId: idSchema.optional(),
+  name: z.string().min(1),
+  email: z.string().email().optional(),
+  phone: z.string().optional(),
+  organization: z.string().optional(),
+  title: z.string().optional(),
+  source: z.string().optional(),
+  notes: z.string().optional(),
+  metadata: metadataSchema,
+});
+
+export const browserOutreachMessageSchema = baseRecordSchema.extend({
+  applicationId: idSchema,
+  contactId: idSchema.optional(),
+  direction: z.enum(["inbound", "outbound"]),
+  channel: z.enum(["email", "linkedin", "phone", "text", "other"]),
+  subject: z.string().optional(),
+  body: z.string().optional(),
+  sentAt: dateTimeSchema.optional(),
+  receivedAt: dateTimeSchema.optional(),
+  metadata: metadataSchema,
+});
+
+export const browserLifecycleEventSchema = baseRecordSchema.extend({
+  applicationId: idSchema,
+  status: browserLifecycleStatusSchema,
+  occurredAt: dateTimeSchema,
+  title: z.string().min(1),
+  description: z.string().optional(),
+  source: z.enum(["manual", "import", "system"]).default("manual"),
+  metadata: metadataSchema,
+});
+
+export const browserInterviewSchema = baseRecordSchema.extend({
+  applicationId: idSchema,
+  contactIds: z.array(idSchema).default([]),
+  stage: z.enum([
+    "recruiter_screen",
+    "technical_screen",
+    "onsite_loop",
+    "other",
+  ]),
+  startsAt: dateTimeSchema,
+  endsAt: dateTimeSchema.optional(),
+  location: z.string().optional(),
+  meetingUrl: optionalUrlSchema,
+  notes: z.string().optional(),
+  outcome: z
+    .enum(["scheduled", "completed", "cancelled", "no_show"])
+    .default("scheduled"),
+  metadata: metadataSchema,
+});
+
+export const browserOfferSchema = baseRecordSchema.extend({
+  applicationId: idSchema,
+  status: z.enum([
+    "received",
+    "negotiating",
+    "accepted",
+    "declined",
+    "expired",
+  ]),
+  receivedAt: dateTimeSchema.optional(),
+  deadlineAt: dateTimeSchema.optional(),
+  baseSalary: z.number().nonnegative().optional(),
+  currency: z.string().min(3).max(3).optional(),
+  summary: z.string().optional(),
+  metadata: metadataSchema,
+});
+
+export const browserArtifactSchema = baseRecordSchema.extend({
+  applicationId: idSchema.optional(),
+  kind: z.enum([
+    "resume",
+    "cover_letter",
+    "job_posting",
+    "portfolio",
+    "notes",
+    "other",
+  ]),
+  label: z.string().min(1),
+  url: optionalUrlSchema,
+  privateBlobRef: z.string().optional(),
+  notes: z.string().optional(),
+  metadata: metadataSchema,
+});
+
+export const browserReminderSchema = baseRecordSchema.extend({
+  applicationId: idSchema.optional(),
+  contactId: idSchema.optional(),
+  title: z.string().min(1),
+  dueAt: dateTimeSchema,
+  completedAt: dateTimeSchema.optional(),
+  snoozedUntil: dateTimeSchema.optional(),
+  notes: z.string().optional(),
+  metadata: metadataSchema,
+});
+
+export const browserSettingsSchema = z.object({
+  id: z.literal("settings"),
+  schemaVersion: z.number().int().positive(),
+  createdAt: dateTimeSchema,
+  updatedAt: dateTimeSchema,
+  timezone: z.string().optional(),
+  defaultReminderDays: z.number().int().nonnegative().default(7),
+  importPreferences: z
+    .object({
+      duplicateStrategy: z.enum(["skip", "update", "create"]).default("update"),
+    })
+    .default({}),
+  metadata: metadataSchema,
+});
+
+export const browserDatabaseExportSchema = z.object({
+  schemaVersion: z.number().int().positive(),
+  exportedAt: dateTimeSchema,
+  applications: z.array(browserApplicationSchema).default([]),
+  contacts: z.array(browserContactSchema).default([]),
+  outreachMessages: z.array(browserOutreachMessageSchema).default([]),
+  lifecycleEvents: z.array(browserLifecycleEventSchema).default([]),
+  interviews: z.array(browserInterviewSchema).default([]),
+  offers: z.array(browserOfferSchema).default([]),
+  artifacts: z.array(browserArtifactSchema).default([]),
+  reminders: z.array(browserReminderSchema).default([]),
+  settings: browserSettingsSchema.optional(),
+});

--- a/test/browser-application-domain.test.js
+++ b/test/browser-application-domain.test.js
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  browserApplicationSchema,
+  browserDatabaseExportSchema,
+  browserLifecycleStatusLabels,
+  browserLifecycleStatusValues,
+} from "../src/domain/browser-application.js";
+
+describe("browser application domain schemas", () => {
+  it("defines the canonical browser lifecycle statuses and labels", () => {
+    expect(browserLifecycleStatusValues).toEqual([
+      "applied",
+      "outreach_sent",
+      "recruiter_screen",
+      "technical_screen",
+      "onsite_loop",
+      "offer",
+      "accepted",
+      "rejected",
+      "withdrawn",
+      "closed_archived",
+    ]);
+    expect(browserLifecycleStatusLabels.closed_archived).toBe(
+      "Closed / archived",
+    );
+  });
+
+  it("validates a minimal anonymized application record", () => {
+    const record = browserApplicationSchema.parse({
+      id: "app_fake_001",
+      company: "Example Robotics",
+      role: "Staff Software Engineer",
+      status: "applied",
+      jobUrl: "https://jobs.example.test/staff-engineer",
+      createdAt: "2026-01-15T10:00:00.000Z",
+      updatedAt: "2026-01-15T10:00:00.000Z",
+    });
+
+    expect(record.metadata).toEqual({});
+  });
+
+  it("validates a normalized full-database export envelope", () => {
+    const exported = browserDatabaseExportSchema.parse({
+      schemaVersion: 1,
+      exportedAt: "2026-01-15T10:00:00.000Z",
+      applications: [
+        {
+          id: "app_fake_001",
+          company: "Example Robotics",
+          role: "Staff Software Engineer",
+          status: "recruiter_screen",
+          createdAt: "2026-01-15T10:00:00.000Z",
+          updatedAt: "2026-01-16T10:00:00.000Z",
+        },
+      ],
+      contacts: [
+        {
+          id: "contact_fake_001",
+          applicationId: "app_fake_001",
+          name: "Casey Recruiter",
+          email: "casey.recruiter@example.test",
+          createdAt: "2026-01-15T10:00:00.000Z",
+          updatedAt: "2026-01-15T10:00:00.000Z",
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_fake_001",
+          applicationId: "app_fake_001",
+          status: "recruiter_screen",
+          title: "Recruiter screen scheduled",
+          occurredAt: "2026-01-16T10:00:00.000Z",
+          createdAt: "2026-01-16T10:00:00.000Z",
+          updatedAt: "2026-01-16T10:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(exported.applications).toHaveLength(1);
+    expect(exported.lifecycleEvents[0].source).toBe("manual");
+  });
+});


### PR DESCRIPTION
### Motivation

- Define the production web architecture for jobbot3000 so user-owned job-search data lives in the browser (IndexedDB) rather than a server-side SQLite store.
- Provide a minimal, normalized browser data contract and runtime validators to guide future IndexedDB repo, import/export, and UI work without changing existing CLI behavior.
- Surface migration guidance from the current 32-column CSV/SQLite/NDJSON concepts so importers and migrations can be implemented safely.

### Description

- Added `docs/browser-first-architecture.md` describing IndexedDB as the source of truth, static/container-only server role, offline-first behavior, backup/restore expectations, and CSV/SQLite/NDJSON migration notes.
- Introduced Zod runtime validators in `src/domain/browser-application.js` that define canonical lifecycle slugs and typed schemas for applications, contacts, outreach messages, lifecycle events, interviews, offers, artifacts, reminders, settings, and a database export envelope.
- Updated `README.md` to point to the new browser-first architecture and clarify that the existing SQLite CLI store remains a migration/source-of-truth for the CLI preview (not the future browser production store).
- Added `test/browser-application-domain.test.js` with anonymized example records that exercise lifecycle values and the full export-envelope schema; no real personal data was added.

### Testing

- Ran formatting and style checks: `npx prettier --check README.md docs/browser-first-architecture.md src/domain/browser-application.js test/browser-application-domain.test.js` (passed for the changed files) and `npm run format:check` (reported pre-existing repo-wide formatting drift unrelated to this PR).
- Ran lint, typecheck, and full CI tests: `npm run lint` (passed), `npm run typecheck` (passed), and `npm run test:ci` (passed; test runner summary: 942 tests passed across suites, including the new domain tests).
- Performed targeted verification commands `git diff --check` and `git diff -- README.md docs/browser-first-architecture.md src/domain/browser-application.js test/browser-application-domain.test.js | ./scripts/scan-secrets.py` (no secrets detected and no diff-check failures for these files).

Note: `npm run format:check` flagged many pre-existing style issues across the repo; this PR formatted and validated the files it changed and added targeted Prettier checks for them. Follow-ups: add optional TypeScript re-exports or a browser TS runtime companion in a later PR if desired, and implement the IndexedDB repository and import/export flows in subsequent work.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40ed182200832fb922e41f3faac438)