### PR TITLE
Add Sugarkube Helm chart and OCI publishing workflow

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -98,7 +98,8 @@ jobs:
           set -euo pipefail
           printf '%s' "${GHCR_TOKEN}" | helm registry login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
-      - name: Refuse to republish existing chart version
+      - name: Check for existing chart version
+        id: existing-chart
         shell: bash
         run: |
           set -euo pipefail
@@ -106,11 +107,14 @@ jobs:
           chart_version="${{ needs.validate.outputs.chart_version }}"
           mkdir -p /tmp/jobbot3000-existing-chart
           if helm pull "${chart_ref}" --version "${chart_version}" --destination /tmp/jobbot3000-existing-chart >/dev/null 2>&1; then
-            echo "Chart ${chart_ref}:${chart_version} already exists; bump charts/jobbot3000/Chart.yaml version before publishing." >&2
-            exit 1
+            echo "Chart ${chart_ref}:${chart_version} already exists; skipping publish. Bump charts/jobbot3000/Chart.yaml version before publishing chart changes." >&2
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+            exit 0
           fi
+          echo "exists=false" >> "${GITHUB_OUTPUT}"
 
       - name: Package chart
+        if: steps.existing-chart.outputs.exists == 'false'
         shell: bash
         run: |
           set -euo pipefail
@@ -118,12 +122,14 @@ jobs:
           helm package charts/jobbot3000 --destination .helm-dist
 
       - name: Push chart to GHCR
+        if: steps.existing-chart.outputs.exists == 'false'
         shell: bash
         run: |
           set -euo pipefail
           helm push ".helm-dist/jobbot3000-${{ needs.validate.outputs.chart_version }}.tgz" oci://ghcr.io/futuroptimist/charts
 
       - name: Summarize published chart
+        if: steps.existing-chart.outputs.exists == 'false'
         shell: bash
         run: |
           chart_ref="${{ needs.validate.outputs.chart_ref }}"
@@ -134,4 +140,17 @@ jobs:
             echo "Published immutable chart: \`${chart_ref}:${chart_version}\`"
             echo "Sugarkube pin instructions: set the jobbot3000 chart repository to \`${chart_ref}\` and chart version to \`${chart_version}\`."
             echo "Deploy with an immutable app image tag such as \`main-<short-sha>\`; chart versions and image tags are intentionally bumped independently."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Summarize skipped chart publish
+        if: steps.existing-chart.outputs.exists == 'true'
+        shell: bash
+        run: |
+          chart_ref="${{ needs.validate.outputs.chart_ref }}"
+          chart_version="${{ needs.validate.outputs.chart_version }}"
+          {
+            echo "## jobbot3000 Helm chart publish skipped"
+            echo ""
+            echo "Chart already exists: \`${chart_ref}:${chart_version}\`"
+            echo "Bump \`charts/jobbot3000/Chart.yaml\` version before publishing chart changes."
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -1,0 +1,132 @@
+name: Validate and publish Helm chart
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "charts/jobbot3000/**"
+      - "scripts/validate-helm.sh"
+      - ".github/workflows/ci-helm.yml"
+  push:
+    branches: [main]
+    tags:
+      - "v*.*.*"
+    paths:
+      - "charts/jobbot3000/**"
+      - "scripts/validate-helm.sh"
+      - ".github/workflows/ci-helm.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: Helm lint and template
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      chart_version: ${{ steps.chart.outputs.chart_version }}
+      chart_ref: ${{ steps.chart.outputs.chart_ref }}
+      publish: ${{ steps.chart.outputs.publish }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Read chart metadata
+        id: chart
+        shell: bash
+        run: |
+          set -euo pipefail
+          chart_version="$(helm show chart charts/jobbot3000 | awk -F': ' '$1 == "version" { print $2; exit }')"
+          chart_ref="oci://ghcr.io/futuroptimist/charts/jobbot3000"
+          publish="false"
+          if { [ "${GITHUB_EVENT_NAME}" = "push" ] && { [ "${GITHUB_REF}" = "refs/heads/main" ] || [[ "${GITHUB_REF}" == refs/tags/v*.*.* ]]; }; } || [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            publish="true"
+          fi
+          {
+            echo "chart_version=${chart_version}"
+            echo "chart_ref=${chart_ref}"
+            echo "publish=${publish}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Validate Helm chart
+        run: scripts/validate-helm.sh charts/jobbot3000
+
+      - name: Summarize Helm validation
+        shell: bash
+        run: |
+          {
+            echo "## jobbot3000 Helm chart validation"
+            echo ""
+            echo "Chart: \`${{ steps.chart.outputs.chart_ref }}\`"
+            echo "Version: \`${{ steps.chart.outputs.chart_version }}\`"
+            echo "Validated: \`helm lint\`, default template render, staging render, and production render."
+            echo "Publish candidate: \`${{ steps.chart.outputs.publish }}\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  publish:
+    name: Publish OCI chart
+    runs-on: ubuntu-latest
+    needs: validate
+    if: needs.validate.outputs.publish == 'true'
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Log in to GHCR
+        shell: bash
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          printf '%s' "${GHCR_TOKEN}" | helm registry login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
+
+      - name: Refuse to republish existing chart version
+        shell: bash
+        run: |
+          set -euo pipefail
+          chart_ref="${{ needs.validate.outputs.chart_ref }}"
+          chart_version="${{ needs.validate.outputs.chart_version }}"
+          mkdir -p /tmp/jobbot3000-existing-chart
+          if helm pull "${chart_ref}" --version "${chart_version}" --destination /tmp/jobbot3000-existing-chart >/dev/null 2>&1; then
+            echo "Chart ${chart_ref}:${chart_version} already exists; bump charts/jobbot3000/Chart.yaml version before publishing." >&2
+            exit 1
+          fi
+
+      - name: Package chart
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .helm-dist
+          helm package charts/jobbot3000 --destination .helm-dist
+
+      - name: Push chart to GHCR
+        shell: bash
+        run: |
+          set -euo pipefail
+          helm push ".helm-dist/jobbot3000-${{ needs.validate.outputs.chart_version }}.tgz" oci://ghcr.io/futuroptimist/charts
+
+      - name: Summarize published chart
+        shell: bash
+        run: |
+          chart_ref="${{ needs.validate.outputs.chart_ref }}"
+          chart_version="${{ needs.validate.outputs.chart_version }}"
+          {
+            echo "## jobbot3000 Helm chart published"
+            echo ""
+            echo "Published immutable chart: \`${chart_ref}:${chart_version}\`"
+            echo "Sugarkube pin instructions: set the jobbot3000 chart repository to \`${chart_ref}\` and chart version to \`${chart_version}\`."
+            echo "Deploy with an immutable app image tag such as \`main-<short-sha>\`; chart versions and image tags are intentionally bumped independently."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 2
 
       - name: Set up Helm
         uses: azure/setup-helm@v4
@@ -42,8 +44,15 @@ jobs:
           chart_version="$(helm show chart charts/jobbot3000 | awk -F': ' '$1 == "version" { print $2; exit }')"
           chart_ref="oci://ghcr.io/futuroptimist/charts/jobbot3000"
           publish="false"
-          if [ "${GITHUB_EVENT_NAME}" = "push" ] && { [ "${GITHUB_REF}" = "refs/heads/main" ] || [[ "${GITHUB_REF}" == refs/tags/v*.*.* ]]; }; then
-            publish="true"
+          if [ "${GITHUB_EVENT_NAME}" = "push" ]; then
+            if [[ "${GITHUB_REF}" == refs/tags/v*.*.* ]]; then
+              publish="true"
+            elif [ "${GITHUB_REF}" = "refs/heads/main" ]; then
+              changed_files="$(git diff-tree --no-commit-id --name-only -r "${GITHUB_SHA}")"
+              if grep -Eq '^(charts/jobbot3000/|scripts/validate-helm\.sh$|\.github/workflows/ci-helm\.yml$)' <<< "${changed_files}"; then
+                publish="true"
+              fi
+            fi
           fi
           {
             echo "chart_version=${chart_version}"

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -11,15 +11,11 @@ on:
     branches: [main]
     tags:
       - "v*.*.*"
-    paths:
-      - "charts/jobbot3000/**"
-      - "scripts/validate-helm.sh"
-      - ".github/workflows/ci-helm.yml"
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   validate:

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -48,7 +48,7 @@ jobs:
             if [[ "${GITHUB_REF}" == refs/tags/v*.*.* ]]; then
               publish="true"
             elif [ "${GITHUB_REF}" = "refs/heads/main" ]; then
-              changed_files="$(git diff-tree --no-commit-id --name-only -r "${GITHUB_SHA}")"
+              changed_files="$(git diff-tree --no-commit-id --name-only -r -m "${GITHUB_SHA}")"
               if grep -Eq '^(charts/jobbot3000/|scripts/validate-helm\.sh$|\.github/workflows/ci-helm\.yml$)' <<< "${changed_files}"; then
                 publish="true"
               fi
@@ -107,9 +107,15 @@ jobs:
           chart_version="${{ needs.validate.outputs.chart_version }}"
           mkdir -p /tmp/jobbot3000-existing-chart
           if helm pull "${chart_ref}" --version "${chart_version}" --destination /tmp/jobbot3000-existing-chart >/dev/null 2>&1; then
-            echo "Chart ${chart_ref}:${chart_version} already exists; skipping publish. Bump charts/jobbot3000/Chart.yaml version before publishing chart changes." >&2
+            echo "Chart ${chart_ref}:${chart_version} already exists; refusing to republish. Bump charts/jobbot3000/Chart.yaml version before publishing chart changes." >&2
+            {
+              echo "## jobbot3000 Helm chart publish refused"
+              echo ""
+              echo "Chart already exists: \`${chart_ref}:${chart_version}\`"
+              echo "Bump \`charts/jobbot3000/Chart.yaml\` version before publishing chart changes."
+            } >> "${GITHUB_STEP_SUMMARY}"
             echo "exists=true" >> "${GITHUB_OUTPUT}"
-            exit 0
+            exit 1
           fi
           echo "exists=false" >> "${GITHUB_OUTPUT}"
 
@@ -140,17 +146,4 @@ jobs:
             echo "Published immutable chart: \`${chart_ref}:${chart_version}\`"
             echo "Sugarkube pin instructions: set the jobbot3000 chart repository to \`${chart_ref}\` and chart version to \`${chart_version}\`."
             echo "Deploy with an immutable app image tag such as \`main-<short-sha>\`; chart versions and image tags are intentionally bumped independently."
-          } >> "${GITHUB_STEP_SUMMARY}"
-
-      - name: Summarize skipped chart publish
-        if: steps.existing-chart.outputs.exists == 'true'
-        shell: bash
-        run: |
-          chart_ref="${{ needs.validate.outputs.chart_ref }}"
-          chart_version="${{ needs.validate.outputs.chart_version }}"
-          {
-            echo "## jobbot3000 Helm chart publish skipped"
-            echo ""
-            echo "Chart already exists: \`${chart_ref}:${chart_version}\`"
-            echo "Bump \`charts/jobbot3000/Chart.yaml\` version before publishing chart changes."
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -42,7 +42,7 @@ jobs:
           chart_version="$(helm show chart charts/jobbot3000 | awk -F': ' '$1 == "version" { print $2; exit }')"
           chart_ref="oci://ghcr.io/futuroptimist/charts/jobbot3000"
           publish="false"
-          if { [ "${GITHUB_EVENT_NAME}" = "push" ] && { [ "${GITHUB_REF}" = "refs/heads/main" ] || [[ "${GITHUB_REF}" == refs/tags/v*.*.* ]]; }; } || [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+          if [ "${GITHUB_EVENT_NAME}" = "push" ] && { [ "${GITHUB_REF}" = "refs/heads/main" ] || [[ "${GITHUB_REF}" == refs/tags/v*.*.* ]]; }; then
             publish="true"
           fi
           {

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+charts/*/templates/*.yaml

--- a/README.md
+++ b/README.md
@@ -149,6 +149,16 @@ console.log(await response.json());
 
 Run the snippet with `node example.js` after saving it to a file in the project root.
 
+## Release and deployment
+
+Production deployments use the static, browser-local web build. The container serves static assets and `/healthz` and `/livez`; it does not own private tracker data, Secrets, or application data volumes.
+
+- [docs/release-ghcr.md](docs/release-ghcr.md) explains the GHCR image workflow and immutable image tags such as `ghcr.io/futuroptimist/jobbot3000:main-<short-sha>`.
+- [docs/release-helm.md](docs/release-helm.md) explains the app-owned Helm chart, OCI publishing workflow, and Sugarkube chart pin for `oci://ghcr.io/futuroptimist/charts/jobbot3000`.
+- [charts/jobbot3000/ci](charts/jobbot3000/ci) contains placeholder dev, staging, and production values examples for Sugarkube-owned environment configuration.
+
+Image tags and chart versions are intentionally separate: bump the image tag for a new static app build, and bump `charts/jobbot3000/Chart.yaml` `version` for Kubernetes packaging or default-value changes.
+
 ## Documentation
 
 - [DESIGN.md](DESIGN.md) – architecture details and roadmap

--- a/charts/jobbot3000/Chart.yaml
+++ b/charts/jobbot3000/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: jobbot3000
+description: Browser-local job application tracker static web app for Sugarkube
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/jobbot3000/ci/dev-values.yaml
+++ b/charts/jobbot3000/ci/dev-values.yaml
@@ -1,0 +1,7 @@
+image:
+  tag: main-latest
+
+ingress:
+  enabled: true
+  host: jobbot3000.dev.example.test
+  className: nginx

--- a/charts/jobbot3000/ci/prod-values.yaml
+++ b/charts/jobbot3000/ci/prod-values.yaml
@@ -1,0 +1,19 @@
+image:
+  tag: main-PRODUCTION_SHA
+
+ingress:
+  enabled: true
+  host: jobbot3000.example.test
+  className: nginx
+  tls:
+    - secretName: jobbot3000-prod-tls-example
+      hosts:
+        - jobbot3000.example.test
+
+resources:
+  requests:
+    cpu: 25m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 128Mi

--- a/charts/jobbot3000/ci/staging-values.yaml
+++ b/charts/jobbot3000/ci/staging-values.yaml
@@ -1,0 +1,11 @@
+image:
+  tag: main-STAGING_SHA
+
+ingress:
+  enabled: true
+  host: jobbot3000.staging.example.test
+  className: nginx
+  tls:
+    - secretName: jobbot3000-staging-tls-example
+      hosts:
+        - jobbot3000.staging.example.test

--- a/charts/jobbot3000/templates/_helpers.tpl
+++ b/charts/jobbot3000/templates/_helpers.tpl
@@ -1,0 +1,29 @@
+{{- define "jobbot3000.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "jobbot3000.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "jobbot3000.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "jobbot3000.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "jobbot3000.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "jobbot3000.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/jobbot3000/templates/deployment.yaml
+++ b/charts/jobbot3000/templates/deployment.yaml
@@ -3,32 +3,37 @@ kind: Deployment
 metadata:
   name: {{ include "jobbot3000.fullname" . }}
   labels:
-    {{ include "jobbot3000.labels" . | nindent 4 }}
+{{- include "jobbot3000.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      {{ include "jobbot3000.selectorLabels" . | nindent 6 }}
+{{- include "jobbot3000.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        {{ include "jobbot3000.selectorLabels" . | nindent 8 }}
+{{- include "jobbot3000.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
-        {{ toYaml . | nindent 8 }}
+{{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.podAnnotations }}
       annotations:
-        {{ toYaml . | nindent 8 }}
+{{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       securityContext:
-        {{ toYaml .Values.securityContext | nindent 8 }}
+{{- toYaml .Values.securityContext | nindent 8 }}
       containers:
         - name: {{ include "jobbot3000.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
-            {{ toYaml .Values.containerSecurityContext | nindent 12 }}
+{{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          env:
+            - name: PORT
+              value: {{ .Values.containerPort | quote }}
+            - name: JOBBOT_WEB_PORT
+              value: {{ .Values.containerPort | quote }}
           ports:
             - name: http
               containerPort: {{ .Values.containerPort }}
@@ -51,5 +56,11 @@ spec:
             failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
           {{- with .Values.resources }}
           resources:
-            {{ toYaml . | nindent 12 }}
+{{- toYaml . | nindent 12 }}
           {{- end }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/charts/jobbot3000/templates/deployment.yaml
+++ b/charts/jobbot3000/templates/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "jobbot3000.fullname" . }}
+  labels:
+    {{ include "jobbot3000.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{ include "jobbot3000.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{ include "jobbot3000.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{ toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      securityContext:
+        {{ toYaml .Values.securityContext | nindent 8 }}
+      containers:
+        - name: {{ include "jobbot3000.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{ toYaml .Values.containerSecurityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.containerPort }}
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.probes.readiness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.liveness.path }}
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          {{- with .Values.resources }}
+          resources:
+            {{ toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/jobbot3000/templates/deployment.yaml
+++ b/charts/jobbot3000/templates/deployment.yaml
@@ -12,10 +12,10 @@ spec:
   template:
     metadata:
       labels:
-{{- include "jobbot3000.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
 {{- toYaml . | nindent 8 }}
         {{- end }}
+{{- include "jobbot3000.selectorLabels" . | nindent 8 }}
       {{- with .Values.podAnnotations }}
       annotations:
 {{- toYaml . | nindent 8 }}

--- a/charts/jobbot3000/templates/ingress.yaml
+++ b/charts/jobbot3000/templates/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "jobbot3000.fullname" . }}
+  labels:
+    {{ include "jobbot3000.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "jobbot3000.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/charts/jobbot3000/templates/ingress.yaml
+++ b/charts/jobbot3000/templates/ingress.yaml
@@ -4,10 +4,10 @@ kind: Ingress
 metadata:
   name: {{ include "jobbot3000.fullname" . }}
   labels:
-    {{ include "jobbot3000.labels" . | nindent 4 }}
+{{- include "jobbot3000.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}
   annotations:
-    {{ toYaml . | nindent 4 }}
+{{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   {{- with .Values.ingress.className }}
@@ -15,7 +15,7 @@ spec:
   {{- end }}
   {{- with .Values.ingress.tls }}
   tls:
-    {{ toYaml . | nindent 4 }}
+{{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
     - host: {{ .Values.ingress.host | quote }}

--- a/charts/jobbot3000/templates/service.yaml
+++ b/charts/jobbot3000/templates/service.yaml
@@ -3,7 +3,7 @@ kind: Service
 metadata:
   name: {{ include "jobbot3000.fullname" . }}
   labels:
-    {{ include "jobbot3000.labels" . | nindent 4 }}
+{{- include "jobbot3000.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -12,4 +12,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{ include "jobbot3000.selectorLabels" . | nindent 4 }}
+{{- include "jobbot3000.selectorLabels" . | nindent 4 }}

--- a/charts/jobbot3000/templates/service.yaml
+++ b/charts/jobbot3000/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "jobbot3000.fullname" . }}
+  labels:
+    {{ include "jobbot3000.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{ include "jobbot3000.selectorLabels" . | nindent 4 }}

--- a/charts/jobbot3000/values.yaml
+++ b/charts/jobbot3000/values.yaml
@@ -1,0 +1,56 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/futuroptimist/jobbot3000
+  tag: main-latest
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+podLabels: {}
+podAnnotations: {}
+
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 101
+  runAsGroup: 101
+  fsGroup: 101
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+service:
+  type: ClusterIP
+  port: 80
+
+containerPort: 8080
+
+ingress:
+  enabled: false
+  host: jobbot3000.example.test
+  className: ""
+  annotations: {}
+  tls: []
+
+resources: {}
+
+probes:
+  readiness:
+    path: /healthz
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 2
+    failureThreshold: 3
+  liveness:
+    path: /livez
+    initialDelaySeconds: 10
+    periodSeconds: 20
+    timeoutSeconds: 2
+    failureThreshold: 3

--- a/charts/jobbot3000/values.yaml
+++ b/charts/jobbot3000/values.yaml
@@ -13,9 +13,9 @@ podAnnotations: {}
 
 securityContext:
   runAsNonRoot: true
-  runAsUser: 101
-  runAsGroup: 101
-  fsGroup: 101
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
   seccompProfile:
     type: RuntimeDefault
 

--- a/docs/release-helm.md
+++ b/docs/release-helm.md
@@ -12,7 +12,7 @@ The chart renders a `Deployment`, `Service`, and optional `Ingress`. It does not
 
 Bump `charts/jobbot3000/Chart.yaml` `version` for every chart behavior change before publishing. Examples include Kubernetes manifest changes, default value changes, probe changes, labels, or Sugarkube-facing contract updates.
 
-Do not rely on rerunning CI to replace a chart package. OCI chart versions are immutable for this repo: `.github/workflows/ci-helm.yml` checks GHCR and fails if the same chart version already exists.
+Do not rely on rerunning CI to replace a chart package. OCI chart versions are immutable for this repo: `.github/workflows/ci-helm.yml` checks GHCR and skips publishing if the same chart version already exists.
 
 `appVersion` can track the application package version, but Sugarkube should pin the image with `image.tag` rather than assuming `appVersion` is deployable.
 
@@ -24,7 +24,7 @@ Pull requests run Helm validation only:
 scripts/validate-helm.sh charts/jobbot3000
 ```
 
-Pushes to `main` and semver tags such as `v1.2.3` publish the OCI chart after validation. Manual workflow dispatches run validation only and do not publish. The publish job logs in to GHCR with `GITHUB_TOKEN`, refuses an existing chart version, packages the chart, pushes it to `oci://ghcr.io/futuroptimist/charts`, and writes the published version to the GitHub Actions summary.
+Pushes to `main` and semver tags such as `v1.2.3` publish the OCI chart after validation. Manual workflow dispatches run validation only and do not publish. The publish job logs in to GHCR with `GITHUB_TOKEN`, skips an existing chart version, packages new chart versions, pushes them to `oci://ghcr.io/futuroptimist/charts`, and writes the published or skipped version to the GitHub Actions summary.
 
 ## Sugarkube chart pin after publish
 

--- a/docs/release-helm.md
+++ b/docs/release-helm.md
@@ -1,0 +1,57 @@
+# Helm chart release workflow
+
+jobbot3000 owns a Helm chart at `charts/jobbot3000` so Sugarkube can deploy the static, browser-local app from the generic app contract. The chart publishes to:
+
+```text
+oci://ghcr.io/futuroptimist/charts/jobbot3000
+```
+
+The chart renders a `Deployment`, `Service`, and optional `Ingress`. It does not create Secrets, persistent volumes, or server-side application data storage because production tracker data remains in each user's browser IndexedDB.
+
+## Chart version bumps
+
+Bump `charts/jobbot3000/Chart.yaml` `version` for every chart behavior change before publishing. Examples include Kubernetes manifest changes, default value changes, probe changes, labels, or Sugarkube-facing contract updates.
+
+Do not rely on rerunning CI to replace a chart package. OCI chart versions are immutable for this repo: `.github/workflows/ci-helm.yml` checks GHCR and fails if the same chart version already exists.
+
+`appVersion` can track the application package version, but Sugarkube should pin the image with `image.tag` rather than assuming `appVersion` is deployable.
+
+## Publishing
+
+Pull requests run Helm validation only:
+
+```bash
+scripts/validate-helm.sh charts/jobbot3000
+```
+
+Pushes to `main`, semver tags such as `v1.2.3`, and manual workflow dispatches publish the OCI chart after validation. The publish job logs in to GHCR with `GITHUB_TOKEN`, refuses an existing chart version, packages the chart, pushes it to `oci://ghcr.io/futuroptimist/charts`, and writes the published version to the GitHub Actions summary.
+
+## Sugarkube chart pin after publish
+
+After the workflow publishes, copy the summary values into Sugarkube's app pin:
+
+```yaml
+chart:
+  repository: oci://ghcr.io/futuroptimist/charts/jobbot3000
+  version: 0.1.0
+values:
+  image:
+    repository: ghcr.io/futuroptimist/jobbot3000
+    tag: main-<short-sha>
+```
+
+Use the workflow's exact chart version and the image workflow's immutable `main-<short-sha>` tag. Avoid mutable tags such as `main-latest` for production rollouts.
+
+## Image tags versus chart versions
+
+Chart versions describe Kubernetes deployment packaging: manifests, defaults, probes, ingress support, and other Sugarkube contract details.
+
+Image tags describe the static web app build that runs in the pod. Most application-only changes need a new image tag but do not need a chart version bump. Chart-only changes need a chart version bump even when the image tag stays the same.
+
+Use the example values files as starting points only:
+
+- `charts/jobbot3000/ci/dev-values.yaml`
+- `charts/jobbot3000/ci/staging-values.yaml`
+- `charts/jobbot3000/ci/prod-values.yaml`
+
+They intentionally use placeholder `.example.test` hosts and example TLS secret names. Replace those placeholders inside Sugarkube-owned environment configuration; do not commit real hostnames, Secrets, or user data volumes to this app chart.

--- a/docs/release-helm.md
+++ b/docs/release-helm.md
@@ -12,7 +12,7 @@ The chart renders a `Deployment`, `Service`, and optional `Ingress`. It does not
 
 Bump `charts/jobbot3000/Chart.yaml` `version` for every chart behavior change before publishing. Examples include Kubernetes manifest changes, default value changes, probe changes, labels, or Sugarkube-facing contract updates.
 
-Do not rely on rerunning CI to replace a chart package. OCI chart versions are immutable for this repo: `.github/workflows/ci-helm.yml` checks GHCR and skips publishing if the same chart version already exists.
+Do not rely on rerunning CI to replace a chart package. OCI chart versions are immutable for this repo: `.github/workflows/ci-helm.yml` checks GHCR and fails real publish candidates if the same chart version already exists.
 
 `appVersion` can track the application package version, but Sugarkube should pin the image with `image.tag` rather than assuming `appVersion` is deployable.
 
@@ -24,7 +24,7 @@ Pull requests run Helm validation only:
 scripts/validate-helm.sh charts/jobbot3000
 ```
 
-Pushes to `main` and semver tags such as `v1.2.3` publish the OCI chart after validation. Manual workflow dispatches run validation only and do not publish. The publish job logs in to GHCR with `GITHUB_TOKEN`, skips an existing chart version, packages new chart versions, pushes them to `oci://ghcr.io/futuroptimist/charts`, and writes the published or skipped version to the GitHub Actions summary.
+Pushes to `main` publish the OCI chart after validation only when chart, workflow, or Helm validation inputs changed. Semver tags such as `v1.2.3` are always publish candidates after validation. Manual workflow dispatches run validation only and do not publish. The publish job logs in to GHCR with `GITHUB_TOKEN`, refuses an existing chart version, packages new chart versions, pushes them to `oci://ghcr.io/futuroptimist/charts`, and writes the published version to the GitHub Actions summary.
 
 ## Sugarkube chart pin after publish
 

--- a/docs/release-helm.md
+++ b/docs/release-helm.md
@@ -24,7 +24,7 @@ Pull requests run Helm validation only:
 scripts/validate-helm.sh charts/jobbot3000
 ```
 
-Pushes to `main`, semver tags such as `v1.2.3`, and manual workflow dispatches publish the OCI chart after validation. The publish job logs in to GHCR with `GITHUB_TOKEN`, refuses an existing chart version, packages the chart, pushes it to `oci://ghcr.io/futuroptimist/charts`, and writes the published version to the GitHub Actions summary.
+Pushes to `main` and semver tags such as `v1.2.3` publish the OCI chart after validation. Manual workflow dispatches run validation only and do not publish. The publish job logs in to GHCR with `GITHUB_TOKEN`, refuses an existing chart version, packages the chart, pushes it to `oci://ghcr.io/futuroptimist/charts`, and writes the published version to the GitHub Actions summary.
 
 ## Sugarkube chart pin after publish
 

--- a/scripts/validate-helm.sh
+++ b/scripts/validate-helm.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="${1:-charts/jobbot3000}"
+
+helm lint "${chart_dir}"
+helm template jobbot3000 "${chart_dir}" --set image.tag=main-TESTSHA >/dev/null
+helm template jobbot3000-staging "${chart_dir}" \
+  -f "${chart_dir}/ci/staging-values.yaml" \
+  --set image.tag=main-STAGINGTEST \
+  --set ingress.host=jobbot3000.staging.example.test >/dev/null
+helm template jobbot3000-prod "${chart_dir}" \
+  -f "${chart_dir}/ci/prod-values.yaml" \
+  --set image.tag=main-PRODTEST \
+  --set ingress.host=jobbot3000.example.test >/dev/null


### PR DESCRIPTION
### Motivation
- Provide an app-owned Helm chart and CI publishing path so Sugarkube can deploy jobbot3000 from an immutable OCI chart at `oci://ghcr.io/futuroptimist/charts/jobbot3000`.
- Preserve the browser-first/static deployment contract by making the chart a static web app package that does not create Secrets or persistent application-data volumes by default.
- Make chart consumption predictable for Sugarkube by exposing image repository/tag/pull policy, service and container ports, ingress configuration, probes, security contexts, and pod labels/annotations as values.

### Description
- Added a Helm chart at `charts/jobbot3000` including `Chart.yaml`, `values.yaml`, templates for `Deployment`, `Service`, and optional `Ingress`, and helper templates for names/labels; probes for `/healthz` and `/livez` and security contexts are configurable via values.
- Added CI example values under `charts/jobbot3000/ci` for `dev`, `staging`, and `prod` to show expected Sugarkube consumption patterns without real hostnames or secrets.
- Added `scripts/validate-helm.sh` to run `helm lint` and multiple `helm template` renders, and added `.github/workflows/ci-helm.yml` to validate chart changes on PRs and to publish immutable OCI charts to GHCR on `main`, semver tags, or manual dispatch while refusing to republish an existing chart version.
- Added `docs/release-helm.md` describing when to bump `Chart.yaml` `version`, how to publish the chart, Sugarkube pin instructions, and how image tags differ from chart versions, and updated `README.md` to link the image and chart release docs.

### Testing
- Local/CI repository checks: ran `npm run lint`, `npm run typecheck`, `npm run test:ci`, and `npm run build`, all of which completed successfully in the run reported above.
- Formatting: ran `npm run format:check` which reported pre-existing repository-wide Prettier warnings unrelated to this PR (staged files were formatted by pre-commit hooks), so repository formatting remains unchanged by this PR.
- Helm validation and templating: ran `scripts/validate-helm.sh`, `helm lint charts/jobbot3000`, `helm template jobbot3000 charts/jobbot3000 --set image.tag=main-TESTSHA`, and templated renders for staging and prod with the CI value files, all of which succeeded after installing Helm for validation.
- Secret scan: ran `git diff | python scripts/scan-secrets.py` against the PR diff and it returned no secrets detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a45e3bdd6bc832fbbf3a359d9e48504)