### PR TITLE
Harden static browser-only tracker production mode

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,23 @@
 # syntax=docker/dockerfile:1.7
-FROM node:20-slim AS base
+FROM node:20-slim AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev
+RUN npm ci
 
-FROM node:20-slim AS runtime
-ENV NODE_ENV=production
-WORKDIR /app
-COPY --from=base /app/node_modules ./node_modules
-COPY package.json package-lock.json ./
-COPY bin ./bin
+FROM deps AS build
 COPY src ./src
 COPY scripts ./scripts
-COPY docs ./docs
-RUN mkdir -p /data && chown node:node /data
+RUN npm run build
+
+FROM node:20-slim AS runtime
+ENV NODE_ENV=production \
+    JOBBOT_STATIC_DIR=/app/dist \
+    JOBBOT_WEB_PORT=3000
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+COPY --from=build /app/dist ./dist
+COPY scripts/static-server.js ./scripts/static-server.js
 EXPOSE 3000
-VOLUME ["/data"]
 USER node
-CMD ["node", "scripts/web-server.js", "--env", "production", "--host", "0.0.0.0"]
+CMD ["node", "scripts/static-server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:20-slim AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci --omit=dev --ignore-scripts
 
 FROM deps AS build
 COPY src ./src
@@ -15,9 +15,11 @@ ENV NODE_ENV=production \
     JOBBOT_WEB_PORT=3000
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci --omit=dev && npm cache clean --force
+COPY --from=deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
-COPY scripts/static-server.js ./scripts/static-server.js
+COPY src ./src
+COPY scripts ./scripts
+RUN npm cache clean --force
 EXPOSE 3000
 USER node
 CMD ["node", "scripts/static-server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,7 @@ WORKDIR /app
 COPY package.json package-lock.json ./
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
-COPY src ./src
-COPY scripts ./scripts
+COPY --from=build /app/scripts/static-server.js ./scripts/static-server.js
 RUN npm cache clean --force
 EXPOSE 3000
 USER node

--- a/README.md
+++ b/README.md
@@ -7,13 +7,10 @@
 
 **jobbot3000** is a self-hosted, open-source job search copilot.
 
-The production web direction is browser-first: private application tracking data should live in user-owned IndexedDB, while the deployed server/container serves static assets and health endpoints. This is a planned architecture rather than a completed implementation; see [docs/browser-first-architecture.md](docs/browser-first-architecture.md) for the data contract and migration path.
+The production web tracker is browser-first: private application tracking data lives in user-owned IndexedDB, while the deployed server/container serves static assets and health endpoints. See [docs/browser-first-architecture.md](docs/browser-first-architecture.md) for the data contract and [docs/privacy-and-security.md](docs/privacy-and-security.md) for operating boundaries.
 
 > [!WARNING]
-> The web interface is an experimental preview for local use only. Running production builds or
-> deploying to shared or cloud infrastructure can leak secrets, PII, and other sensitive data.
-> Operate on trusted hardware while we implement hardened authentication, storage, and network
-> isolation. Track the hardening plan in [docs/web-security-roadmap.md](docs/web-security-roadmap.md).
+> The static IndexedDB tracker can be deployed as a browser-only app because private tracker data is not posted back to the server. The CLI/development server mode remains sensitive: command endpoints, provider-token management, local files, and SQLite-backed workflows are intended for trusted local or explicitly secured environments only.
 
 ## Quickstart
 
@@ -25,7 +22,9 @@ npm run dev
 # Open http://127.0.0.1:3100
 ```
 
-That's it! The web server will start with all backend functionality enabled.
+For production static tracker builds, run `npm run build` and serve `dist/` with `npm run start:static`; `/healthz` and `/livez` are available for container probes.
+
+The development web server starts with backend functionality enabled.
 Use `npm run web:server -- --disable-native-cli` if you want to explore the
 mock-only UI without spawning CLI subprocesses.
 
@@ -157,6 +156,7 @@ Run the snippet with `node example.js` after saving it to a file in the project 
 - [docs/prompt-docs-summary.md](docs/prompt-docs-summary.md) – prompt reference index
 - [docs/user-journeys.md](docs/user-journeys.md) – primary user journeys and flows
 - [docs/browser-first-architecture.md](docs/browser-first-architecture.md) – planned IndexedDB-first production web architecture and browser data contract
+- [docs/privacy-and-security.md](docs/privacy-and-security.md) – browser-only production privacy model, backups, clearing data, quota caveats, and static security headers
 - [docs/indexeddb-persistence.md](docs/indexeddb-persistence.md) – browser IndexedDB persistence, backup/restore, and quota caveats
 - [docs/spreadsheet-replacement.md](docs/spreadsheet-replacement.md) – CSV/JSON/NDJSON import-export workflow for replacing the current spreadsheet
 - [docs/backup-restore-guide.md](docs/backup-restore-guide.md) – backup, restore, and verification

--- a/docker-compose.web.yml
+++ b/docker-compose.web.yml
@@ -9,13 +9,9 @@ services:
       - JOBBOT_WEB_ENV=production
       - JOBBOT_WEB_HOST=0.0.0.0
       - JOBBOT_WEB_PORT=3000
-      - JOBBOT_DATA_DIR=/data
-      - JOBBOT_WEB_ENABLE_NATIVE_CLI=1
-      - JOBBOT_WEB_HEALTH_URL=http://127.0.0.1:3000/health
+      - JOBBOT_WEB_HEALTH_URL=http://127.0.0.1:3000/healthz
     ports:
       - "3000:3000"
-    volumes:
-      - ./data:/data
     read_only: true
     tmpfs:
       - /tmp
@@ -26,17 +22,10 @@ services:
       - ALL
     healthcheck:
       test:
-        - CMD
-        - node
-        - scripts/docker-healthcheck.js
+        - CMD-SHELL
+        - >-
+          node -e "fetch(process.env.JOBBOT_WEB_HEALTH_URL || 'http://127.0.0.1:3000/healthz').then((response) => { if (!response.ok) process.exit(1); }).catch(() => process.exit(1))"
       interval: 30s
       timeout: 5s
       retries: 3
       start_period: 5s
-    command:
-      - node
-      - scripts/web-server.js
-      - --env
-      - production
-      - --host
-      - 0.0.0.0

--- a/docs/privacy-and-security.md
+++ b/docs/privacy-and-security.md
@@ -1,0 +1,35 @@
+# Browser tracker privacy and security
+
+The production tracker is a static, browser-only application. The container or server serves HTML, CSS, JavaScript, the web manifest, and health endpoints; private tracker records are stored in the user's browser IndexedDB database named `jobbot3000`.
+
+## What stays in IndexedDB
+
+The browser tracker stores applications, contacts, outreach messages, lifecycle events, interviews, offers, artifact links, reminders, and tracker settings in IndexedDB. Imported CSV contents are parsed in the browser and written directly to IndexedDB only after the user chooses **Apply import**.
+
+## What does not leave the browser
+
+In static production mode, application data, outreach text, notes, resumes, artifact metadata, and imported files are not posted to jobbot3000 server APIs. Backup exports are generated with `Blob` URLs in the browser and downloaded by the browser. The static server has no `/commands` endpoint and does not open the CLI SQLite repositories.
+
+The optional CLI/development web server is separate. It can run command endpoints, update `.env` provider tokens, and use local files or SQLite when explicitly started with CLI features enabled.
+
+## Back up and restore
+
+Use **Import/Export → Backup now** or **Settings → Backup now** to download a JSON backup. CSV and NDJSON exports are also available for spreadsheet migration and auditing. Store backups in a private encrypted location such as an OS-encrypted home directory, password manager file vault, or encrypted cloud folder.
+
+To restore, use **Import/Export** and import a trusted CSV replacement file. JSON full-restore support is provided by the IndexedDB repository contract and can be wired to UI restore flows without server storage.
+
+## Clear all data
+
+Open **Settings → Clear local data**. Confirm the destructive prompt to clear all tracker object stores in the browser's `jobbot3000` IndexedDB database. Clearing browser site data from browser settings has the same effect and may also remove service worker/cache state.
+
+## Browser quota caveats
+
+IndexedDB quota is controlled by the browser and device. Low disk space, private browsing modes, enterprise policies, or browser cleanup settings can evict local data. Keep periodic backups and avoid relying on one browser profile as the only copy.
+
+## Artifact file guidance
+
+The tracker stores artifact links/metadata, not private file bytes. Keep resumes, cover letters, transcripts, and offer documents in private storage you control. Prefer encrypted local folders or an encrypted document vault, and link to those locations only when appropriate for your threat model.
+
+## Static server headers
+
+`scripts/static-server.js` emits a restrictive Content Security Policy, Permissions Policy, Referrer Policy, `X-Content-Type-Options: nosniff`, and COOP headers. `/healthz` and `/livez` return JSON liveness responses without touching user data.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
     "web:screenshots": "node scripts/generate-web-screenshots.js",
     "typecheck": "tsc -p tsconfig.json",
     "prepare": "npx simple-git-hooks",
-    "postinstall": "node scripts/install-console-font.js"
+    "postinstall": "node scripts/install-console-font.js",
+    "build": "node scripts/build-static.js",
+    "start:static": "node scripts/static-server.js"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/build-static.js
+++ b/scripts/build-static.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const distDir = path.join(repoRoot, "dist");
+const assetsDir = path.join(distDir, "assets");
+
+await fs.rm(distDir, { recursive: true, force: true });
+await fs.mkdir(assetsDir, { recursive: true });
+
+await fs.copyFile(
+  path.join(repoRoot, "src/web/tracker/index.html"),
+  path.join(distDir, "tracker.html"),
+);
+await fs.copyFile(
+  path.join(repoRoot, "src/web/tracker/tracker.js"),
+  path.join(assetsDir, "tracker.js"),
+);
+await fs.copyFile(
+  path.join(repoRoot, "src/web/tracker/tracker.css"),
+  path.join(assetsDir, "tracker.css"),
+);
+
+const statusCss = [
+  ":root{color-scheme:dark;--background:#0b0d0f;--surface:#111827;--foreground:#f8fafc",
+  ";--muted:#94a3b8;--accent:#38bdf8;--pill-bg:rgba(56,189,248,.12)",
+  ";--pill-border:rgba(56,189,248,.35);--pill-text:#e2e8f0",
+  ";--card-border:rgba(148,163,184,.25);--card-surface:#111827}",
+  "body{margin:0;padding:2rem;font:16px/1.5 system-ui,sans-serif",
+  ";background:var(--background);color:var(--foreground)}",
+  "a{color:var(--accent)}",
+  ".card{border:1px solid var(--card-border);border-radius:1rem;padding:1rem",
+  ";background:var(--surface)}",
+  ".pill{display:inline-block;border:1px solid var(--pill-border);border-radius:999px",
+  ";padding:.35rem .7rem;color:var(--pill-text);background:var(--pill-bg)}",
+  ".primary-nav{display:flex;gap:.75rem;flex-wrap:wrap}.muted{color:var(--muted)}",
+].join("");
+await fs.writeFile(
+  path.join(assetsDir, "status-hub.css"),
+  `${statusCss}\n`,
+  "utf8",
+);
+
+const indexHtml = `<!doctype html>
+<html lang="en" data-theme="dark">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>jobbot3000 static tracker</title><link rel="stylesheet" href="/assets/status-hub.css"></head>
+<body><main class="card"><p class="pill">jobbot3000 static production mode</p>
+<h1>Browser-only application tracker</h1>
+<p>Private tracker data stays in this browser's IndexedDB.
+This server only serves static assets and health endpoints.</p>
+<nav class="primary-nav"><a href="/tracker">Open tracker</a><a href="/healthz">healthz</a>
+<a href="/livez">livez</a></nav>
+</main></body></html>\n`;
+await fs.writeFile(path.join(distDir, "index.html"), indexHtml, "utf8");
+await fs.writeFile(path.join(distDir, "404.html"), indexHtml, "utf8");
+
+const manifest = {
+  name: "jobbot3000 Application Tracker",
+  short_name: "jobbot3000",
+  start_url: "/tracker",
+  display: "standalone",
+  background_color: "#0b0d0f",
+  theme_color: "#38bdf8",
+};
+await fs.writeFile(
+  path.join(distDir, "manifest.webmanifest"),
+  `${JSON.stringify(manifest, null, 2)}\n`,
+  "utf8",
+);
+
+console.log(`Built static tracker into ${path.relative(repoRoot, distDir)}/`);

--- a/scripts/static-server.js
+++ b/scripts/static-server.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+import express from "express";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const distDir = path.resolve(
+  process.env.JOBBOT_STATIC_DIR ?? path.join(repoRoot, "dist"),
+);
+const host = process.env.HOST ?? process.env.JOBBOT_WEB_HOST ?? "0.0.0.0";
+const port = Number(process.env.PORT ?? process.env.JOBBOT_WEB_PORT ?? 3000);
+
+const securityHeaders = Object.freeze({
+  "Content-Security-Policy": [
+    "default-src 'self'",
+    "script-src 'self'",
+    "style-src 'self'",
+    "img-src 'self' data:",
+    "font-src 'self'",
+    "connect-src 'self'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+  ].join("; "),
+  "Permissions-Policy": [
+    "accelerometer=()",
+    "autoplay=()",
+    "camera=()",
+    "geolocation=()",
+    "gyroscope=()",
+    "microphone=()",
+    "payment=()",
+    "usb=()",
+  ].join(", "),
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "X-Content-Type-Options": "nosniff",
+  "Cross-Origin-Opener-Policy": "same-origin",
+});
+
+const app = express();
+app.disable("x-powered-by");
+app.use((req, res, next) => {
+  for (const [name, value] of Object.entries(securityHeaders))
+    res.setHeader(name, value);
+  if (req.secure || req.get("x-forwarded-proto") === "https") {
+    res.setHeader(
+      "Strict-Transport-Security",
+      "max-age=63072000; includeSubDomains; preload",
+    );
+  }
+  next();
+});
+
+const health = (_req, res) =>
+  res
+    .status(200)
+    .json({ status: "ok", mode: "static", persistence: "browser-indexeddb" });
+app.get("/healthz", health);
+app.get("/livez", health);
+app.get("/health", health);
+app.get("/ready", health);
+app.get("/tracker", (_req, res) =>
+  res.sendFile(path.join(distDir, "tracker.html")),
+);
+app.use(
+  express.static(distDir, {
+    index: "index.html",
+    immutable: true,
+    maxAge: "1h",
+  }),
+);
+app.use((_req, res) =>
+  res.status(404).sendFile(path.join(distDir, "404.html")),
+);
+
+const server = app.listen(port, host, () => {
+  const address = server.address();
+  const actualPort =
+    typeof address === "object" && address ? address.port : port;
+  console.log(
+    `jobbot static tracker listening on http://${host}:${actualPort}`,
+  );
+});

--- a/scripts/static-server.js
+++ b/scripts/static-server.js
@@ -69,18 +69,14 @@ app.get("/healthz", health);
 app.get("/livez", health);
 app.get("/health", health);
 app.get("/ready", health);
-const noCache = (_req, res, next) => {
+const sendNoStoreFile = (fileName) => (_req, res) => {
   res.setHeader("Cache-Control", "no-store");
-  next();
+  res.sendFile(path.join(distDir, fileName));
 };
 
-app.get("/tracker", noCache, (_req, res) =>
-  res.sendFile(path.join(distDir, "tracker.html")),
-);
-app.get(
-  ["/", "/index.html", "/tracker.html", "/manifest.webmanifest"],
-  noCache,
-);
+app.get(["/", "/index.html"], sendNoStoreFile("index.html"));
+app.get(["/tracker", "/tracker.html"], sendNoStoreFile("tracker.html"));
+app.get("/manifest.webmanifest", sendNoStoreFile("manifest.webmanifest"));
 app.use(
   express.static(distDir, {
     index: "index.html",

--- a/scripts/static-server.js
+++ b/scripts/static-server.js
@@ -9,7 +9,15 @@ const distDir = path.resolve(
   process.env.JOBBOT_STATIC_DIR ?? path.join(repoRoot, "dist"),
 );
 const host = process.env.HOST ?? process.env.JOBBOT_WEB_HOST ?? "0.0.0.0";
-const port = Number(process.env.PORT ?? process.env.JOBBOT_WEB_PORT ?? 3000);
+const rawPort = process.env.PORT ?? process.env.JOBBOT_WEB_PORT ?? "3000";
+const port = Number.parseInt(rawPort, 10);
+if (!/^[1-9]\d*$/.test(rawPort) || !Number.isInteger(port) || port > 65535) {
+  console.error(
+    `Invalid static server port "${rawPort}". ` +
+      "Set PORT or JOBBOT_WEB_PORT to an integer from 1 to 65535.",
+  );
+  process.exit(1);
+}
 
 const securityHeaders = Object.freeze({
   "Content-Security-Policy": [
@@ -61,13 +69,21 @@ app.get("/healthz", health);
 app.get("/livez", health);
 app.get("/health", health);
 app.get("/ready", health);
-app.get("/tracker", (_req, res) =>
+const noCache = (_req, res, next) => {
+  res.setHeader("Cache-Control", "no-store");
+  next();
+};
+
+app.get("/tracker", noCache, (_req, res) =>
   res.sendFile(path.join(distDir, "tracker.html")),
+);
+app.get(
+  ["/", "/index.html", "/tracker.html", "/manifest.webmanifest"],
+  noCache,
 );
 app.use(
   express.static(distDir, {
     index: "index.html",
-    immutable: true,
     maxAge: "1h",
   }),
 );

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -6928,10 +6928,22 @@ export function createWebApp({
   const trackerStylesBuffer = readFileSync(
     new URL("./tracker/tracker.css", import.meta.url),
   );
+  const trackerManifestBuffer = Buffer.from(
+    `${JSON.stringify({
+      name: "jobbot3000 Application Tracker",
+      short_name: "jobbot3000",
+      start_url: "/tracker",
+      display: "standalone",
+      background_color: "#0b0d0f",
+      theme_color: "#38bdf8",
+    })}\n`,
+    "utf8",
+  );
   const statusHubScriptGzip = gzipSync(statusHubScriptBuffer);
   const trackerHtmlGzip = gzipSync(trackerHtmlBuffer);
   const trackerScriptGzip = gzipSync(trackerScriptBuffer);
   const trackerStylesGzip = gzipSync(trackerStylesBuffer);
+  const trackerManifestGzip = gzipSync(trackerManifestBuffer);
   const statusHubStylesBuffer = Buffer.from(STATUS_PAGE_STYLES, "utf8");
   const statusHubStylesGzip = gzipSync(statusHubStylesBuffer);
   const app = express();
@@ -7056,6 +7068,14 @@ export function createWebApp({
       contentType: "text/html",
       rawBuffer: trackerHtmlBuffer,
       gzipBuffer: trackerHtmlGzip,
+    });
+  });
+
+  app.get("/manifest.webmanifest", (req, res) => {
+    sendCompressedAsset(req, res, {
+      contentType: "application/manifest+json",
+      rawBuffer: trackerManifestBuffer,
+      gzipBuffer: trackerManifestGzip,
     });
   });
 

--- a/src/web/tracker/index.html
+++ b/src/web/tracker/index.html
@@ -122,8 +122,6 @@
             <div class="tracker-actions">
               <button class="button" data-export="json">Backup now</button
               ><button class="button" data-export="csv">Export CSV</button
-              ><button class="button" data-export="json">
-                Export JSON backup</button
               ><button class="button" data-export="ndjson">
                 Export NDJSON
               </button>

--- a/src/web/tracker/index.html
+++ b/src/web/tracker/index.html
@@ -6,6 +6,7 @@
     <title>jobbot3000 Application Tracker</title>
     <link rel="stylesheet" href="/assets/status-hub.css" />
     <link rel="stylesheet" href="/assets/tracker.css" />
+    <link rel="manifest" href="/manifest.webmanifest" />
   </head>
   <body>
     <a href="#tracker-main" class="pill">Skip to tracker</a>
@@ -114,8 +115,13 @@
           </article>
           <article class="card">
             <h3>Export backups</h3>
+            <p>
+              Use <strong>Backup now</strong> to download a JSON backup of
+              everything currently stored in IndexedDB.
+            </p>
             <div class="tracker-actions">
-              <button class="button" data-export="csv">Export CSV</button
+              <button class="button" data-export="json">Backup now</button
+              ><button class="button" data-export="csv">Export CSV</button
               ><button class="button" data-export="json">
                 Export JSON backup</button
               ><button class="button" data-export="ndjson">
@@ -130,9 +136,15 @@
         <h2>Settings</h2>
         <p class="muted">
           This static tracker needs no login, API tokens, or backend beyond
-          asset serving.
+          asset serving. Back up before clearing data.
         </p>
-        <button class="button" data-clear-data>Clear local tracker data</button>
+        <div class="tracker-actions">
+          <button class="button" data-export="json">Backup now</button
+          ><button class="button danger-button" data-clear-data>
+            Clear local data
+          </button>
+        </div>
+        <p class="muted" data-settings-result></p>
       </section>
       <section class="tracker-view" data-view="detail" hidden>
         <button class="button" data-back-to-list>← Back to applications</button>

--- a/src/web/tracker/tracker.css
+++ b/src/web/tracker/tracker.css
@@ -103,3 +103,8 @@
     grid-template-columns: 1fr;
   }
 }
+.danger-button {
+  border-color: rgba(248, 113, 113, 0.65);
+  background: rgba(127, 29, 29, 0.35);
+  color: #fecaca;
+}

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -804,9 +804,14 @@ function init() {
     (b) => (b.onclick = () => exportData(b.dataset.export)),
   );
   $("[data-clear-data]").onclick = async () => {
-    if (confirm("Clear all local tracker data?")) {
+    const ok = confirm(
+      "Clear all local tracker data from this browser? This cannot be undone unless you have a backup.",
+    );
+    if (ok) {
       await repo.clear();
-      refresh();
+      const result = $("[data-settings-result]");
+      if (result) result.textContent = "Local IndexedDB tracker data cleared.";
+      await refresh();
     }
   };
   refresh();

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -388,4 +388,42 @@ test.describe("browser application tracker", () => {
       "jobbot3000-backup.json",
     );
   });
+
+  test("retains IndexedDB data across reload, exports backup, and clears local data", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await page.setInputFiles("[data-import-file]", {
+      name: "fake-applications.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(csvFixture),
+    });
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+    await page.getByRole("button", { name: "Apply import" }).click();
+
+    await page.reload();
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await expect(page.locator("[data-applications-table]")).toContainText(
+      "Example Labs",
+    );
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Backup now" }).click();
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toBe("jobbot3000-backup.json");
+
+    page.on("dialog", (dialog) => dialog.accept());
+    await page.getByRole("button", { name: "Settings" }).click();
+    await page.getByRole("button", { name: "Clear local data" }).click();
+    await expect(page.locator("[data-settings-result]")).toContainText(
+      "Local IndexedDB tracker data cleared.",
+    );
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await expect(page.getByText("No applications yet")).toBeVisible();
+  });
 });

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -400,6 +400,9 @@ test.describe("browser application tracker", () => {
     });
     await page.getByRole("button", { name: "Preview/dry-run" }).click();
     await page.getByRole("button", { name: "Apply import" }).click();
+    await expect(page.locator("[data-import-result]")).toContainText(
+      "Import applied",
+    );
 
     await page.reload();
     await page

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -383,7 +383,7 @@ test.describe("browser application tracker", () => {
 
     await page.getByRole("button", { name: "Import/Export" }).click();
     const download = page.waitForEvent("download");
-    await page.getByRole("button", { name: "Export JSON backup" }).click();
+    await page.getByRole("button", { name: "Backup now" }).click();
     await expect((await download).suggestedFilename()).toBe(
       "jobbot3000-backup.json",
     );

--- a/test/web-deployment.test.js
+++ b/test/web-deployment.test.js
@@ -1,58 +1,95 @@
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { readFile } from 'node:fs/promises';
-import { describe, it, expect } from 'vitest';
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFile } from "node:fs/promises";
+import { describe, it, expect } from "vitest";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const repoRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(__dirname, "..");
 
-describe('web deployment artifacts', () => {
-  it('ships a Dockerfile for the web server', async () => {
-    const dockerfilePath = path.join(repoRoot, 'Dockerfile');
-    const dockerfile = await readFile(dockerfilePath, 'utf8');
-    expect(dockerfile).toContain('FROM node:20-slim AS base');
-    expect(dockerfile).toContain('npm ci --omit=dev');
-    expect(dockerfile).toContain('CMD ["node", "scripts/web-server.js"');
+describe("web deployment artifacts", () => {
+  it("ships a Dockerfile for the web server", async () => {
+    const dockerfilePath = path.join(repoRoot, "Dockerfile");
+    const dockerfile = await readFile(dockerfilePath, "utf8");
+    expect(dockerfile).toContain("FROM node:20-slim AS deps");
+    expect(dockerfile).toContain("npm run build");
+    expect(dockerfile).toContain('CMD ["node", "scripts/static-server.js"]');
   });
 
-  it('provides a docker-compose definition wiring the web server defaults', async () => {
-    const composePath = path.join(repoRoot, 'docker-compose.web.yml');
-    const compose = await readFile(composePath, 'utf8');
-    expect(compose).toContain('services:');
-    expect(compose).toContain('JOBBOT_WEB_ENV=production');
-    expect(compose).toContain('JOBBOT_DATA_DIR=/data');
-    expect(compose).toContain('JOBBOT_WEB_ENABLE_NATIVE_CLI=1');
+  it("provides a docker-compose definition wiring the web server defaults", async () => {
+    const composePath = path.join(repoRoot, "docker-compose.web.yml");
+    const compose = await readFile(composePath, "utf8");
+    expect(compose).toContain("services:");
+    expect(compose).toContain("JOBBOT_WEB_ENV=production");
+    expect(compose).toContain("JOBBOT_DATA_DIR=/data");
+    expect(compose).toContain("JOBBOT_WEB_ENABLE_NATIVE_CLI=1");
   });
 
-  it('defines a docker-compose healthcheck targeting the web server /health endpoint', async () => {
-    const composePath = path.join(repoRoot, 'docker-compose.web.yml');
-    const compose = await readFile(composePath, 'utf8');
-    expect(compose).toContain('healthcheck:');
-    expect(compose).toContain('scripts/docker-healthcheck.js');
-    expect(compose).toContain('http://127.0.0.1:3000/health');
+  it("defines a docker-compose healthcheck targeting the web server /health endpoint", async () => {
+    const composePath = path.join(repoRoot, "docker-compose.web.yml");
+    const compose = await readFile(composePath, "utf8");
+    expect(compose).toContain("healthcheck:");
+    expect(compose).toContain("scripts/docker-healthcheck.js");
+    expect(compose).toContain("http://127.0.0.1:3000/health");
   });
 
-  it('locks the runtime profile with read-only rootfs and a custom seccomp policy', async () => {
-    const composePath = path.join(repoRoot, 'docker-compose.web.yml');
-    const compose = await readFile(composePath, 'utf8');
-    expect(compose).toContain('read_only: true');
+  it("locks the runtime profile with read-only rootfs and a custom seccomp policy", async () => {
+    const composePath = path.join(repoRoot, "docker-compose.web.yml");
+    const compose = await readFile(composePath, "utf8");
+    expect(compose).toContain("read_only: true");
     expect(compose).toMatch(/security_opt:\s*\n\s+- no-new-privileges:true/);
     expect(compose).toMatch(/seccomp=\.\/config\/seccomp\/jobbot-web\.json/);
 
-    const seccompPath = path.join(repoRoot, 'config', 'seccomp', 'jobbot-web.json');
-    const profile = JSON.parse(await readFile(seccompPath, 'utf8'));
-    expect(profile.defaultAction).toBe('SCMP_ACT_ERRNO');
+    const seccompPath = path.join(
+      repoRoot,
+      "config",
+      "seccomp",
+      "jobbot-web.json",
+    );
+    const profile = JSON.parse(await readFile(seccompPath, "utf8"));
+    expect(profile.defaultAction).toBe("SCMP_ACT_ERRNO");
     const architectures = profile.architectures
       ? new Set(profile.architectures)
       : new Set(profile.archMap?.map((entry) => entry.architecture));
-    expect(architectures.has('SCMP_ARCH_X86_64')).toBe(true);
+    expect(architectures.has("SCMP_ARCH_X86_64")).toBe(true);
 
     const syscallNames = new Set(
       profile.syscalls
-        ?.filter((entry) => entry.action === 'SCMP_ACT_ALLOW')
-        .flatMap((entry) => entry.names ?? []) ?? []
+        ?.filter((entry) => entry.action === "SCMP_ACT_ALLOW")
+        .flatMap((entry) => entry.names ?? []) ?? [],
     );
-    expect(syscallNames.has('accept4')).toBe(true);
-    expect(syscallNames.has('clone3')).toBe(false);
+    expect(syscallNames.has("accept4")).toBe(true);
+    expect(syscallNames.has("clone3")).toBe(false);
+  });
+
+  it("builds a static browser-only tracker surface with health probes", async () => {
+    const packageJson = JSON.parse(
+      await readFile(path.join(repoRoot, "package.json"), "utf8"),
+    );
+    expect(packageJson.scripts.build).toBe("node scripts/build-static.js");
+    expect(packageJson.scripts["start:static"]).toBe(
+      "node scripts/static-server.js",
+    );
+
+    const staticServer = await readFile(
+      path.join(repoRoot, "scripts", "static-server.js"),
+      "utf8",
+    );
+    expect(staticServer).toContain('app.get("/healthz"');
+    expect(staticServer).toContain('app.get("/livez"');
+    expect(staticServer).toContain("Content-Security-Policy");
+    expect(staticServer).not.toContain("/commands");
+    expect(staticServer).not.toContain("better-sqlite3");
+    expect(staticServer).not.toMatch(/writeFile|appendFile|createWriteStream/);
+  });
+
+  it("documents static privacy boundaries and IndexedDB backup guidance", async () => {
+    const doc = await readFile(
+      path.join(repoRoot, "docs", "privacy-and-security.md"),
+      "utf8",
+    );
+    expect(doc).toContain("stored in the user's browser IndexedDB");
+    expect(doc).toContain("are not posted to jobbot3000 server APIs");
+    expect(doc).toContain("Clear local data");
+    expect(doc).toContain("Browser quota caveats");
   });
 });

--- a/test/web-deployment.test.js
+++ b/test/web-deployment.test.js
@@ -12,24 +12,38 @@ describe("web deployment artifacts", () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");
     expect(dockerfile).toContain("FROM node:20-slim AS deps");
     expect(dockerfile).toContain("npm run build");
+    expect(dockerfile).toContain("COPY --from=build /app/dist ./dist");
+    expect(dockerfile).toContain(
+      "COPY --from=build /app/scripts/static-server.js ./scripts/static-server.js",
+    );
     expect(dockerfile).toContain('CMD ["node", "scripts/static-server.js"]');
+    const runtimeStage = dockerfile.slice(dockerfile.indexOf("AS runtime"));
+    expect(runtimeStage).not.toContain("COPY src ./src");
+    expect(runtimeStage).not.toContain("scripts/web-server.js");
   });
 
-  it("provides a docker-compose definition wiring the web server defaults", async () => {
+  it("provides a docker-compose definition with static-only production defaults", async () => {
     const composePath = path.join(repoRoot, "docker-compose.web.yml");
     const compose = await readFile(composePath, "utf8");
     expect(compose).toContain("services:");
     expect(compose).toContain("JOBBOT_WEB_ENV=production");
-    expect(compose).toContain("JOBBOT_DATA_DIR=/data");
-    expect(compose).toContain("JOBBOT_WEB_ENABLE_NATIVE_CLI=1");
+    expect(compose).toContain(
+      "JOBBOT_WEB_HEALTH_URL=http://127.0.0.1:3000/healthz",
+    );
+    expect(compose).not.toContain("JOBBOT_DATA_DIR");
+    expect(compose).not.toContain("JOBBOT_WEB_ENABLE_NATIVE_CLI");
+    expect(compose).not.toContain("./data:/data");
+    expect(compose).not.toContain("scripts/web-server.js");
+    expect(compose).not.toMatch(/^\s*command:/m);
   });
 
-  it("defines a docker-compose healthcheck targeting the web server /health endpoint", async () => {
+  it("defines a docker-compose healthcheck targeting the static /healthz endpoint", async () => {
     const composePath = path.join(repoRoot, "docker-compose.web.yml");
     const compose = await readFile(composePath, "utf8");
     expect(compose).toContain("healthcheck:");
-    expect(compose).toContain("scripts/docker-healthcheck.js");
-    expect(compose).toContain("http://127.0.0.1:3000/health");
+    expect(compose).toContain("http://127.0.0.1:3000/healthz");
+    expect(compose).not.toContain("scripts/docker-healthcheck.js");
+    expect(compose).not.toMatch(/http:\/\/127\.0\.0\.1:3000\/health(?!z)/);
   });
 
   it("locks the runtime profile with read-only rootfs and a custom seccomp policy", async () => {
@@ -76,6 +90,19 @@ describe("web deployment artifacts", () => {
     );
     expect(staticServer).toContain('app.get("/healthz"');
     expect(staticServer).toContain('app.get("/livez"');
+    expect(staticServer).toContain(
+      'app.get(["/", "/index.html"], sendNoStoreFile("index.html"))',
+    );
+    expect(staticServer).toContain(
+      'app.get(["/tracker", "/tracker.html"], sendNoStoreFile("tracker.html"))',
+    );
+    expect(staticServer).toContain(
+      'app.get("/manifest.webmanifest", sendNoStoreFile("manifest.webmanifest"))',
+    );
+    expect(staticServer).toContain(
+      'res.setHeader("Cache-Control", "no-store")',
+    );
+    expect(staticServer).not.toContain("immutable");
     expect(staticServer).toContain("Content-Security-Policy");
     expect(staticServer).not.toContain("/commands");
     expect(staticServer).not.toContain("better-sqlite3");


### PR DESCRIPTION
### Motivation
- Make the production web path safe to expose as a static/browser-only app where private tracker data remains in the user's browser IndexedDB. 
- Keep the CLI/development server and its SQLite/ filesystem persistence separate and opt-in so containers do not accidentally persist private data.

### Description
- Add static build and serve tooling: `scripts/build-static.js` produces a `dist/` static site and `scripts/static-server.js` serves it with restrictive security headers and `/healthz`/`/livez` liveness endpoints; `package.json` gains `build` and `start:static` scripts. 
- Update `Dockerfile` to build the static assets and run the static server image so runtime containers do not start the CLI-capable web server. 
- Browser UI hardening: add manifest link and “Backup now” export flow plus a confirmed “Clear local data” action that clears the `jobbot3000` IndexedDB and shows success messaging. 
- Server-side: expose the tracker manifest via `src/web/server.js` so non-static/dev server mode still resolves the manifest; server still emits strong CSP/permissions/referrer headers. 
- Documentation and tests: add `docs/privacy-and-security.md`, update `README.md` to clarify deployment boundaries, and add tests asserting static server health probes, static privacy boundaries, and a Playwright coverage test that verifies reload/backup/clear flows (Playwright test added but environment browser executable may be missing). 

### Testing
- Formatting and lint: ran `npx prettier --check ...` for changed files (ok) and `npm run format:check` (repo-wide Prettier warnings remain on unrelated files); `npm run lint` passed. 
- Typecheck and build: `npm run typecheck` passed and `npm run build` produced `dist/` successfully. 
- Unit/CI tests: `npx vitest run test/web-deployment.test.js test/web-storage-indexeddb-repository.test.js` passed. 
- Static server smoke: `npm run build && PORT=3911 npm run start:static` then `curl http://127.0.0.1:3911/healthz` and `curl -I /tracker` succeeded and returned the expected JSON and security headers. 
- Playwright / end-to-end: `npx playwright test ...` was attempted but blocked because the Chromium executable was not installed in this environment (run `npx playwright install` in CI to enable). 
- Full `npm run test:ci` was attempted but an existing long-running CLI test/hook blocked completion in this environment and was stopped; focused Vitest checks above passed.

Residual notes: repo-wide Prettier/style warnings pre-existed and are unchanged by this PR, Playwright-based e2e checks require browser install in CI, and `test:ci` can be flaky because it drives heavier environment setup; follow-ups may add CI steps to ensure Playwright browsers are available and to separate any long-running CLI tasks in `test:ci`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a44bae1c14c832f8a7eb2ef970fea64)