### PR TITLE
Add browser IndexedDB persistence repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Run the snippet with `node example.js` after saving it to a file in the project 
 - [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) – prompt reference index
 - [docs/user-journeys.md](docs/user-journeys.md) – primary user journeys and flows
 - [docs/browser-first-architecture.md](docs/browser-first-architecture.md) – planned IndexedDB-first production web architecture and browser data contract
+- [docs/indexeddb-persistence.md](docs/indexeddb-persistence.md) – browser IndexedDB persistence, backup/restore, and quota caveats
 - [docs/backup-restore-guide.md](docs/backup-restore-guide.md) – backup, restore, and verification
   steps
 - [docs/web-ux-guidelines.md](docs/web-ux-guidelines.md) – layout, typography, and interaction guardrails

--- a/docs/indexeddb-persistence.md
+++ b/docs/indexeddb-persistence.md
@@ -1,0 +1,37 @@
+# IndexedDB persistence
+
+jobbot3000's production web tracker stores user-owned application tracking data in the browser's IndexedDB database named `jobbot3000`. The web app does not need server-side persistence for applications, contacts, outreach, lifecycle events, interviews, offers, artifacts, reminders, or local tracker settings.
+
+## What is stored
+
+Version 1 creates these object stores:
+
+- `applications`
+- `contacts`
+- `outreachMessages`
+- `lifecycleEvents`
+- `interviews`
+- `offers`
+- `artifacts`
+- `reminders`
+- `settings`
+
+Records are validated with the browser application schemas before writes and before imports. The first artifact implementation stores metadata and URLs only; it does not store `File` or `Blob` contents.
+
+## Where data lives
+
+IndexedDB is private to the browser profile and origin. A local development server, a production host name, and a different browser profile each get separate storage. Clearing site data, using private browsing, browser profile reset, or origin changes can remove or hide the database.
+
+## Backup and restore
+
+Use the repository export flow to create a JSON backup containing all object stores. Keep backups in a safe location that you control, because jobbot3000 does not upload application tracker data to a server. Before restoring, the import path validates the whole file and can run in dry-run mode to report schema errors or record ID conflicts without changing stored data.
+
+Recommended backup cadence:
+
+1. Export after major application-tracking sessions.
+2. Export before clearing browser data, switching domains, or changing browser profiles.
+3. Keep multiple dated copies so an accidental bad import can be rolled back manually.
+
+## Quota and browser caveats
+
+Browsers enforce storage quotas per origin and may reclaim storage under device pressure. jobbot3000 reports quota errors separately from schema errors so the UI can tell users to free space or export and prune old data. Exact quota behavior varies by browser and operating system.

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "axe-core": "^4.10.0",
         "cspell": "^8.15.4",
         "eslint": "^9.36.0",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^16.4.0",
         "jsdom": "^27.0.1",
         "lighthouse": "^11.7.1",
@@ -4706,6 +4707,16 @@
       },
       "optionalDependencies": {
         "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "axe-core": "^4.10.0",
     "cspell": "^8.15.4",
     "eslint": "^9.36.0",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^16.4.0",
     "jsdom": "^27.0.1",
     "lighthouse": "^11.7.1",

--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -171,6 +171,7 @@ export const browserApplicationSchema = z.object({
   remote: z.boolean().optional(),
   compensationText: optionalTrimmedStringSchema,
   appliedAt: isoDateTimeSchema.optional(),
+  followUpDate: isoDateTimeSchema.optional(),
   closedAt: isoDateTimeSchema.optional(),
   notes: optionalTrimmedStringSchema,
   createdAt: isoDateTimeSchema,

--- a/src/web/storage/indexedDbRepository.js
+++ b/src/web/storage/indexedDbRepository.js
@@ -257,6 +257,12 @@ const assertReferencesExist = async (db, record) => {
   }
 };
 
+const addChildRecord = async (db, storeName, record) => {
+  const parsed = parseRecord(storeName, record);
+  await assertReferencesExist(db, parsed);
+  return addRecord(db, storeName, parsed);
+};
+
 const putChildRecord = async (db, storeName, record) => {
   const parsed = parseRecord(storeName, record);
   await assertReferencesExist(db, parsed);
@@ -378,10 +384,10 @@ export const createIndexedDbRepository = async (options = {}) => {
       return safe(() => putChildRecord(db, "contacts", record));
     },
     addOutreachMessage(record) {
-      return safe(() => putChildRecord(db, "outreachMessages", record));
+      return safe(() => addChildRecord(db, "outreachMessages", record));
     },
     addLifecycleEvent(record) {
-      return safe(() => putChildRecord(db, "lifecycleEvents", record));
+      return safe(() => addChildRecord(db, "lifecycleEvents", record));
     },
     upsertInterview(record) {
       return safe(() => putChildRecord(db, "interviews", record));
@@ -434,26 +440,23 @@ export const createIndexedDbRepository = async (options = {}) => {
           ),
         );
         const existingKeys = new Set(
-          STORE_NAMES.flatMap((name) =>
-            existingRecords[name].map(({ id }) => `${name}:${id}`),
+          STORE_NAMES.flatMap((storeName) =>
+            existingRecords[storeName].map(({ id }) => `${storeName}:${id}`),
           ),
         );
-        const incomingKeys = STORE_NAMES.flatMap((name) => {
-          if (name === "settings")
-            return parsed.settings ? ["settings:local"] : [];
-          return parsed[name].map(({ id }) => `${name}:${id}`);
+        const incomingRecords = STORE_NAMES.flatMap((storeName) => {
+          if (storeName === "settings")
+            return parsed.settings
+              ? [{ storeName, id: parsed.settings.id }]
+              : [];
+          return parsed[storeName].map(({ id }) => ({ storeName, id }));
         });
-        const conflicts = incomingKeys.filter((key) => existingKeys.has(key));
+        const conflicts = incomingRecords.filter(({ storeName, id }) =>
+          existingKeys.has(`${storeName}:${id}`),
+        );
         const hasExistingData = STORE_NAMES.some(
           (name) => existingRecords[name].length > 0,
         );
-        if (hasExistingData && !allowOverwrite) {
-          throw new IndexedDbRepositoryError(
-            "import_conflict",
-            "Import would replace existing IndexedDB records.",
-            { details: { conflicts, hasExistingData } },
-          );
-        }
         if (dryRun)
           return {
             imported: false,
@@ -466,7 +469,15 @@ export const createIndexedDbRepository = async (options = {}) => {
               ]),
             ),
             conflicts,
+            hasExistingData,
           };
+        if (hasExistingData && !allowOverwrite) {
+          throw new IndexedDbRepositoryError(
+            "import_conflict",
+            "Import would replace existing IndexedDB records.",
+            { details: { conflicts, hasExistingData } },
+          );
+        }
         const tx = db.transaction(STORE_NAMES, "readwrite");
         const done = transactionDone(tx);
         for (const storeName of STORE_NAMES) tx.objectStore(storeName).clear();

--- a/src/web/storage/indexedDbRepository.js
+++ b/src/web/storage/indexedDbRepository.js
@@ -272,7 +272,11 @@ const putChildRecord = async (db, storeName, record) => {
 const deleteFromIndex = async (db, storeName, indexName, value) => {
   const tx = db.transaction(storeName, "readwrite");
   const done = transactionDone(tx);
-  const store = tx.objectStore(storeName);
+  await deleteMatchingFromStore(tx.objectStore(storeName), indexName, value);
+  await done;
+};
+
+const deleteMatchingFromStore = async (store, indexName, value) => {
   const source = store.indexNames.contains(`by_${indexName}`)
     ? store.index(`by_${indexName}`)
     : store;
@@ -292,7 +296,6 @@ const deleteFromIndex = async (db, storeName, indexName, value) => {
     };
     request.onerror = () => reject(request.error);
   });
-  await done;
 };
 
 const validateImport = (data) => {
@@ -339,23 +342,18 @@ export const createIndexedDbRepository = async (options = {}) => {
     },
     async deleteApplication(id) {
       return safe(async () => {
-        const relatedRecords = await Promise.all(
-          APPLICATION_CASCADE_STORES.map(async (storeName) => [
-            storeName,
-            (await getAll(db, storeName)).filter(
-              (record) => record.applicationId === id,
-            ),
-          ]),
-        );
         const tx = db.transaction(
           ["applications", ...APPLICATION_CASCADE_STORES],
           "readwrite",
         );
         const done = transactionDone(tx);
         tx.objectStore("applications").delete(id);
-        for (const [storeName, records] of relatedRecords) {
-          const store = tx.objectStore(storeName);
-          records.forEach((record) => store.delete(record.id));
+        for (const storeName of APPLICATION_CASCADE_STORES) {
+          await deleteMatchingFromStore(
+            tx.objectStore(storeName),
+            "applicationId",
+            id,
+          );
         }
         await done;
       });
@@ -408,18 +406,37 @@ export const createIndexedDbRepository = async (options = {}) => {
     },
     async exportAllData() {
       return safe(async () => {
+        const tx = db.transaction(STORE_NAMES, "readonly");
+        const done = transactionDone(tx);
+        const storeResults = await Promise.all(
+          STORE_NAMES.map((storeName) =>
+            requestToPromise(tx.objectStore(storeName).getAll()),
+          ),
+        );
+        await done;
+        const [
+          applications,
+          contacts,
+          outreachMessages,
+          lifecycleEvents,
+          interviews,
+          offers,
+          artifacts,
+          reminders,
+          settingsAll,
+        ] = storeResults;
         const result = browserApplicationExportSchema.safeParse({
           schemaVersion: DATABASE_VERSION,
           exportedAt: new Date().toISOString(),
-          applications: await getAll(db, "applications"),
-          contacts: await getAll(db, "contacts"),
-          outreachMessages: await getAll(db, "outreachMessages"),
-          lifecycleEvents: await getAll(db, "lifecycleEvents"),
-          interviews: await getAll(db, "interviews"),
-          offers: await getAll(db, "offers"),
-          artifacts: await getAll(db, "artifacts"),
-          reminders: await getAll(db, "reminders"),
-          settings: (await getAll(db, "settings"))[0],
+          applications,
+          contacts,
+          outreachMessages,
+          lifecycleEvents,
+          interviews,
+          offers,
+          artifacts,
+          reminders,
+          settings: settingsAll[0],
         });
         if (!result.success) {
           throw new IndexedDbRepositoryError(

--- a/src/web/storage/indexedDbRepository.js
+++ b/src/web/storage/indexedDbRepository.js
@@ -133,15 +133,25 @@ export const migrations = {
       ]);
     }
 
-    createStore(db, "interviews");
-    createStore(db, "offers");
+    const interviews = createStore(db, "interviews");
+    if (interviews) {
+      ensureIndex(interviews, "by_applicationId", "applicationId");
+    }
+
+    const offers = createStore(db, "offers");
+    if (offers) {
+      ensureIndex(offers, "by_applicationId", "applicationId");
+    }
 
     const artifacts = createStore(db, "artifacts");
     if (artifacts) {
       ensureIndex(artifacts, "by_applicationId", "applicationId");
     }
 
-    createStore(db, "reminders");
+    const reminders = createStore(db, "reminders");
+    if (reminders) {
+      ensureIndex(reminders, "by_applicationId", "applicationId");
+    }
     createStore(db, "settings");
   },
 };
@@ -448,6 +458,8 @@ export const createIndexedDbRepository = async (options = {}) => {
         return result.data;
       });
     },
+    // Full-restore operation: non-dry-run imports replace every store.
+    // Callers should dry-run first and set allowOverwrite when existing data may be cleared.
     async importAllData(data, { dryRun = false, allowOverwrite = false } = {}) {
       return safe(async () => {
         const { parsed } = validateImport(data);

--- a/src/web/storage/indexedDbRepository.js
+++ b/src/web/storage/indexedDbRepository.js
@@ -114,7 +114,10 @@ export const migrations = {
       ensureIndex(applications, "by_followUpDate", "followUpDate");
     }
 
-    createStore(db, "contacts");
+    const contacts = createStore(db, "contacts");
+    if (contacts) {
+      ensureIndex(contacts, "by_applicationId", "applicationId");
+    }
 
     const outreachMessages = createStore(db, "outreachMessages");
     if (outreachMessages) {
@@ -162,10 +165,10 @@ export const openJobbotDatabase = ({
   const idb = getIndexedDb(indexedDb);
   return new Promise((resolve, reject) => {
     const request = idb.open(databaseName, version);
-    request.onupgradeneeded = () => {
+    request.onupgradeneeded = (event) => {
       const db = request.result;
       for (
-        let currentVersion = (request.oldVersion ?? 0) + 1;
+        let currentVersion = event.oldVersion + 1;
         currentVersion <= version;
         currentVersion += 1
       ) {
@@ -199,6 +202,15 @@ const getAll = async (db, storeName) => {
   return records;
 };
 
+const addRecord = async (db, storeName, record) => {
+  const parsed = parseRecord(storeName, record);
+  const tx = db.transaction(storeName, "readwrite");
+  const done = transactionDone(tx);
+  tx.objectStore(storeName).add(parsed);
+  await done;
+  return parsed;
+};
+
 const putRecord = async (db, storeName, record) => {
   const parsed = parseRecord(storeName, record);
   const tx = db.transaction(storeName, "readwrite");
@@ -208,18 +220,76 @@ const putRecord = async (db, storeName, record) => {
   return parsed;
 };
 
+const assertReferencesExist = async (db, record) => {
+  const stores = ["applications"];
+  const contactIds = [record.contactId, ...(record.contactIds ?? [])].filter(
+    Boolean,
+  );
+  if (contactIds.length > 0) stores.push("contacts");
+
+  const tx = db.transaction(stores, "readonly");
+  const done = transactionDone(tx);
+  const application = await requestToPromise(
+    tx.objectStore("applications").get(record.applicationId),
+  );
+  const contacts = await Promise.all(
+    contactIds.map((contactId) =>
+      requestToPromise(tx.objectStore("contacts").get(contactId)),
+    ),
+  );
+  await done;
+
+  if (!application) {
+    throw new IndexedDbRepositoryError(
+      "schema_validation_failed",
+      "Referenced application does not exist.",
+      { details: { applicationId: record.applicationId } },
+    );
+  }
+
+  const missingContactIds = contactIds.filter((_, index) => !contacts[index]);
+  if (missingContactIds.length > 0) {
+    throw new IndexedDbRepositoryError(
+      "schema_validation_failed",
+      "Referenced contact does not exist.",
+      { details: { contactIds: missingContactIds } },
+    );
+  }
+};
+
+const putChildRecord = async (db, storeName, record) => {
+  const parsed = parseRecord(storeName, record);
+  await assertReferencesExist(db, parsed);
+  return putRecord(db, storeName, parsed);
+};
+
 const deleteFromIndex = async (db, storeName, indexName, value) => {
-  const records = await getAll(db, storeName);
   const tx = db.transaction(storeName, "readwrite");
   const done = transactionDone(tx);
   const store = tx.objectStore(storeName);
-  records
-    .filter((record) => record[indexName] === value)
-    .forEach((record) => store.delete(record.id));
+  const source = store.indexNames.contains(`by_${indexName}`)
+    ? store.index(`by_${indexName}`)
+    : store;
+
+  await new Promise((resolve, reject) => {
+    const request = source.openCursor(source === store ? undefined : value);
+    request.onsuccess = () => {
+      const cursor = request.result;
+      if (!cursor) {
+        resolve();
+        return;
+      }
+      if (source !== store || cursor.value[indexName] === value) {
+        cursor.delete();
+      }
+      cursor.continue();
+    };
+    request.onerror = () => reject(request.error);
+  });
   await done;
 };
 
-const validateImport = (data, { allowOverwrite }) => {
+const validateImport = (data) => {
   const result = browserApplicationExportSchema.safeParse(data);
   if (!result.success) {
     throw new IndexedDbRepositoryError(
@@ -228,7 +298,7 @@ const validateImport = (data, { allowOverwrite }) => {
       { details: result.error.flatten() },
     );
   }
-  return { parsed: result.data, allowOverwrite };
+  return { parsed: result.data };
 };
 
 export const createIndexedDbRepository = async (options = {}) => {
@@ -256,7 +326,7 @@ export const createIndexedDbRepository = async (options = {}) => {
       db.close();
     },
     createApplication(application) {
-      return safe(() => putRecord(db, "applications", application));
+      return safe(() => addRecord(db, "applications", application));
     },
     updateApplication(application) {
       return safe(() => putRecord(db, "applications", application));
@@ -305,22 +375,22 @@ export const createIndexedDbRepository = async (options = {}) => {
       });
     },
     upsertContact(record) {
-      return safe(() => putRecord(db, "contacts", record));
+      return safe(() => putChildRecord(db, "contacts", record));
     },
     addOutreachMessage(record) {
-      return safe(() => putRecord(db, "outreachMessages", record));
+      return safe(() => putChildRecord(db, "outreachMessages", record));
     },
     addLifecycleEvent(record) {
-      return safe(() => putRecord(db, "lifecycleEvents", record));
+      return safe(() => putChildRecord(db, "lifecycleEvents", record));
     },
     upsertInterview(record) {
-      return safe(() => putRecord(db, "interviews", record));
+      return safe(() => putChildRecord(db, "interviews", record));
     },
     upsertOffer(record) {
-      return safe(() => putRecord(db, "offers", record));
+      return safe(() => putChildRecord(db, "offers", record));
     },
     upsertArtifact(record) {
-      return safe(() => putRecord(db, "artifacts", record));
+      return safe(() => putChildRecord(db, "artifacts", record));
     },
     async listDueFollowUps(now = new Date().toISOString()) {
       return safe(async () =>
@@ -331,8 +401,8 @@ export const createIndexedDbRepository = async (options = {}) => {
       );
     },
     async exportAllData() {
-      return safe(async () =>
-        browserApplicationExportSchema.parse({
+      return safe(async () => {
+        const result = browserApplicationExportSchema.safeParse({
           schemaVersion: DATABASE_VERSION,
           exportedAt: new Date().toISOString(),
           applications: await getAll(db, "applications"),
@@ -344,32 +414,44 @@ export const createIndexedDbRepository = async (options = {}) => {
           artifacts: await getAll(db, "artifacts"),
           reminders: await getAll(db, "reminders"),
           settings: (await getAll(db, "settings"))[0],
-        }),
-      );
+        });
+        if (!result.success) {
+          throw new IndexedDbRepositoryError(
+            "schema_validation_failed",
+            "Export data does not match the browser application export schema.",
+            { details: result.error.flatten() },
+          );
+        }
+        return result.data;
+      });
     },
     async importAllData(data, { dryRun = false, allowOverwrite = false } = {}) {
       return safe(async () => {
-        const { parsed } = validateImport(data, { allowOverwrite });
-        const existingIds = new Set(
-          (
-            await Promise.all(
-              STORE_NAMES.filter((name) => name !== "settings").map((name) =>
-                getAll(db, name),
-              ),
-            )
-          )
-            .flat()
-            .map(({ id }) => id),
+        const { parsed } = validateImport(data);
+        const existingRecords = Object.fromEntries(
+          await Promise.all(
+            STORE_NAMES.map(async (name) => [name, await getAll(db, name)]),
+          ),
         );
-        const incomingIds = STORE_NAMES.filter(
-          (name) => name !== "settings",
-        ).flatMap((name) => parsed[name].map(({ id }) => id));
-        const conflicts = incomingIds.filter((id) => existingIds.has(id));
-        if (conflicts.length > 0 && !allowOverwrite) {
+        const existingKeys = new Set(
+          STORE_NAMES.flatMap((name) =>
+            existingRecords[name].map(({ id }) => `${name}:${id}`),
+          ),
+        );
+        const incomingKeys = STORE_NAMES.flatMap((name) => {
+          if (name === "settings")
+            return parsed.settings ? ["settings:local"] : [];
+          return parsed[name].map(({ id }) => `${name}:${id}`);
+        });
+        const conflicts = incomingKeys.filter((key) => existingKeys.has(key));
+        const hasExistingData = STORE_NAMES.some(
+          (name) => existingRecords[name].length > 0,
+        );
+        if (hasExistingData && !allowOverwrite) {
           throw new IndexedDbRepositoryError(
             "import_conflict",
-            "Import would overwrite existing records.",
-            { details: { conflicts } },
+            "Import would replace existing IndexedDB records.",
+            { details: { conflicts, hasExistingData } },
           );
         }
         if (dryRun)

--- a/src/web/storage/indexedDbRepository.js
+++ b/src/web/storage/indexedDbRepository.js
@@ -1,0 +1,425 @@
+import {
+  browserApplicationArtifactSchema,
+  browserApplicationContactSchema,
+  browserApplicationExportSchema,
+  browserApplicationInterviewSchema,
+  browserApplicationLifecycleEventSchema,
+  browserApplicationOfferSchema,
+  browserApplicationOutreachMessageSchema,
+  browserApplicationReminderSchema,
+  browserApplicationSchema,
+  browserApplicationSettingsSchema,
+} from "../../domain/browserApplication.js";
+
+export const DATABASE_NAME = "jobbot3000";
+export const DATABASE_VERSION = 1;
+
+export const STORE_NAMES = [
+  "applications",
+  "contacts",
+  "outreachMessages",
+  "lifecycleEvents",
+  "interviews",
+  "offers",
+  "artifacts",
+  "reminders",
+  "settings",
+];
+
+const STORE_SCHEMAS = {
+  applications: browserApplicationSchema,
+  contacts: browserApplicationContactSchema,
+  outreachMessages: browserApplicationOutreachMessageSchema,
+  lifecycleEvents: browserApplicationLifecycleEventSchema,
+  interviews: browserApplicationInterviewSchema,
+  offers: browserApplicationOfferSchema,
+  artifacts: browserApplicationArtifactSchema,
+  reminders: browserApplicationReminderSchema,
+  settings: browserApplicationSettingsSchema,
+};
+
+const APPLICATION_CASCADE_STORES = STORE_NAMES.filter(
+  (storeName) => !["applications", "settings"].includes(storeName),
+);
+
+export class IndexedDbRepositoryError extends Error {
+  constructor(code, message, options = {}) {
+    super(message, options);
+    this.name = "IndexedDbRepositoryError";
+    this.code = code;
+    this.cause = options.cause;
+    this.details = options.details;
+  }
+}
+
+const wrapError = (error, fallbackCode, fallbackMessage) => {
+  if (error instanceof IndexedDbRepositoryError) return error;
+  if (error?.name === "QuotaExceededError") {
+    return new IndexedDbRepositoryError(
+      "quota_exceeded",
+      "IndexedDB quota was exceeded while saving jobbot3000 data.",
+      { cause: error },
+    );
+  }
+  return new IndexedDbRepositoryError(fallbackCode, fallbackMessage, {
+    cause: error,
+  });
+};
+
+const parseRecord = (storeName, record) => {
+  const result = STORE_SCHEMAS[storeName].safeParse(record);
+  if (!result.success) {
+    throw new IndexedDbRepositoryError(
+      "schema_validation_failed",
+      `Invalid ${storeName} record.`,
+      { details: result.error.flatten() },
+    );
+  }
+  return result.data;
+};
+
+const requestToPromise = (request) =>
+  new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+const transactionDone = (transaction) =>
+  new Promise((resolve, reject) => {
+    transaction.oncomplete = () => resolve();
+    transaction.onabort = () => reject(transaction.error);
+    transaction.onerror = () => reject(transaction.error);
+  });
+
+const createStore = (db, name) => {
+  if (!db.objectStoreNames.contains(name)) {
+    return db.createObjectStore(name, { keyPath: "id" });
+  }
+  return null;
+};
+
+const ensureIndex = (store, name, keyPath, options = {}) => {
+  if (!store.indexNames.contains(name)) {
+    store.createIndex(name, keyPath, options);
+  }
+};
+
+export const migrations = {
+  1(db) {
+    const applications = createStore(db, "applications");
+    if (applications) {
+      ensureIndex(applications, "by_company", "company");
+      ensureIndex(applications, "by_status", "status");
+      ensureIndex(applications, "by_appliedAt", "appliedAt");
+      ensureIndex(applications, "by_followUpDate", "followUpDate");
+    }
+
+    createStore(db, "contacts");
+
+    const outreachMessages = createStore(db, "outreachMessages");
+    if (outreachMessages) {
+      ensureIndex(outreachMessages, "by_applicationId", "applicationId");
+    }
+
+    const lifecycleEvents = createStore(db, "lifecycleEvents");
+    if (lifecycleEvents) {
+      ensureIndex(lifecycleEvents, "by_applicationId", "applicationId");
+      ensureIndex(lifecycleEvents, "by_applicationId_occurredAt", [
+        "applicationId",
+        "occurredAt",
+      ]);
+    }
+
+    createStore(db, "interviews");
+    createStore(db, "offers");
+
+    const artifacts = createStore(db, "artifacts");
+    if (artifacts) {
+      ensureIndex(artifacts, "by_applicationId", "applicationId");
+    }
+
+    createStore(db, "reminders");
+    createStore(db, "settings");
+  },
+};
+
+const getIndexedDb = (indexedDb) => {
+  const resolved = indexedDb ?? globalThis.indexedDB;
+  if (!resolved) {
+    throw new IndexedDbRepositoryError(
+      "indexeddb_unavailable",
+      "IndexedDB is unavailable in this browser context.",
+    );
+  }
+  return resolved;
+};
+
+export const openJobbotDatabase = ({
+  databaseName = DATABASE_NAME,
+  version = DATABASE_VERSION,
+  indexedDb,
+} = {}) => {
+  const idb = getIndexedDb(indexedDb);
+  return new Promise((resolve, reject) => {
+    const request = idb.open(databaseName, version);
+    request.onupgradeneeded = () => {
+      const db = request.result;
+      for (
+        let currentVersion = (request.oldVersion ?? 0) + 1;
+        currentVersion <= version;
+        currentVersion += 1
+      ) {
+        migrations[currentVersion]?.(db, request.transaction);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () =>
+      reject(
+        wrapError(
+          request.error,
+          "open_failed",
+          "Unable to open jobbot3000 IndexedDB database.",
+        ),
+      );
+    request.onblocked = () =>
+      reject(
+        new IndexedDbRepositoryError(
+          "open_blocked",
+          "IndexedDB upgrade is blocked by another open jobbot3000 tab.",
+        ),
+      );
+  });
+};
+
+const getAll = async (db, storeName) => {
+  const tx = db.transaction(storeName, "readonly");
+  const done = transactionDone(tx);
+  const records = await requestToPromise(tx.objectStore(storeName).getAll());
+  await done;
+  return records;
+};
+
+const putRecord = async (db, storeName, record) => {
+  const parsed = parseRecord(storeName, record);
+  const tx = db.transaction(storeName, "readwrite");
+  const done = transactionDone(tx);
+  tx.objectStore(storeName).put(parsed);
+  await done;
+  return parsed;
+};
+
+const deleteFromIndex = async (db, storeName, indexName, value) => {
+  const records = await getAll(db, storeName);
+  const tx = db.transaction(storeName, "readwrite");
+  const done = transactionDone(tx);
+  const store = tx.objectStore(storeName);
+  records
+    .filter((record) => record[indexName] === value)
+    .forEach((record) => store.delete(record.id));
+  await done;
+};
+
+const validateImport = (data, { allowOverwrite }) => {
+  const result = browserApplicationExportSchema.safeParse(data);
+  if (!result.success) {
+    throw new IndexedDbRepositoryError(
+      "schema_validation_failed",
+      "Import data does not match the browser application export schema.",
+      { details: result.error.flatten() },
+    );
+  }
+  return { parsed: result.data, allowOverwrite };
+};
+
+export const createIndexedDbRepository = async (options = {}) => {
+  let db;
+  try {
+    db = await openJobbotDatabase(options);
+  } catch (error) {
+    throw wrapError(
+      error,
+      "open_failed",
+      "Unable to open jobbot3000 IndexedDB database.",
+    );
+  }
+
+  const safe = async (operation) => {
+    try {
+      return await operation();
+    } catch (error) {
+      throw wrapError(error, "operation_failed", "IndexedDB operation failed.");
+    }
+  };
+
+  return {
+    close() {
+      db.close();
+    },
+    createApplication(application) {
+      return safe(() => putRecord(db, "applications", application));
+    },
+    updateApplication(application) {
+      return safe(() => putRecord(db, "applications", application));
+    },
+    async deleteApplication(id) {
+      return safe(async () => {
+        const relatedRecords = await Promise.all(
+          APPLICATION_CASCADE_STORES.map(async (storeName) => [
+            storeName,
+            (await getAll(db, storeName)).filter(
+              (record) => record.applicationId === id,
+            ),
+          ]),
+        );
+        const tx = db.transaction(
+          ["applications", ...APPLICATION_CASCADE_STORES],
+          "readwrite",
+        );
+        const done = transactionDone(tx);
+        tx.objectStore("applications").delete(id);
+        for (const [storeName, records] of relatedRecords) {
+          const store = tx.objectStore(storeName);
+          records.forEach((record) => store.delete(record.id));
+        }
+        await done;
+      });
+    },
+    async listApplications() {
+      return safe(async () =>
+        (await getAll(db, "applications")).sort((a, b) =>
+          (b.appliedAt ?? b.createdAt).localeCompare(
+            a.appliedAt ?? a.createdAt,
+          ),
+        ),
+      );
+    },
+    async getApplication(id) {
+      return safe(async () => {
+        const tx = db.transaction("applications", "readonly");
+        const done = transactionDone(tx);
+        const record = await requestToPromise(
+          tx.objectStore("applications").get(id),
+        );
+        await done;
+        return record ?? null;
+      });
+    },
+    upsertContact(record) {
+      return safe(() => putRecord(db, "contacts", record));
+    },
+    addOutreachMessage(record) {
+      return safe(() => putRecord(db, "outreachMessages", record));
+    },
+    addLifecycleEvent(record) {
+      return safe(() => putRecord(db, "lifecycleEvents", record));
+    },
+    upsertInterview(record) {
+      return safe(() => putRecord(db, "interviews", record));
+    },
+    upsertOffer(record) {
+      return safe(() => putRecord(db, "offers", record));
+    },
+    upsertArtifact(record) {
+      return safe(() => putRecord(db, "artifacts", record));
+    },
+    async listDueFollowUps(now = new Date().toISOString()) {
+      return safe(async () =>
+        (await getAll(db, "applications")).filter(
+          (application) =>
+            application.followUpDate && application.followUpDate <= now,
+        ),
+      );
+    },
+    async exportAllData() {
+      return safe(async () =>
+        browserApplicationExportSchema.parse({
+          schemaVersion: DATABASE_VERSION,
+          exportedAt: new Date().toISOString(),
+          applications: await getAll(db, "applications"),
+          contacts: await getAll(db, "contacts"),
+          outreachMessages: await getAll(db, "outreachMessages"),
+          lifecycleEvents: await getAll(db, "lifecycleEvents"),
+          interviews: await getAll(db, "interviews"),
+          offers: await getAll(db, "offers"),
+          artifacts: await getAll(db, "artifacts"),
+          reminders: await getAll(db, "reminders"),
+          settings: (await getAll(db, "settings"))[0],
+        }),
+      );
+    },
+    async importAllData(data, { dryRun = false, allowOverwrite = false } = {}) {
+      return safe(async () => {
+        const { parsed } = validateImport(data, { allowOverwrite });
+        const existingIds = new Set(
+          (
+            await Promise.all(
+              STORE_NAMES.filter((name) => name !== "settings").map((name) =>
+                getAll(db, name),
+              ),
+            )
+          )
+            .flat()
+            .map(({ id }) => id),
+        );
+        const incomingIds = STORE_NAMES.filter(
+          (name) => name !== "settings",
+        ).flatMap((name) => parsed[name].map(({ id }) => id));
+        const conflicts = incomingIds.filter((id) => existingIds.has(id));
+        if (conflicts.length > 0 && !allowOverwrite) {
+          throw new IndexedDbRepositoryError(
+            "import_conflict",
+            "Import would overwrite existing records.",
+            { details: { conflicts } },
+          );
+        }
+        if (dryRun)
+          return {
+            imported: false,
+            counts: Object.fromEntries(
+              STORE_NAMES.map((name) => [
+                name,
+                name === "settings"
+                  ? Number(Boolean(parsed.settings))
+                  : parsed[name].length,
+              ]),
+            ),
+            conflicts,
+          };
+        const tx = db.transaction(STORE_NAMES, "readwrite");
+        const done = transactionDone(tx);
+        for (const storeName of STORE_NAMES) tx.objectStore(storeName).clear();
+        for (const storeName of STORE_NAMES.filter(
+          (name) => name !== "settings",
+        )) {
+          for (const record of parsed[storeName])
+            tx.objectStore(storeName).put(record);
+        }
+        if (parsed.settings) tx.objectStore("settings").put(parsed.settings);
+        await done;
+        return {
+          imported: true,
+          counts: Object.fromEntries(
+            STORE_NAMES.map((name) => [
+              name,
+              name === "settings"
+                ? Number(Boolean(parsed.settings))
+                : parsed[name].length,
+            ]),
+          ),
+          conflicts,
+        };
+      });
+    },
+    async clearAllData() {
+      return safe(async () => {
+        const tx = db.transaction(STORE_NAMES, "readwrite");
+        const done = transactionDone(tx);
+        for (const storeName of STORE_NAMES) tx.objectStore(storeName).clear();
+        await done;
+      });
+    },
+    async _deleteByApplicationId(storeName, applicationId) {
+      return deleteFromIndex(db, storeName, "applicationId", applicationId);
+    },
+  };
+};

--- a/test/web-storage-indexeddb-repository.test.js
+++ b/test/web-storage-indexeddb-repository.test.js
@@ -1,0 +1,210 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { indexedDB } from "fake-indexeddb";
+
+import {
+  DATABASE_NAME,
+  DATABASE_VERSION,
+  IndexedDbRepositoryError,
+  createIndexedDbRepository,
+  openJobbotDatabase,
+} from "../src/web/storage/indexedDbRepository.js";
+
+const now = "2026-01-02T03:04:05.000Z";
+const later = "2026-01-03T03:04:05.000Z";
+
+const application = {
+  id: "app_fake_001",
+  company: "Example Robotics",
+  role: "Staff Software Engineer",
+  status: "applied",
+  postingUrl: "https://example.test/jobs/staff-engineer",
+  appliedAt: now,
+  followUpDate: later,
+  createdAt: now,
+  updatedAt: now,
+};
+
+const contact = {
+  id: "contact_fake_001",
+  applicationId: application.id,
+  name: "Jordan Example",
+  email: "jordan@example.test",
+  createdAt: now,
+  updatedAt: now,
+};
+
+const lifecycleEvent = {
+  id: "event_fake_001",
+  applicationId: application.id,
+  status: "applied",
+  occurredAt: now,
+  source: "manual",
+  createdAt: now,
+};
+
+const outreachMessage = {
+  id: "message_fake_001",
+  applicationId: application.id,
+  contactId: contact.id,
+  direction: "outbound",
+  channel: "email",
+  subject: "Hello",
+  createdAt: now,
+  updatedAt: now,
+};
+
+const interview = {
+  id: "interview_fake_001",
+  applicationId: application.id,
+  contactIds: [contact.id],
+  stage: "recruiter_screen",
+  startsAt: later,
+  outcome: "scheduled",
+  createdAt: now,
+  updatedAt: now,
+};
+
+const offer = {
+  id: "offer_fake_001",
+  applicationId: application.id,
+  status: "received",
+  baseSalaryMin: 100000,
+  baseSalaryMax: 120000,
+  currency: "USD",
+  createdAt: now,
+  updatedAt: now,
+};
+
+const artifact = {
+  id: "artifact_fake_001",
+  applicationId: application.id,
+  kind: "job_posting",
+  name: "Posting URL",
+  url: "https://example.test/jobs/staff-engineer",
+  private: true,
+  createdAt: now,
+  updatedAt: now,
+};
+
+const deleteDatabase = () =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(DATABASE_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => resolve();
+  });
+
+afterEach(async () => {
+  await deleteDatabase();
+});
+
+describe("IndexedDB repository", () => {
+  it("initializes a v1 database with tracker stores and indexes", async () => {
+    const db = await openJobbotDatabase({ indexedDb: indexedDB });
+
+    expect(db.version).toBe(DATABASE_VERSION);
+    for (const storeName of [
+      "applications",
+      "artifacts",
+      "contacts",
+      "interviews",
+      "lifecycleEvents",
+      "offers",
+      "outreachMessages",
+      "reminders",
+      "settings",
+    ]) {
+      expect(db.objectStoreNames.contains(storeName)).toBe(true);
+    }
+
+    const tx = db.transaction([
+      "applications",
+      "lifecycleEvents",
+      "outreachMessages",
+      "artifacts",
+    ]);
+    expect(Array.from(tx.objectStore("applications").indexNames)).toEqual([
+      "by_appliedAt",
+      "by_company",
+      "by_followUpDate",
+      "by_status",
+    ]);
+    expect(Array.from(tx.objectStore("lifecycleEvents").indexNames)).toContain(
+      "by_applicationId_occurredAt",
+    );
+    expect(Array.from(tx.objectStore("outreachMessages").indexNames)).toContain(
+      "by_applicationId",
+    );
+    expect(Array.from(tx.objectStore("artifacts").indexNames)).toContain(
+      "by_applicationId",
+    );
+    db.close();
+  });
+
+  it("writes, reads, exports, clears, and restores application tracker data", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+
+    await repo.createApplication(application);
+    await repo.upsertContact(contact);
+    await repo.addOutreachMessage(outreachMessage);
+    await repo.addLifecycleEvent(lifecycleEvent);
+    await repo.upsertInterview(interview);
+    await repo.upsertOffer(offer);
+    await repo.upsertArtifact(artifact);
+
+    expect(await repo.getApplication(application.id)).toMatchObject({
+      company: "Example Robotics",
+    });
+    expect(await repo.listApplications()).toHaveLength(1);
+    expect(
+      await repo.listDueFollowUps("2026-01-04T00:00:00.000Z"),
+    ).toHaveLength(1);
+
+    const exported = await repo.exportAllData();
+    expect(exported.applications).toHaveLength(1);
+    expect(exported.contacts).toHaveLength(1);
+    expect(exported.lifecycleEvents[0].source).toBe("manual");
+
+    await repo.clearAllData();
+    expect(await repo.listApplications()).toHaveLength(0);
+
+    const dryRun = await repo.importAllData(exported, { dryRun: true });
+    expect(dryRun).toMatchObject({
+      imported: false,
+      counts: { applications: 1 },
+    });
+
+    await repo.importAllData(exported);
+    expect(await repo.getApplication(application.id)).toMatchObject({
+      role: "Staff Software Engineer",
+    });
+
+    repo.close();
+  });
+
+  it("rejects invalid writes and import conflicts with browser-friendly errors", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+
+    await expect(
+      repo.createApplication({ ...application, status: "bogus" }),
+    ).rejects.toMatchObject({
+      code: "schema_validation_failed",
+    });
+
+    await repo.createApplication(application);
+    const exported = await repo.exportAllData();
+    await expect(
+      repo.importAllData(exported, { dryRun: true }),
+    ).rejects.toMatchObject({
+      code: "import_conflict",
+    });
+
+    repo.close();
+  });
+
+  it("reports unavailable IndexedDB before opening", async () => {
+    await expect(
+      createIndexedDbRepository({ indexedDb: undefined }),
+    ).rejects.toBeInstanceOf(IndexedDbRepositoryError);
+  });
+});

--- a/test/web-storage-indexeddb-repository.test.js
+++ b/test/web-storage-indexeddb-repository.test.js
@@ -197,10 +197,11 @@ describe("IndexedDB repository", () => {
 
     await repo.createApplication(application);
     const exported = await repo.exportAllData();
-    await expect(
-      repo.importAllData(exported, { dryRun: true }),
-    ).rejects.toMatchObject({
-      code: "import_conflict",
+    const dryRun = await repo.importAllData(exported, { dryRun: true });
+    expect(dryRun).toMatchObject({
+      imported: false,
+      conflicts: [{ storeName: "applications", id: application.id }],
+      hasExistingData: true,
     });
 
     repo.close();
@@ -227,6 +228,80 @@ describe("IndexedDB repository", () => {
     repo.close();
   });
 
+  it("updates an existing application", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+
+    await repo.createApplication(application);
+    await repo.updateApplication({
+      ...application,
+      role: "Principal Software Engineer",
+      status: "recruiter_screen",
+      updatedAt: later,
+    });
+
+    await expect(repo.getApplication(application.id)).resolves.toMatchObject({
+      role: "Principal Software Engineer",
+      status: "recruiter_screen",
+      updatedAt: later,
+    });
+
+    repo.close();
+  });
+
+  it("deletes an application and cascades application-scoped records", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+
+    await repo.createApplication(application);
+    await repo.upsertContact(contact);
+    await repo.addOutreachMessage(outreachMessage);
+    await repo.addLifecycleEvent(lifecycleEvent);
+    await repo.upsertInterview(interview);
+    await repo.upsertOffer(offer);
+    await repo.upsertArtifact(artifact);
+
+    await repo.deleteApplication(application.id);
+
+    expect(await repo.getApplication(application.id)).toBeNull();
+    const exported = await repo.exportAllData();
+    expect(exported.applications).toHaveLength(0);
+    expect(exported.contacts).toHaveLength(0);
+    expect(exported.outreachMessages).toHaveLength(0);
+    expect(exported.lifecycleEvents).toHaveLength(0);
+    expect(exported.interviews).toHaveLength(0);
+    expect(exported.offers).toHaveLength(0);
+    expect(exported.artifacts).toHaveLength(0);
+
+    repo.close();
+  });
+
+  it("rejects duplicate outreach messages and lifecycle events", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+
+    await repo.createApplication(application);
+    await repo.upsertContact(contact);
+    await repo.addOutreachMessage(outreachMessage);
+    await repo.addLifecycleEvent(lifecycleEvent);
+
+    await expect(
+      repo.addOutreachMessage({
+        ...outreachMessage,
+        subject: "Overwritten subject",
+      }),
+    ).rejects.toMatchObject({ code: "operation_failed" });
+    await expect(
+      repo.addLifecycleEvent({
+        ...lifecycleEvent,
+        status: "recruiter_screen",
+      }),
+    ).rejects.toMatchObject({ code: "operation_failed" });
+
+    const exported = await repo.exportAllData();
+    expect(exported.outreachMessages).toEqual([outreachMessage]);
+    expect(exported.lifecycleEvents).toEqual([lifecycleEvent]);
+
+    repo.close();
+  });
+
   it("requires overwrite permission before full-replace imports", async () => {
     const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
 
@@ -243,9 +318,24 @@ describe("IndexedDB repository", () => {
       ],
     };
 
+    const dryRunWithoutOverwrite = await repo.importAllData(replacement, {
+      dryRun: true,
+    });
+    expect(dryRunWithoutOverwrite).toMatchObject({
+      imported: false,
+      conflicts: [],
+      hasExistingData: true,
+    });
+    expect(await repo.getApplication(application.id)).toMatchObject({
+      company: "Example Robotics",
+    });
+
     await expect(repo.importAllData(replacement)).rejects.toMatchObject({
       code: "import_conflict",
       details: { hasExistingData: true, conflicts: [] },
+    });
+    expect(await repo.getApplication(application.id)).toMatchObject({
+      company: "Example Robotics",
     });
 
     const dryRun = await repo.importAllData(replacement, {
@@ -258,6 +348,43 @@ describe("IndexedDB repository", () => {
     expect(await repo.getApplication(application.id)).toBeNull();
     expect(await repo.getApplication("app_fake_002")).toMatchObject({
       company: "Replacement Robotics",
+    });
+
+    repo.close();
+  });
+
+  it("scopes import conflicts to each object store", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const sharedId = "shared_id";
+    const importedApplication = {
+      ...application,
+      id: "imported_app",
+      company: "Imported Robotics",
+    };
+
+    await repo.createApplication({ ...application, id: sharedId });
+
+    const dryRun = await repo.importAllData(
+      {
+        schemaVersion: DATABASE_VERSION,
+        exportedAt: now,
+        applications: [importedApplication],
+        contacts: [
+          { ...contact, id: sharedId, applicationId: importedApplication.id },
+        ],
+        outreachMessages: [],
+        lifecycleEvents: [],
+        interviews: [],
+        offers: [],
+        artifacts: [],
+        reminders: [],
+      },
+      { dryRun: true },
+    );
+
+    expect(dryRun.conflicts).toEqual([]);
+    expect(await repo.getApplication(sharedId)).toMatchObject({
+      company: "Example Robotics",
     });
 
     repo.close();

--- a/test/web-storage-indexeddb-repository.test.js
+++ b/test/web-storage-indexeddb-repository.test.js
@@ -119,6 +119,7 @@ describe("IndexedDB repository", () => {
 
     const tx = db.transaction([
       "applications",
+      "contacts",
       "lifecycleEvents",
       "outreachMessages",
       "artifacts",
@@ -129,6 +130,9 @@ describe("IndexedDB repository", () => {
       "by_followUpDate",
       "by_status",
     ]);
+    expect(Array.from(tx.objectStore("contacts").indexNames)).toContain(
+      "by_applicationId",
+    );
     expect(Array.from(tx.objectStore("lifecycleEvents").indexNames)).toContain(
       "by_applicationId_occurredAt",
     );
@@ -197,6 +201,63 @@ describe("IndexedDB repository", () => {
       repo.importAllData(exported, { dryRun: true }),
     ).rejects.toMatchObject({
       code: "import_conflict",
+    });
+
+    repo.close();
+  });
+
+  it("rejects duplicate application creates and dangling child references", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+
+    await repo.createApplication(application);
+    await expect(repo.createApplication(application)).rejects.toMatchObject({
+      code: "operation_failed",
+    });
+    await expect(
+      repo.upsertContact({ ...contact, applicationId: "missing_app" }),
+    ).rejects.toMatchObject({
+      code: "schema_validation_failed",
+      details: { applicationId: "missing_app" },
+    });
+    await expect(repo.upsertInterview(interview)).rejects.toMatchObject({
+      code: "schema_validation_failed",
+      details: { contactIds: [contact.id] },
+    });
+
+    repo.close();
+  });
+
+  it("requires overwrite permission before full-replace imports", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+
+    await repo.createApplication(application);
+    const exported = await repo.exportAllData();
+    const replacement = {
+      ...exported,
+      applications: [
+        {
+          ...application,
+          id: "app_fake_002",
+          company: "Replacement Robotics",
+        },
+      ],
+    };
+
+    await expect(repo.importAllData(replacement)).rejects.toMatchObject({
+      code: "import_conflict",
+      details: { hasExistingData: true, conflicts: [] },
+    });
+
+    const dryRun = await repo.importAllData(replacement, {
+      dryRun: true,
+      allowOverwrite: true,
+    });
+    expect(dryRun.conflicts).toEqual([]);
+
+    await repo.importAllData(replacement, { allowOverwrite: true });
+    expect(await repo.getApplication(application.id)).toBeNull();
+    expect(await repo.getApplication("app_fake_002")).toMatchObject({
+      company: "Replacement Robotics",
     });
 
     repo.close();

--- a/test/web-storage-indexeddb-repository.test.js
+++ b/test/web-storage-indexeddb-repository.test.js
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { indexedDB } from "fake-indexeddb";
 
 import {
@@ -7,6 +7,7 @@ import {
   IndexedDbRepositoryError,
   createIndexedDbRepository,
   openJobbotDatabase,
+  migrations,
 } from "../src/web/storage/indexedDbRepository.js";
 
 const now = "2026-01-02T03:04:05.000Z";
@@ -122,7 +123,10 @@ describe("IndexedDB repository", () => {
       "contacts",
       "lifecycleEvents",
       "outreachMessages",
+      "interviews",
+      "offers",
       "artifacts",
+      "reminders",
     ]);
     expect(Array.from(tx.objectStore("applications").indexNames)).toEqual([
       "by_appliedAt",
@@ -139,10 +143,46 @@ describe("IndexedDB repository", () => {
     expect(Array.from(tx.objectStore("outreachMessages").indexNames)).toContain(
       "by_applicationId",
     );
+    expect(Array.from(tx.objectStore("interviews").indexNames)).toContain(
+      "by_applicationId",
+    );
+    expect(Array.from(tx.objectStore("offers").indexNames)).toContain(
+      "by_applicationId",
+    );
     expect(Array.from(tx.objectStore("artifacts").indexNames)).toContain(
       "by_applicationId",
     );
+    expect(Array.from(tx.objectStore("reminders").indexNames)).toContain(
+      "by_applicationId",
+    );
     db.close();
+  });
+
+  it("starts future migrations from the IndexedDB upgrade event oldVersion", async () => {
+    const originalV1 = migrations[1];
+    const originalV2 = migrations[2];
+    const v1Spy = vi.fn(originalV1);
+    const v2Spy = vi.fn();
+
+    const db = await openJobbotDatabase({ indexedDb: indexedDB, version: 1 });
+    db.close();
+
+    migrations[1] = v1Spy;
+    migrations[2] = v2Spy;
+    try {
+      const upgraded = await openJobbotDatabase({
+        indexedDb: indexedDB,
+        version: 2,
+      });
+      upgraded.close();
+    } finally {
+      migrations[1] = originalV1;
+      if (originalV2) migrations[2] = originalV2;
+      else delete migrations[2];
+    }
+
+    expect(v1Spy).not.toHaveBeenCalled();
+    expect(v2Spy).toHaveBeenCalledTimes(1);
   });
 
   it("writes, reads, exports, clears, and restores application tracker data", async () => {
@@ -223,6 +263,98 @@ describe("IndexedDB repository", () => {
     await expect(repo.upsertInterview(interview)).rejects.toMatchObject({
       code: "schema_validation_failed",
       details: { contactIds: [contact.id] },
+    });
+
+    repo.close();
+  });
+
+  it("validates child record parents before committing writes", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+
+    await repo.createApplication(application);
+    await repo.upsertContact(contact);
+
+    await expect(
+      repo.addOutreachMessage({
+        ...outreachMessage,
+        id: "message_missing_app",
+        applicationId: "missing_app",
+      }),
+    ).rejects.toMatchObject({
+      code: "schema_validation_failed",
+      details: { applicationId: "missing_app" },
+    });
+    await expect(
+      repo.addLifecycleEvent({
+        ...lifecycleEvent,
+        id: "event_missing_app",
+        applicationId: "missing_app",
+      }),
+    ).rejects.toMatchObject({ code: "schema_validation_failed" });
+    await expect(
+      repo.upsertOffer({
+        ...offer,
+        id: "offer_missing_app",
+        applicationId: "missing_app",
+      }),
+    ).rejects.toMatchObject({ code: "schema_validation_failed" });
+    await expect(
+      repo.upsertArtifact({
+        ...artifact,
+        id: "artifact_missing_app",
+        applicationId: "missing_app",
+      }),
+    ).rejects.toMatchObject({ code: "schema_validation_failed" });
+    await expect(
+      repo.upsertInterview({
+        ...interview,
+        id: "interview_missing_contact",
+        contactIds: ["missing_contact"],
+      }),
+    ).rejects.toMatchObject({
+      code: "schema_validation_failed",
+      details: { contactIds: ["missing_contact"] },
+    });
+    await expect(
+      repo.addOutreachMessage({
+        ...outreachMessage,
+        id: "message_missing_contact",
+        contactId: "missing_contact",
+      }),
+    ).rejects.toMatchObject({
+      code: "schema_validation_failed",
+      details: { contactIds: ["missing_contact"] },
+    });
+
+    const exported = await repo.exportAllData();
+    expect(exported.outreachMessages).toHaveLength(0);
+    expect(exported.lifecycleEvents).toHaveLength(0);
+    expect(exported.interviews).toHaveLength(0);
+    expect(exported.offers).toHaveLength(0);
+    expect(exported.artifacts).toHaveLength(0);
+
+    repo.close();
+  });
+
+  it("returns structured schema validation details for invalid exports", async () => {
+    const db = await openJobbotDatabase({ indexedDb: indexedDB });
+    const tx = db.transaction(["contacts"], "readwrite");
+    const done = new Promise((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onabort = () => reject(tx.error);
+      tx.onerror = () => reject(tx.error);
+    });
+    tx.objectStore("contacts").put({
+      ...contact,
+      applicationId: "missing_app",
+    });
+    await done;
+    db.close();
+
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await expect(repo.exportAllData()).rejects.toMatchObject({
+      code: "schema_validation_failed",
+      details: expect.objectContaining({ fieldErrors: expect.any(Object) }),
     });
 
     repo.close();


### PR DESCRIPTION
### Motivation
- Provide a browser-first, durable persistence layer so user-owned application tracking data can live in IndexedDB without server persistence.
- Support a versioned DB with the object stores and indexes needed by the tracker (applications, contacts, outreachMessages, lifecycleEvents, interviews, offers, artifacts, reminders, settings).
- Offer safe import/export, schema-validated writes, and migration hooks so data can be backed up/restored and the DB can be upgraded in future versions.

### Description
- Added a browser-only repository implementation at `src/web/storage/indexedDbRepository.js` with v1 migrations, object stores, and indexes (application by company/status/appliedAt/followUpDate; outreach/lifecycle/artifact indexes). 
- Implemented repository operations: `createApplication`, `updateApplication`, `deleteApplication`, `listApplications`, `getApplication`, `upsertContact`, `addOutreachMessage`, `addLifecycleEvent`, `upsertInterview`, `upsertOffer`, `upsertArtifact`, `listDueFollowUps`, `exportAllData`, `importAllData` (with dry-run and conflict detection), `clearAllData`, and helpers for migrations and cascade deletes.
- Added runtime validation and browser-friendly error types (`IndexedDbRepositoryError`) for unavailable IndexedDB, quota exceeded, schema validation failures, blocked upgrades, and import conflicts; validation uses the existing Zod schemas and the export schema.
- Small schema and doc updates: added `followUpDate` to `browserApplication` schema, added tests in `test/web-storage-indexeddb-repository.test.js`, added `docs/indexeddb-persistence.md` and README link, and added `fake-indexeddb` as a dev dependency for tests.

### Testing
- `npx vitest run test/web-storage-indexeddb-repository.test.js test/browser-application-schema.test.js` — passed (all new browser-storage tests and schema tests succeed).
- `npm run lint` — passed.
- `npm run typecheck` (`tsc -p tsconfig.json`) — passed.
- `npm run test:ci` — passed (full CI test run completed successfully in this environment).
- `npm run format:check` — reported pre-existing formatting warnings across many unrelated files; files modified for this change were formatted during commit hooks and the new files conform to project Prettier rules.

Residual notes: the implementation uses `fake-indexeddb` for Node tests; runtime uses the browser `indexedDB` global. Follow-ups could add optional compaction/pruning UIs, user-facing backup/restore workflows in the web UI, and future migration steps for v2+ schema changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4160c87660832f94dd10edaba0ecd9)