### PR TITLE
Build browser application tracker UI

### DIFF
--- a/src/web/server.js
+++ b/src/web/server.js
@@ -7022,6 +7022,33 @@ export function createWebApp({
     });
   });
 
+  app.get("/tracker", async (_req, res) => {
+    const html = await fs.readFile(
+      new URL("./tracker/index.html", import.meta.url),
+    );
+    res.set("Content-Type", "text/html; charset=utf-8");
+    res.set("Cache-Control", "no-store");
+    res.send(html);
+  });
+
+  app.get("/tracker/app.js", async (_req, res) => {
+    const script = await fs.readFile(
+      new URL("./tracker/app.js", import.meta.url),
+    );
+    res.set("Content-Type", "application/javascript; charset=utf-8");
+    res.set("Cache-Control", "no-store");
+    res.send(script);
+  });
+
+  app.get("/tracker/app.css", async (_req, res) => {
+    const stylesheet = await fs.readFile(
+      new URL("./tracker/app.css", import.meta.url),
+    );
+    res.set("Content-Type", "text/css; charset=utf-8");
+    res.set("Cache-Control", "no-store");
+    res.send(stylesheet);
+  });
+
   app.get("/", async (req, res) => {
     const sessionId = ensureClientSession(req, res, { sessionManager });
     const forcedSecure = process.env.JOBBOT_WEB_SESSION_SECURE === "1";

--- a/src/web/tracker/app.css
+++ b/src/web/tracker/app.css
@@ -1,0 +1,226 @@
+:root {
+  color-scheme: dark;
+  --bg: #0f172a;
+  --panel: #111c33;
+  --text: #e5edf9;
+  --muted: #9fb0c8;
+  --brand: #67e8f9;
+  --line: #263852;
+  --danger: #f87171;
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+  background: linear-gradient(135deg, #08111f, #14213d);
+  color: var(--text);
+}
+a {
+  color: var(--brand);
+}
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+.skip-link {
+  position: absolute;
+  left: -999px;
+}
+.skip-link:focus {
+  left: 1rem;
+  top: 1rem;
+  z-index: 3;
+}
+.app-header {
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 2rem;
+  max-width: 1380px;
+  margin: auto;
+}
+.eyebrow {
+  color: var(--brand);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+}
+.lede {
+  color: var(--muted);
+  max-width: 70ch;
+}
+.tabs {
+  position: sticky;
+  top: 0;
+  display: flex;
+  gap: 0.5rem;
+  overflow: auto;
+  padding: 0.75rem 2rem;
+  background: rgba(8, 17, 31, 0.92);
+  border-block: 1px solid var(--line);
+  z-index: 2;
+}
+.tabs a {
+  padding: 0.65rem 0.9rem;
+  border-radius: 999px;
+  text-decoration: none;
+  color: var(--text);
+}
+.tabs a[aria-current="true"] {
+  background: var(--brand);
+  color: #082032;
+}
+.panel {
+  max-width: 1380px;
+  margin: 1rem auto;
+  padding: 1.25rem;
+  background: rgba(17, 28, 51, 0.88);
+  border: 1px solid var(--line);
+  border-radius: 1.25rem;
+  box-shadow: 0 18px 60px #0005;
+}
+.button {
+  border: 0;
+  border-radius: 0.75rem;
+  background: var(--brand);
+  color: #082032;
+  font-weight: 700;
+  padding: 0.7rem 1rem;
+  cursor: pointer;
+}
+.button--secondary {
+  background: #a7f3d0;
+}
+.button--danger {
+  background: var(--danger);
+  color: #260606;
+}
+.icon-button {
+  float: right;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text);
+  font-size: 1.5rem;
+}
+.filters,
+.grid,
+.section-heading,
+.actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: end;
+}
+.grid {
+  align-items: start;
+}
+.grid > * {
+  flex: 1 1 320px;
+}
+label {
+  display: grid;
+  gap: 0.35rem;
+  color: var(--muted);
+  font-weight: 650;
+}
+input,
+select,
+textarea {
+  border: 1px solid var(--line);
+  border-radius: 0.65rem;
+  background: #0b1324;
+  color: var(--text);
+  padding: 0.65rem;
+}
+textarea {
+  width: 100%;
+}
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1rem;
+}
+.metric,
+.followup-card,
+.timeline li {
+  padding: 1rem;
+  border: 1px solid var(--line);
+  border-radius: 1rem;
+  background: #0b1324;
+}
+.metric strong {
+  display: block;
+  font-size: 1.7rem;
+}
+.table-wrap {
+  overflow: auto;
+  margin-top: 1rem;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 1050px;
+}
+th,
+td {
+  border-bottom: 1px solid var(--line);
+  padding: 0.75rem;
+  text-align: left;
+  vertical-align: top;
+}
+tr:focus-within,
+tr:hover {
+  background: #17243d;
+}
+.empty,
+.muted {
+  color: var(--muted);
+}
+.followups {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1rem;
+}
+.detail {
+  min-width: min(900px, 92vw);
+  max-height: 85vh;
+  overflow: auto;
+}
+.detail-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+.timeline {
+  padding-left: 1.2rem;
+}
+pre {
+  white-space: pre-wrap;
+  background: #08111f;
+  border: 1px solid var(--line);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  min-height: 5rem;
+}
+:focus-visible {
+  outline: 3px solid var(--brand);
+  outline-offset: 2px;
+}
+@media (max-width: 700px) {
+  .app-header {
+    display: block;
+  }
+  .panel,
+  .app-header {
+    padding: 1rem;
+  }
+  .tabs {
+    padding: 0.5rem;
+  }
+}

--- a/src/web/tracker/app.js
+++ b/src/web/tracker/app.js
@@ -1,0 +1,560 @@
+/* global document, indexedDB, location, prompt, confirm, addEventListener */
+/* eslint max-len: off */
+const STATUSES = [
+  "applied",
+  "outreach_sent",
+  "recruiter_screen",
+  "technical_screen",
+  "onsite_loop",
+  "offer",
+  "accepted",
+  "rejected",
+  "withdrawn",
+  "closed_archived",
+];
+const STORES = [
+  "applications",
+  "contacts",
+  "outreachMessages",
+  "lifecycleEvents",
+  "interviews",
+  "offers",
+  "artifacts",
+  "reminders",
+  "settings",
+];
+const $ = (s, r = document) => r.querySelector(s);
+const $$ = (s, r = document) => [...r.querySelectorAll(s)];
+const now = () => new Date().toISOString();
+const id = (p = "id") =>
+  `${p}_${crypto.randomUUID?.() ?? Math.random().toString(36).slice(2)}`;
+const esc = (s) =>
+  String(s ?? "").replace(
+    /[&<>"']/g,
+    (c) =>
+      ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[
+        c
+      ],
+  );
+const date = (s) => (s ? String(s).slice(0, 10) : "");
+class TrackerRepository {
+  constructor(db) {
+    this.db = db;
+  }
+  static open() {
+    return new Promise((res, rej) => {
+      const req = indexedDB.open("jobbot3000", 1);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        for (const n of STORES) {
+          if (!db.objectStoreNames.contains(n)) {
+            const st = db.createObjectStore(n, { keyPath: "id" });
+            if (n !== "settings")
+              st.createIndex("by_applicationId", "applicationId", {
+                unique: false,
+              });
+          }
+        }
+      };
+      req.onsuccess = () => res(new TrackerRepository(req.result));
+      req.onerror = () => rej(req.error);
+    });
+  }
+  tx(n, m = "readonly") {
+    return this.db.transaction(n, m).objectStore(n);
+  }
+  all(n) {
+    return new Promise((res, rej) => {
+      const r = this.tx(n).getAll();
+      r.onsuccess = () => res(r.result);
+      r.onerror = () => rej(r.error);
+    });
+  }
+  put(n, v) {
+    return new Promise((res, rej) => {
+      const r = this.tx(n, "readwrite").put(v);
+      r.onsuccess = () => res(v);
+      r.onerror = () => rej(r.error);
+    });
+  }
+  add(n, v) {
+    return new Promise((res, rej) => {
+      const r = this.tx(n, "readwrite").add(v);
+      r.onsuccess = () => res(v);
+      r.onerror = () => rej(r.error);
+    });
+  }
+  get(n, k) {
+    return new Promise((res, rej) => {
+      const r = this.tx(n).get(k);
+      r.onsuccess = () => res(r.result);
+      r.onerror = () => rej(r.error);
+    });
+  }
+  async clear() {
+    await Promise.all(
+      STORES.map(
+        (n) =>
+          new Promise((res, rej) => {
+            const r = this.tx(n, "readwrite").clear();
+            r.onsuccess = res;
+            r.onerror = () => rej(r.error);
+          }),
+      ),
+    );
+  }
+  async exportAllData() {
+    const data = { schemaVersion: 1, exportedAt: now() };
+    for (const n of STORES) data[n] = await this.all(n);
+    data.settings = data.settings[0];
+    return data;
+  }
+  async importAllData(data) {
+    await this.clear();
+    for (const n of STORES.filter((n) => n !== "settings"))
+      for (const r of data[n] || []) await this.put(n, r);
+    if (data.settings) await this.put("settings", data.settings);
+  }
+}
+const parseCsv = (t) => {
+  const rows = [];
+  let r = [],
+    f = "",
+    q = false;
+  for (let i = 0; i < String(t).length; i++) {
+    const c = t[i];
+    if (q) {
+      if (c === '"' && t[i + 1] === '"') {
+        f += '"';
+        i++;
+      } else if (c === '"') q = false;
+      else f += c;
+    } else if (c === '"') q = true;
+    else if (c === ",") {
+      r.push(f);
+      f = "";
+    } else if (c === "\n") {
+      r.push(f);
+      rows.push(r);
+      r = [];
+      f = "";
+    } else if (c !== "\r") f += c;
+  }
+  r.push(f);
+  if (r.some(Boolean)) rows.push(r);
+  const h = (rows.shift() || []).map((x) => x.trim());
+  return rows
+    .filter((x) => x.some(Boolean))
+    .map((v) => Object.fromEntries(h.map((k, i) => [k, v[i] || ""])));
+};
+const toCsv = (rows) => {
+  const cols = [
+    "application_id",
+    "company",
+    "role_title",
+    "status",
+    "applied_at",
+    "posting_url",
+    "application_channel",
+    "follow_up_date",
+    "outreach_status",
+    "interview_stage",
+    "outcome",
+    "fit_score_100",
+    "notes",
+  ];
+  const cell = (v) =>
+    /[",\n]/.test((v = String(v ?? ""))) ? `"${v.replaceAll('"', '""')}"` : v;
+  return [
+    cols.join(","),
+    ...rows.map((r) => cols.map((c) => cell(r[c])).join(",")),
+  ].join("\n");
+};
+const bundleFromCsv = (txt) => {
+  const ts = now();
+  const apps = parseCsv(txt).map((r) => ({
+    id: r.application_id || id("app"),
+    company: r.company || "Unknown company",
+    role: r.role_title || r.role || "Unknown role",
+    status: STATUSES.includes(r.status) ? r.status : "applied",
+    source: r.application_channel || undefined,
+    postingUrl: r.posting_url || undefined,
+    appliedAt: r.applied_at ? new Date(r.applied_at).toISOString() : ts,
+    followUpDate: r.follow_up_date
+      ? new Date(r.follow_up_date).toISOString()
+      : undefined,
+    notes: [
+      r.notes,
+      r.fit_score_100 && `fit_score_100:${r.fit_score_100}`,
+      r.outreach_status && `outreach_status:${r.outreach_status}`,
+      r.interview_stage && `interview_stage:${r.interview_stage}`,
+      r.outcome && `outcome:${r.outcome}`,
+    ]
+      .filter(Boolean)
+      .join("\n"),
+    createdAt: ts,
+    updatedAt: ts,
+  }));
+  return {
+    schemaVersion: 1,
+    exportedAt: ts,
+    applications: apps,
+    contacts: [],
+    outreachMessages: [],
+    lifecycleEvents: apps.map((a) => ({
+      id: id("event"),
+      applicationId: a.id,
+      status: a.status,
+      occurredAt: a.appliedAt || ts,
+      source: "csv_import",
+      createdAt: ts,
+    })),
+    interviews: [],
+    offers: [],
+    artifacts: [],
+    reminders: [],
+  };
+};
+let repo,
+  state = { apps: [], bundle: null, selected: null };
+function meta(app, k) {
+  return (
+    (app.notes || "")
+      .split(/\n/)
+      .find((l) => l.startsWith(`${k}:`))
+      ?.slice(k.length + 1) || ""
+  );
+}
+function sortApps(apps) {
+  const [k, d] = ($("[name=sort]")?.value || "appliedAt:desc").split(":");
+  return [...apps].sort(
+    (a, b) =>
+      String(a[k] || "").localeCompare(String(b[k] || "")) *
+      (d === "desc" ? -1 : 1),
+  );
+}
+async function load() {
+  state.bundle = await repo.exportAllData();
+  state.apps = state.bundle.applications;
+  render();
+}
+function render() {
+  renderNav();
+  renderStatusOptions();
+  renderMetrics();
+  renderTable();
+  renderFollowups();
+  renderOutreach();
+}
+function renderNav() {
+  const h = location.hash || "#dashboard";
+  $$(".tabs a").forEach((a) => a.setAttribute("aria-current", a.hash === h));
+}
+function renderStatusOptions() {
+  const s = $("[name=status]");
+  if (s && s.options.length === 1)
+    STATUSES.forEach((x) =>
+      s.insertAdjacentHTML("beforeend", `<option>${x}</option>`),
+    );
+}
+function renderMetrics() {
+  const b = state.bundle,
+    a = state.apps,
+    out = b.outreachMessages.length,
+    inter = b.interviews.length,
+    offers = b.offers.length;
+  const recruiter = a.filter((x) => x.status === "recruiter_screen").length;
+  const rate = a.length
+    ? Math.round(((out + recruiter + inter + offers) / a.length) * 100)
+    : 0;
+  $("[data-metrics]").innerHTML = [
+    ["Total applications", a.length],
+    ["Outreach sent", out],
+    ["Recruiter screens", recruiter],
+    ["Interviews", inter],
+    ["Offers", offers],
+    ["Response rate", `${rate}%`],
+  ]
+    .map(
+      ([l, v]) =>
+        `<div class="metric"><span>${l}</span><strong>${v}</strong></div>`,
+    )
+    .join("");
+  const weeks = {};
+  a.forEach((x) => {
+    const w = date(x.appliedAt);
+    weeks[w] = (weeks[w] || 0) + 1;
+  });
+  $("[data-weekly]").textContent = `Weekly application count: ${
+    Object.entries(weeks)
+      .slice(-8)
+      .map(([d, c]) => `${d}: ${c}`)
+      .join(" • ") || "No applications yet"
+  }`;
+}
+function renderTable() {
+  const q = $("[name=search]").value.toLowerCase(),
+    st = $("[name=status]").value;
+  const rows = sortApps(
+    state.apps.filter(
+      (a) =>
+        (!st || a.status === st) &&
+        `${a.company} ${a.role} ${a.status}`.toLowerCase().includes(q),
+    ),
+  );
+  $("[data-empty]").hidden = rows.length > 0;
+  $("tbody", $("[data-applications-table]")).innerHTML = rows
+    .map(
+      (a) =>
+        `<tr><td><button class="linklike" data-open="${esc(a.id)}">${esc(a.company)}</button></td><td>${esc(a.role)}</td><td>${esc(a.status)}</td><td>${date(a.appliedAt)}</td><td>${date(a.followUpDate)}</td><td>${esc(meta(a, "outreach_status"))}</td><td>${esc(meta(a, "interview_stage"))}</td><td>${esc(meta(a, "outcome"))}</td><td>${esc(meta(a, "fit_score_100"))}</td><td>${a.postingUrl ? `<a href="${esc(a.postingUrl)}">Posting</a>` : ""}</td></tr>`,
+    )
+    .join("");
+}
+function renderFollowups() {
+  const today = date(now());
+  const groups = { Overdue: [], "Due today": [], Upcoming: [] };
+  state.apps
+    .filter((a) => a.followUpDate)
+    .forEach((a) => {
+      const d = date(a.followUpDate);
+      groups[
+        d < today ? "Overdue" : d === today ? "Due today" : "Upcoming"
+      ].push(a);
+    });
+  $("[data-followups]").innerHTML = Object.entries(groups)
+    .map(
+      ([g, items]) =>
+        `<div><h3>${g}</h3>${items.map((a) => `<div class="followup-card"><strong>${esc(a.company)}</strong><p>${esc(a.role)} • ${date(a.followUpDate)}</p><button class="button" data-done="${esc(a.id)}">Mark done</button> <button class="button button--secondary" data-snooze="${esc(a.id)}">Snooze 7 days</button></div>`).join("") || '<p class="muted">None</p>'}</div>`,
+    )
+    .join("");
+}
+function renderOutreach() {
+  const b = state.bundle;
+  $("[data-outreach-list]").innerHTML =
+    [...b.contacts, ...b.outreachMessages]
+      .map(
+        (x) =>
+          `<div class="followup-card"><strong>${esc(x.name || x.channel || "Message")}</strong><p>${esc(x.company || x.subject || x.body || "")}</p></div>`,
+      )
+      .join("") || '<p class="muted">No contacts or outreach yet.</p>';
+}
+async function openDetail(idv) {
+  const a = await repo.get("applications", idv);
+  if (!a) return;
+  state.selected = a;
+  const b = await repo.exportAllData();
+  const by = (r) => r.applicationId === a.id;
+  $("[data-detail]").innerHTML =
+    `<h2>${esc(a.company)} — ${esc(a.role)}</h2><form data-edit-form class="detail-grid"><label>Company<input name="company" required value="${esc(a.company)}"></label><label>Role title<input name="role" required value="${esc(a.role)}"></label><label>Posting URL<input name="postingUrl" type="url" value="${esc(a.postingUrl)}"></label><label>Application channel<input name="source" value="${esc(a.source)}"></label><label>Status<select name="status">${STATUSES.map((s) => `<option ${s === a.status ? "selected" : ""}>${s}</option>`).join("")}</select></label><label>Applied at<input name="appliedAt" type="date" value="${date(a.appliedAt)}"></label><label>Follow-up date<input name="followUpDate" type="date" value="${date(a.followUpDate)}"></label><label>Notes<textarea name="notes">${esc(a.notes)}</textarea></label><button class="button" type="submit">Save application</button></form><h3>Add records</h3><div class="actions"><button class="button" data-add="outreach">Add outreach message</button><button class="button" data-add="interview">Log interview</button><button class="button" data-add="offer">Log offer</button><button class="button" data-add="artifact">Add link/artifact</button></div><h3>Lifecycle timeline</h3><ul class="timeline">${[...b.lifecycleEvents.filter(by), ...b.outreachMessages.filter(by), ...b.interviews.filter(by), ...b.offers.filter(by), ...b.artifacts.filter(by)].map((x) => `<li>${esc(x.status || x.channel || x.stage || x.name)} <span class="muted">${date(x.occurredAt || x.sentAt || x.startsAt || x.createdAt)}</span></li>`).join("") || "<li>No lifecycle events yet.</li>"}</ul>`;
+  $("[data-detail-dialog]").showModal();
+}
+async function saveEdit(form) {
+  const a = { ...state.selected };
+  new FormData(form).forEach((v, k) => (a[k] = v || undefined));
+  a.appliedAt = a.appliedAt ? new Date(a.appliedAt).toISOString() : undefined;
+  a.followUpDate = a.followUpDate
+    ? new Date(a.followUpDate).toISOString()
+    : undefined;
+  a.updatedAt = now();
+  await repo.put("applications", a);
+  await repo.add("lifecycleEvents", {
+    id: id("event"),
+    applicationId: a.id,
+    status: a.status,
+    occurredAt: now(),
+    source: "manual",
+    note: "Application updated",
+    createdAt: now(),
+  });
+  await load();
+  openDetail(a.id);
+}
+async function newApp() {
+  const company = prompt("Company?");
+  if (!company) return;
+  const role = prompt("Role title?");
+  if (!role) return;
+  const postingUrl = prompt("Posting URL?") || undefined;
+  const source = prompt("Application channel?") || undefined;
+  const ts = now();
+  const app = {
+    id: id("app"),
+    company,
+    role,
+    postingUrl,
+    source,
+    status: "applied",
+    appliedAt: ts,
+    createdAt: ts,
+    updatedAt: ts,
+  };
+  await repo.add("applications", app);
+  await repo.add("lifecycleEvents", {
+    id: id("event"),
+    applicationId: app.id,
+    status: "applied",
+    occurredAt: ts,
+    source: "manual",
+    createdAt: ts,
+  });
+  await load();
+  openDetail(app.id);
+}
+async function addRecord(kind) {
+  const a = state.selected,
+    ts = now();
+  if (kind === "outreach")
+    await repo.add("outreachMessages", {
+      id: id("msg"),
+      applicationId: a.id,
+      direction: "outbound",
+      channel: "email",
+      body: prompt("Outreach message?") || "Outreach sent",
+      sentAt: ts,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+  if (kind === "interview")
+    await repo.put("interviews", {
+      id: id("int"),
+      applicationId: a.id,
+      contactIds: [],
+      stage: "recruiter_screen",
+      startsAt: ts,
+      outcome: "scheduled",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+  if (kind === "offer")
+    await repo.put("offers", {
+      id: id("offer"),
+      applicationId: a.id,
+      status: "received",
+      createdAt: ts,
+      updatedAt: ts,
+    });
+  if (kind === "artifact")
+    await repo.put("artifacts", {
+      id: id("art"),
+      applicationId: a.id,
+      kind: "link",
+      name: prompt("Link name?") || "Link",
+      url: prompt("URL?") || undefined,
+      private: true,
+      createdAt: ts,
+      updatedAt: ts,
+    });
+  await load();
+  openDetail(a.id);
+}
+function download(name, text, type) {
+  const a = document.createElement("a");
+  a.href = URL.createObjectURL(new Blob([text], { type }));
+  a.download = name;
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+document.addEventListener("click", async (e) => {
+  const t = e.target.closest("button,[data-open],[data-export]");
+  if (!t) return;
+  if (t.dataset.action === "new-application") newApp();
+  if (t.dataset.open) openDetail(t.dataset.open);
+  if (t.dataset.done) {
+    const a = await repo.get("applications", t.dataset.done);
+    a.followUpDate = undefined;
+    a.updatedAt = now();
+    await repo.put("applications", a);
+    load();
+  }
+  if (t.dataset.snooze) {
+    const a = await repo.get("applications", t.dataset.snooze);
+    const d = new Date();
+    d.setDate(d.getDate() + 7);
+    a.followUpDate = d.toISOString();
+    a.updatedAt = now();
+    await repo.put("applications", a);
+    load();
+  }
+  if (t.dataset.add) addRecord(t.dataset.add);
+  if (
+    t.dataset.action === "clear-data" &&
+    confirm("Clear all local tracker data?")
+  ) {
+    await repo.clear();
+    load();
+  }
+  if (t.dataset.action === "preview-import") {
+    const text =
+      $("[name=csv]").value || (await $("[name=file]").files[0]?.text()) || "";
+    const b = bundleFromCsv(text);
+    $("[data-import-preview]").textContent =
+      `Dry-run OK: ${b.applications.length} applications, ${b.lifecycleEvents.length} lifecycle events.`;
+  }
+  if (t.dataset.export) {
+    const b = await repo.exportAllData();
+    if (t.dataset.export === "json")
+      download(
+        "jobbot3000-backup.json",
+        JSON.stringify(b, null, 2),
+        "application/json",
+      );
+    if (t.dataset.export === "ndjson")
+      download(
+        "jobbot3000-backup.ndjson",
+        [
+          JSON.stringify({ type: "meta", schemaVersion: 1, exportedAt: now() }),
+          ...STORES.flatMap((s) =>
+            (s === "settings"
+              ? b.settings
+                ? [b.settings]
+                : []
+              : b[s] || []
+            ).map((r) => JSON.stringify({ type: s, record: r })),
+          ),
+        ].join("\n"),
+        "application/x-ndjson",
+      );
+    if (t.dataset.export === "csv")
+      download(
+        "jobbot3000-applications.csv",
+        toCsv(
+          b.applications.map((a) => ({
+            application_id: a.id,
+            company: a.company,
+            role_title: a.role,
+            status: a.status,
+            applied_at: date(a.appliedAt),
+            posting_url: a.postingUrl,
+            application_channel: a.source,
+            follow_up_date: date(a.followUpDate),
+            outreach_status: meta(a, "outreach_status"),
+            interview_stage: meta(a, "interview_stage"),
+            outcome: meta(a, "outcome"),
+            fit_score_100: meta(a, "fit_score_100"),
+            notes: a.notes,
+          })),
+        ),
+        "text/csv",
+      );
+  }
+});
+document.addEventListener("submit", async (e) => {
+  if (e.target.matches("[data-edit-form]")) {
+    e.preventDefault();
+    await saveEdit(e.target);
+  }
+  if (e.target.matches("[data-import-form]")) {
+    e.preventDefault();
+    const text =
+      $("[name=csv]").value || (await $("[name=file]").files[0]?.text()) || "";
+    await repo.importAllData(bundleFromCsv(text));
+    $("[data-import-preview]").textContent = "Import applied.";
+    await load();
+  }
+});
+document.addEventListener("input", (e) => {
+  if (e.target.closest("[data-filter-form]")) renderTable();
+});
+addEventListener("hashchange", renderNav);
+repo = await TrackerRepository.open();
+await load();

--- a/src/web/tracker/index.html
+++ b/src/web/tracker/index.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>jobbot3000 application tracker</title>
+    <link rel="stylesheet" href="/tracker/app.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to main content</a>
+    <header class="app-header">
+      <div>
+        <p class="eyebrow">
+          Browser-only • IndexedDB-first • No login required
+        </p>
+        <h1>jobbot3000 application tracker</h1>
+        <p class="lede">
+          Replace the spreadsheet with a private, local-first tracker for
+          applications, outreach, interviews, offers, and outcomes.
+        </p>
+      </div>
+      <button
+        class="button button--secondary"
+        type="button"
+        data-action="new-application"
+      >
+        New application
+      </button>
+    </header>
+    <nav class="tabs" aria-label="Tracker sections">
+      <a href="#dashboard">Dashboard</a>
+      <a href="#applications">Applications</a>
+      <a href="#follow-ups">Follow-ups</a>
+      <a href="#outreach">Contacts/Outreach</a>
+      <a href="#import-export">Import/Export</a>
+      <a href="#settings">Settings</a>
+    </nav>
+    <main id="main" tabindex="-1">
+      <section id="dashboard" class="panel">
+        <h2>Dashboard</h2>
+        <div class="metrics" data-metrics></div>
+        <div class="weekly" data-weekly></div>
+      </section>
+      <section id="applications" class="panel">
+        <div class="section-heading">
+          <div>
+            <h2>Applications</h2>
+            <p>Sort, filter, edit, and open lifecycle details.</p>
+          </div>
+          <button class="button" type="button" data-action="new-application">
+            New application
+          </button>
+        </div>
+        <form class="filters" data-filter-form>
+          <label
+            >Search<input
+              name="search"
+              type="search"
+              placeholder="Company, role, status" /></label
+          ><label
+            >Status<select name="status">
+              <option value="">Any status</option>
+            </select></label
+          ><label
+            >Sort<select name="sort">
+              <option value="appliedAt:desc">Applied newest</option>
+              <option value="company:asc">Company A-Z</option>
+              <option value="followUpDate:asc">Follow-up soonest</option>
+              <option value="fit:desc">Fit score</option>
+            </select></label
+          >
+        </form>
+        <p class="empty" data-empty hidden>
+          No applications yet. Import a CSV or create a new application.
+        </p>
+        <div class="table-wrap">
+          <table data-applications-table>
+            <thead>
+              <tr>
+                <th>Company</th>
+                <th>Role</th>
+                <th>Status</th>
+                <th>Applied</th>
+                <th>Follow-up</th>
+                <th>Outreach</th>
+                <th>Interview</th>
+                <th>Outcome</th>
+                <th>Fit</th>
+                <th>Links</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+      <section id="follow-ups" class="panel">
+        <h2>Follow-ups</h2>
+        <div class="followups" data-followups></div>
+      </section>
+      <section id="outreach" class="panel">
+        <h2>Contacts/Outreach</h2>
+        <p class="muted">Outreach messages are stored only in this browser.</p>
+        <div data-outreach-list></div>
+      </section>
+      <section id="import-export" class="panel">
+        <h2>Import/Export</h2>
+        <div class="grid">
+          <form data-import-form>
+            <h3>Import compact CSV</h3>
+            <label
+              >CSV file<input
+                name="file"
+                type="file"
+                accept=".csv,text/csv" /></label
+            ><textarea
+              name="csv"
+              rows="7"
+              placeholder="Paste compact CSV here"
+            ></textarea>
+            <div class="actions">
+              <button class="button" type="button" data-action="preview-import">
+                Preview / dry-run</button
+              ><button class="button button--secondary" type="submit">
+                Apply import
+              </button>
+            </div>
+            <pre data-import-preview aria-live="polite"></pre>
+          </form>
+          <div>
+            <h3>Export backups</h3>
+            <p>Downloads are generated locally from IndexedDB.</p>
+            <div class="actions">
+              <button class="button" type="button" data-export="csv">
+                Export CSV</button
+              ><button class="button" type="button" data-export="json">
+                Export JSON backup</button
+              ><button class="button" type="button" data-export="ndjson">
+                Export NDJSON
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section id="settings" class="panel">
+        <h2>Settings</h2>
+        <p>
+          No API tokens, login, or backend are required for the tracker. Data is
+          saved in this browser's IndexedDB database.
+        </p>
+        <button
+          class="button button--danger"
+          type="button"
+          data-action="clear-data"
+        >
+          Clear local tracker data
+        </button>
+      </section>
+    </main>
+    <dialog data-detail-dialog>
+      <form method="dialog" class="detail">
+        <button class="icon-button" value="close" aria-label="Close">×</button>
+        <div data-detail></div>
+      </form>
+    </dialog>
+    <script type="module" src="/tracker/app.js"></script>
+  </body>
+</html>

--- a/test/web-tracker-ui.test.js
+++ b/test/web-tracker-ui.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import fs from "node:fs/promises";
+
+import { createWebApp } from "../src/web/server.js";
+
+describe("browser application tracker UI", () => {
+  it("serves a backend-free IndexedDB tracker shell", async () => {
+    const app = createWebApp({
+      commandAdapter: {},
+      csrf: { token: "test-csrf-token" },
+    });
+    const server = await new Promise((resolve) => {
+      const instance = app.listen(0, "127.0.0.1", () => resolve(instance));
+    });
+    try {
+      const { port } = server.address();
+      const response = await fetch(`http://127.0.0.1:${port}/tracker`);
+      const html = await response.text();
+      expect(response.status).toBe(200);
+      expect(html).toContain("Dashboard");
+      expect(html).toContain("Applications");
+      expect(html).toContain("Follow-ups");
+      expect(html).toContain("Contacts/Outreach");
+      expect(html).toContain("Import/Export");
+      expect(html).toContain("Settings");
+      expect(html).toContain("/tracker/app.js");
+    } finally {
+      await new Promise((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
+  it("keeps core tracker operations in the browser asset", async () => {
+    const script = await fs.readFile("src/web/tracker/app.js", "utf8");
+    expect(script).toContain("class TrackerRepository");
+    expect(script).toContain('indexedDB.open("jobbot3000", 1)');
+    expect(script).toContain("bundleFromCsv");
+    expect(script).toContain("exportAllData");
+    expect(script).toContain("outreachMessages");
+    expect(script).toContain("interviews");
+    expect(script).toContain("offers");
+  });
+});


### PR DESCRIPTION
### Motivation
- Replace the existing spreadsheet workflow with a browser-first, local-only application tracker that keeps private data in IndexedDB and requires no server-side tokens or login.
- Provide a minimal, production-oriented app shell and UX for applications, outreach, interviews, offers, follow-ups, import/export, and basic analytics so users can migrate from a CSV spreadsheet to a private web tracker.
- Surface a small, testable surface that can be shipped as static assets and progressively hardened for production later.

### Description
- Added a new tracker app shell and assets under `src/web/tracker/`: `index.html`, `app.css`, and `app.js` implementing Dashboard, Applications, Follow-ups, Contacts/Outreach, Import/Export, and Settings views and UI behaviors (sort/filter table, application detail edit, lifecycle timeline, new-application flow, follow-up mark/dismiss/snooze, CRUD for outreach/interview/offer/artifact, CSV preview/import and CSV/JSON/NDJSON export, and basic analytics).
- Exposed three new routes in the web server to serve the tracker assets: `/tracker`, `/tracker/app.js`, and `/tracker/app.css` in `src/web/server.js` so the tracker is backend-free and loads entirely in the browser.
- Implemented a small browser-side IndexedDB helper (inside `src/web/tracker/app.js`) that mirrors the repository schema/stores used elsewhere: `applications`, `contacts`, `outreachMessages`, `lifecycleEvents`, `interviews`, `offers`, `artifacts`, `reminders`, and `settings` with import/export helpers and CSV parsing/serialization.
- Added a focused test `test/web-tracker-ui.test.js` which verifies the `/tracker` shell serves and that the browser asset contains the core local-tracker logic (repository, `bundleFromCsv`, `exportAllData`, and lifecycle stores).

### Testing
- Ran lint: `npm run lint` — passed.
- Ran typecheck: `npm run typecheck` — passed.
- Ran the CI test runner for the tracker test: `npm run test:ci -- test/web-tracker-ui.test.js` — passed and the test invocation executed the repository Vitest suite (the run completed successfully in the environment used here).
- Ran targeted Vitest: `npx vitest run test/web-tracker-ui.test.js` — passed (both tests in the new spec passed).
- Captured screenshots to exercise the server front-end: `npm run web:screenshots` — succeeded and saved screenshots under `docs/screenshots/` for the status UI flows.
- Formatting check: `npm run format:check` — failed due to repository-wide pre-existing formatting warnings outside this change set; the new tracker files were formatted with Prettier to keep the PR focused and avoid unrelated churn.
- Secrets scan: `git diff | ./scripts/scan-secrets.py` — ran as part of verification and returned no findings for the introduced files.

Notes: the change keeps all tracker reads/writes client-side (IndexedDB) and avoids adding new runtime dependencies; follow-ups include adding end-to-end Playwright screenshot tests covering import, empty state, list and detail interactions, and accessibility refinements as next steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42310639cc832fb41c36acd7c6ad61)