### PR TITLE
Add Sugarkube Helm chart and OCI publishing workflow

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -1,0 +1,136 @@
+name: Validate and publish Helm chart
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "charts/jobbot3000/**"
+      - "scripts/validate-helm.sh"
+      - ".github/workflows/ci-helm.yml"
+      - "docs/release-helm.md"
+      - "README.md"
+  push:
+    branches: [main]
+    tags:
+      - "v*.*.*"
+    paths:
+      - "charts/jobbot3000/**"
+      - "scripts/validate-helm.sh"
+      - ".github/workflows/ci-helm.yml"
+      - "docs/release-helm.md"
+      - "README.md"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CHART_DIR: charts/jobbot3000
+  CHART_REPOSITORY: oci://ghcr.io/futuroptimist/charts
+
+jobs:
+  validate:
+    name: Lint and template Helm chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      chart_version: ${{ steps.meta.outputs.chart_version }}
+      publish: ${{ steps.meta.outputs.publish }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Validate Helm chart
+        run: ./scripts/validate-helm.sh "${CHART_DIR}"
+
+      - name: Compute chart metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          chart_version="$(helm show chart "${CHART_DIR}" | awk -F': ' '$1 == "version" { print $2; exit }')"
+          publish=false
+
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            case "${GITHUB_REF}" in
+              refs/heads/main|refs/tags/v[0-9]*.[0-9]*.[0-9]*)
+                publish=true
+                ;;
+            esac
+          fi
+
+          {
+            echo "chart_version=${chart_version}"
+            echo "publish=${publish}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Summarize validation
+        shell: bash
+        run: |
+          {
+            echo "## jobbot3000 Helm chart validation"
+            echo ""
+            echo "Chart: \`${CHART_DIR}\`"
+            echo "Version: \`${{ steps.meta.outputs.chart_version }}\`"
+            echo "Publish eligible: \`${{ steps.meta.outputs.publish }}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  publish:
+    name: Publish OCI Helm chart
+    runs-on: ubuntu-latest
+    needs: validate
+    if: needs.validate.outputs.publish == 'true'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Log in to GHCR for Helm OCI
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: printf '%s' "${GHCR_TOKEN}" | helm registry login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+
+      - name: Refuse to republish existing chart version
+        shell: bash
+        run: |
+          set -euo pipefail
+          chart_ref="${CHART_REPOSITORY}/jobbot3000"
+          chart_version="${{ needs.validate.outputs.chart_version }}"
+
+          if helm show chart "${chart_ref}" --version "${chart_version}" >/tmp/existing-jobbot3000-chart.yaml 2>/tmp/existing-jobbot3000-chart.err; then
+            echo "Chart ${chart_ref}:${chart_version} already exists; bump ${CHART_DIR}/Chart.yaml version before publishing." >&2
+            exit 1
+          fi
+
+      - name: Package Helm chart
+        run: helm package "${CHART_DIR}" --destination /tmp/jobbot3000-chart
+
+      - name: Push Helm chart to GHCR OCI registry
+        shell: bash
+        run: |
+          set -euo pipefail
+          chart_package="/tmp/jobbot3000-chart/jobbot3000-${{ needs.validate.outputs.chart_version }}.tgz"
+          helm push "${chart_package}" "${CHART_REPOSITORY}"
+
+      - name: Summarize published chart
+        shell: bash
+        run: |
+          chart_version="${{ needs.validate.outputs.chart_version }}"
+          chart_ref="${CHART_REPOSITORY}/jobbot3000"
+          {
+            echo "## jobbot3000 Helm chart published"
+            echo ""
+            echo "Published chart: \`${chart_ref}:${chart_version}\`"
+            echo "Sugarkube chart repository: \`${chart_ref}\`"
+            echo "Sugarkube chart version pin: \`${chart_version}\`"
+            echo ""
+            echo "Update Sugarkube to pin \`${chart_ref}\` at version \`${chart_version}\` and set \`image.tag\` to the desired immutable image tag, for example \`main-<short-sha>\`."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+charts/**/templates/*.yaml
+charts/**/templates/*.tpl

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm run dev
 # Open http://127.0.0.1:3100
 ```
 
-For production static tracker builds, run `npm run build` and serve `dist/` with `npm run start:static`; `/healthz` and `/livez` are available for container probes.
+For production static tracker builds, run `npm run build` and serve `dist/` with `npm run start:static`; `/healthz` and `/livez` are available for container probes. The production image is published to `ghcr.io/futuroptimist/jobbot3000`, and the Sugarkube-ready Helm chart is published to `oci://ghcr.io/futuroptimist/charts/jobbot3000`; see [docs/release-ghcr.md](docs/release-ghcr.md) and [docs/release-helm.md](docs/release-helm.md) for release and deployment details.
 
 The development web server starts with backend functionality enabled.
 Use `npm run web:server -- --disable-native-cli` if you want to explore the
@@ -158,6 +158,8 @@ Run the snippet with `node example.js` after saving it to a file in the project 
 - [docs/browser-first-architecture.md](docs/browser-first-architecture.md) – planned IndexedDB-first production web architecture and browser data contract
 - [docs/privacy-and-security.md](docs/privacy-and-security.md) – browser-only production privacy model, backups, clearing data, quota caveats, and static security headers
 - [docs/indexeddb-persistence.md](docs/indexeddb-persistence.md) – browser IndexedDB persistence, backup/restore, and quota caveats
+- [docs/release-ghcr.md](docs/release-ghcr.md) – GHCR static image release workflow
+- [docs/release-helm.md](docs/release-helm.md) – Helm chart validation, OCI publishing, and Sugarkube chart pin workflow
 - [docs/spreadsheet-replacement.md](docs/spreadsheet-replacement.md) – CSV/JSON/NDJSON import-export workflow for replacing the current spreadsheet
 - [docs/backup-restore-guide.md](docs/backup-restore-guide.md) – backup, restore, and verification
   steps

--- a/charts/jobbot3000/Chart.yaml
+++ b/charts/jobbot3000/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v2
+name: jobbot3000
+description: Browser-local job search tracker static web app for Sugarkube generic app deployments.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://github.com/futuroptimist/jobbot3000
+sources:
+  - https://github.com/futuroptimist/jobbot3000
+maintainers:
+  - name: futuroptimist
+annotations:
+  org.opencontainers.image.source: https://github.com/futuroptimist/jobbot3000

--- a/charts/jobbot3000/templates/_helpers.tpl
+++ b/charts/jobbot3000/templates/_helpers.tpl
@@ -1,0 +1,29 @@
+{{- define "jobbot3000.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "jobbot3000.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "jobbot3000.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | quote }}
+app.kubernetes.io/name: {{ include "jobbot3000.name" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+{{- end -}}
+
+{{- define "jobbot3000.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "jobbot3000.name" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+{{- end -}}

--- a/charts/jobbot3000/templates/deployment.yaml
+++ b/charts/jobbot3000/templates/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "jobbot3000.fullname" . }}
+  labels:
+    {{- include "jobbot3000.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "jobbot3000.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "jobbot3000.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      containers:
+        - name: {{ include "jobbot3000.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/jobbot3000/templates/ingress.yaml
+++ b/charts/jobbot3000/templates/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "jobbot3000.fullname" . }}
+  labels:
+    {{- include "jobbot3000.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "jobbot3000.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/charts/jobbot3000/templates/service.yaml
+++ b/charts/jobbot3000/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jobbot3000.fullname" . }}
+  labels:
+    {{- include "jobbot3000.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "jobbot3000.selectorLabels" . | nindent 4 }}

--- a/charts/jobbot3000/values-dev.yaml
+++ b/charts/jobbot3000/values-dev.yaml
@@ -1,0 +1,14 @@
+image:
+  tag: main-latest
+
+ingress:
+  enabled: false
+  host: jobbot3000-dev.example.invalid
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 32Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi

--- a/charts/jobbot3000/values-prod.yaml
+++ b/charts/jobbot3000/values-prod.yaml
@@ -1,0 +1,20 @@
+image:
+  tag: main-REPLACE_WITH_RELEASE_SHA
+  pullPolicy: IfNotPresent
+
+ingress:
+  enabled: true
+  host: jobbot3000.example.invalid
+  className: nginx
+  tls:
+    - secretName: jobbot3000-tls-placeholder
+      hosts:
+        - jobbot3000.example.invalid
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 500m
+    memory: 256Mi

--- a/charts/jobbot3000/values-staging.yaml
+++ b/charts/jobbot3000/values-staging.yaml
@@ -1,0 +1,16 @@
+image:
+  tag: main-TESTSHA
+
+ingress:
+  enabled: true
+  host: jobbot3000-staging.example.invalid
+  className: nginx
+  tls: []
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 32Mi
+  limits:
+    cpu: 250m
+    memory: 128Mi

--- a/charts/jobbot3000/values.yaml
+++ b/charts/jobbot3000/values.yaml
@@ -1,0 +1,54 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/jobbot3000
+  tag: main-latest
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+podLabels: {}
+podAnnotations: {}
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 101
+  runAsGroup: 101
+  fsGroup: 101
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 80
+
+containerPort: 8080
+
+ingress:
+  enabled: false
+  host: jobbot3000.example.invalid
+  className: ""
+  annotations: {}
+  tls: []
+
+resources: {}
+
+probes:
+  liveness:
+    path: /livez
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+  readiness:
+    path: /healthz
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3

--- a/docs/release-helm.md
+++ b/docs/release-helm.md
@@ -1,0 +1,68 @@
+# Helm chart release guide
+
+jobbot3000 owns its Sugarkube-ready Helm chart in `charts/jobbot3000`. The chart is published as an immutable OCI artifact at `oci://ghcr.io/futuroptimist/charts/jobbot3000`.
+
+## Chart versions vs. image tags
+
+- **Chart version**: `charts/jobbot3000/Chart.yaml` `version`. Bump this only when Kubernetes manifests, default values, chart docs, or the deployment contract change.
+- **App version**: `charts/jobbot3000/Chart.yaml` `appVersion`. This documents the application release but does not select the image at runtime.
+- **Image tag**: `values.yaml` `image.tag`, or a Sugarkube override. This selects the container image, such as `main-<short-sha>`, while the chart version remains the deployment package version.
+
+Sugarkube should pin both the chart version and an immutable image tag. Updating the browser app without a chart contract change usually means changing only the Sugarkube `image.tag` value.
+
+## When to bump `Chart.yaml` version
+
+Bump `charts/jobbot3000/Chart.yaml` `version` before merging changes that affect any of these areas:
+
+- rendered Deployment, Service, or Ingress resources;
+- chart values, defaults, or example environment values;
+- probe, port, resource, label, annotation, or security context behavior;
+- compatibility with the Sugarkube generic app deployment contract.
+
+Chart versions are immutable after publishing. If a publish job reports that the version already exists in GHCR, do not delete or overwrite it; bump the chart version and merge a new release commit.
+
+## Validate the chart locally
+
+```bash
+./scripts/validate-helm.sh charts/jobbot3000
+helm lint charts/jobbot3000
+helm template jobbot3000 charts/jobbot3000 --set image.tag=main-TESTSHA
+helm template jobbot3000-staging charts/jobbot3000 \
+  -f charts/jobbot3000/values-staging.yaml \
+  --set image.tag=main-TESTSHA \
+  --set ingress.host=jobbot3000-staging.example.invalid
+helm template jobbot3000-prod charts/jobbot3000 \
+  -f charts/jobbot3000/values-prod.yaml \
+  --set image.tag=main-TESTSHA \
+  --set ingress.host=jobbot3000.example.invalid
+```
+
+The chart intentionally does not create Secrets, PersistentVolumes, PersistentVolumeClaims, or user-data volumes. jobbot3000 serves static assets and stores private tracker data in the browser's IndexedDB.
+
+## Publish the chart
+
+1. Bump `charts/jobbot3000/Chart.yaml` `version` explicitly when the chart contract changes.
+2. Open a pull request. `.github/workflows/ci-helm.yml` runs `helm lint` and template checks on PRs.
+3. Merge to `main`, or push a semver tag such as `v0.1.0`. The workflow packages the chart and pushes it to GHCR only for eligible push events.
+4. Confirm the workflow summary prints the published chart reference and version pin.
+
+The workflow refuses to publish if `oci://ghcr.io/futuroptimist/charts/jobbot3000:<version>` already exists.
+
+## Bump Sugarkube after publish
+
+After the chart publish succeeds, update Sugarkube's app pin to the printed values:
+
+```yaml
+chart:
+  repository: oci://ghcr.io/futuroptimist/charts/jobbot3000
+  version: 0.1.0
+values:
+  image:
+    repository: ghcr.io/futuroptimist/jobbot3000
+    tag: main-REPLACE_WITH_RELEASE_SHA
+  ingress:
+    enabled: true
+    host: jobbot3000.example.invalid
+```
+
+Replace the example host and image tag in Sugarkube. Do not put real hostnames, TLS secrets, or user data into this repository's default chart values.

--- a/scripts/validate-helm.sh
+++ b/scripts/validate-helm.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="${1:-charts/jobbot3000}"
+
+helm lint "${chart_dir}"
+helm template jobbot3000 "${chart_dir}" --set image.tag=main-TESTSHA >/tmp/jobbot3000-default.yaml
+helm template jobbot3000-staging "${chart_dir}" \
+  -f "${chart_dir}/values-staging.yaml" \
+  --set image.tag=main-TESTSHA \
+  --set ingress.host=jobbot3000-staging.example.invalid >/tmp/jobbot3000-staging.yaml
+helm template jobbot3000-prod "${chart_dir}" \
+  -f "${chart_dir}/values-prod.yaml" \
+  --set image.tag=main-TESTSHA \
+  --set ingress.host=jobbot3000.example.invalid \
+  --set ingress.tls[0].hosts[0]=jobbot3000.example.invalid >/tmp/jobbot3000-prod.yaml


### PR DESCRIPTION
### Motivation
- Provide an app-owned Helm chart and CI publish workflow so Sugarkube can deploy jobbot3000 via the generic app contract and pin an immutable OCI chart at `oci://ghcr.io/futuroptimist/charts/jobbot3000`.
- Keep the chart aligned with the repository-owned image at `ghcr.io/futuroptimist/jobbot3000` while avoiding server-side persistence, secrets, or user data volumes.

### Description
- Add a Helm chart at `charts/jobbot3000` including `Chart.yaml`, `values.yaml` (dev/staging/prod examples), and templates for `Deployment`, `Service`, optional `Ingress`, and helpers; chart supports `image.repository`, `image.tag`, `image.pullPolicy`, service/container ports, `ingress.*`, `resources`, `podLabels`/`podAnnotations`, `securityContext` / `containerSecurityContext`, and probes for `/healthz` and `/livez`.
- Add a local validator script `scripts/validate-helm.sh` that runs `helm lint` and `helm template` for default, staging, and prod example values.
- Add CI workflow `.github/workflows/ci-helm.yml` to run lint/template checks on PRs and publish immutable OCI chart versions to GHCR on eligible `main` or semver-tag pushes, including a guard that refuses to republish an existing chart version and prints the published chart ref plus Sugarkube pin instructions in the workflow summary.
- Add docs `docs/release-helm.md` explaining when to bump `Chart.yaml` version, how to publish, and how image tags differ from chart versions, and update `README.md` to link the image and chart release docs; add `.prettierignore` to avoid formatting helm templates during repository-wide Prettier runs.

### Testing
- `./scripts/validate-helm.sh charts/jobbot3000` — passed locally after installing Helm (ran `helm lint` and `helm template` for default/staging/prod) and produced rendered manifests without secrets or PVs.
- `helm lint charts/jobbot3000 && helm template jobbot3000 charts/jobbot3000 --set image.tag=main-TESTSHA` — passed and wrote `/tmp/jobbot3000-template.yaml`.
- `npm run typecheck`, `npm run lint`, `npm run build`, and `npm run test:ci` — all completed successfully (`npm run test:ci` reports 974 tests passed in this environment).
- `npx prettier --check` on the new chart and workflow files and targeted template files — passed; note `npm run format:check` flagged repository-wide Prettier drift outside this patch (changed files were formatted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45e3a2e848832f84cfccfe9d4eb59d)