### PR TITLE
feat: add Sugarkube Helm chart publishing

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -1,0 +1,154 @@
+name: Helm chart
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "charts/jobbot3000/**"
+      - "scripts/validate-helm.sh"
+      - ".github/workflows/ci-helm.yml"
+      - "docs/release-helm.md"
+      - "README.md"
+  push:
+    branches: [main]
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+    paths:
+      - "charts/jobbot3000/**"
+      - "scripts/validate-helm.sh"
+      - ".github/workflows/ci-helm.yml"
+      - "docs/release-helm.md"
+      - "README.md"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CHART_DIR: charts/jobbot3000
+  OCI_REGISTRY: ghcr.io
+  OCI_REPOSITORY: futuroptimist/charts
+  CHART_REF: oci://ghcr.io/futuroptimist/charts/jobbot3000
+
+jobs:
+  validate:
+    name: Lint and render chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      chart_version: ${{ steps.chart.outputs.version }}
+      publish: ${{ steps.publish.outputs.publish }}
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Validate Helm chart
+        run: scripts/validate-helm.sh "$CHART_DIR"
+
+      - name: Read chart version
+        id: chart
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(helm show chart "$CHART_DIR" | awk '$1 == "version:" { print $2; exit }')"
+          if [ -z "$version" ]; then
+            echo "Chart.yaml version is required." >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Decide whether to publish
+        id: publish
+        shell: bash
+        run: |
+          set -euo pipefail
+          publish=false
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            case "${GITHUB_REF}" in
+              refs/heads/main|refs/tags/v[0-9]*.[0-9]*.[0-9]*) publish=true ;;
+            esac
+          fi
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+            publish=true
+          fi
+          echo "publish=${publish}" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize validation
+        shell: bash
+        run: |
+          {
+            echo "## jobbot3000 Helm validation"
+            echo ""
+            echo "Chart version: \`${{ steps.chart.outputs.version }}\`"
+            echo "Chart reference: \`${CHART_REF}\`"
+            echo "Publish candidate: \`${{ steps.publish.outputs.publish }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish:
+    name: Publish OCI chart
+    runs-on: ubuntu-latest
+    needs: validate
+    if: needs.validate.outputs.publish == 'true'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Log in to GHCR for Helm
+        shell: bash
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$GHCR_TOKEN" | helm registry login "$OCI_REGISTRY" -u "$GITHUB_ACTOR" --password-stdin
+
+      - name: Refuse to republish existing chart version
+        shell: bash
+        run: |
+          set -euo pipefail
+          chart_version="${{ needs.validate.outputs.chart_version }}"
+          if helm show chart "oci://${OCI_REGISTRY}/${OCI_REPOSITORY}/jobbot3000" --version "$chart_version" >/tmp/existing-chart.yaml 2>/tmp/existing-chart.err; then
+            echo "Chart version ${chart_version} already exists at ${CHART_REF}; bump charts/jobbot3000/Chart.yaml before publishing." >&2
+            exit 1
+          fi
+          cat /tmp/existing-chart.err || true
+
+      - name: Package chart
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .helm-packages
+          helm package "$CHART_DIR" --destination .helm-packages
+
+      - name: Push chart to GHCR OCI registry
+        id: push
+        shell: bash
+        run: |
+          set -euo pipefail
+          chart_package=".helm-packages/jobbot3000-${{ needs.validate.outputs.chart_version }}.tgz"
+          helm push "$chart_package" "oci://${OCI_REGISTRY}/${OCI_REPOSITORY}"
+          echo "chart_package=${chart_package}" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize published chart
+        shell: bash
+        run: |
+          chart_version="${{ needs.validate.outputs.chart_version }}"
+          {
+            echo "## jobbot3000 Helm chart published"
+            echo ""
+            echo "Published chart: \`${CHART_REF}\`"
+            echo "Published chart version: \`${chart_version}\`"
+            echo ""
+            echo "### Sugarkube pin instructions"
+            echo ""
+            echo "Pin chart repository \`oci://ghcr.io/futuroptimist/charts/jobbot3000\` with chart version \`${chart_version}\`."
+            echo "Set the app image tag separately, for example \`image.tag=main-<short-sha>\`."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+charts/**/templates/*.yaml
+charts/**/templates/*.tpl

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ npm run dev
 
 For production static tracker builds, run `npm run build` and serve `dist/` with `npm run start:static`; `/healthz` and `/livez` are available for container probes.
 
+Container images are published to `ghcr.io/futuroptimist/jobbot3000`, and the app-owned Sugarkube Helm chart is published at `oci://ghcr.io/futuroptimist/charts/jobbot3000`. See [docs/release-ghcr.md](docs/release-ghcr.md) for image release details and [docs/release-helm.md](docs/release-helm.md) for chart versioning, publishing, and Sugarkube pin guidance.
+
 The development web server starts with backend functionality enabled.
 Use `npm run web:server -- --disable-native-cli` if you want to explore the
 mock-only UI without spawning CLI subprocesses.

--- a/charts/jobbot3000/Chart.yaml
+++ b/charts/jobbot3000/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: jobbot3000
+description: Browser-first static jobbot3000 web app for Sugarkube generic app deployments.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://github.com/futuroptimist/jobbot3000
+sources:
+  - https://github.com/futuroptimist/jobbot3000
+maintainers:
+  - name: futuroptimist

--- a/charts/jobbot3000/README.md
+++ b/charts/jobbot3000/README.md
@@ -1,0 +1,18 @@
+# jobbot3000 Helm chart
+
+This app-owned chart deploys the static, browser-first jobbot3000 web app using the Sugarkube generic app contract. It renders a Deployment, Service, optional Ingress, and HTTP probes for `/healthz` and `/livez`.
+
+The chart intentionally does not create Secrets, PVCs, databases, or user-data volumes. Private application tracker data stays in the user's browser-owned IndexedDB; the container only serves static assets and health endpoints.
+
+## Examples
+
+```bash
+helm lint charts/jobbot3000
+helm template jobbot3000 charts/jobbot3000 --set image.tag=main-TESTSHA
+helm template jobbot3000 charts/jobbot3000 \
+  -f charts/jobbot3000/values-staging.yaml \
+  --set image.tag=main-TESTSHA \
+  --set ingress.host=jobbot3000-staging.example.test
+```
+
+Use `values-dev.yaml`, `values-staging.yaml`, and `values-prod.yaml` as placeholders for Sugarkube environment overlays. Replace example hosts and image tags before deployment.

--- a/charts/jobbot3000/templates/_helpers.tpl
+++ b/charts/jobbot3000/templates/_helpers.tpl
@@ -1,0 +1,29 @@
+{{- define "jobbot3000.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "jobbot3000.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "jobbot3000.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "jobbot3000.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "jobbot3000.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "jobbot3000.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/jobbot3000/templates/deployment.yaml
+++ b/charts/jobbot3000/templates/deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "jobbot3000.fullname" . }}
+  labels:
+    {{- include "jobbot3000.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "jobbot3000.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "jobbot3000.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/jobbot3000/templates/ingress.yaml
+++ b/charts/jobbot3000/templates/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "jobbot3000.fullname" . }}
+  labels:
+    {{- include "jobbot3000.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ required "ingress.host is required when ingress.enabled=true" .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "jobbot3000.fullname" . }}
+                port:
+                  name: http
+{{- end }}

--- a/charts/jobbot3000/templates/service.yaml
+++ b/charts/jobbot3000/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jobbot3000.fullname" . }}
+  labels:
+    {{- include "jobbot3000.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "jobbot3000.selectorLabels" . | nindent 4 }}

--- a/charts/jobbot3000/values-dev.yaml
+++ b/charts/jobbot3000/values-dev.yaml
@@ -1,0 +1,13 @@
+image:
+  tag: main-latest
+  pullPolicy: Always
+
+ingress:
+  enabled: false
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    memory: 128Mi

--- a/charts/jobbot3000/values-prod.yaml
+++ b/charts/jobbot3000/values-prod.yaml
@@ -1,0 +1,18 @@
+image:
+  tag: main-REPLACE_WITH_SHA
+
+ingress:
+  enabled: true
+  host: jobbot3000.example.test
+  className: nginx
+  tls:
+    - secretName: jobbot3000-tls
+      hosts:
+        - jobbot3000.example.test
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    memory: 128Mi

--- a/charts/jobbot3000/values-staging.yaml
+++ b/charts/jobbot3000/values-staging.yaml
@@ -1,0 +1,15 @@
+image:
+  tag: main-REPLACE_WITH_SHA
+
+ingress:
+  enabled: true
+  host: jobbot3000-staging.example.test
+  className: nginx
+  tls: []
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    memory: 128Mi

--- a/charts/jobbot3000/values.yaml
+++ b/charts/jobbot3000/values.yaml
@@ -1,0 +1,56 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/jobbot3000
+  tag: main-latest
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+podLabels: {}
+podAnnotations: {}
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 80
+
+containerPort: 8080
+
+probes:
+  liveness:
+    path: /livez
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 2
+    failureThreshold: 3
+  readiness:
+    path: /healthz
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+
+resources: {}
+
+ingress:
+  enabled: false
+  host: ""
+  className: ""
+  annotations: {}
+  tls: []

--- a/docs/release-helm.md
+++ b/docs/release-helm.md
@@ -1,0 +1,46 @@
+# Helm chart release guide
+
+jobbot3000 owns its Sugarkube deployment chart at `charts/jobbot3000` and publishes immutable OCI chart versions to `oci://ghcr.io/futuroptimist/charts/jobbot3000`.
+
+## Chart version vs. image tag
+
+- `charts/jobbot3000/Chart.yaml` `version` is the Helm package version. Bump it whenever chart templates, default values, example values, or chart behavior changes.
+- `Chart.yaml` `appVersion` is descriptive metadata for the app release and does not control the container tag.
+- `image.tag` selects the GHCR container image deployed by Sugarkube, such as `main-<short-sha>` from the image workflow.
+- Chart versions and image tags are intentionally independent: a new image can be deployed with the same chart, and chart-only changes can be published without changing the image.
+
+## Before publishing
+
+1. Make the chart change under `charts/jobbot3000`.
+2. Explicitly bump `charts/jobbot3000/Chart.yaml` `version` using SemVer. Reusing a published version is rejected by CI.
+3. Validate locally:
+
+```bash
+scripts/validate-helm.sh charts/jobbot3000
+helm template jobbot3000 charts/jobbot3000 --set image.tag=main-TESTSHA
+```
+
+## Publishing
+
+The `Helm chart` workflow validates the chart on pull requests. It publishes only for pushes to `main`, SemVer tags like `v1.2.3`, or manual dispatch from `main`.
+
+Publication steps performed by CI:
+
+1. Run `helm lint` and render default, staging, and production example manifests.
+2. Read `charts/jobbot3000/Chart.yaml` `version`.
+3. Check GHCR for an existing `jobbot3000:<chart-version>` OCI package and fail if it already exists.
+4. Package the chart and push it to `oci://ghcr.io/futuroptimist/charts`.
+5. Print the published chart version and Sugarkube pin instructions in the workflow summary.
+
+## Bumping Sugarkube after publish
+
+After CI publishes a chart version:
+
+1. Open the Sugarkube app values or deployment pin for jobbot3000.
+2. Set the chart reference to `oci://ghcr.io/futuroptimist/charts/jobbot3000`.
+3. Set the chart version to the version printed by the workflow summary.
+4. Set `image.repository` to `ghcr.io/futuroptimist/jobbot3000` unless Sugarkube already uses the chart default.
+5. Set `image.tag` to the immutable image tag produced by the image workflow, for example `main-<short-sha>`.
+6. Keep environment hostnames and TLS secrets in Sugarkube overlays; the chart examples use placeholder `.example.test` hosts only.
+
+The chart does not create Secrets, PVCs, databases, or user data volumes because production tracker data stays in browser-owned IndexedDB.

--- a/scripts/validate-helm.sh
+++ b/scripts/validate-helm.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="${1:-charts/jobbot3000}"
+image_tag="${JOBBOT_HELM_IMAGE_TAG:-main-TESTSHA}"
+staging_host="${JOBBOT_HELM_STAGING_HOST:-jobbot3000-staging.example.test}"
+prod_host="${JOBBOT_HELM_PROD_HOST:-jobbot3000.example.test}"
+
+helm lint "${chart_dir}"
+helm template jobbot3000 "${chart_dir}" --set "image.tag=${image_tag}" >/tmp/jobbot3000-helm-default.yaml
+helm template jobbot3000 "${chart_dir}" \
+  -f "${chart_dir}/values-staging.yaml" \
+  --set "image.tag=${image_tag}" \
+  --set "ingress.host=${staging_host}" >/tmp/jobbot3000-helm-staging.yaml
+helm template jobbot3000 "${chart_dir}" \
+  -f "${chart_dir}/values-prod.yaml" \
+  --set "image.tag=${image_tag}" \
+  --set "ingress.host=${prod_host}" >/tmp/jobbot3000-helm-prod.yaml
+
+printf 'Rendered Helm manifests to /tmp/jobbot3000-helm-{default,staging,prod}.yaml\n'


### PR DESCRIPTION
### Motivation

- Provide an app-owned Helm chart and CI-driven OCI chart publishing so Sugarkube can deploy jobbot3000 via the generic app contract and pin immutable chart versions in GHCR.
- Keep the runtime container as a static, browser-first server (no server-side data persistence or user-data volumes) and make image and chart versioning independent for safe Sugarkube rollouts.

### Description

- Added an app-owned Helm chart at `charts/jobbot3000` (Chart version `0.1.0`) that renders a `Deployment`, `Service`, optional `Ingress`, pod labels/annotations, `securityContext`/`containerSecurityContext`, resources, and HTTP probes for `/healthz` (readiness) and `/livez` (liveness). The default image repository is `ghcr.io/futuroptimist/jobbot3000`.
- Added environment overlays: `values-dev.yaml`, `values-staging.yaml`, and `values-prod.yaml` with placeholder hosts and example immutable `image.tag` values for Sugarkube overlays.
- Added `scripts/validate-helm.sh` which runs `helm lint` and `helm template` for default, staging, and prod examples to validate renderability locally.
- Added GitHub Actions workflow `.github/workflows/ci-helm.yml` to run lint/render on PRs and to publish immutable OCI chart packages to `oci://ghcr.io/futuroptimist/charts/jobbot3000` on pushes to `main`, semver tags, or manual dispatch from `main`; the workflow refuses to republish an existing chart `version` and prints Sugarkube pin instructions in the summary.
- Added `docs/release-helm.md` documenting when to bump `Chart.yaml` `version`, how to publish, and how chart versions differ from image tags, and updated `README.md` to link image and chart docs; added `.prettierignore` entries to avoid formatting Helm template files as plain YAML.

### Testing

- `npm run format:check` — failed due to Prettier warnings in many unrelated tracked files (258 files); staged files passed the repo pre-commit checks (`prettier --check` was run as part of commit hooks). ❌
- `npm run lint` — succeeded (ESLint run completed). ✅
- `npm run typecheck` — succeeded (`tsc` completed). ✅
- `npm run test:ci` — succeeded (full suite: `974` tests passed during local `test:ci`). ✅
- `npm run build` — succeeded (static build into `dist/`). ✅
- `scripts/validate-helm.sh charts/jobbot3000` — succeeded and rendered default/staging/prod manifests to `/tmp`. ✅
- `helm lint charts/jobbot3000` — succeeded. ✅
- `helm template jobbot3000 charts/jobbot3000 --set image.tag=main-TESTSHA` — succeeded. ✅
- `helm template` with `values-staging.yaml` and `values-prod.yaml` and example `ingress.host` overrides — succeeded. ✅
- `git diff --cached | ./scripts/scan-secrets.py` — run on the staged changes (no secrets found). ✅

Notes and follow-ups: bump `charts/jobbot3000/Chart.yaml` `version` before publishing a new chart package because CI will refuse to republish an existing version; actual pushing of the chart package to GHCR is performed by the CI `publish` job (requires `GITHUB_TOKEN` permissions) and was not executed locally during validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45e3b79138832f9d8371f5d6040fe9)