### PR TITLE
Implement browser IndexedDB repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Run the snippet with `node example.js` after saving it to a file in the project 
 - [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) – prompt reference index
 - [docs/user-journeys.md](docs/user-journeys.md) – primary user journeys and flows
 - [docs/browser-first-architecture.md](docs/browser-first-architecture.md) – planned IndexedDB-first production web architecture and browser data contract
+- [docs/indexeddb-persistence.md](docs/indexeddb-persistence.md) – browser IndexedDB persistence, backup/restore, and quota behavior
 - [docs/backup-restore-guide.md](docs/backup-restore-guide.md) – backup, restore, and verification
   steps
 - [docs/web-ux-guidelines.md](docs/web-ux-guidelines.md) – layout, typography, and interaction guardrails

--- a/docs/indexeddb-persistence.md
+++ b/docs/indexeddb-persistence.md
@@ -1,0 +1,68 @@
+# IndexedDB persistence
+
+jobbot3000 stores production browser tracker data in the user's browser-owned IndexedDB database named
+`jobbot3000`. The database is the durable source of truth for application tracking data and does not
+call server endpoints for create, update, delete, export, or import operations.
+
+## Version 1 stores
+
+Version 1 creates object stores for the normalized browser application model:
+
+- `applications`
+- `contacts`
+- `outreachMessages`
+- `lifecycleEvents`
+- `interviews`
+- `offers`
+- `artifacts`
+- `reminders`
+- `settings`
+
+The repository validates all writes and imports against the browser application schemas before data is
+committed. Artifact records store metadata and URLs only in this implementation; users should keep
+resume, cover letter, PDF, and take-home file contents in user-managed files until Blob storage is
+explicitly designed and tested.
+
+## Where the data lives
+
+IndexedDB data is scoped by browser profile and site origin. For example, data created at
+`http://127.0.0.1:3100` is separate from data created at another host, port, browser, profile, or
+private browsing session. Clearing site data, resetting the browser profile, uninstalling the app, or
+using browser cleanup tools can delete the local database.
+
+The server-side SQLite repository and CLI import/export flows still exist for compatibility, but they
+are not the production browser tracker's persistence layer. Browser application CRUD should use the
+IndexedDB repository instead of sending private tracker records to the server.
+
+## Backup and restore
+
+Use the repository's JSON export as the full-fidelity backup format. A backup contains the schema
+version, export timestamp, applications, contacts, outreach messages, lifecycle events, interviews,
+offers, artifact metadata, reminders, and optional settings. Store backups somewhere outside the
+browser profile, such as an encrypted local folder or a trusted password-manager attachment vault.
+
+Before restoring a backup, the repository performs a dry-run capable validation pass. Invalid schema
+versions, malformed records, duplicate IDs, dangling application/contact references, and conflicting
+record IDs are reported before data is written. Imports can be run as dry-runs to show counts and
+conflicts without changing IndexedDB.
+
+Recommended user workflow:
+
+1. Export a JSON backup before clearing browser storage, switching browsers, or upgrading devices.
+2. Save the backup outside the browser profile.
+3. On the target browser origin, run a dry-run import and review validation/conflict results.
+4. Restore only after the dry-run succeeds.
+5. Export another backup after large imports or manual cleanup sessions.
+
+## Quota and availability caveats
+
+IndexedDB quotas vary by browser, device free space, storage pressure, and private browsing mode. The
+repository maps quota failures to a browser-friendly `quota_exceeded` error so the UI can ask users to
+export data, free space, or remove large optional metadata. Because this first implementation stores
+artifact metadata rather than file contents, normal multi-year application tracking records should
+remain small.
+
+Some browser contexts disable IndexedDB entirely, including certain private browsing modes, locked-down
+enterprise profiles, or test environments without an IndexedDB shim. The repository reports
+`indexeddb_unavailable` in those contexts and should show a clear message instead of falling back to
+`localStorage` for application data.

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "axe-core": "^4.10.0",
         "cspell": "^8.15.4",
         "eslint": "^9.36.0",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^16.4.0",
         "jsdom": "^27.0.1",
         "lighthouse": "^11.7.1",
@@ -4706,6 +4707,16 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "axe-core": "^4.10.0",
     "cspell": "^8.15.4",
     "eslint": "^9.36.0",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^16.4.0",
     "jsdom": "^27.0.1",
     "lighthouse": "^11.7.1",

--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -171,6 +171,7 @@ export const browserApplicationSchema = z.object({
   remote: z.boolean().optional(),
   compensationText: optionalTrimmedStringSchema,
   appliedAt: isoDateTimeSchema.optional(),
+  followUpDate: isoDateTimeSchema.optional(),
   closedAt: isoDateTimeSchema.optional(),
   notes: optionalTrimmedStringSchema,
   createdAt: isoDateTimeSchema,

--- a/src/web/storage/indexedDbRepository.js
+++ b/src/web/storage/indexedDbRepository.js
@@ -1,0 +1,406 @@
+import {
+  browserApplicationArtifactSchema,
+  browserApplicationContactSchema,
+  browserApplicationExportSchema,
+  browserApplicationInterviewSchema,
+  browserApplicationLifecycleEventSchema,
+  browserApplicationOfferSchema,
+  browserApplicationOutreachMessageSchema,
+  browserApplicationReminderSchema,
+  browserApplicationSchema,
+  browserApplicationSettingsSchema,
+} from "../../domain/browserApplication.js";
+
+export const DATABASE_NAME = "jobbot3000";
+export const DATABASE_VERSION = 1;
+
+export class IndexedDbRepositoryError extends Error {
+  constructor(code, message, options = {}) {
+    super(message, options);
+    this.name = "IndexedDbRepositoryError";
+    this.code = code;
+    this.cause = options.cause;
+    this.details = options.details;
+  }
+}
+
+const STORE_SCHEMAS = {
+  applications: browserApplicationSchema,
+  contacts: browserApplicationContactSchema,
+  outreachMessages: browserApplicationOutreachMessageSchema,
+  lifecycleEvents: browserApplicationLifecycleEventSchema,
+  interviews: browserApplicationInterviewSchema,
+  offers: browserApplicationOfferSchema,
+  artifacts: browserApplicationArtifactSchema,
+  reminders: browserApplicationReminderSchema,
+  settings: browserApplicationSettingsSchema,
+};
+
+const EXPORT_STORES = [
+  "applications",
+  "contacts",
+  "outreachMessages",
+  "lifecycleEvents",
+  "interviews",
+  "offers",
+  "artifacts",
+  "reminders",
+];
+
+const ALL_STORES = [...EXPORT_STORES, "settings"];
+
+const APPLICATION_INDEXES = [
+  ["by_company", "company"],
+  ["by_status", "status"],
+  ["by_appliedAt", "appliedAt"],
+  ["by_followUpDate", "followUpDate"],
+];
+
+const MIGRATIONS = [
+  {
+    version: 1,
+    migrate(db) {
+      createStore(db, "applications", APPLICATION_INDEXES);
+      createStore(db, "contacts", [["by_applicationId", "applicationId"]]);
+      createStore(db, "outreachMessages", [
+        ["by_applicationId", "applicationId"],
+      ]);
+      createStore(db, "lifecycleEvents", [
+        ["by_applicationId", "applicationId"],
+        ["by_applicationId_occurredAt", ["applicationId", "occurredAt"]],
+      ]);
+      createStore(db, "interviews", [["by_applicationId", "applicationId"]]);
+      createStore(db, "offers", [["by_applicationId", "applicationId"]]);
+      createStore(db, "artifacts", [["by_applicationId", "applicationId"]]);
+      createStore(db, "reminders", [
+        ["by_applicationId", "applicationId"],
+        ["by_dueAt", "dueAt"],
+      ]);
+      createStore(db, "settings");
+    },
+  },
+];
+
+function createStore(db, name, indexes = []) {
+  if (db.objectStoreNames.contains(name)) {
+    return db.transaction.objectStore(name);
+  }
+
+  const store = db.createObjectStore(name, { keyPath: "id" });
+  indexes.forEach(([indexName, keyPath, options]) => {
+    store.createIndex(indexName, keyPath, options);
+  });
+  return store;
+}
+
+function isQuotaError(error) {
+  return error?.name === "QuotaExceededError" || error?.code === 22;
+}
+
+function mapRequestError(error, fallbackCode = "indexeddb_request_failed") {
+  if (isQuotaError(error)) {
+    return new IndexedDbRepositoryError(
+      "quota_exceeded",
+      "IndexedDB quota was exceeded while writing jobbot3000 data.",
+      { cause: error },
+    );
+  }
+
+  return new IndexedDbRepositoryError(
+    fallbackCode,
+    error?.message ?? "IndexedDB request failed.",
+    { cause: error },
+  );
+}
+
+function validateRecord(storeName, record) {
+  const result = STORE_SCHEMAS[storeName].safeParse(record);
+  if (!result.success) {
+    throw new IndexedDbRepositoryError(
+      "schema_validation_failed",
+      `${storeName} record failed schema validation.`,
+      { details: result.error.flatten() },
+    );
+  }
+  return result.data;
+}
+
+function requestToPromise(request, errorCode) {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(mapRequestError(request.error, errorCode));
+  });
+}
+
+function transactionDone(transaction) {
+  return new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onerror = () => reject(mapRequestError(transaction.error));
+    transaction.onabort = () => reject(mapRequestError(transaction.error));
+  });
+}
+
+function normalizeExport(data) {
+  return browserApplicationExportSchema.parse({
+    schemaVersion: DATABASE_VERSION,
+    exportedAt: new Date().toISOString(),
+    applications: [],
+    contacts: [],
+    outreachMessages: [],
+    lifecycleEvents: [],
+    interviews: [],
+    offers: [],
+    artifacts: [],
+    reminders: [],
+    ...data,
+  });
+}
+
+export function openIndexedDbDatabase({
+  indexedDB: indexedDb = globalThis.indexedDB,
+  name = DATABASE_NAME,
+  version = DATABASE_VERSION,
+} = {}) {
+  if (!indexedDb?.open) {
+    return Promise.reject(
+      new IndexedDbRepositoryError(
+        "indexeddb_unavailable",
+        "IndexedDB is unavailable in this browser context.",
+      ),
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    const request = indexedDb.open(name, version);
+
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      const oldVersion = request.oldVersion ?? 0;
+      MIGRATIONS.filter(
+        ({ version: targetVersion }) => targetVersion > oldVersion,
+      ).forEach(({ migrate }) => migrate(db, request.transaction));
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(mapRequestError(request.error, "indexeddb_open_failed"));
+    request.onblocked = () =>
+      reject(
+        new IndexedDbRepositoryError(
+          "indexeddb_blocked",
+          "Opening the jobbot3000 IndexedDB database was blocked by another tab.",
+        ),
+      );
+  });
+}
+
+export function createIndexedDbRepository(options = {}) {
+  let dbPromise;
+
+  const getDb = () => {
+    dbPromise ??= openIndexedDbDatabase(options);
+    return dbPromise;
+  };
+
+  async function withStore(storeName, mode, callback) {
+    const db = await getDb();
+    const transaction = db.transaction(storeName, mode);
+    const store = Array.isArray(storeName)
+      ? undefined
+      : transaction.objectStore(storeName);
+    const result = await callback(store, transaction);
+    await transactionDone(transaction);
+    return result;
+  }
+
+  async function putRecord(storeName, record) {
+    const parsed = validateRecord(storeName, record);
+    await withStore(storeName, "readwrite", (store) =>
+      requestToPromise(store.put(parsed)),
+    );
+    return parsed;
+  }
+
+  async function addRecord(storeName, record) {
+    const parsed = validateRecord(storeName, record);
+    await withStore(storeName, "readwrite", (store) =>
+      requestToPromise(store.add(parsed)),
+    );
+    return parsed;
+  }
+
+  async function getAll(storeName) {
+    return withStore(storeName, "readonly", (store) =>
+      requestToPromise(store.getAll()),
+    );
+  }
+
+  async function getRecord(storeName, id) {
+    return withStore(storeName, "readonly", (store) =>
+      requestToPromise(store.get(id)),
+    );
+  }
+
+  async function replaceAll(exportData) {
+    await withStore(ALL_STORES, "readwrite", async (_store, transaction) => {
+      await Promise.all(
+        ALL_STORES.map((storeName) =>
+          requestToPromise(transaction.objectStore(storeName).clear()),
+        ),
+      );
+      for (const storeName of EXPORT_STORES) {
+        const store = transaction.objectStore(storeName);
+        for (const record of exportData[storeName]) {
+          await requestToPromise(store.put(record));
+        }
+      }
+      if (exportData.settings) {
+        await requestToPromise(
+          transaction.objectStore("settings").put(exportData.settings),
+        );
+      }
+    });
+  }
+
+  return {
+    async createApplication(application) {
+      return addRecord("applications", application);
+    },
+    async updateApplication(application) {
+      return putRecord("applications", application);
+    },
+    async deleteApplication(id) {
+      const db = await getDb();
+      const transaction = db.transaction(ALL_STORES, "readwrite");
+      await Promise.all(
+        EXPORT_STORES.map((storeName) => {
+          if (storeName === "applications") {
+            return requestToPromise(
+              transaction.objectStore(storeName).delete(id),
+            );
+          }
+          return deleteByApplicationId(transaction.objectStore(storeName), id);
+        }),
+      );
+      await transactionDone(transaction);
+    },
+    async listApplications() {
+      return getAll("applications");
+    },
+    async getApplication(id) {
+      return getRecord("applications", id);
+    },
+    async upsertContact(contact) {
+      return putRecord("contacts", contact);
+    },
+    async addOutreachMessage(message) {
+      return addRecord("outreachMessages", message);
+    },
+    async addLifecycleEvent(event) {
+      return addRecord("lifecycleEvents", event);
+    },
+    async upsertInterview(interview) {
+      return putRecord("interviews", interview);
+    },
+    async upsertOffer(offer) {
+      return putRecord("offers", offer);
+    },
+    async upsertArtifact(artifact) {
+      return putRecord("artifacts", artifact);
+    },
+    async listDueFollowUps(now = new Date().toISOString()) {
+      const reminders = await getAll("reminders");
+      return reminders
+        .filter(({ completedAt, dueAt }) => !completedAt && dueAt <= now)
+        .sort((a, b) => a.dueAt.localeCompare(b.dueAt));
+    },
+    async exportAllData() {
+      const records = {};
+      for (const storeName of EXPORT_STORES) {
+        records[storeName] = await getAll(storeName);
+      }
+      const settings = await getRecord("settings", "local");
+      return normalizeExport({ ...records, settings });
+    },
+    async importAllData(data, { dryRun = false, conflict = "fail" } = {}) {
+      let parsed;
+      try {
+        parsed = normalizeExport(data);
+      } catch (error) {
+        throw new IndexedDbRepositoryError(
+          "schema_validation_failed",
+          "Import data failed browser application schema validation.",
+          { cause: error, details: error.flatten?.() },
+        );
+      }
+
+      const current = await this.exportAllData();
+      const conflicts = findImportConflicts(current, parsed);
+      if (conflicts.length > 0 && conflict !== "replace") {
+        throw new IndexedDbRepositoryError(
+          "import_conflict",
+          "Import would overwrite existing IndexedDB records.",
+          { details: { conflicts } },
+        );
+      }
+
+      const summary = summarizeImport(parsed, conflicts);
+      if (!dryRun) {
+        await replaceAll(
+          conflict === "replace" ? mergeExport(current, parsed) : parsed,
+        );
+      }
+      return summary;
+    },
+    async clearAllData() {
+      await replaceAll(normalizeExport({}));
+    },
+    async close() {
+      const db = await getDb();
+      db.close();
+      dbPromise = undefined;
+    },
+  };
+}
+
+async function deleteByApplicationId(store, applicationId) {
+  const records = await requestToPromise(
+    store.index("by_applicationId").getAllKeys(applicationId),
+  );
+  await Promise.all(records.map((key) => requestToPromise(store.delete(key))));
+}
+
+function summarizeImport(exportData, conflicts) {
+  return {
+    dryRunValid: true,
+    schemaVersion: exportData.schemaVersion,
+    conflicts,
+    counts: Object.fromEntries(
+      EXPORT_STORES.map((storeName) => [
+        storeName,
+        exportData[storeName].length,
+      ]),
+    ),
+  };
+}
+
+function findImportConflicts(current, incoming) {
+  return EXPORT_STORES.flatMap((storeName) => {
+    const currentIds = new Set(current[storeName].map(({ id }) => id));
+    return incoming[storeName]
+      .filter(({ id }) => currentIds.has(id))
+      .map(({ id }) => ({ storeName, id }));
+  });
+}
+
+function mergeExport(current, incoming) {
+  const merged = { ...incoming };
+  for (const storeName of EXPORT_STORES) {
+    const incomingIds = new Set(incoming[storeName].map(({ id }) => id));
+    merged[storeName] = [
+      ...current[storeName].filter(({ id }) => !incomingIds.has(id)),
+      ...incoming[storeName],
+    ];
+  }
+  merged.settings = incoming.settings ?? current.settings;
+  return merged;
+}

--- a/test/indexed-db-repository.test.js
+++ b/test/indexed-db-repository.test.js
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { IDBFactory } from "fake-indexeddb";
+
+import {
+  DATABASE_NAME,
+  createIndexedDbRepository,
+  openIndexedDbDatabase,
+} from "../src/web/storage/indexedDbRepository.js";
+
+const now = "2026-01-02T03:04:05.000Z";
+const later = "2026-01-05T03:04:05.000Z";
+
+function createFactory() {
+  return new IDBFactory();
+}
+
+function repository(indexedDB = createFactory()) {
+  return createIndexedDbRepository({ indexedDB });
+}
+
+const application = {
+  id: "app_fake_001",
+  company: "Example Robotics",
+  role: "Staff Software Engineer",
+  status: "applied",
+  postingUrl: "https://example.test/jobs/staff-engineer",
+  appliedAt: now,
+  followUpDate: later,
+  createdAt: now,
+  updatedAt: now,
+};
+
+const contact = {
+  id: "contact_fake_001",
+  applicationId: application.id,
+  name: "Jordan Example",
+  email: "jordan@example.test",
+  createdAt: now,
+  updatedAt: now,
+};
+
+const lifecycleEvent = {
+  id: "event_fake_001",
+  applicationId: application.id,
+  status: "applied",
+  occurredAt: now,
+  source: "manual",
+  createdAt: now,
+};
+
+const reminder = {
+  id: "reminder_fake_001",
+  applicationId: application.id,
+  dueAt: now,
+  summary: "Follow up with recruiter",
+  createdAt: now,
+  updatedAt: now,
+};
+
+describe("IndexedDB repository", () => {
+  let dbFactory;
+
+  beforeEach(() => {
+    dbFactory = createFactory();
+  });
+
+  afterEach(async () => {
+    await new Promise((resolve, reject) => {
+      const request = dbFactory.deleteDatabase(DATABASE_NAME);
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+      request.onblocked = () => resolve();
+    });
+  });
+
+  it("initializes a version 1 database with tracker stores and indexes", async () => {
+    const db = await openIndexedDbDatabase({ indexedDB: dbFactory });
+
+    expect(db.version).toBe(1);
+    expect(Array.from(db.objectStoreNames)).toEqual([
+      "applications",
+      "artifacts",
+      "contacts",
+      "interviews",
+      "lifecycleEvents",
+      "offers",
+      "outreachMessages",
+      "reminders",
+      "settings",
+    ]);
+
+    const transaction = db.transaction("applications", "readonly");
+    const indexes = Array.from(
+      transaction.objectStore("applications").indexNames,
+    );
+    expect(indexes).toEqual([
+      "by_appliedAt",
+      "by_company",
+      "by_followUpDate",
+      "by_status",
+    ]);
+    db.close();
+  });
+
+  it("writes, reads, updates, and deletes application records", async () => {
+    const repo = repository(dbFactory);
+
+    await repo.createApplication(application);
+    expect(await repo.getApplication(application.id)).toEqual(application);
+
+    await repo.updateApplication({ ...application, status: "outreach_sent" });
+    expect((await repo.listApplications())[0].status).toBe("outreach_sent");
+
+    await repo.deleteApplication(application.id);
+    expect(await repo.getApplication(application.id)).toBeUndefined();
+    await repo.close();
+  });
+
+  it("validates writes through browser schemas", async () => {
+    const repo = repository(dbFactory);
+
+    await expect(
+      repo.createApplication({ ...application, status: "not_a_status" }),
+    ).rejects.toMatchObject({ code: "schema_validation_failed" });
+    await repo.close();
+  });
+
+  it("exports, clears, validates dry-run imports, and restores all data", async () => {
+    const repo = repository(dbFactory);
+
+    await repo.createApplication(application);
+    await repo.upsertContact(contact);
+    await repo.addLifecycleEvent(lifecycleEvent);
+    await repo.importAllData(
+      { applications: [application], reminders: [reminder] },
+      { conflict: "replace" },
+    );
+
+    const exported = await repo.exportAllData();
+    expect(exported.applications).toHaveLength(1);
+    expect(exported.contacts).toHaveLength(1);
+    expect(exported.lifecycleEvents).toHaveLength(1);
+    expect(exported.reminders).toHaveLength(1);
+
+    await repo.clearAllData();
+    expect(await repo.listApplications()).toEqual([]);
+
+    const dryRun = await repo.importAllData(exported, { dryRun: true });
+    expect(dryRun.counts.applications).toBe(1);
+    expect(await repo.listApplications()).toEqual([]);
+
+    await repo.importAllData(exported);
+    expect(await repo.getApplication(application.id)).toEqual(application);
+    expect(await repo.listDueFollowUps(later)).toEqual([reminder]);
+    await repo.close();
+  });
+
+  it("reports import conflicts before overwriting existing records", async () => {
+    const repo = repository(dbFactory);
+
+    await repo.createApplication(application);
+    await expect(
+      repo.importAllData({ applications: [application] }),
+    ).rejects.toMatchObject({
+      code: "import_conflict",
+      details: {
+        conflicts: [{ storeName: "applications", id: application.id }],
+      },
+    });
+    await repo.close();
+  });
+
+  it("reports IndexedDB unavailable errors", async () => {
+    await expect(
+      openIndexedDbDatabase({ indexedDB: undefined }),
+    ).rejects.toMatchObject({
+      code: "indexeddb_unavailable",
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a browser-first durable persistence layer so private application tracker data is stored in user-owned IndexedDB rather than the server SQLite store.
- Equip the app with a versioned v1 database, import/export, migrations, and schema-validated writes so backups, restores, and future migrations are possible without server dependencies.

### Description
- Add a vanilla IndexedDB repository at `src/web/storage/indexedDbRepository.js` with v1 `MIGRATIONS`, object stores for the tracker model, and requested indexes (company, status, appliedAt, followUpDate, applicationId/occurredAt, artifacts by application, reminders by dueAt). 
- Implement repository operations including `createApplication`, `updateApplication`, `deleteApplication`, `listApplications`, `getApplication`, `upsertContact`, `addOutreachMessage`, `addLifecycleEvent`, `upsertInterview`, `upsertOffer`, `upsertArtifact`, `listDueFollowUps`, `exportAllData`, and `importAllData` with dry-run validation and conflict handling.
- Validate every write and import against the `src/domain/browserApplication.js` Zod schemas and add an optional `followUpDate` field to support follow-up indexing.
- Add browser-friendly error mapping (`indexeddb_unavailable`, `quota_exceeded`, `schema_validation_failed`, `import_conflict`) and migration helpers for future version bumps.
- Add tests using `fake-indexeddb` at `test/indexed-db-repository.test.js` covering DB initialization/migrations, CRUD, validation, export/clear/dry-run import/restore, conflict detection, due follow-ups, and unavailable IndexedDB handling.
- Add documentation `docs/indexeddb-persistence.md` describing where data lives, backup/restore workflow, artifact metadata behavior, and quota/unavailability caveats, and link it from the `README`.
- Add `fake-indexeddb` as a dev dependency for Node/Vitest browser-like testing.

### Testing
- Ran focused unit tests with `npx vitest run test/indexed-db-repository.test.js test/browser-application-schema.test.js` and they passed.
- Ran the full CI suite with `npm run test:ci` and it completed successfully in this environment.
- Ran `npx prettier --check` on the changed files and they passed the focused Prettier check; the repository-wide `npm run format:check` reported pre-existing formatting drift on unrelated files (not introduced by this change).
- Ran `npm run lint` and `npm run typecheck` which both completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4160be1364832f8280da8a44f3f445)