### PR TITLE
Add Sugarkube Helm chart and OCI publishing workflow

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -1,0 +1,142 @@
+name: Validate and publish Helm chart
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "charts/jobbot3000/**"
+      - "scripts/validate-helm-chart.sh"
+      - ".github/workflows/ci-helm.yml"
+      - "docs/release-helm.md"
+  push:
+    branches: [main]
+    tags:
+      - "v*.*.*"
+      - "jobbot3000-chart-v*.*.*"
+    paths:
+      - "charts/jobbot3000/**"
+      - "scripts/validate-helm-chart.sh"
+      - ".github/workflows/ci-helm.yml"
+      - "docs/release-helm.md"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CHART_DIR: charts/jobbot3000
+  OCI_REGISTRY: ghcr.io
+  OCI_NAMESPACE: futuroptimist/charts
+
+jobs:
+  validate:
+    name: Helm lint and render
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      chart_version: ${{ steps.chart.outputs.version }}
+      publish: ${{ steps.meta.outputs.publish }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Read chart version
+        id: chart
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(helm show chart "${CHART_DIR}" | awk '/^version:/ {print $2}')"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Decide publish eligibility
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish=false
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            case "${GITHUB_REF}" in
+              refs/heads/main|refs/tags/v[0-9]*.[0-9]*.[0-9]*|refs/tags/jobbot3000-chart-v[0-9]*.[0-9]*.[0-9]*)
+                publish=true
+                ;;
+            esac
+          fi
+          echo "publish=${publish}" >> "${GITHUB_OUTPUT}"
+
+      - name: Validate chart
+        run: scripts/validate-helm-chart.sh "${CHART_DIR}"
+
+      - name: Summarize validation
+        shell: bash
+        run: |
+          {
+            echo "## jobbot3000 Helm chart validation"
+            echo ""
+            echo "Chart version: \`${{ steps.chart.outputs.version }}\`"
+            echo "Chart ref after publish: \`oci://ghcr.io/futuroptimist/charts/jobbot3000 --version ${{ steps.chart.outputs.version }}\`"
+            echo "Publish eligible: \`${{ steps.meta.outputs.publish }}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  publish:
+    name: Publish OCI chart
+    runs-on: ubuntu-latest
+    needs: validate
+    if: needs.validate.outputs.publish == 'true'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Log in to GHCR
+        shell: bash
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          printf '%s' "${GHCR_TOKEN}" | helm registry login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+
+      - name: Refuse to republish existing chart version
+        shell: bash
+        run: |
+          set -euo pipefail
+          chart_version="${{ needs.validate.outputs.chart_version }}"
+          if helm pull "oci://${OCI_REGISTRY}/${OCI_NAMESPACE}/jobbot3000" --version "${chart_version}" --destination /tmp >/dev/null 2>&1; then
+            echo "Chart version ${chart_version} already exists in oci://${OCI_REGISTRY}/${OCI_NAMESPACE}/jobbot3000; bump charts/jobbot3000/Chart.yaml version before publishing." >&2
+            exit 1
+          fi
+
+      - name: Package chart
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p dist/charts
+          helm package "${CHART_DIR}" --destination dist/charts
+
+      - name: Push chart to GHCR OCI registry
+        shell: bash
+        run: |
+          set -euo pipefail
+          chart_version="${{ needs.validate.outputs.chart_version }}"
+          helm push "dist/charts/jobbot3000-${chart_version}.tgz" "oci://${OCI_REGISTRY}/${OCI_NAMESPACE}"
+
+      - name: Summarize published chart
+        shell: bash
+        run: |
+          chart_version="${{ needs.validate.outputs.chart_version }}"
+          chart_ref="oci://${OCI_REGISTRY}/${OCI_NAMESPACE}/jobbot3000"
+          {
+            echo "## jobbot3000 Helm chart published"
+            echo ""
+            echo "Published chart version: \`${chart_version}\`"
+            echo "Chart ref: \`${chart_ref}\`"
+            echo "Sugarkube pin instructions: set the app chart repository to \`${chart_ref}\` and chart version to \`${chart_version}\`."
+            echo "Example render: \`helm template jobbot3000 ${chart_ref} --version ${chart_version} --set image.tag=main-SHORTSHA\`"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+charts/**/templates/*.yaml
+charts/**/templates/*.tpl

--- a/README.md
+++ b/README.md
@@ -149,6 +149,13 @@ console.log(await response.json());
 
 Run the snippet with `node example.js` after saving it to a file in the project root.
 
+## Release and deployment
+
+The production deployment artifact is a static, browser-local web app: the container serves built assets plus `/healthz` and `/livez`, while private tracker data stays in user-owned IndexedDB.
+
+- [GHCR image release workflow](docs/release-ghcr.md) explains immutable image tags such as `ghcr.io/futuroptimist/jobbot3000:main-SHORTSHA` and why Sugarkube should avoid mutable production tags.
+- [Helm chart release workflow](docs/release-helm.md) explains the app-owned chart at `oci://ghcr.io/futuroptimist/charts/jobbot3000`, when to bump `charts/jobbot3000/Chart.yaml`, and how Sugarkube should pin chart versions separately from image tags.
+
 ## Documentation
 
 - [DESIGN.md](DESIGN.md) – architecture details and roadmap

--- a/charts/jobbot3000/Chart.yaml
+++ b/charts/jobbot3000/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: jobbot3000
+description: Static browser-local job search tracker for Sugarkube generic app deployments.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://github.com/futuroptimist/jobbot3000
+sources:
+  - https://github.com/futuroptimist/jobbot3000
+maintainers:
+  - name: futuroptimist

--- a/charts/jobbot3000/ci/values-prod.yaml
+++ b/charts/jobbot3000/ci/values-prod.yaml
@@ -1,0 +1,11 @@
+image:
+  tag: main-TESTSHA
+
+ingress:
+  enabled: true
+  host: jobbot3000.example.invalid
+  className: sugarkube
+  tls:
+    - secretName: jobbot3000-tls-example
+      hosts:
+        - jobbot3000.example.invalid

--- a/charts/jobbot3000/ci/values-staging.yaml
+++ b/charts/jobbot3000/ci/values-staging.yaml
@@ -1,0 +1,7 @@
+image:
+  tag: main-TESTSHA
+
+ingress:
+  enabled: true
+  host: jobbot3000-staging.example.invalid
+  className: sugarkube

--- a/charts/jobbot3000/templates/_helpers.tpl
+++ b/charts/jobbot3000/templates/_helpers.tpl
@@ -1,0 +1,29 @@
+{{- define "jobbot3000.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "jobbot3000.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "jobbot3000.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "jobbot3000.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "jobbot3000.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "jobbot3000.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/jobbot3000/templates/deployment.yaml
+++ b/charts/jobbot3000/templates/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "jobbot3000.fullname" . }}
+  labels:
+    {{ include "jobbot3000.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{ include "jobbot3000.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{ include "jobbot3000.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      securityContext:
+        {{ toYaml .Values.securityContext | nindent 8 }}
+      containers:
+        - name: {{ include "jobbot3000.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{ toYaml .Values.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          {{- with .Values.resources }}
+          resources:
+            {{ toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/jobbot3000/templates/ingress.yaml
+++ b/charts/jobbot3000/templates/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "jobbot3000.fullname" . }}
+  labels:
+    {{ include "jobbot3000.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ required "ingress.host is required when ingress.enabled=true" .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "jobbot3000.fullname" . }}
+                port:
+                  name: http
+{{- end }}

--- a/charts/jobbot3000/templates/service.yaml
+++ b/charts/jobbot3000/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jobbot3000.fullname" . }}
+  labels:
+    {{ include "jobbot3000.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{ include "jobbot3000.selectorLabels" . | nindent 4 }}

--- a/charts/jobbot3000/values-dev.yaml
+++ b/charts/jobbot3000/values-dev.yaml
@@ -1,0 +1,13 @@
+image:
+  tag: main-latest
+
+podLabels:
+  sugarkube.io/environment: dev
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 256Mi

--- a/charts/jobbot3000/values-prod.yaml
+++ b/charts/jobbot3000/values-prod.yaml
@@ -1,0 +1,22 @@
+image:
+  tag: main-REPLACE_WITH_SHORT_SHA
+
+podLabels:
+  sugarkube.io/environment: prod
+
+ingress:
+  enabled: true
+  host: jobbot3000.example.invalid
+  className: sugarkube
+  tls:
+    - secretName: jobbot3000-tls-example
+      hosts:
+        - jobbot3000.example.invalid
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 96Mi
+  limits:
+    cpu: 500m
+    memory: 384Mi

--- a/charts/jobbot3000/values-staging.yaml
+++ b/charts/jobbot3000/values-staging.yaml
@@ -1,0 +1,19 @@
+image:
+  tag: main-REPLACE_WITH_SHORT_SHA
+
+podLabels:
+  sugarkube.io/environment: staging
+
+ingress:
+  enabled: true
+  host: jobbot3000-staging.example.invalid
+  className: sugarkube
+  tls: []
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 96Mi
+  limits:
+    cpu: 500m
+    memory: 384Mi

--- a/charts/jobbot3000/values.yaml
+++ b/charts/jobbot3000/values.yaml
@@ -1,0 +1,55 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/jobbot3000
+  tag: main-latest
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+podLabels: {}
+podAnnotations: {}
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 80
+
+containerPort: 8080
+
+ingress:
+  enabled: false
+  host: ""
+  className: ""
+  annotations: {}
+  tls: []
+
+resources: {}
+
+probes:
+  liveness:
+    path: /livez
+    initialDelaySeconds: 10
+    periodSeconds: 20
+    timeoutSeconds: 2
+    failureThreshold: 3
+  readiness:
+    path: /healthz
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3

--- a/docs/release-helm.md
+++ b/docs/release-helm.md
@@ -1,0 +1,64 @@
+# Helm chart release workflow
+
+jobbot3000 owns its Sugarkube deploy chart in `charts/jobbot3000`. The chart publishes to GHCR as an OCI chart at:
+
+```text
+oci://ghcr.io/futuroptimist/charts/jobbot3000
+```
+
+The chart deploys only the static web container. It does not create Secrets, persistent volumes, or server-side data stores because production tracker data remains in each user's browser IndexedDB.
+
+## When to bump `Chart.yaml` version
+
+Bump `charts/jobbot3000/Chart.yaml` `version` for every chart package you intend to publish. OCI chart versions are immutable: the workflow refuses to publish when the same chart version already exists in GHCR.
+
+Bump the chart version when you change Kubernetes-rendered behavior, including templates, defaults, probes, labels, annotations, ingress handling, or Sugarkube-facing values. Use SemVer-style increments:
+
+- patch: docs-adjacent chart fixes or safe default tweaks,
+- minor: new optional values or backwards-compatible resources,
+- major: breaking values changes or deployment contract changes.
+
+`appVersion` is informational and does not replace the chart package version.
+
+## Validate locally
+
+```bash
+scripts/validate-helm-chart.sh charts/jobbot3000
+```
+
+That wrapper runs `helm lint`, renders the default chart with a test image tag, and renders staging/prod ingress examples.
+
+## Publish the chart
+
+Open a pull request with the chart change and version bump. The `Validate and publish Helm chart` workflow lints and renders the chart on PRs.
+
+After merge, a push to `main` publishes the chart when validation passes. SemVer tags such as `v1.2.3` and chart tags such as `jobbot3000-chart-v1.2.3` are also publish-eligible. The workflow logs in with `GITHUB_TOKEN`, checks whether the target chart version already exists, packages the chart, and pushes it to GHCR.
+
+The run summary prints the published version and the Sugarkube pin to copy.
+
+## Bump the Sugarkube chart pin
+
+After publish, update the Sugarkube app definition to pin both:
+
+```text
+chart: oci://ghcr.io/futuroptimist/charts/jobbot3000
+version: 0.1.0
+```
+
+Replace `0.1.0` with the published chart version from the workflow summary. Keep environment-specific values outside this app repo unless they are generic examples. The example files under `charts/jobbot3000/values-*.yaml` use placeholder `.example.invalid` hosts only.
+
+## Image tags vs. chart versions
+
+The image tag selects the static web build to run, for example:
+
+```text
+ghcr.io/futuroptimist/jobbot3000:main-abc123def456
+```
+
+The chart version selects the Kubernetes packaging and defaults, for example:
+
+```text
+oci://ghcr.io/futuroptimist/charts/jobbot3000 --version 0.1.0
+```
+
+Sugarkube should pin both independently: update the image tag for app-code releases, update the chart version for deployment-contract changes, and update both when a release needs new Kubernetes behavior plus a new image.

--- a/scripts/validate-helm-chart.sh
+++ b/scripts/validate-helm-chart.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="${1:-charts/jobbot3000}"
+
+helm lint "${chart_dir}"
+helm template jobbot3000 "${chart_dir}" --set image.tag=main-TESTSHA >/tmp/jobbot3000-default.yaml
+helm template jobbot3000-staging "${chart_dir}" -f "${chart_dir}/ci/values-staging.yaml" >/tmp/jobbot3000-staging.yaml
+helm template jobbot3000-prod "${chart_dir}" -f "${chart_dir}/ci/values-prod.yaml" >/tmp/jobbot3000-prod.yaml


### PR DESCRIPTION
### Motivation

- Provide an app-owned Helm chart so Sugarkube can deploy jobbot3000 using the generic app deployment contract and pin immutable chart versions. 
- Keep the repo-owned deployment contract aligned with the existing GHCR image publish flow (`ghcr.io/futuroptimist/jobbot3000`).
- Avoid server-side state in the chart because the production tracker is browser-local and stores private data in IndexedDB.

### Description

- Added an application Helm chart at `charts/jobbot3000` including `Chart.yaml`, `values.yaml`, dev/staging/prod example values, and templates for `Deployment`, `Service`, and optional `Ingress`, with support for `image.repository`, `image.tag`, `image.pullPolicy`, service/container ports, `ingress.enabled`, `ingress.host`, `ingress.className`, `ingress.tls`, `resources`, pod `labels`/`annotations`, `securityContext`, `containerSecurityContext`, and probes for `/healthz` and `/livez`.
- Added `scripts/validate-helm-chart.sh` to run `helm lint` and `helm template` renders for default/staging/prod fixtures and `.prettierignore` entries so Prettier does not rewrite Go-template YAML.
- Added a GitHub Actions workflow `.github/workflows/ci-helm.yml` that lints/renders the chart on PRs and publishes an OCI chart to `oci://ghcr.io/futuroptimist/charts/jobbot3000` only on `main` pushes or semver-style tags while refusing to republish an existing chart version.
- Added `docs/release-helm.md` describing when to bump `Chart.yaml`, how to publish, Sugarkube pin instructions, and clarifying image tag vs chart version, and updated `README.md` release/deployment links.

### Testing

- Ran formatting and style checks with `npm run format:check` which reported repository-wide formatting drift (pre-existing warnings) while staged chart files passed the pre-commit prettier check.
- Ran code validation and CI suites with `npm run lint`, `npm run typecheck`, `npm run test:ci`, and `npm run build`, all of which completed successfully in this environment.
- Validated the chart locally with `helm lint charts/jobbot3000`, `helm template jobbot3000 charts/jobbot3000 --set image.tag=main-TESTSHA`, and `scripts/validate-helm-chart.sh charts/jobbot3000`, all of which succeeded and produced rendered manifests for default, staging, and prod examples.
- Verified repository checks `git diff --cached --check` and `git diff --cached | ./scripts/scan-secrets.py` ran without detecting blocking issues in the staged changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45e3b12d64832fb06d51fc08ae8664)