### PR TITLE
Implement browser IndexedDB repository

### DIFF
--- a/docs/browser-first-architecture.md
+++ b/docs/browser-first-architecture.md
@@ -141,3 +141,23 @@ control.
 3. Add JSON, NDJSON, and CSV import/export around the browser model.
 4. Move UI tracker screens to the IndexedDB repository.
 5. Harden service worker, static deployment, health checks, Docker, Helm, and Sugarkube integration.
+
+## IndexedDB repository implementation
+
+The browser repository in `src/web/storage/indexedDbRepository.js` is the durable source of truth for production web tracker data. It opens a versioned `jobbot3000` IndexedDB database and creates v1 object stores for applications, contacts, outreach messages, lifecycle events, interviews, offers, artifacts, reminders, and settings. Application data is never persisted through server endpoints by this repository, and application records are not mirrored to `localStorage`.
+
+The v1 schema indexes the tracker fields the UI needs for common views: company, status, applied date, and follow-up date on applications; application ownership on outreach and artifacts; and `(applicationId, occurredAt)` on lifecycle events. Migrations are centralized in the repository so future database version bumps can add stores or indexes without rewriting the open path.
+
+Artifacts intentionally store metadata and URLs first. File and Blob bodies are not written to IndexedDB in this implementation, which keeps backups smaller and avoids surprising quota usage until binary artifact storage has a dedicated design and tests.
+
+### Backup and restore
+
+Users should create regular backups with the repository export flow. `exportAllData()` returns a JSON document validated by the browser application export schema, including all application-owned stores plus local settings. To restore, pass that document to `importAllData()`. Use `{ dryRun: true }` before applying a restore to validate schema shape, dangling references, duplicate ids, and conflicts without changing the browser database.
+
+Import conflicts are reported when an incoming record uses an existing id with different contents. The default behavior fails fast so users do not accidentally overwrite local work; explicit restore flows may choose a replace strategy after warning the user and confirming that a backup exists.
+
+### Browser storage and quota caveats
+
+IndexedDB lives inside the user's browser profile for the current origin. Clearing site data, using private browsing sessions, changing browser profiles, or uninstalling the browser can remove the database. Browser quota policies also vary by browser, available disk space, and device settings. If quota is exceeded, the repository raises a quota-specific error so the UI can ask the user to export a backup, remove unneeded records, or retry on a device with more storage.
+
+Because the data is local-first and browser-owned, users are responsible for keeping backup files somewhere durable, such as an encrypted external drive or a trusted cloud folder. Backup files may contain job-search history, contacts, compensation notes, interview details, and other sensitive personal data, so they should be handled as private records.

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "axe-core": "^4.10.0",
         "cspell": "^8.15.4",
         "eslint": "^9.36.0",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^16.4.0",
         "jsdom": "^27.0.1",
         "lighthouse": "^11.7.1",
@@ -4706,6 +4707,16 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "axe-core": "^4.10.0",
     "cspell": "^8.15.4",
     "eslint": "^9.36.0",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^16.4.0",
     "jsdom": "^27.0.1",
     "lighthouse": "^11.7.1",

--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -171,6 +171,7 @@ export const browserApplicationSchema = z.object({
   remote: z.boolean().optional(),
   compensationText: optionalTrimmedStringSchema,
   appliedAt: isoDateTimeSchema.optional(),
+  followUpDate: isoDateTimeSchema.optional(),
   closedAt: isoDateTimeSchema.optional(),
   notes: optionalTrimmedStringSchema,
   createdAt: isoDateTimeSchema,

--- a/src/web/storage/indexedDbRepository.js
+++ b/src/web/storage/indexedDbRepository.js
@@ -1,0 +1,340 @@
+import { ZodError } from "zod";
+
+import {
+  browserApplicationArtifactSchema,
+  browserApplicationContactSchema,
+  browserApplicationExportSchema,
+  browserApplicationInterviewSchema,
+  browserApplicationLifecycleEventSchema,
+  browserApplicationOfferSchema,
+  browserApplicationOutreachMessageSchema,
+  browserApplicationReminderSchema,
+  browserApplicationSchema,
+  browserApplicationSettingsSchema,
+} from "../../domain/browserApplication.js";
+
+export const INDEXED_DB_DATABASE_NAME = "jobbot3000";
+export const INDEXED_DB_SCHEMA_VERSION = 1;
+
+const STORE_SCHEMAS = {
+  applications: browserApplicationSchema,
+  contacts: browserApplicationContactSchema,
+  outreachMessages: browserApplicationOutreachMessageSchema,
+  lifecycleEvents: browserApplicationLifecycleEventSchema,
+  interviews: browserApplicationInterviewSchema,
+  offers: browserApplicationOfferSchema,
+  artifacts: browserApplicationArtifactSchema,
+  reminders: browserApplicationReminderSchema,
+  settings: browserApplicationSettingsSchema,
+};
+
+const STORE_NAMES = Object.keys(STORE_SCHEMAS);
+
+export class IndexedDbRepositoryError extends Error {
+  constructor(message, { code, cause } = {}) {
+    super(message, { cause });
+    this.name = "IndexedDbRepositoryError";
+    this.code = code;
+  }
+}
+
+export class IndexedDbUnavailableError extends IndexedDbRepositoryError {
+  constructor(
+    message = "IndexedDB is unavailable in this browser",
+    options = {},
+  ) {
+    super(message, { ...options, code: "indexeddb_unavailable" });
+    this.name = "IndexedDbUnavailableError";
+  }
+}
+
+export class IndexedDbQuotaExceededError extends IndexedDbRepositoryError {
+  constructor(message = "IndexedDB quota was exceeded", options = {}) {
+    super(message, { ...options, code: "quota_exceeded" });
+    this.name = "IndexedDbQuotaExceededError";
+  }
+}
+
+export class IndexedDbSchemaValidationError extends IndexedDbRepositoryError {
+  constructor(message = "Record failed schema validation", options = {}) {
+    super(message, { ...options, code: "schema_validation_failed" });
+    this.name = "IndexedDbSchemaValidationError";
+    this.issues = options.cause instanceof ZodError ? options.cause.issues : [];
+  }
+}
+
+export class IndexedDbImportConflictError extends IndexedDbRepositoryError {
+  constructor(
+    message = "Import contains records that conflict with existing data",
+    options = {},
+  ) {
+    super(message, { ...options, code: "import_conflict" });
+    this.name = "IndexedDbImportConflictError";
+    this.conflicts = options.conflicts ?? [];
+  }
+}
+
+const normalizeError = (error) => {
+  if (error instanceof IndexedDbRepositoryError) return error;
+  if (error?.name === "QuotaExceededError")
+    return new IndexedDbQuotaExceededError(undefined, { cause: error });
+  return error;
+};
+
+const promisifyRequest = (request) =>
+  new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(normalizeError(request.error));
+  });
+
+const promisifyTransaction = (transaction) =>
+  new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(normalizeError(transaction.error));
+    transaction.onabort = () => reject(normalizeError(transaction.error));
+  });
+
+const getAll = (store) => promisifyRequest(store.getAll());
+
+const createStore = (db, name) =>
+  db.objectStoreNames.contains(name)
+    ? null
+    : db.createObjectStore(name, { keyPath: "id" });
+
+export const migrations = {
+  1(db) {
+    const applications = createStore(db, "applications");
+    applications?.createIndex("by_company", "company", { unique: false });
+    applications?.createIndex("by_status", "status", { unique: false });
+    applications?.createIndex("by_appliedAt", "appliedAt", { unique: false });
+    applications?.createIndex("by_followUpDate", "followUpDate", {
+      unique: false,
+    });
+
+    createStore(db, "contacts");
+    const outreach = createStore(db, "outreachMessages");
+    outreach?.createIndex("by_applicationId", "applicationId", {
+      unique: false,
+    });
+    const lifecycle = createStore(db, "lifecycleEvents");
+    lifecycle?.createIndex(
+      "by_applicationId_occurredAt",
+      ["applicationId", "occurredAt"],
+      { unique: false },
+    );
+    createStore(db, "interviews");
+    createStore(db, "offers");
+    const artifacts = createStore(db, "artifacts");
+    artifacts?.createIndex("by_applicationId", "applicationId", {
+      unique: false,
+    });
+    createStore(db, "reminders");
+    createStore(db, "settings");
+  },
+};
+
+const validate = (schema, record) => {
+  try {
+    return schema.parse(record);
+  } catch (error) {
+    throw new IndexedDbSchemaValidationError(undefined, { cause: error });
+  }
+};
+
+const validateExport = (data) => {
+  try {
+    return browserApplicationExportSchema.parse(data);
+  } catch (error) {
+    throw new IndexedDbSchemaValidationError(
+      "Import data failed schema validation",
+      { cause: error },
+    );
+  }
+};
+
+const put = async (db, storeName, schema, record) => {
+  const parsed = validate(schema, record);
+  const transaction = db.transaction(storeName, "readwrite");
+  transaction.objectStore(storeName).put(parsed);
+  await promisifyTransaction(transaction);
+  return parsed;
+};
+
+const deleteApplicationById = async (db, applicationId) => {
+  const transaction = db.transaction(STORE_NAMES, "readwrite");
+  transaction.objectStore("applications").delete(applicationId);
+
+  for (const storeName of STORE_NAMES.filter(
+    (name) => !["applications", "settings"].includes(name),
+  )) {
+    const store = transaction.objectStore(storeName);
+    const records = await promisifyRequest(store.getAll());
+    records
+      .filter((record) => record.applicationId === applicationId)
+      .forEach((record) => store.delete(record.id));
+  }
+
+  await promisifyTransaction(transaction);
+};
+
+const recordsEqual = (left, right) =>
+  JSON.stringify(left) === JSON.stringify(right);
+
+export function openIndexedDbRepository({
+  indexedDB: idb = globalThis.indexedDB,
+  databaseName = INDEXED_DB_DATABASE_NAME,
+} = {}) {
+  if (!idb?.open) throw new IndexedDbUnavailableError();
+
+  const openPromise = new Promise((resolve, reject) => {
+    const request = idb.open(databaseName, INDEXED_DB_SCHEMA_VERSION);
+    request.onupgradeneeded = (event) => {
+      for (
+        let version = event.oldVersion + 1;
+        version <= INDEXED_DB_SCHEMA_VERSION;
+        version += 1
+      ) {
+        migrations[version]?.(request.result, request.transaction);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(normalizeError(request.error));
+    request.onblocked = () =>
+      reject(
+        new IndexedDbRepositoryError("IndexedDB open was blocked", {
+          code: "open_blocked",
+        }),
+      );
+  });
+
+  const withDb = async (callback) => callback(await openPromise);
+
+  return {
+    ready: openPromise.then(() => undefined),
+    close: async () => withDb((db) => db.close()),
+    createApplication: (record) =>
+      withDb((db) => put(db, "applications", browserApplicationSchema, record)),
+    updateApplication: (record) =>
+      withDb((db) => put(db, "applications", browserApplicationSchema, record)),
+    deleteApplication: (id) => withDb((db) => deleteApplicationById(db, id)),
+    getApplication: (id) =>
+      withDb((db) =>
+        promisifyRequest(
+          db.transaction("applications").objectStore("applications").get(id),
+        ),
+      ),
+    listApplications: () =>
+      withDb((db) =>
+        getAll(db.transaction("applications").objectStore("applications")),
+      ),
+    upsertContact: (record) =>
+      withDb((db) =>
+        put(db, "contacts", browserApplicationContactSchema, record),
+      ),
+    addOutreachMessage: (record) =>
+      withDb((db) =>
+        put(
+          db,
+          "outreachMessages",
+          browserApplicationOutreachMessageSchema,
+          record,
+        ),
+      ),
+    addLifecycleEvent: (record) =>
+      withDb((db) =>
+        put(
+          db,
+          "lifecycleEvents",
+          browserApplicationLifecycleEventSchema,
+          record,
+        ),
+      ),
+    upsertInterview: (record) =>
+      withDb((db) =>
+        put(db, "interviews", browserApplicationInterviewSchema, record),
+      ),
+    upsertOffer: (record) =>
+      withDb((db) => put(db, "offers", browserApplicationOfferSchema, record)),
+    upsertArtifact: (record) =>
+      withDb((db) =>
+        put(db, "artifacts", browserApplicationArtifactSchema, record),
+      ),
+    listDueFollowUps: (dueAt = new Date().toISOString()) =>
+      withDb(async (db) => {
+        const applications = await getAll(
+          db.transaction("applications").objectStore("applications"),
+        );
+        return applications.filter(
+          ({ followUpDate }) => followUpDate && followUpDate <= dueAt,
+        );
+      }),
+    exportAllData: () =>
+      withDb(async (db) => {
+        const tx = db.transaction(STORE_NAMES);
+        const entries = await Promise.all(
+          STORE_NAMES.map(async (name) => [
+            name,
+            await getAll(tx.objectStore(name)),
+          ]),
+        );
+        const data = Object.fromEntries(entries);
+        return browserApplicationExportSchema.parse({
+          schemaVersion: 1,
+          exportedAt: new Date().toISOString(),
+          ...data,
+          settings: data.settings[0],
+        });
+      }),
+    clear: () =>
+      withDb(async (db) => {
+        const tx = db.transaction(STORE_NAMES, "readwrite");
+        STORE_NAMES.forEach((name) => tx.objectStore(name).clear());
+        await promisifyTransaction(tx);
+      }),
+    importAllData: (data, { dryRun = false, conflictStrategy = "fail" } = {}) =>
+      withDb(async (db) => {
+        const parsed = validateExport(data);
+        const conflicts = [];
+        const tx = db.transaction(STORE_NAMES, "readonly");
+        for (const storeName of STORE_NAMES) {
+          const records =
+            storeName === "settings"
+              ? [parsed.settings].filter(Boolean)
+              : parsed[storeName];
+          const store = tx.objectStore(storeName);
+          for (const record of records) {
+            const existing = await promisifyRequest(store.get(record.id));
+            if (existing && !recordsEqual(existing, record))
+              conflicts.push({ storeName, id: record.id });
+          }
+        }
+        if (conflicts.length > 0 && conflictStrategy === "fail")
+          throw new IndexedDbImportConflictError(undefined, { conflicts });
+        if (dryRun)
+          return {
+            ok: true,
+            counts: Object.fromEntries(
+              STORE_NAMES.map((name) => [
+                name,
+                name === "settings"
+                  ? Number(Boolean(parsed.settings))
+                  : parsed[name].length,
+              ]),
+            ),
+            conflicts,
+          };
+        const writeTx = db.transaction(STORE_NAMES, "readwrite");
+        for (const storeName of STORE_NAMES) {
+          const records =
+            storeName === "settings"
+              ? [parsed.settings].filter(Boolean)
+              : parsed[storeName];
+          records.forEach((record) =>
+            writeTx.objectStore(storeName).put(record),
+          );
+        }
+        await promisifyTransaction(writeTx);
+        return { ok: true, conflicts };
+      }),
+  };
+}

--- a/test/indexed-db-repository.test.js
+++ b/test/indexed-db-repository.test.js
@@ -1,0 +1,229 @@
+import { IDBFactory } from "fake-indexeddb";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  IndexedDbImportConflictError,
+  IndexedDbSchemaValidationError,
+  IndexedDbUnavailableError,
+  INDEXED_DB_SCHEMA_VERSION,
+  openIndexedDbRepository,
+} from "../src/web/storage/indexedDbRepository.js";
+
+const now = "2026-01-02T03:04:05.000Z";
+const later = "2026-01-03T03:04:05.000Z";
+const databaseName = () => `jobbot3000_test_${crypto.randomUUID()}`;
+
+const application = {
+  id: "app_fake_001",
+  company: "Example Robotics",
+  role: "Staff Software Engineer",
+  status: "applied",
+  postingUrl: "https://example.test/jobs/staff-engineer",
+  appliedAt: now,
+  followUpDate: later,
+  createdAt: now,
+  updatedAt: now,
+};
+
+const contact = {
+  id: "contact_fake_001",
+  applicationId: application.id,
+  name: "Jordan Example",
+  email: "jordan@example.test",
+  createdAt: now,
+  updatedAt: now,
+};
+
+const fullExport = {
+  schemaVersion: 1,
+  exportedAt: now,
+  applications: [application],
+  contacts: [contact],
+  outreachMessages: [
+    {
+      id: "message_fake_001",
+      applicationId: application.id,
+      contactId: contact.id,
+      direction: "outbound",
+      channel: "email",
+      subject: "Intro",
+      createdAt: now,
+      updatedAt: now,
+    },
+  ],
+  lifecycleEvents: [
+    {
+      id: "event_fake_001",
+      applicationId: application.id,
+      status: "applied",
+      occurredAt: now,
+      source: "manual",
+      createdAt: now,
+    },
+  ],
+  interviews: [
+    {
+      id: "interview_fake_001",
+      applicationId: application.id,
+      contactIds: [contact.id],
+      stage: "recruiter_screen",
+      startsAt: later,
+      createdAt: now,
+      updatedAt: now,
+    },
+  ],
+  offers: [
+    {
+      id: "offer_fake_001",
+      applicationId: application.id,
+      status: "received",
+      baseSalaryMin: 100000,
+      baseSalaryMax: 120000,
+      currency: "USD",
+      createdAt: now,
+      updatedAt: now,
+    },
+  ],
+  artifacts: [
+    {
+      id: "artifact_fake_001",
+      applicationId: application.id,
+      kind: "link",
+      name: "Job posting",
+      url: "https://example.test/jobs/staff-engineer",
+      createdAt: now,
+      updatedAt: now,
+    },
+  ],
+  reminders: [
+    {
+      id: "reminder_fake_001",
+      applicationId: application.id,
+      contactId: contact.id,
+      dueAt: later,
+      summary: "Follow up",
+      createdAt: now,
+      updatedAt: now,
+    },
+  ],
+  settings: {
+    id: "local",
+    schemaVersion: 1,
+    defaultExportFormat: "json",
+    createdAt: now,
+    updatedAt: now,
+  },
+};
+
+let indexedDB;
+
+beforeEach(() => {
+  indexedDB = new IDBFactory();
+});
+
+describe("IndexedDB repository", () => {
+  it("initializes a v1 database with the tracker object stores and indexes", async () => {
+    const repository = openIndexedDbRepository({
+      indexedDB,
+      databaseName: databaseName(),
+    });
+    await repository.ready;
+
+    const exported = await repository.exportAllData();
+
+    expect(exported.schemaVersion).toBe(INDEXED_DB_SCHEMA_VERSION);
+    expect(exported.applications).toEqual([]);
+    await repository.close();
+  });
+
+  it("writes, reads, lists, updates, and deletes applications", async () => {
+    const repository = openIndexedDbRepository({
+      indexedDB,
+      databaseName: databaseName(),
+    });
+
+    await expect(
+      repository.createApplication(application),
+    ).resolves.toMatchObject({ id: application.id });
+    await expect(
+      repository.getApplication(application.id),
+    ).resolves.toMatchObject({ company: "Example Robotics" });
+    await expect(repository.listApplications()).resolves.toHaveLength(1);
+    await repository.updateApplication({
+      ...application,
+      status: "recruiter_screen",
+    });
+    await expect(
+      repository.getApplication(application.id),
+    ).resolves.toMatchObject({ status: "recruiter_screen" });
+    await repository.deleteApplication(application.id);
+    await expect(
+      repository.getApplication(application.id),
+    ).resolves.toBeUndefined();
+    await repository.close();
+  });
+
+  it("stores related tracker records and lists due follow ups", async () => {
+    const repository = openIndexedDbRepository({
+      indexedDB,
+      databaseName: databaseName(),
+    });
+
+    await repository.importAllData(fullExport, { conflictStrategy: "replace" });
+
+    await expect(
+      repository.listDueFollowUps("2026-01-04T00:00:00.000Z"),
+    ).resolves.toEqual([expect.objectContaining({ id: application.id })]);
+    await expect(repository.exportAllData()).resolves.toMatchObject({
+      applications: [expect.objectContaining({ id: application.id })],
+      contacts: [expect.objectContaining({ id: contact.id })],
+      outreachMessages: [expect.objectContaining({ id: "message_fake_001" })],
+      lifecycleEvents: [expect.objectContaining({ id: "event_fake_001" })],
+      interviews: [expect.objectContaining({ id: "interview_fake_001" })],
+      offers: [expect.objectContaining({ id: "offer_fake_001" })],
+      artifacts: [expect.objectContaining({ id: "artifact_fake_001" })],
+      reminders: [expect.objectContaining({ id: "reminder_fake_001" })],
+    });
+    await repository.close();
+  });
+
+  it("dry-runs import validation without writing and can restore after clear", async () => {
+    const repository = openIndexedDbRepository({
+      indexedDB,
+      databaseName: databaseName(),
+    });
+
+    await expect(
+      repository.importAllData(fullExport, { dryRun: true }),
+    ).resolves.toMatchObject({ ok: true, counts: { applications: 1 } });
+    await expect(repository.listApplications()).resolves.toEqual([]);
+    await repository.importAllData(fullExport);
+    await repository.clear();
+    await expect(repository.listApplications()).resolves.toEqual([]);
+    await repository.importAllData(fullExport);
+    await expect(repository.listApplications()).resolves.toHaveLength(1);
+    await repository.close();
+  });
+
+  it("reports repository setup, validation, and import errors", async () => {
+    expect(() => openIndexedDbRepository({ indexedDB: undefined })).toThrow(
+      IndexedDbUnavailableError,
+    );
+
+    const repository = openIndexedDbRepository({
+      indexedDB,
+      databaseName: databaseName(),
+    });
+    await expect(
+      repository.createApplication({ ...application, status: "bad_status" }),
+    ).rejects.toBeInstanceOf(IndexedDbSchemaValidationError);
+    await repository.createApplication(application);
+    await expect(
+      repository.importAllData({
+        ...fullExport,
+        applications: [{ ...application, role: "Different" }],
+      }),
+    ).rejects.toBeInstanceOf(IndexedDbImportConflictError);
+    await repository.close();
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a browser-first durable persistence layer so the web UI can store all user application-tracking data locally and version the schema for future migrations.
- Support export/import, dry-run validation, and the follow-up/reminder workflows the UI requires without relying on server-side storage.

### Description
- Add a versioned IndexedDB repository at `src/web/storage/indexedDbRepository.js` that defines v1 migrations, object stores, indexes, CRUD helpers, export/import, dry-run validation, and conflict detection.
- Extend the browser application schema (`src/domain/browserApplication.js`) with `followUpDate` and wire the schema validators into repository writes so all writes are schema-checked.
- Implement browser-friendly error classes for unavailable IndexedDB, quota exceeded, schema validation failure, and import conflicts, and avoid storing binary File/Blob bodies (artifacts store metadata/URLs only).
- Add tests using `fake-indexeddb` at `test/indexed-db-repository.test.js` covering initialization, CRUD, related records, due follow-ups, export/clear/restore, dry-run imports, validation errors, and import conflicts, and document behavior in `docs/browser-first-architecture.md`.

### Testing
- `npm run format:check` — reported repo-wide Prettier drift unrelated to these changes (status: failed for unrelated files); local changed files were formatted with `npx prettier --write` to satisfy team style for this PR.
- `npm run lint` — passed for the modified code (status: passed).
- `npm run typecheck` — passed (status: passed).
- `npm run test -- test/indexed-db-repository.test.js test/browser-application-schema.test.js` — passed (status: passed).
- `npm run test:ci` — ran full CI test suite (including Playwright specs) and completed with all tests passing (953 tests passed, status: passed).

Residual notes: `fake-indexeddb` was added as a dev dependency for Node-based tests so repository logic can be exercised in a non-browser environment; artifacts currently store metadata/URLs only (no blobs) to avoid quota surprises; migrations are centralized in `migrations` to support future schema bumps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4160a25f04832fb5d4acd91e8ec4ef)