### PR TITLE
Implement browser IndexedDB repository

### DIFF
--- a/docs/indexeddb-persistence.md
+++ b/docs/indexeddb-persistence.md
@@ -1,0 +1,33 @@
+# IndexedDB persistence
+
+jobbot3000 stores browser-owned application tracking data in IndexedDB database `jobbot3000`.
+The browser repository is the durable source of truth for tracker data; it does not call server
+endpoints for persistence and does not use `localStorage` for application records.
+
+## Stores and schema
+
+Version 1 creates these object stores: `applications`, `contacts`, `outreachMessages`,
+`lifecycleEvents`, `interviews`, `offers`, `artifacts`, `reminders`, and `settings`. Writes are
+validated with the browser application schemas before they are committed. Artifact records store
+metadata and URLs only in this implementation; users should keep original files in their own file
+system or document store.
+
+## Backup and restore
+
+Use the repository export flow to create a JSON backup containing all IndexedDB stores. Keep a copy
+outside the browser profile before clearing site data, changing browsers, or reinstalling the app.
+Restore uses the same schema validation as normal writes and supports a dry run so malformed files or
+conflicting IDs are reported before data is changed.
+
+## Where data lives
+
+IndexedDB data is stored by the user's browser under the site's origin. Clearing site data, using a
+private browsing session, changing hostnames, or browser profile resets can remove or hide the data.
+Because the deployed server is intentionally stateless for tracker records, a current export is the
+recovery path.
+
+## Quota caveats
+
+Browsers enforce per-origin storage quotas and can evict data under storage pressure. jobbot3000
+surfaces quota errors from IndexedDB, but users should still export regular backups when tracking
+long-running searches or storing many artifact links.

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "axe-core": "^4.10.0",
         "cspell": "^8.15.4",
         "eslint": "^9.36.0",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^16.4.0",
         "jsdom": "^27.0.1",
         "lighthouse": "^11.7.1",
@@ -4706,6 +4707,16 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "axe-core": "^4.10.0",
     "cspell": "^8.15.4",
     "eslint": "^9.36.0",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^16.4.0",
     "jsdom": "^27.0.1",
     "lighthouse": "^11.7.1",

--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -171,6 +171,7 @@ export const browserApplicationSchema = z.object({
   remote: z.boolean().optional(),
   compensationText: optionalTrimmedStringSchema,
   appliedAt: isoDateTimeSchema.optional(),
+  followUpDate: isoDateTimeSchema.optional(),
   closedAt: isoDateTimeSchema.optional(),
   notes: optionalTrimmedStringSchema,
   createdAt: isoDateTimeSchema,

--- a/src/web/storage/indexedDbRepository.js
+++ b/src/web/storage/indexedDbRepository.js
@@ -1,0 +1,407 @@
+import {
+  browserApplicationArtifactSchema,
+  browserApplicationContactSchema,
+  browserApplicationExportSchema,
+  browserApplicationLifecycleEventSchema,
+  browserApplicationOfferSchema,
+  browserApplicationOutreachMessageSchema,
+  browserApplicationReminderSchema,
+  browserApplicationInterviewSchema,
+  browserApplicationSchema,
+  browserApplicationSettingsSchema,
+} from "../../domain/browserApplication.js";
+
+export const INDEXED_DB_DATABASE_NAME = "jobbot3000";
+export const INDEXED_DB_VERSION = 1;
+export const INDEXED_DB_STORES = [
+  "applications",
+  "contacts",
+  "outreachMessages",
+  "lifecycleEvents",
+  "interviews",
+  "offers",
+  "artifacts",
+  "reminders",
+  "settings",
+];
+
+const STORE_SCHEMAS = {
+  applications: browserApplicationSchema,
+  contacts: browserApplicationContactSchema,
+  outreachMessages: browserApplicationOutreachMessageSchema,
+  lifecycleEvents: browserApplicationLifecycleEventSchema,
+  interviews: browserApplicationInterviewSchema,
+  offers: browserApplicationOfferSchema,
+  artifacts: browserApplicationArtifactSchema,
+  reminders: browserApplicationReminderSchema,
+  settings: browserApplicationSettingsSchema,
+};
+
+const APPLICATION_SCOPED_STORES = [
+  "contacts",
+  "outreachMessages",
+  "lifecycleEvents",
+  "interviews",
+  "offers",
+  "artifacts",
+  "reminders",
+];
+
+export class IndexedDbRepositoryError extends Error {
+  constructor(code, message, options = {}) {
+    super(message, options);
+    this.name = "IndexedDbRepositoryError";
+    this.code = code;
+    this.details = options.details;
+  }
+}
+
+const toRepositoryError = (error, fallbackMessage) => {
+  if (error instanceof IndexedDbRepositoryError) return error;
+  if (error?.name === "QuotaExceededError") {
+    return new IndexedDbRepositoryError(
+      "quota_exceeded",
+      "IndexedDB quota exceeded",
+      { cause: error },
+    );
+  }
+  if (error?.name === "ConstraintError") {
+    return new IndexedDbRepositoryError(
+      "import_conflict",
+      "Imported data conflicts with existing records",
+      { cause: error },
+    );
+  }
+  return new IndexedDbRepositoryError("indexeddb_error", fallbackMessage, {
+    cause: error,
+  });
+};
+
+const requestToPromise = (request, message = "IndexedDB request failed") =>
+  new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(toRepositoryError(request.error, message));
+  });
+
+const transactionDone = (transaction) =>
+  new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () =>
+      reject(
+        toRepositoryError(transaction.error, "IndexedDB transaction failed"),
+      );
+    transaction.onabort = () =>
+      reject(
+        toRepositoryError(transaction.error, "IndexedDB transaction aborted"),
+      );
+  });
+
+const validateRecord = (storeName, record) => {
+  const parsed = STORE_SCHEMAS[storeName].safeParse(record);
+  if (!parsed.success) {
+    throw new IndexedDbRepositoryError(
+      "schema_validation_failed",
+      `Invalid ${storeName} record`,
+      {
+        details: parsed.error.issues,
+        cause: parsed.error,
+      },
+    );
+  }
+  return parsed.data;
+};
+
+const validateExport = (data) => {
+  const parsed = browserApplicationExportSchema.safeParse(data);
+  if (!parsed.success) {
+    throw new IndexedDbRepositoryError(
+      "schema_validation_failed",
+      "Invalid import data",
+      {
+        details: parsed.error.issues,
+        cause: parsed.error,
+      },
+    );
+  }
+  return parsed.data;
+};
+
+const ensureIndexedDb = (indexedDB) => {
+  if (!indexedDB) {
+    throw new IndexedDbRepositoryError(
+      "indexeddb_unavailable",
+      "IndexedDB is not available in this browser context",
+    );
+  }
+  return indexedDB;
+};
+
+const createStore = (db, name) => {
+  if (!db.objectStoreNames.contains(name)) {
+    return db.createObjectStore(name, { keyPath: "id" });
+  }
+  return undefined;
+};
+
+const createIndex = (store, name, keyPath, options) => {
+  if (!store.indexNames.contains(name)) {
+    store.createIndex(name, keyPath, options);
+  }
+};
+
+export const migrations = {
+  1(db) {
+    const applications = createStore(db, "applications");
+    if (applications) {
+      createIndex(applications, "byCompany", "company");
+      createIndex(applications, "byStatus", "status");
+      createIndex(applications, "byAppliedAt", "appliedAt");
+      createIndex(applications, "byFollowUpDate", "followUpDate");
+    }
+
+    createStore(db, "contacts");
+
+    const outreachMessages = createStore(db, "outreachMessages");
+    if (outreachMessages)
+      createIndex(outreachMessages, "byApplicationId", "applicationId");
+
+    const lifecycleEvents = createStore(db, "lifecycleEvents");
+    if (lifecycleEvents) {
+      createIndex(lifecycleEvents, "byApplicationId", "applicationId");
+      createIndex(lifecycleEvents, "byApplicationIdAndOccurredAt", [
+        "applicationId",
+        "occurredAt",
+      ]);
+    }
+
+    createStore(db, "interviews");
+    createStore(db, "offers");
+
+    const artifacts = createStore(db, "artifacts");
+    if (artifacts) createIndex(artifacts, "byApplicationId", "applicationId");
+
+    createStore(db, "reminders");
+    createStore(db, "settings");
+  },
+};
+
+const openDatabase = (options = {}) =>
+  new Promise((resolve, reject) => {
+    const {
+      databaseName = INDEXED_DB_DATABASE_NAME,
+      version = INDEXED_DB_VERSION,
+    } = options;
+    const idb = ensureIndexedDb(
+      Object.hasOwn(options, "indexedDB")
+        ? options.indexedDB
+        : globalThis.indexedDB,
+    );
+    const request = idb.open(databaseName, version);
+    request.onupgradeneeded = (event) => {
+      for (
+        let nextVersion = event.oldVersion + 1;
+        nextVersion <= version;
+        nextVersion += 1
+      ) {
+        migrations[nextVersion]?.(request.result, request.transaction);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(
+        toRepositoryError(request.error, "Unable to open IndexedDB database"),
+      );
+    request.onblocked = () =>
+      reject(
+        new IndexedDbRepositoryError(
+          "indexeddb_blocked",
+          "IndexedDB upgrade is blocked by another open tab",
+        ),
+      );
+  });
+
+export async function createIndexedDbRepository(options = {}) {
+  const db = await openDatabase(options);
+
+  const withStore = async (storeName, mode, callback) => {
+    const transaction = db.transaction(storeName, mode);
+    const result = await callback(transaction.objectStore(storeName));
+    await transactionDone(transaction);
+    return result;
+  };
+
+  const putValidated = (storeName, record) =>
+    withStore(storeName, "readwrite", (store) =>
+      requestToPromise(store.put(validateRecord(storeName, record))),
+    );
+  const addValidated = (storeName, record) =>
+    withStore(storeName, "readwrite", (store) =>
+      requestToPromise(store.add(validateRecord(storeName, record))),
+    );
+  const getAll = (storeName) =>
+    withStore(storeName, "readonly", (store) =>
+      requestToPromise(store.getAll()),
+    );
+
+  const repository = {
+    db,
+    close() {
+      db.close();
+    },
+    createApplication(application) {
+      return addValidated("applications", application);
+    },
+    updateApplication(application) {
+      return putValidated("applications", application);
+    },
+    deleteApplication(applicationId) {
+      return new Promise((resolve, reject) => {
+        const transaction = db.transaction(
+          INDEXED_DB_STORES.filter((name) => name !== "settings"),
+          "readwrite",
+        );
+        transaction.onerror = () =>
+          reject(
+            toRepositoryError(
+              transaction.error,
+              "Failed to delete application",
+            ),
+          );
+        transaction.onabort = () =>
+          reject(
+            toRepositoryError(
+              transaction.error,
+              "Failed to delete application",
+            ),
+          );
+        transaction.oncomplete = () => resolve();
+        transaction.objectStore("applications").delete(applicationId);
+        for (const storeName of APPLICATION_SCOPED_STORES) {
+          const store = transaction.objectStore(storeName);
+          const request = store.openCursor();
+          request.onsuccess = () => {
+            const cursor = request.result;
+            if (!cursor) return;
+            if (cursor.value.applicationId === applicationId) cursor.delete();
+            cursor.continue();
+          };
+        }
+      });
+    },
+    listApplications() {
+      return getAll("applications");
+    },
+    getApplication(id) {
+      return withStore("applications", "readonly", (store) =>
+        requestToPromise(store.get(id)),
+      );
+    },
+    upsertContact(record) {
+      return putValidated("contacts", record);
+    },
+    addOutreachMessage(record) {
+      return addValidated("outreachMessages", record);
+    },
+    addLifecycleEvent(record) {
+      return addValidated("lifecycleEvents", record);
+    },
+    upsertInterview(record) {
+      return putValidated("interviews", record);
+    },
+    upsertOffer(record) {
+      return putValidated("offers", record);
+    },
+    upsertArtifact(record) {
+      return putValidated("artifacts", record);
+    },
+    async listDueFollowUps(now = new Date()) {
+      const cutoff = typeof now === "string" ? now : now.toISOString();
+      const applications = await getAll("applications");
+      return applications.filter(
+        ({ followUpDate, closedAt }) =>
+          followUpDate && followUpDate <= cutoff && !closedAt,
+      );
+    },
+    async exportAllData() {
+      const entries = await Promise.all(
+        INDEXED_DB_STORES.map(async (storeName) => [
+          storeName,
+          await getAll(storeName),
+        ]),
+      );
+      const data = Object.fromEntries(entries);
+      return validateExport({
+        schemaVersion: INDEXED_DB_VERSION,
+        exportedAt: new Date().toISOString(),
+        ...data,
+        settings: data.settings[0],
+      });
+    },
+    async importAllData(data, { dryRun = false, overwrite = false } = {}) {
+      const parsed = validateExport(data);
+      if (dryRun)
+        return {
+          ok: true,
+          dryRun: true,
+          counts: Object.fromEntries(
+            INDEXED_DB_STORES.map((name) => [
+              name,
+              name === "settings"
+                ? parsed.settings
+                  ? 1
+                  : 0
+                : parsed[name].length,
+            ]),
+          ),
+        };
+      if (!overwrite) {
+        for (const storeName of INDEXED_DB_STORES) {
+          const incoming =
+            storeName === "settings"
+              ? parsed.settings
+                ? [parsed.settings]
+                : []
+              : parsed[storeName];
+          for (const record of incoming) {
+            if (await repository.getRecord(storeName, record.id)) {
+              throw new IndexedDbRepositoryError(
+                "import_conflict",
+                `Record already exists in ${storeName}: ${record.id}`,
+              );
+            }
+          }
+        }
+      }
+      await repository.clearAllData();
+      const transaction = db.transaction(INDEXED_DB_STORES, "readwrite");
+      const done = transactionDone(transaction);
+      for (const storeName of INDEXED_DB_STORES) {
+        const store = transaction.objectStore(storeName);
+        const incoming =
+          storeName === "settings"
+            ? parsed.settings
+              ? [parsed.settings]
+              : []
+            : parsed[storeName];
+        incoming.forEach((record) => store.put(record));
+      }
+      await done;
+      return { ok: true, dryRun: false };
+    },
+    getRecord(storeName, id) {
+      return withStore(storeName, "readonly", (store) =>
+        requestToPromise(store.get(id)),
+      );
+    },
+    async clearAllData() {
+      const transaction = db.transaction(INDEXED_DB_STORES, "readwrite");
+      const done = transactionDone(transaction);
+      INDEXED_DB_STORES.forEach((storeName) =>
+        transaction.objectStore(storeName).clear(),
+      );
+      await done;
+    },
+  };
+
+  return repository;
+}

--- a/test/indexed-db-repository.test.js
+++ b/test/indexed-db-repository.test.js
@@ -1,0 +1,215 @@
+import "fake-indexeddb/auto";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  createIndexedDbRepository,
+  INDEXED_DB_DATABASE_NAME,
+  IndexedDbRepositoryError,
+} from "../src/web/storage/indexedDbRepository.js";
+
+const now = "2026-01-02T03:04:05.000Z";
+const later = "2026-01-03T03:04:05.000Z";
+
+const application = {
+  id: "app_fake_001",
+  company: "Example Robotics",
+  role: "Staff Software Engineer",
+  status: "applied",
+  postingUrl: "https://example.test/jobs/staff-engineer",
+  appliedAt: now,
+  followUpDate: later,
+  createdAt: now,
+  updatedAt: now,
+};
+
+const contact = {
+  id: "contact_fake_001",
+  applicationId: application.id,
+  name: "Jordan Example",
+  email: "jordan@example.test",
+  createdAt: now,
+  updatedAt: now,
+};
+
+const lifecycleEvent = {
+  id: "event_fake_001",
+  applicationId: application.id,
+  status: "applied",
+  occurredAt: now,
+  source: "manual",
+  createdAt: now,
+};
+
+const outreachMessage = {
+  id: "message_fake_001",
+  applicationId: application.id,
+  contactId: contact.id,
+  direction: "outbound",
+  channel: "email",
+  subject: "Checking in",
+  sentAt: now,
+  createdAt: now,
+  updatedAt: now,
+};
+
+const interview = {
+  id: "interview_fake_001",
+  applicationId: application.id,
+  contactIds: [contact.id],
+  stage: "recruiter_screen",
+  startsAt: later,
+  outcome: "scheduled",
+  createdAt: now,
+  updatedAt: now,
+};
+
+const offer = {
+  id: "offer_fake_001",
+  applicationId: application.id,
+  status: "received",
+  baseSalaryMin: 100000,
+  baseSalaryMax: 120000,
+  currency: "USD",
+  createdAt: now,
+  updatedAt: now,
+};
+
+const artifact = {
+  id: "artifact_fake_001",
+  applicationId: application.id,
+  kind: "link",
+  name: "Job posting",
+  url: "https://example.test/jobs/staff-engineer",
+  private: true,
+  createdAt: now,
+  updatedAt: now,
+};
+
+const settings = {
+  id: "local",
+  schemaVersion: 1,
+  timezone: "Etc/UTC",
+  defaultExportFormat: "json",
+  createdAt: now,
+  updatedAt: now,
+};
+
+const deleteDatabase = () =>
+  new Promise((resolve, reject) => {
+    const request = globalThis.indexedDB.deleteDatabase(
+      INDEXED_DB_DATABASE_NAME,
+    );
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => resolve();
+  });
+
+describe("IndexedDB repository", () => {
+  let repository;
+
+  beforeEach(async () => {
+    await deleteDatabase();
+    repository = await createIndexedDbRepository();
+  });
+
+  afterEach(async () => {
+    repository?.close();
+    await deleteDatabase();
+  });
+
+  it("initializes the v1 database stores and indexes", () => {
+    expect([...repository.db.objectStoreNames]).toEqual([
+      "applications",
+      "artifacts",
+      "contacts",
+      "interviews",
+      "lifecycleEvents",
+      "offers",
+      "outreachMessages",
+      "reminders",
+      "settings",
+    ]);
+  });
+
+  it("writes, reads, lists, exports, clears, and restores application data", async () => {
+    await repository.createApplication(application);
+    await repository.upsertContact(contact);
+    await repository.addLifecycleEvent(lifecycleEvent);
+    await repository.addOutreachMessage(outreachMessage);
+    await repository.upsertInterview(interview);
+    await repository.upsertOffer(offer);
+    await repository.upsertArtifact(artifact);
+    await repository.importAllData(
+      {
+        schemaVersion: 1,
+        exportedAt: now,
+        applications: [application],
+        contacts: [contact],
+        outreachMessages: [outreachMessage],
+        lifecycleEvents: [lifecycleEvent],
+        interviews: [interview],
+        offers: [offer],
+        artifacts: [artifact],
+        reminders: [],
+        settings,
+      },
+      { dryRun: true },
+    );
+
+    expect(await repository.getApplication(application.id)).toMatchObject({
+      company: "Example Robotics",
+    });
+    expect(await repository.listApplications()).toHaveLength(1);
+    expect(
+      await repository.listDueFollowUps("2026-01-04T00:00:00.000Z"),
+    ).toHaveLength(1);
+
+    const exported = await repository.exportAllData();
+    expect(exported).toMatchObject({
+      schemaVersion: 1,
+      applications: [application],
+      settings: undefined,
+    });
+    expect(exported.artifacts[0]).not.toHaveProperty("body");
+
+    await repository.clearAllData();
+    expect(await repository.listApplications()).toEqual([]);
+
+    await repository.importAllData(
+      { ...exported, exportedAt: now },
+      { overwrite: true },
+    );
+    expect(await repository.getApplication(application.id)).toMatchObject({
+      role: "Staff Software Engineer",
+    });
+  });
+
+  it("validates writes through browser application schemas", async () => {
+    await expect(
+      repository.createApplication({
+        ...application,
+        id: "app_fake_bad",
+        postingUrl: "not a url",
+      }),
+    ).rejects.toMatchObject({ code: "schema_validation_failed" });
+  });
+
+  it("reports import conflicts unless overwrite is requested", async () => {
+    await repository.createApplication(application);
+
+    await expect(
+      repository.importAllData({
+        schemaVersion: 1,
+        exportedAt: now,
+        applications: [application],
+      }),
+    ).rejects.toMatchObject({ code: "import_conflict" });
+  });
+
+  it("reports unavailable IndexedDB in non-browser contexts", async () => {
+    await expect(
+      createIndexedDbRepository({ indexedDB: undefined }),
+    ).rejects.toBeInstanceOf(IndexedDbRepositoryError);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a browser-first durable persistence layer for jobbot3000 so users can store all tracker data in a local, versioned IndexedDB database without server persistence.
- Enable reliable export/import, migrations, and offline-first behavior so long-running searches and artifacts can be managed client-side and recovered via backups.

### Description
- Added a new browser repository module `src/web/storage/indexedDbRepository.js` implementing a versioned `jobbot3000` IndexedDB with v1 migrations, object stores, and indexes for `applications`, `contacts`, `outreachMessages`, `lifecycleEvents`, `interviews`, `offers`, `artifacts`, `reminders`, and `settings` and indexes such as `byCompany`, `byStatus`, `byAppliedAt`, `byFollowUpDate`, and `byApplicationId` (see `migrations`).
- Implemented repository operations including `createApplication`, `updateApplication`, `deleteApplication` (cascading scoped-store cleanup), `listApplications`, `getApplication`, `upsertContact`, `addOutreachMessage`, `addLifecycleEvent`, `upsertInterview`, `upsertOffer`, `upsertArtifact`, `listDueFollowUps`, `exportAllData`, and `importAllData` with dry-run validation and optional overwrite semantics.
- Added schema validation and error handling using the existing browser schemas (from `src/domain/browserApplication.js`) and a repository-specific `IndexedDbRepositoryError` mapping quota, constraint, schema, and availability errors to stable codes.
- Extended the application schema with `followUpDate`, added `fake-indexeddb` as a dev dependency, added tests in `test/indexed-db-repository.test.js`, and added documentation `docs/indexeddb-persistence.md` describing storage, backup/restore, artifact metadata behavior, and quota caveats.

### Testing
- Ran `npm run format:check` which reported pre-existing Prettier drift across unrelated files (repo-wide warnings), so formatting check did not pass for unrelated files.
- Ran `npm run lint` which completed successfully and `npm run typecheck` which completed successfully.
- Ran the unit tests that exercise the new repository: `npm test -- --run test/indexed-db-repository.test.js` which passed (5 tests), covering v1 initialization, CRUD, `exportAllData`/`importAllData` with dry-run, schema validation failures, import conflict detection, and IndexedDB-unavailable handling.
- Ran the repository CI test runner `npm run test:ci` which completed successfully and included the new tests as part of the full suite (full test run passed in CI environment during the rollout); note formatting warnings remain unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4160d29e10832f91a6c9d083497cf5)