### PR TITLE
Finalize production readiness: docs, deterministic backups, tests, and build metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,17 @@ Production deployments use the static, browser-local web build. The container se
 
 Image tags and chart versions are intentionally separate: bump the image tag for a new static app build, and bump `charts/jobbot3000/Chart.yaml` `version` for Kubernetes packaging or default-value changes.
 
+## Production readiness and deployment
+
+- [Production readiness](docs/production-readiness.md) summarizes the static/browser-local contract, verification, rollback, and dev/staging seeding guidance.
+- [Backup and restore guide](docs/backup-restore-guide.md) explains CSV, JSON, and NDJSON backups.
+- [Import the current spreadsheet](docs/import-current-spreadsheet.md) covers the Google Sheets migration workflow.
+- [GHCR image release](docs/release-ghcr.md) and [Helm chart release](docs/release-helm.md) document publishing.
+
+### Deploy with Sugarkube
+
+Sugarkube owns the cluster-side runbook and pinned environment values. At a high level: publish `ghcr.io/futuroptimist/jobbot3000` with an immutable `main-SHORTSHA` tag, publish `oci://ghcr.io/futuroptimist/charts/jobbot3000` when chart content changes, deploy staging with that immutable tag, verify `/`, `/healthz`, and `/livez`, import and export a backup through the browser UI, then promote production with the same immutable tag. Do not add real hostnames, secrets, or mutable production tags here.
+
 ## Documentation
 
 - [DESIGN.md](DESIGN.md) – architecture details and roadmap

--- a/charts/jobbot3000/ci/dev-values.yaml
+++ b/charts/jobbot3000/ci/dev-values.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: main-latest
+  tag: main-1111111
 
 ingress:
   enabled: true

--- a/charts/jobbot3000/values.yaml
+++ b/charts/jobbot3000/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/futuroptimist/jobbot3000
-  tag: main-latest
+  tag: main-0000000
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/docs/backup-restore-guide.md
+++ b/docs/backup-restore-guide.md
@@ -100,3 +100,29 @@ Run a quick checklist before resuming normal operations:
   a sandbox directory.
 - Combine the NDJSON export and archive with offsite replication to stay ready
   for disaster recovery.
+
+## Browser tracker production backup formats
+
+For the static production tracker, jobbot3000 data is browser-local IndexedDB data. The server only serves static files and health probes.
+
+- **CSV**: human-editable, spreadsheet-shaped, 32-column, one-row-per-application compatibility format. Use it for Google Sheets interchange or manual review.
+- **JSON**: canonical full-fidelity backup bundle. Use it for normal backup/restore of applications, contacts, outreach, lifecycle events, interviews, offers, artifacts, reminders, and settings.
+- **NDJSON**: line-oriented full-fidelity stream. Use it when line-by-line inspection, streaming, or text diffs are useful.
+
+Use CSV when a spreadsheet needs to read or edit the application list. Use JSON before clearing data, changing browsers, or promoting jobbot3000 as the primary tracker. Use NDJSON alongside JSON when you want an easy-to-inspect full-fidelity stream.
+
+### Verify browser backups before clearing data
+
+1. Export JSON and NDJSON.
+2. Restore into an empty browser profile or staging browser.
+3. Check record counts by store and representative applications, contacts, outreach messages, interviews, offers, artifacts, reminders, and settings.
+4. Re-export and compare canonical records where possible.
+5. Only then clear the original browser profile or archive the spreadsheet.
+
+### Restore into dev/staging/prod browsers
+
+Dev, staging, and prod are separate browser/storage profiles unless you import the same backup into each. Open the deployed app, use the browser UI import/restore flow, verify records, then export a fresh backup from that environment. Seed dev/staging with anonymized JSON/NDJSON or fake fixtures only.
+
+### Browser data boundary
+
+Never bake real user data into images, charts, Helm values, ConfigMaps, Secrets, PVCs, repo fixtures, `.env` files, SQLite databases, static server logs, or local backup directories committed to git. Real backups should stay in private user-controlled storage outside public repos and container artifacts.

--- a/docs/import-current-spreadsheet.md
+++ b/docs/import-current-spreadsheet.md
@@ -1,0 +1,38 @@
+# Import the current spreadsheet
+
+Use this guide to move from the current Google Sheets tracker to jobbot3000 while keeping CSV as a spreadsheet-compatible backup and JSON/NDJSON as full-fidelity restore points.
+
+## Export Google Sheets as CSV
+
+1. Open the tracker spreadsheet.
+2. Choose **File → Download → Comma Separated Values (.csv)** for the active sheet.
+3. Save the file locally with a date in the filename, for example `jobbot3000-spreadsheet-YYYY-MM-DD.csv`.
+4. Do not commit the CSV or place it in a Docker image, Helm chart, ConfigMap, Secret, PVC, or public repo.
+
+## Import into jobbot3000
+
+1. Open `/tracker` in the browser profile you will use.
+2. Go to **Import/Export** and select the CSV.
+3. Run **Preview/dry-run** first.
+4. Confirm row counts, conflicts, malformed dates/URLs, and representative normalized records.
+5. Apply the import only after the preview looks correct.
+
+## Back up after import
+
+- Export CSV for a human-editable spreadsheet-compatible snapshot.
+- Export JSON as the canonical full-fidelity backup.
+- Export NDJSON as a line-oriented full-fidelity backup.
+
+CSV is one row per application and is not full fidelity after you add multiple outreach messages, interviews, offers, artifacts, reminders, or settings. Keep JSON/NDJSON before clearing browser data, changing devices, or retiring the spreadsheet.
+
+## Restore test
+
+1. Open an empty browser profile or staging deployment.
+2. Import the JSON backup and verify application count and representative child records.
+3. Clear that test profile.
+4. Import the NDJSON backup and verify the same records.
+5. Re-export JSON/NDJSON and compare canonical records before deleting older backups.
+
+## Transition backup cadence
+
+During the first week, export JSON and NDJSON after each tracking session and export CSV whenever you need spreadsheet review. After the workflow is trusted, keep at least weekly JSON/NDJSON backups plus ad-hoc backups before bulk imports, clears, browser upgrades, or deployment changes.

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -1,0 +1,70 @@
+# Production readiness
+
+jobbot3000 production mode is a static, browser-local application tracker. The deployed container serves HTML, CSS, JavaScript, the web manifest, and health probes only; private tracker records are created, imported, exported, restored, and cleared in the user's browser IndexedDB.
+
+## Safe to deploy publicly
+
+- Static app shell and assets.
+- `/`, `/tracker`, `/healthz`, and `/livez` verification paths.
+- Docker image `ghcr.io/futuroptimist/jobbot3000` and Helm chart `oci://ghcr.io/futuroptimist/charts/jobbot3000`.
+- Fake fixtures and anonymized screenshots used by tests/docs.
+
+## Stays local to the browser
+
+Applications, contacts, outreach messages, notes, interviews, offers, artifacts, reminders, settings, imported CSV/JSON/NDJSON content, and generated backups stay in IndexedDB or in files the user downloads locally. They must not be posted to jobbot3000 server APIs.
+
+## Never store in Kubernetes or server files
+
+Do not put real tracker data in images, charts, Helm values, ConfigMaps, Secrets, PVCs, repo fixtures, static server logs, `.env` files, local backup directories, or SQLite databases. Dev, staging, and production are separate browser/storage profiles unless the same backup is imported into each.
+
+## Backup formats
+
+- **CSV**: 32-column spreadsheet-compatible, one-row-per-application format. Use for Google Sheets interchange and human edits. It is not full fidelity once an application has multiple outreach messages, interviews, offers, artifacts, reminders, or settings.
+- **JSON**: canonical full-fidelity backup bundle. Prefer this for routine restore points before clearing data or changing browsers.
+- **NDJSON**: line-oriented full-fidelity stream. Use when a line-by-line backup is easier to inspect, diff, or process.
+
+## First-use checklist
+
+1. Open the deployed tracker in the browser profile you will use day to day.
+2. Import the current spreadsheet CSV or create one fake/manual application first.
+3. Check application count, representative records, follow-up dates, outreach, interviews, and outcomes.
+4. Export JSON and NDJSON backups before deleting or archiving the old spreadsheet.
+5. Export CSV if you still want a spreadsheet-shaped backup.
+
+## First production deploy checklist
+
+1. Publish the image with an immutable tag such as `main-SHORTSHA`.
+2. Publish the Helm chart only when chart content changes.
+3. Deploy staging with the immutable image tag.
+4. Verify `/`, `/tracker`, `/healthz`, `/livez`, static assets, and security headers.
+5. Import a backup through the browser UI and export a fresh backup from the browser UI.
+6. Promote production with the same immutable image tag; do not use `latest`, `main`, or `main-latest` for production pins.
+
+## Restore checklist
+
+1. Use an empty or intentionally disposable browser profile when testing restore.
+2. Dry-run/preview when available and confirm record counts by store.
+3. Restore JSON for canonical full-fidelity backups or NDJSON for line-oriented full-fidelity backups.
+4. Verify representative applications, contacts, outreach, interviews, offers, artifacts, reminders, and settings.
+5. Re-export JSON/NDJSON and retain the verified backup before clearing any old data.
+
+## Rollback checklist
+
+1. Roll back the static image/chart deployment to the previous immutable tag.
+2. Re-open the browser profile; IndexedDB data should remain local and unaffected by server rollback.
+3. If browser data was intentionally cleared, restore the last verified JSON/NDJSON backup through the UI.
+4. Re-run health checks and export a fresh backup after rollback verification.
+
+## Verification checklist
+
+Run the repo checks from the release prompt where tooling is available: `npm ci`, format, lint, typecheck, `npm run test:ci`, build, screenshots, Helm validation/templates, Docker build, container smoke, and curls for `/`, `/healthz`, and `/livez`.
+
+## Dev/staging seeding
+
+To seed dev or staging, open that deployed app in a separate browser profile and import an anonymized JSON/NDJSON backup or dev-only fake fixture through the browser UI. Do not commit Daniel's real data, real backups, personal Drive links, emails, outreach text, resumes, or private settings.
+
+## Known limitations and follow-ups
+
+- Browser storage is local to each profile/device and subject to browser quota and clearing behavior.
+- CSV remains intentionally spreadsheet-shaped and cannot represent all repeated child records.
+- There is no server database, authentication, multi-user sync, or external API dependency in static tracker mode.

--- a/scripts/build-static.js
+++ b/scripts/build-static.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from "node:fs/promises";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -11,9 +12,38 @@ const assetsDir = path.join(distDir, "assets");
 await fs.rm(distDir, { recursive: true, force: true });
 await fs.mkdir(assetsDir, { recursive: true });
 
-await fs.copyFile(
-  path.join(repoRoot, "src/web/tracker/index.html"),
+const packageJson = JSON.parse(
+  await fs.readFile(path.join(repoRoot, "package.json"), "utf8"),
+);
+const gitSha = (() => {
+  try {
+    return execFileSync("git", ["rev-parse", "--short=12", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return process.env.GITHUB_SHA?.slice(0, 12) || "unknown";
+  }
+})();
+const buildTime = process.env.SOURCE_DATE_EPOCH
+  ? new Date(Number(process.env.SOURCE_DATE_EPOCH) * 1000).toISOString()
+  : new Date().toISOString();
+const applyBuildMetadata = (html) =>
+  html
+    .replaceAll("__JOBBOT_VERSION__", packageJson.version || "unknown")
+    .replaceAll("__JOBBOT_GIT_SHA__", gitSha || "unknown")
+    .replaceAll("__JOBBOT_BUILD_TIME__", buildTime || "unknown");
+
+await fs.writeFile(
   path.join(distDir, "tracker.html"),
+  applyBuildMetadata(
+    await fs.readFile(
+      path.join(repoRoot, "src/web/tracker/index.html"),
+      "utf8",
+    ),
+  ),
+  "utf8",
 );
 await fs.copyFile(
   path.join(repoRoot, "src/web/tracker/tracker.js"),
@@ -55,8 +85,16 @@ This server only serves static assets and health endpoints.</p>
 <nav class="primary-nav"><a href="/tracker">Open tracker</a><a href="/healthz">healthz</a>
 <a href="/livez">livez</a></nav>
 </main></body></html>\n`;
-await fs.writeFile(path.join(distDir, "index.html"), indexHtml, "utf8");
-await fs.writeFile(path.join(distDir, "404.html"), indexHtml, "utf8");
+await fs.writeFile(
+  path.join(distDir, "index.html"),
+  applyBuildMetadata(indexHtml),
+  "utf8",
+);
+await fs.writeFile(
+  path.join(distDir, "404.html"),
+  applyBuildMetadata(indexHtml),
+  "utf8",
+);
 
 const manifest = {
   name: "jobbot3000 Application Tracker",

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -691,10 +691,22 @@ export const browserApplicationExportToRows = (bundle) => {
 };
 export const exportCompactCsv = (bundle) =>
   serializeCsv(browserApplicationExportToRows(bundle));
-export const exportJsonBackup = (bundle) =>
-  `${JSON.stringify(browserApplicationExportSchema.parse(bundle), null, 2)}\n`;
-export const exportNdjsonBackup = (bundle) => {
+const sortRecords = (records) =>
+  [...records].sort((a, b) => String(a.id).localeCompare(String(b.id)));
+export const canonicalizeBrowserApplicationExport = (bundle) => {
   const parsed = browserApplicationExportSchema.parse(bundle);
+  const ordered = {
+    schemaVersion: parsed.schemaVersion,
+    exportedAt: parsed.exportedAt,
+  };
+  for (const store of ARRAY_STORES) ordered[store] = sortRecords(parsed[store]);
+  if (parsed.settings) ordered.settings = parsed.settings;
+  return ordered;
+};
+export const exportJsonBackup = (bundle) =>
+  `${JSON.stringify(canonicalizeBrowserApplicationExport(bundle), null, 2)}\n`;
+export const exportNdjsonBackup = (bundle) => {
+  const parsed = canonicalizeBrowserApplicationExport(bundle);
   const stores = ARRAY_STORES;
   return (
     [

--- a/src/web/tracker/index.html
+++ b/src/web/tracker/index.html
@@ -23,6 +23,10 @@
       <nav class="primary-nav" aria-label="Site navigation">
         <a href="/">Status hub</a>
       </nav>
+      <p class="muted" data-build-version>
+        Version __JOBBOT_VERSION__ · SHA __JOBBOT_GIT_SHA__ · Built
+        __JOBBOT_BUILD_TIME__ · Mode static
+      </p>
     </header>
     <main id="tracker-main" class="tracker-shell">
       <nav class="tracker-nav" aria-label="Tracker sections"></nav>

--- a/test/production-readiness-backup-restore.test.js
+++ b/test/production-readiness-backup-restore.test.js
@@ -1,0 +1,209 @@
+import { readFile } from "node:fs/promises";
+
+import { afterEach, describe, expect, it } from "vitest";
+import { indexedDB } from "fake-indexeddb";
+
+import {
+  DATABASE_NAME,
+  createIndexedDbRepository,
+} from "../src/web/storage/indexedDbRepository.js";
+import {
+  COMPACT_CSV_COLUMNS,
+  canonicalizeBrowserApplicationExport,
+  exportCompactCsv,
+  exportJsonBackup,
+  exportNdjsonBackup,
+  importCompactCsv,
+  importJsonBackup,
+  importNdjsonBackup,
+  parseCsv,
+} from "../src/web/import-export/spreadsheet.js";
+
+const deleteDatabase = () =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(DATABASE_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => resolve();
+  });
+
+afterEach(async () => {
+  await deleteDatabase();
+});
+
+const fixture = () => readFile("test/fixtures/fake-applications.csv", "utf8");
+const withoutExportedAt = (bundle) => {
+  const canonical = canonicalizeBrowserApplicationExport(bundle);
+  return { ...canonical, exportedAt: "<ignored>" };
+};
+
+describe("production backup and restore readiness", () => {
+  it("runs an end-to-end fake-data CSV to JSON/NDJSON restore smoke", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    expect(await repo.listApplications()).toEqual([]);
+
+    const imported = await importCompactCsv(await fixture(), repo, {
+      mode: "replace",
+    });
+    expect(imported.imported).toBe(true);
+    expect(imported.preview.rowCount).toBe(2);
+
+    const manualApplication = {
+      id: "app_manual_gamma_003",
+      company: "Gamma Example Labs",
+      role: "Principal Test Engineer",
+      status: "applied",
+      source: "manual",
+      postingUrl: "https://jobs.example.test/gamma/principal-test",
+      followUpDate: "2026-04-10T23:59:59.000Z",
+      notes: "Fake manual readiness note.",
+      createdAt: "2026-04-01T00:00:00.000Z",
+      updatedAt: "2026-04-01T00:00:00.000Z",
+    };
+    await repo.createApplication(manualApplication);
+    await repo.updateApplication({
+      ...manualApplication,
+      status: "offer",
+      followUpDate: undefined,
+      updatedAt: "2026-04-02T00:00:00.000Z",
+    });
+    await repo.upsertContact({
+      id: "contact_manual_gamma_recruiter",
+      applicationId: manualApplication.id,
+      name: "Fake Recruiter",
+      company: "Gamma Example Labs",
+      createdAt: "2026-04-02T00:00:00.000Z",
+      updatedAt: "2026-04-02T00:00:00.000Z",
+    });
+    await repo.addOutreachMessage({
+      id: "message_manual_gamma_intro",
+      applicationId: manualApplication.id,
+      contactId: "contact_manual_gamma_recruiter",
+      direction: "outbound",
+      channel: "email",
+      body: "Fake outreach body for backup tests.",
+      sentAt: "2026-04-02T12:00:00.000Z",
+      createdAt: "2026-04-02T12:00:00.000Z",
+      updatedAt: "2026-04-02T12:00:00.000Z",
+    });
+    await repo.upsertInterview({
+      id: "interview_manual_gamma_screen",
+      applicationId: manualApplication.id,
+      contactIds: ["contact_manual_gamma_recruiter"],
+      stage: "recruiter_screen",
+      startsAt: "2026-04-05T15:00:00.000Z",
+      outcome: "completed",
+      createdAt: "2026-04-02T00:00:00.000Z",
+      updatedAt: "2026-04-05T16:00:00.000Z",
+    });
+    await repo.upsertOffer({
+      id: "offer_manual_gamma",
+      applicationId: manualApplication.id,
+      status: "received",
+      baseSalaryMin: 200000,
+      baseSalaryMax: 210000,
+      currency: "USD",
+      createdAt: "2026-04-06T00:00:00.000Z",
+      updatedAt: "2026-04-06T00:00:00.000Z",
+    });
+
+    const full = await repo.exportAllData();
+    expect(full.applications).toHaveLength(3);
+    expect(
+      full.applications.find(({ id }) => id === manualApplication.id),
+    ).toMatchObject({
+      company: "Gamma Example Labs",
+      status: "offer",
+      followUpDate: undefined,
+    });
+    expect(parseCsv(exportCompactCsv(full))).toHaveLength(3);
+    expect(exportCompactCsv(full).split("\n")[0]).toBe(
+      COMPACT_CSV_COLUMNS.join(","),
+    );
+
+    const json = exportJsonBackup(full);
+    const ndjson = exportNdjsonBackup(full);
+    await repo.clearAllData();
+    expect(await repo.listApplications()).toEqual([]);
+
+    await repo.importAllData(importJsonBackup(json), { allowOverwrite: true });
+    const restoredJson = await repo.exportAllData();
+    expect(withoutExportedAt(restoredJson)).toEqual(withoutExportedAt(full));
+
+    await repo.clearAllData();
+    await repo.importAllData(importNdjsonBackup(ndjson), {
+      allowOverwrite: true,
+    });
+    const restoredNdjson = await repo.exportAllData();
+    expect(withoutExportedAt(restoredNdjson)).toEqual(withoutExportedAt(full));
+    expect(
+      exportJsonBackup(restoredNdjson).replace(
+        restoredNdjson.exportedAt,
+        full.exportedAt,
+      ),
+    ).toBe(exportJsonBackup(full));
+
+    repo.close();
+  });
+
+  it("validates integrity, deterministic exports, and bad backups", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await importCompactCsv(await fixture(), repo, { mode: "replace" });
+    const bundle = await repo.exportAllData();
+    const reversed = {
+      ...bundle,
+      applications: [...bundle.applications].reverse(),
+      contacts: [...bundle.contacts].reverse(),
+      outreachMessages: [...bundle.outreachMessages].reverse(),
+    };
+
+    expect(exportJsonBackup(reversed)).toBe(exportJsonBackup(bundle));
+    expect(exportNdjsonBackup(reversed)).toBe(exportNdjsonBackup(bundle));
+    expect(exportCompactCsv(reversed).split("\n")[0]).toBe(
+      COMPACT_CSV_COLUMNS.join(","),
+    );
+
+    const dryRun = await repo.importAllData(bundle, { dryRun: true });
+    expect(dryRun).toMatchObject({ imported: false, hasExistingData: true });
+    expect(dryRun.counts.applications).toBe(2);
+    expect(await repo.listApplications()).toHaveLength(2);
+    await expect(repo.importAllData(bundle)).rejects.toMatchObject({
+      code: "import_conflict",
+    });
+
+    expect(() => importJsonBackup("{")).toThrow();
+    expect(() =>
+      importNdjsonBackup('{"type":"applications","record":}\n'),
+    ).toThrow();
+    expect(() =>
+      importJsonBackup(JSON.stringify({ ...bundle, schemaVersion: 2 })),
+    ).toThrow();
+    expect(() =>
+      importJsonBackup(
+        JSON.stringify({
+          ...bundle,
+          applications: [bundle.applications[0], bundle.applications[0]],
+        }),
+      ),
+    ).toThrow(/Duplicate applications id/);
+    const missingContacts = { ...bundle };
+    delete missingContacts.contacts;
+    expect(() => importJsonBackup(JSON.stringify(missingContacts))).toThrow();
+
+    const before = await repo.exportAllData();
+    await expect(
+      repo.importAllData(
+        {
+          ...bundle,
+          applications: [{ ...bundle.applications[0], company: "" }],
+        },
+        { allowOverwrite: true },
+      ),
+    ).rejects.toMatchObject({ code: "schema_validation_failed" });
+    expect(withoutExportedAt(await repo.exportAllData())).toEqual(
+      withoutExportedAt(before),
+    );
+
+    repo.close();
+  });
+});

--- a/test/production-static-contracts.test.js
+++ b/test/production-static-contracts.test.js
@@ -1,0 +1,66 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const read = (relative) => readFile(path.join(repoRoot, relative), "utf8");
+
+describe("production static privacy and deployment contracts", () => {
+  it("keeps tracker data in IndexedDB without private-data POST handlers", async () => {
+    const tracker = await read("src/web/tracker/tracker.js");
+    const server = await read("scripts/static-server.js");
+    expect(tracker).toContain('indexedDB.open("jobbot3000", 1)');
+    expect(tracker).not.toMatch(/fetch\s*\(/);
+    expect(tracker).not.toMatch(/XMLHttpRequest/);
+    expect(server).not.toMatch(/app\.post|app\.put|app\.patch|app\.delete/);
+    expect(server).not.toMatch(
+      /writeFile|appendFile|createWriteStream|better-sqlite3/,
+    );
+  });
+
+  it("does not copy private data paths into the runtime Docker image", async () => {
+    const dockerfile = await read("Dockerfile");
+    const dockerignore = await read(".dockerignore");
+    const runtimeStage = dockerfile.slice(dockerfile.indexOf("AS runtime"));
+    expect(runtimeStage).not.toMatch(
+      /COPY (data|\.env|.*backup|.*\.sqlite|.*\.db)/i,
+    );
+    expect(dockerignore).toMatch(/^data\/?$/m);
+    expect(dockerignore).toMatch(/^\.env/m);
+    expect(dockerignore).toMatch(/\*\.sqlite/m);
+    expect(dockerignore).toMatch(/backup/i);
+  });
+
+  it("keeps Helm defaults stateless and immutable-tag shaped", async () => {
+    const values = await read("charts/jobbot3000/values.yaml");
+    const devValues = await read("charts/jobbot3000/ci/dev-values.yaml");
+    const templates = [
+      await read("charts/jobbot3000/templates/deployment.yaml"),
+      await read("charts/jobbot3000/templates/service.yaml"),
+      await read("charts/jobbot3000/templates/ingress.yaml"),
+    ].join("\n");
+    expect(values).toContain("repository: ghcr.io/futuroptimist/jobbot3000");
+    expect(values).toMatch(/tag: main-[0-9a-f]{7}/);
+    expect(`${values}\n${devValues}`).not.toMatch(
+      /tag: (latest|main|main-latest)$/m,
+    );
+    expect(values).toContain("path: /healthz");
+    expect(values).toContain("path: /livez");
+    expect(templates).not.toMatch(/PersistentVolumeClaim|kind: Secret/);
+  });
+
+  it("exposes build/version metadata placeholders and build-time fallbacks", async () => {
+    const html = await read("src/web/tracker/index.html");
+    const build = await read("scripts/build-static.js");
+    expect(html).toContain("data-build-version");
+    expect(html).toContain("__JOBBOT_VERSION__");
+    expect(build).toContain('packageJson.version || "unknown"');
+    expect(build).toContain("GITHUB_SHA");
+    expect(build).toContain("SOURCE_DATE_EPOCH");
+  });
+});


### PR DESCRIPTION
### Motivation

- Finalize the static/browser-local production contract so jobbot3000 can safely replace the spreadsheet workflow while ensuring backups, restores, and release guidance are explicit. 
- Prevent accidental server-side persistence of private tracker data and make backup/restore semantics and verification deterministic and testable. 
- Provide clear first-use / deploy / restore / rollback checklists and dev/staging seeding guidance so operators can safely adopt the app. 

### Description

- Added production and migration docs: `docs/production-readiness.md`, `docs/import-current-spreadsheet.md`, and extended `docs/backup-restore-guide.md`, and linked them from `README.md`. 
- Made JSON/NDJSON exports deterministic by canonicalizing per-store record order and added `canonicalizeBrowserApplicationExport` used by `exportJsonBackup` and `exportNdjsonBackup` in `src/web/import-export/spreadsheet.js`. 
- Added end-to-end fake-data backup/restore and integrity tests in `test/production-readiness-backup-restore.test.js` and static privacy/Helm/Docker contract tests in `test/production-static-contracts.test.js`. 
- Injected build/version metadata into the static UI via placeholders in `src/web/tracker/index.html` and build-time substitution in `scripts/build-static.js`, and adjusted Helm sample tags away from mutable `main-latest` defaults. 

### Testing

- Ran `npm ci` which succeeded, and `npm run format:check` which reported pre-existing repository-wide Prettier warnings outside the scope of this patch. 
- Linting and type checks passed with `npm run lint` and `npm run typecheck`. 
- Focused test suite run `npx vitest run test/production-readiness-backup-restore.test.js test/production-static-contracts.test.js test/web-spreadsheet-import-export.test.js test/web-deployment.test.js test/docs-backup-restore.test.js` completed and the new tests passed. 
- Built and exercised the static server with `npm run build`, `npm run web:screenshots`, started the server via `JOBBOT_WEB_PORT=8080 node scripts/static-server.js`, and verified `/`, `/tracker`, `/healthz`, and `/livez` with `curl` which all succeeded. 
- Environment-limited checks not executed here: `scripts/validate-helm.sh`, `helm lint`, `helm template ...`, and `docker build/run` could not be run because `helm`/`docker` are not available in this environment, so reviewers should run `scripts/validate-helm.sh`, `helm lint charts/jobbot3000`, `helm template jobbot3000 charts/jobbot3000 --set image.tag=main-TESTSHA`, and `docker build -t jobbot3000:final-smoke . && docker run --rm -p 127.0.0.1:8080:8080 jobbot3000:final-smoke` locally or in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4612b38b7c832f890f3afd07da3639)