### PR TITLE
Finalize production readiness: docs, backup/restore tests, build metadata, and Helm/Docker smoke checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,23 @@ Run the snippet with `node example.js` after saving it to a file in the project 
 
 Production deployments use the static, browser-local web build. The container serves static assets and `/healthz` and `/livez`; it does not own private tracker data, Secrets, or application data volumes.
 
+- [docs/production-readiness.md](docs/production-readiness.md) summarizes the final browser-local production contract, first-use checklist, deploy checklist, restore checklist, rollback checklist, and limitations.
+- [docs/backup-restore-guide.md](docs/backup-restore-guide.md) explains when to use CSV, JSON, and NDJSON backups and how to verify restores before clearing data.
+- [docs/import-current-spreadsheet.md](docs/import-current-spreadsheet.md) walks through replacing the current Google Sheets tracker with CSV import plus JSON/NDJSON backups.
 - [docs/release-ghcr.md](docs/release-ghcr.md) explains the GHCR image workflow and immutable image tags such as `ghcr.io/futuroptimist/jobbot3000:main-<short-sha>`.
 - [docs/release-helm.md](docs/release-helm.md) explains the app-owned Helm chart, OCI publishing workflow, and Sugarkube chart pin for `oci://ghcr.io/futuroptimist/charts/jobbot3000`.
 - [charts/jobbot3000/ci](charts/jobbot3000/ci) contains placeholder dev, staging, and production values examples for Sugarkube-owned environment configuration.
+
+### Deploy with Sugarkube
+
+Sugarkube owns environment-specific pins and runbooks; use the Sugarkube jobbot3000 runbook there rather than copying real hostnames or secrets into this repo. High-level flow:
+
+1. Publish the jobbot3000 image.
+2. Publish the Helm chart only when chart content changes.
+3. Deploy staging with an immutable image tag such as `main-<short-sha>`.
+4. Verify `/`, `/tracker`, `/healthz`, and `/livez`.
+5. Import a backup through the browser UI and then export CSV, JSON, and NDJSON from the same browser UI.
+6. Promote production with the same immutable image tag after staging verification.
 
 Image tags and chart versions are intentionally separate: bump the image tag for a new static app build, and bump `charts/jobbot3000/Chart.yaml` `version` for Kubernetes packaging or default-value changes.
 
@@ -169,8 +183,9 @@ Image tags and chart versions are intentionally separate: bump the image tag for
 - [docs/privacy-and-security.md](docs/privacy-and-security.md) – browser-only production privacy model, backups, clearing data, quota caveats, and static security headers
 - [docs/indexeddb-persistence.md](docs/indexeddb-persistence.md) – browser IndexedDB persistence, backup/restore, and quota caveats
 - [docs/spreadsheet-replacement.md](docs/spreadsheet-replacement.md) – CSV/JSON/NDJSON import-export workflow for replacing the current spreadsheet
-- [docs/backup-restore-guide.md](docs/backup-restore-guide.md) – backup, restore, and verification
-  steps
+- [docs/import-current-spreadsheet.md](docs/import-current-spreadsheet.md) – Google Sheets CSV migration and transition backup cadence
+- [docs/backup-restore-guide.md](docs/backup-restore-guide.md) – backup, restore, verification, and dev/staging/prod seeding
+- [docs/production-readiness.md](docs/production-readiness.md) – final production deployment, restore, rollback, and verification checklists
 - [docs/web-ux-guidelines.md](docs/web-ux-guidelines.md) – layout, typography, and interaction guardrails
 - [GitHub Actions: web-screenshots.yml](https://github.com/futuroptimist/jobbot3000/actions/workflows/web-screenshots.yml) – captures the latest UI flows for regressions
 

--- a/charts/jobbot3000/ci/dev-values.yaml
+++ b/charts/jobbot3000/ci/dev-values.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: main-latest
+  tag: main-REPLACE_WITH_SHORT_SHA
 
 ingress:
   enabled: true

--- a/charts/jobbot3000/values.yaml
+++ b/charts/jobbot3000/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/futuroptimist/jobbot3000
-  tag: main-latest
+  tag: main-REPLACE_WITH_SHORT_SHA
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/docs/backup-restore-guide.md
+++ b/docs/backup-restore-guide.md
@@ -1,102 +1,39 @@
-# Backup and Restore Guide
+# Backup and restore guide
 
-Use this guide to capture and restore the persistent state that powers jobbot3000.
-The CLI and web server both read and write from the same directories.
-Back up the entire data root alongside structured exports before performing risky upgrades.
+jobbot3000 production mode stores private tracker data in browser IndexedDB. Backups are explicit browser downloads; the server, Docker image, Helm chart, Kubernetes resources, and repo fixtures must not contain real application data.
 
-## Scope
+## Formats
 
-- `JOBBOT_DATA_DIR` (defaults to `./data/`) stores SQLite databases, job snapshots,
-  deliverables, and resume artifacts.
-- `opportunities.db` inside the data directory persists opportunities, contacts,
-  lifecycle events, and attachment metadata.
-- `JOBBOT_AUDIT_LOG` (defaults to `data/audit/audit-log.jsonl`) records privileged
-  CLI actions.
+| Format | Fidelity                                      | Shape                                                           | Use when                                                                  |
+| ------ | --------------------------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| CSV    | Spreadsheet-compatible, intentionally limited | Stable 32 columns, one row per application                      | Editing in Google Sheets, manual audits, interchange with the old tracker |
+| JSON   | Full fidelity                                 | One canonical backup bundle with schema metadata and all stores | Normal backup/restore, browser migration, pre-clear safety copy           |
+| NDJSON | Full fidelity                                 | One typed JSON record per line plus metadata                    | Streaming, diff-friendly review, automation                               |
 
-Before backing up, pause scheduled tasks and stop any running `npm run web:server`
-processes to avoid writes mid-archive.
+## Verify before clearing data
 
-## Backup
+1. Export JSON and NDJSON from **Import/Export**.
+2. Save them to an encrypted private location outside the repo and Docker build context.
+3. Restore into an empty browser profile or disposable staging origin.
+4. Verify application count, store counts, conflicts, schema version, representative records, and follow-up/reminder state.
+5. Re-export after restore and compare canonicalized records/counts.
+6. Only then clear the original browser data if needed.
 
-1. Resolve data and audit locations:
-   ```bash
-   export JOBBOT_DATA_DIR="${JOBBOT_DATA_DIR:-$(pwd)/data}"
-   export JOBBOT_AUDIT_LOG="${JOBBOT_AUDIT_LOG:-$JOBBOT_DATA_DIR/audit/audit-log.jsonl}"
-   mkdir -p backups
-   ```
-2. Export the SQLite contents as newline-delimited JSON so you can diff or replay
-   entries later:
-   ```bash
-   node scripts/export-data.js > backups/opportunities.ndjson
-   ```
-3. Archive the entire data directory, including attachments and deliverables:
-   ```bash
-   tar -czf backups/jobbot-backup.tgz -C "$JOBBOT_DATA_DIR" .
-   ```
-   On Windows PowerShell, use:
-   ```powershell
-   Compress-Archive -Path "$env:JOBBOT_DATA_DIR\*" -DestinationPath "backups\jobbot-backup.zip"
-   ```
-4. Copy the audit log alongside the archive for compliance reviews:
-   ```bash
-   cp "$JOBBOT_AUDIT_LOG" backups/
-   ```
-5. Store the archive, NDJSON export, and audit log in an encrypted destination
-   such as S3 with server-side encryption or a password-protected external drive.
+## Restore into dev, staging, or production browsers
 
-## Restore
+Dev, staging, and production are separate browser storage profiles unless the same backup is manually imported into each one. To restore or seed an environment:
 
-1. Point `JOBBOT_DATA_DIR` at the directory you want to hydrate and ensure it is
-   empty:
-   ```bash
-   export JOBBOT_DATA_DIR="${JOBBOT_DATA_DIR:-$(pwd)/data}"
-   rm -rf "$JOBBOT_DATA_DIR"
-   mkdir -p "$JOBBOT_DATA_DIR"
-   ```
-2. Extract the archived files:
-   ```bash
-   tar -xzf backups/jobbot-backup.tgz -C "$JOBBOT_DATA_DIR"
-   ```
-   On Windows PowerShell, run:
-   ```powershell
-   Expand-Archive -Path "backups\jobbot-backup.zip" -DestinationPath $env:JOBBOT_DATA_DIR -Force
-   ```
-3. Restore the audit log if present:
-   ```bash
-   cp backups/audit-log.jsonl "$JOBBOT_AUDIT_LOG"
-   ```
-4. Replay the structured export with a dry-run first:
-   ```bash
-   node scripts/import-data.js --source backups/opportunities.ndjson --dry-run
-   ```
-   When the validation succeeds, apply the import:
-   ```bash
-   node scripts/import-data.js --source backups/opportunities.ndjson
-   ```
-5. Restart any background schedulers or the web server after the restore completes.
+1. Open that environment's deployed app in the intended browser profile.
+2. Import an anonymized JSON/NDJSON backup, fake seed data, or the private production backup through the browser UI as appropriate.
+3. Do not commit Daniel's real data, real backups, real Drive links, real emails, outreach messages, resumes, or private settings.
+4. Do not place real backups in public repos, Docker images, Helm values, ConfigMaps, Secrets, PVCs, or server files.
 
-## Verify
+## Choosing a format
 
-Run a quick checklist before resuming normal operations:
+- Use **CSV** when a person needs to inspect or edit one application per row in a spreadsheet.
+- Use **JSON** before clearing data, before browser/profile changes, before production use, and for most restores.
+- Use **NDJSON** when line-oriented validation or automation is easier than a single JSON bundle.
 
-- Confirm analytics metrics load:
-  ```bash
-  jobbot analytics health --json
-  ```
-- Export a temporary snapshot to ensure SQLite reads succeed:
-  ```bash
-  node scripts/export-data.js > /tmp/restore-check.ndjson
-  ```
-- Inspect the audit log tail for recent entries and permissions issues:
-  ```bash
-  tail "$JOBBOT_AUDIT_LOG"
-  ```
+## Failure handling
 
-## Automation tips
-
-- Schedule the export and archive commands via cron or Task Scheduler to create
-  rolling backups.
-- Store multiple generations (daily or weekly) and test restores periodically in
-  a sandbox directory.
-- Combine the NDJSON export and archive with offsite replication to stay ready
-  for disaster recovery.
+Corrupt JSON, malformed NDJSON lines, unsupported backup schema versions, duplicate IDs, missing required stores, and dangling references should fail validation before mutating IndexedDB. Use dry-run/preview flows first; replace restore requires explicit overwrite confirmation when data already exists, and merge flows should report conflicts.

--- a/docs/import-current-spreadsheet.md
+++ b/docs/import-current-spreadsheet.md
@@ -1,0 +1,43 @@
+# Import the current spreadsheet
+
+Use this guide when replacing the current Google Sheets tracker with jobbot3000. Use only private local files for real data; committed fixtures must remain fake/anonymized.
+
+## Export Google Sheets as CSV
+
+1. Open the current tracker spreadsheet.
+2. Select the tab with the one-row-per-application tracker.
+3. Choose **File → Download → Comma-separated values (.csv)**.
+4. Save the file in a private folder, not inside this repository or a Docker build context.
+
+## Import CSV into jobbot3000
+
+1. Open jobbot3000 in the browser profile/origin that will own production data.
+2. Open **Import/Export**.
+3. Select the CSV and run **Preview/dry-run**.
+4. Check row counts, invalid dates/numbers, duplicate IDs, duplicate posting URLs, and conflicts with existing IndexedDB records.
+5. Apply the import only when the preview matches expectations.
+
+## Verify after import
+
+- Compare application count with the spreadsheet row count after excluding blank rows.
+- Spot-check representative companies, roles, statuses, posting URLs, notes, outreach fields, interview stage, outcome, and follow-up dates.
+- Export CSV and confirm the header remains the stable 32-column spreadsheet format.
+
+## Back up after import
+
+- Export **CSV** for spreadsheet-compatible review and manual editing.
+- Export **JSON** as the canonical full-fidelity backup bundle.
+- Export **NDJSON** as the line-oriented full-fidelity backup stream.
+
+CSV is not full-fidelity once one application has multiple outreach messages, contacts, interviews, offers, artifacts, lifecycle events, or reminders. Keep JSON/NDJSON before clearing data or changing browser profiles.
+
+## Restore JSON/NDJSON into an empty profile
+
+1. Create a new browser profile, clear site data, or use a distinct dev/staging/prod origin.
+2. Open jobbot3000 and import the JSON or NDJSON backup through the browser UI.
+3. Confirm schema version, store counts, conflicts, and representative records.
+4. Re-export JSON/NDJSON and compare counts before deleting any original source.
+
+## Transition backup cadence
+
+During the spreadsheet-to-jobbot3000 transition, export JSON and NDJSON after each substantial tracking session and export CSV at least daily while you still want spreadsheet review. Keep at least one known-good backup outside the machine/browser profile that owns the live IndexedDB data.

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -1,0 +1,77 @@
+# Production readiness
+
+jobbot3000 production mode is a static, browser-local application tracker. The pod or container serves HTML, JavaScript, CSS, the web manifest, and `/healthz`/`/livez`; private tracker records are owned by the user's browser profile in IndexedDB.
+
+## Final architecture summary
+
+- **Static app shell:** `npm run build` writes `dist/`, and the production container serves it on port `8080`.
+- **Browser data plane:** applications, contacts, outreach, lifecycle events, interviews, offers, artifacts, reminders, and settings are stored in the browser's `jobbot3000` IndexedDB database.
+- **Backup data plane:** CSV is the spreadsheet-compatible interchange format; JSON and NDJSON are full-fidelity backup/restore formats.
+- **Deployment data plane:** Docker, Helm, Kubernetes, server logs, ConfigMaps, Secrets, and PVCs are not data stores for tracker records.
+
+## Safe to deploy publicly
+
+It is safe to publish and deploy the static application assets, Docker image `ghcr.io/futuroptimist/jobbot3000`, and Helm chart `oci://ghcr.io/futuroptimist/charts/jobbot3000` because they contain only code, static assets, health endpoints, and placeholder configuration. Deploy immutable image tags such as `main-<short-sha>`.
+
+## Local-only data
+
+The following stay local to the browser unless the user explicitly exports a file:
+
+- application rows and notes;
+- contacts and outreach messages;
+- interviews, offers, outcomes, artifacts, and reminders;
+- tracker settings and imported spreadsheet contents.
+
+## Never store in Kubernetes or server files
+
+Do not put real job-application data in container images, Helm values, ConfigMaps, Secrets, PVCs, repo fixtures, static server logs, `.env` files, or local backup directories committed to git. Seed dev/staging/prod by opening the app in the target browser and importing an anonymized JSON/NDJSON backup or fake fixture through the UI.
+
+## Backup format differences
+
+- **CSV:** human-editable, spreadsheet-shaped, one row per application, stable 32-column order. Use it for Google Sheets compatibility and manual review. It cannot represent every repeated child record once an application has multiple outreach messages, interviews, offers, artifacts, or reminders.
+- **JSON:** canonical full-fidelity backup bundle. Use it before clearing data, before browser/profile migrations, and for normal restore.
+- **NDJSON:** full-fidelity line-oriented stream. Use it for diffing, append-friendly tooling, and future automation that wants one typed record per line.
+
+## First-use checklist
+
+1. Open the production app in the browser profile that will own the data.
+2. Import the current spreadsheet CSV or start with a manual application.
+3. Check application counts, conflicts, representative companies/roles, and follow-up dates.
+4. Export JSON and NDJSON backups immediately after the first successful import.
+5. Store backups in an encrypted private location outside the repo and image build context.
+
+## First production deploy checklist
+
+1. Publish the image with an immutable tag (`main-<short-sha>`).
+2. Publish the Helm chart only when chart templates/defaults changed.
+3. Deploy staging with the immutable image tag.
+4. Verify `/`, `/tracker`, `/healthz`, `/livez`, static assets, security headers, and no-store app-shell caching.
+5. Import an anonymized backup through the browser UI for staging smoke checks.
+6. Export CSV, JSON, and NDJSON from the browser UI and verify counts.
+7. Promote production with the same immutable image tag.
+
+## Restore checklist
+
+1. Use a new or intentionally empty browser profile/origin.
+2. Prefer JSON restore for normal full-fidelity recovery; use NDJSON when validating a line-oriented backup.
+3. Dry-run/preview when available and confirm schema version, database version, store counts, and conflicts.
+4. Apply replace restore only after confirming the target IndexedDB can be cleared.
+5. Re-export JSON after restore and compare record counts and representative records.
+
+## Rollback checklist
+
+1. Roll Kubernetes back to the previous immutable image tag or Helm release.
+2. Remember that rollback changes only static code; user data remains in each browser's IndexedDB.
+3. If a bad UI build wrote unwanted local changes, restore the user's last known-good JSON/NDJSON backup into an empty profile.
+4. Do not attempt to recover user tracker data from Kubernetes resources; it should not be there.
+
+## Verification checklist
+
+Run the normal CI checks, static build, screenshot flow, Helm validation, container build, and smoke curls. If Docker, Helm, or browsers are unavailable locally, rely on script-level tests and run the missing commands in CI or a workstation with those tools.
+
+## Known limitations and follow-ups
+
+- Browser storage is origin/profile-specific and subject to browser quota/eviction behavior.
+- CSV remains intentionally lossy for repeated child records; keep JSON/NDJSON as the source for full restore.
+- There is no server-side multi-user database or authentication layer in production static mode.
+- Real backups require user-managed encryption, retention, and offsite storage.

--- a/scripts/build-static.js
+++ b/scripts/build-static.js
@@ -7,6 +7,17 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
 const distDir = path.join(repoRoot, "dist");
 const assetsDir = path.join(distDir, "assets");
+const packageJson = JSON.parse(
+  await fs.readFile(path.join(repoRoot, "package.json"), "utf8"),
+);
+const buildMetadata = {
+  version: packageJson.version ?? "unknown",
+  gitSha: process.env.GITHUB_SHA || process.env.JOBBOT_GIT_SHA || "unknown",
+  buildTimestamp: process.env.SOURCE_DATE_EPOCH
+    ? new Date(Number(process.env.SOURCE_DATE_EPOCH) * 1000).toISOString()
+    : new Date().toISOString(),
+  mode: "static/browser-local",
+};
 
 await fs.rm(distDir, { recursive: true, force: true });
 await fs.mkdir(assetsDir, { recursive: true });
@@ -15,9 +26,18 @@ await fs.copyFile(
   path.join(repoRoot, "src/web/tracker/index.html"),
   path.join(distDir, "tracker.html"),
 );
-await fs.copyFile(
+const trackerJs = await fs.readFile(
   path.join(repoRoot, "src/web/tracker/tracker.js"),
+  "utf8",
+);
+const trackerBuildPreamble = [
+  "/* eslint-disable max-len */",
+  `globalThis.__JOBBOT_BUILD__ = ${JSON.stringify(buildMetadata)};`,
+].join("\n");
+await fs.writeFile(
   path.join(assetsDir, "tracker.js"),
+  `${trackerBuildPreamble}\n${trackerJs}`,
+  "utf8",
 );
 await fs.copyFile(
   path.join(repoRoot, "src/web/tracker/tracker.css"),
@@ -54,6 +74,8 @@ const indexHtml = `<!doctype html>
 This server only serves static assets and health endpoints.</p>
 <nav class="primary-nav"><a href="/tracker">Open tracker</a><a href="/healthz">healthz</a>
 <a href="/livez">livez</a></nav>
+<p class="muted">Version ${buildMetadata.version} • ${buildMetadata.mode} •
+${buildMetadata.gitSha.slice(0, 12)} • ${buildMetadata.buildTimestamp}</p>
 </main></body></html>\n`;
 await fs.writeFile(path.join(distDir, "index.html"), indexHtml, "utf8");
 await fs.writeFile(path.join(distDir, "404.html"), indexHtml, "utf8");

--- a/src/web/tracker/index.html
+++ b/src/web/tracker/index.html
@@ -143,6 +143,12 @@
           </button>
         </div>
         <p class="muted" data-settings-result></p>
+        <section class="card" aria-label="Build information">
+          <h3>Build</h3>
+          <p class="muted" data-build-info>
+            Version unknown • static/browser-local
+          </p>
+        </section>
       </section>
       <section class="tracker-view" data-view="detail" hidden>
         <button class="button" data-back-to-list>← Back to applications</button>

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -42,6 +42,15 @@ const esc = (v) =>
   );
 const id = (p = "id") =>
   `${p}_${Date.now().toString(36)}_${crypto.getRandomValues(new Uint32Array(1))[0].toString(36)}`;
+const buildMetadata = globalThis.__JOBBOT_BUILD__ ?? {};
+const buildLabel = () => {
+  const version = buildMetadata.version || "unknown";
+  const sha = buildMetadata.gitSha || "unknown";
+  const shortSha = sha === "unknown" ? sha : String(sha).slice(0, 12);
+  const timestamp = buildMetadata.buildTimestamp || "unknown";
+  const mode = buildMetadata.mode || "static/browser-local";
+  return `Version ${version} • ${mode} • ${shortSha} • ${timestamp}`;
+};
 function ensureIndex(store, name, keyPath) {
   if (!store.indexNames.contains(name)) store.createIndex(name, keyPath);
 }
@@ -782,6 +791,8 @@ function exportData(fmt) {
   }
 }
 function init() {
+  const buildInfo = $("[data-build-info]");
+  if (buildInfo) buildInfo.textContent = buildLabel();
   renderNav();
   $('[data-filter="status"]').innerHTML += STATUSES.map(
     (s) => `<option>${s}</option>`,

--- a/test/web-deployment.test.js
+++ b/test/web-deployment.test.js
@@ -127,6 +127,32 @@ describe("web deployment artifacts", () => {
     expect(staticServer).not.toMatch(/writeFile|appendFile|createWriteStream/);
   });
 
+  it("proves static tracker source keeps private data in IndexedDB without POSTs", async () => {
+    const tracker = await readFile(
+      path.join(repoRoot, "src", "web", "tracker", "tracker.js"),
+      "utf8",
+    );
+    expect(tracker).toContain('indexedDB.open("jobbot3000", 1)');
+    for (const privateStore of [
+      "applications",
+      "contacts",
+      "outreachMessages",
+      "lifecycleEvents",
+      "interviews",
+      "offers",
+      "artifacts",
+      "reminders",
+      "settings",
+    ]) {
+      expect(tracker).toContain(`"${privateStore}"`);
+    }
+    expect(tracker).not.toMatch(/fetch\s*\(/);
+    expect(tracker).not.toMatch(/XMLHttpRequest|sendBeacon/);
+    expect(tracker).not.toMatch(/method:\s*["']POST["']/i);
+    expect(tracker).not.toContain("/commands");
+    expect(tracker).not.toContain("better-sqlite3");
+  });
+
   it("documents static privacy boundaries and IndexedDB backup guidance", async () => {
     const doc = await readFile(
       path.join(repoRoot, "docs", "privacy-and-security.md"),
@@ -200,5 +226,78 @@ describe("GHCR image workflow", () => {
     );
     expect(doc).toContain("/healthz");
     expect(doc).toContain("/livez");
+  });
+});
+
+describe("Helm chart production contract", () => {
+  it("keeps browser data out of Kubernetes defaults and uses immutable-shaped tags", async () => {
+    const values = await readFile(
+      path.join(repoRoot, "charts", "jobbot3000", "values.yaml"),
+      "utf8",
+    );
+    const deployment = await readFile(
+      path.join(
+        repoRoot,
+        "charts",
+        "jobbot3000",
+        "templates",
+        "deployment.yaml",
+      ),
+      "utf8",
+    );
+    const renderedSources = [
+      values,
+      deployment,
+      await readFile(
+        path.join(
+          repoRoot,
+          "charts",
+          "jobbot3000",
+          "templates",
+          "service.yaml",
+        ),
+        "utf8",
+      ),
+      await readFile(
+        path.join(
+          repoRoot,
+          "charts",
+          "jobbot3000",
+          "templates",
+          "ingress.yaml",
+        ),
+        "utf8",
+      ),
+    ].join("\n");
+
+    expect(values).toContain("repository: ghcr.io/futuroptimist/jobbot3000");
+    expect(values).toContain("tag: main-REPLACE_WITH_SHORT_SHA");
+    expect(values).not.toMatch(/^\s*tag:\s*(latest|main|main-latest)\s*$/m);
+    expect(renderedSources).toContain(
+      "path: {{ .Values.probes.readiness.path }}",
+    );
+    expect(renderedSources).toContain(
+      "path: {{ .Values.probes.liveness.path }}",
+    );
+    expect(values).toContain("path: /healthz");
+    expect(values).toContain("path: /livez");
+    expect(renderedSources).not.toMatch(
+      /kind:\s*(PersistentVolumeClaim|Secret)\b/,
+    );
+    expect(renderedSources).not.toContain("JOBBOT_DATA_DIR");
+    expect(renderedSources).not.toContain("persistentVolume");
+  });
+
+  it("validates default, ingress, staging, and prod helm templates", async () => {
+    const script = await readFile(
+      path.join(repoRoot, "scripts", "validate-helm.sh"),
+      "utf8",
+    );
+    expect(script).toContain('helm lint "${chart_dir}"');
+    expect(script).toContain("--set image.tag=main-TESTSHA");
+    expect(script).toContain(
+      "--set ingress.host=jobbot3000.staging.example.test",
+    );
+    expect(script).toContain("--set ingress.host=jobbot3000.example.test");
   });
 });

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -143,6 +143,197 @@ describe("spreadsheet import/export", () => {
     repo.close();
   });
 
+  it("covers a full fake-data CSV to JSON/NDJSON backup restore workflow", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const csv = await fixture();
+    const importResult = await importCompactCsv(csv, repo, { mode: "replace" });
+    expect(importResult.imported).toBe(true);
+    expect(importResult.preview.rowCount).toBe(2);
+
+    const timestamp = "2026-03-04T05:06:07.000Z";
+    const manualApplication = {
+      id: "app_manual_gamma_003",
+      company: "Demo Analytics",
+      role: "Product Infrastructure Engineer",
+      status: "applied",
+      source: "manual",
+      postingUrl: "https://jobs.example.test/demo-analytics/product-infra",
+      location: "Remote",
+      remote: true,
+      appliedAt: timestamp,
+      followUpDate: "2026-03-10T00:00:00.000Z",
+      notes: "Anonymized manual smoke-test application.",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    };
+    await repo.createApplication(manualApplication);
+    await repo.updateApplication({
+      ...manualApplication,
+      status: "offer",
+      followUpDate: undefined,
+      updatedAt: "2026-03-05T05:06:07.000Z",
+    });
+    await repo.upsertContact({
+      id: "contact_manual_gamma_003",
+      applicationId: manualApplication.id,
+      name: "Taylor Test",
+      email: "taylor.test@example.test",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    await repo.addOutreachMessage({
+      id: "message_manual_gamma_003",
+      applicationId: manualApplication.id,
+      contactId: "contact_manual_gamma_003",
+      direction: "outbound",
+      channel: "email",
+      subject: "Anonymized outreach",
+      body: "Fake outreach body for restore testing.",
+      sentAt: "2026-03-05T12:00:00.000Z",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    await repo.addLifecycleEvent({
+      id: "event_manual_gamma_offer",
+      applicationId: manualApplication.id,
+      status: "offer",
+      occurredAt: "2026-03-06T12:00:00.000Z",
+      source: "manual",
+      note: "Fake final outcome.",
+      createdAt: timestamp,
+    });
+    await repo.upsertInterview({
+      id: "interview_manual_gamma_003",
+      applicationId: manualApplication.id,
+      contactIds: ["contact_manual_gamma_003"],
+      stage: "technical_screen",
+      startsAt: "2026-03-06T15:00:00.000Z",
+      outcome: "completed",
+      preparationNotes: "Fake preparation notes.",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+    await repo.upsertOffer({
+      id: "offer_manual_gamma_003",
+      applicationId: manualApplication.id,
+      status: "received",
+      baseSalaryMin: 150000,
+      baseSalaryMax: 175000,
+      currency: "USD",
+      notes: "Fake offer notes.",
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    });
+
+    const fullBundle = await repo.exportAllData();
+    expect(fullBundle.applications).toHaveLength(3);
+    expect(fullBundle.interviews).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "interview_manual_gamma_003" }),
+      ]),
+    );
+    expect(exportCompactCsv(fullBundle).split("\n")[0]).toBe(
+      COMPACT_CSV_COLUMNS.join(","),
+    );
+    const jsonText = exportJsonBackup(fullBundle);
+    const ndjsonText = exportNdjsonBackup(fullBundle);
+
+    await repo.clearAllData();
+    expect((await repo.exportAllData()).applications).toHaveLength(0);
+    await repo.importAllData(importJsonBackup(jsonText), {
+      allowOverwrite: true,
+    });
+    const restoredJson = await repo.exportAllData();
+    const restoredManual = restoredJson.applications.find(
+      ({ id }) => id === "app_manual_gamma_003",
+    );
+    expect(restoredManual).toMatchObject({
+      id: "app_manual_gamma_003",
+      status: "offer",
+    });
+    expect(restoredManual).not.toHaveProperty("followUpDate");
+    expect(restoredJson.offers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "offer_manual_gamma_003",
+          status: "received",
+        }),
+      ]),
+    );
+
+    await repo.clearAllData();
+    await repo.importAllData(importNdjsonBackup(ndjsonText), {
+      allowOverwrite: true,
+    });
+    const restoredNdjson = await repo.exportAllData();
+    const canonical = (bundle) =>
+      JSON.parse(
+        exportJsonBackup({ ...bundle, exportedAt: fullBundle.exportedAt }),
+      );
+    expect(canonical(restoredNdjson)).toEqual(canonical(fullBundle));
+    expect(
+      importJsonBackup(exportJsonBackup(restoredNdjson)).applications,
+    ).toHaveLength(3);
+
+    repo.close();
+  });
+
+  it("validates backup integrity, dry-runs, conflicts, and malformed restore inputs", async () => {
+    const csv = await fixture();
+    const { bundle } = csvToBrowserApplicationExport(csv, {
+      exportedAt: "2026-03-01T00:00:00.000Z",
+    });
+    expect(exportJsonBackup(bundle)).toBe(exportJsonBackup(bundle));
+    expect(exportNdjsonBackup(bundle)).toBe(exportNdjsonBackup(bundle));
+    expect(exportCompactCsv(bundle).split("\n")[0]).toBe(
+      COMPACT_CSV_COLUMNS.join(","),
+    );
+    expect(bundle.schemaVersion).toBe(1);
+
+    expect(() => importJsonBackup("{not json")).toThrow();
+    expect(() => importNdjsonBackup('{"type":"meta"}\nnot-json\n')).toThrow();
+    expect(() =>
+      importJsonBackup(JSON.stringify({ ...bundle, schemaVersion: 999 })),
+    ).toThrow();
+    expect(() =>
+      importJsonBackup(JSON.stringify({ ...bundle, contacts: undefined })),
+    ).toThrow();
+    expect(() =>
+      importJsonBackup(
+        JSON.stringify({
+          ...bundle,
+          applications: [bundle.applications[0], bundle.applications[0]],
+        }),
+      ),
+    ).toThrow(/Duplicate applications id/);
+
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await repo.importAllData(bundle);
+    const beforeDryRun = await repo.exportAllData();
+    const dryRun = await repo.importAllData(bundle, { dryRun: true });
+    expect(dryRun).toMatchObject({
+      imported: false,
+      hasExistingData: true,
+      counts: { applications: 2, settings: 0 },
+      conflicts: expect.arrayContaining([
+        { storeName: "applications", id: "app_fake_alpha_001" },
+      ]),
+    });
+    expect({
+      ...(await repo.exportAllData()),
+      exportedAt: beforeDryRun.exportedAt,
+    }).toEqual(beforeDryRun);
+    await expect(repo.importAllData(bundle)).rejects.toMatchObject({
+      code: "import_conflict",
+    });
+    expect({
+      ...(await repo.exportAllData()),
+      exportedAt: beforeDryRun.exportedAt,
+    }).toEqual(beforeDryRun);
+
+    repo.close();
+  });
+
   it("preserves CSV timestamp, stage, and outcome exports", async () => {
     const csv = serializeCsv([
       {
@@ -352,9 +543,7 @@ describe("spreadsheet import/export", () => {
       "app_regenerated",
     );
     expect(exported.interviews[0].contactIds).toEqual(
-      expect.not.arrayContaining([
-        expect.stringContaining("app_regenerated"),
-      ]),
+      expect.not.arrayContaining([expect.stringContaining("app_regenerated")]),
     );
     const childCounts = Object.fromEntries(
       childStores.map((store) => [store, exported[store].length]),


### PR DESCRIPTION
### Motivation

- Finalize the browser-first production contract so jobbot3000 can safely replace the spreadsheet workflow with clear backup/restore guidance and verification steps.
- Ensure full-fidelity JSON/NDJSON backups and spreadsheet-compatible CSV workflows are tested end-to-end and that restores are deterministic and safe (dry-run, conflict, and corrupt-input handling).
- Prove the static production surface does not send or persist private tracker data server-side and that Helm/Docker chart defaults align with Sugarkube deployment contracts.
- Surface build/version metadata in the static app for operational visibility during staging and production verification.

### Description

- Added `docs/production-readiness.md`, `docs/import-current-spreadsheet.md`, and tightened `docs/backup-restore-guide.md` and `README.md` links and a compact “Deploy with Sugarkube” flow to explain safe deploys, first-use, restore, rollback, verification, and limitations.
- Implemented build metadata injection in `scripts/build-static.js` and surfaced a compact build label in the tracker UI by prepending `globalThis.__JOBBOT_BUILD__` to the generated tracker bundle and adding a small UI area to show version/sha/timestamp/mode.
- Added and strengthened tests: expanded `test/web-spreadsheet-import-export.test.js` with a full fake-data CSV → JSON/NDJSON backup/restore smoke test and integrity checks, and added static/no-server-PII and Helm contract assertions to `test/web-deployment.test.js` plus a Helm tag example change in `charts/jobbot3000/values.yaml` from `main-latest` to `main-REPLACE_WITH_SHORT_SHA`.
- Kept changes minimal and focused: no schema redesign, no server-side persistence, no Sugarkube edits, and only fake/anonymized fixtures were added; formatted touched files with `prettier`.

### Testing

- Core repo checks and builds were executed: `npm ci` (OK), `npm run build` (OK), `npm run lint` (OK after formatting touched files), and `npm run typecheck` (OK).
- Focused test suites were run and passed: `npx vitest run test/web-spreadsheet-import-export.test.js test/web-deployment.test.js test/web-storage-indexeddb-repository.test.js --pool=forks` (all tests in those files passed), and `npm run web:screenshots` produced screenshots successfully; `PORT=8080 npm run start:static` plus `curl -fsS http://127.0.0.1:8080/`, `/tracker`, `/healthz`, and `/livez` all returned expected responses (OK).
- Notes on environment-limited checks and observed failures: `npm run format:check` reported pre-existing repo-wide formatting warnings (non-blocking) and touched files were formatted; a full `npm run test:ci` initially failed in this environment due to missing native `better-sqlite3` bindings but the focused production-readiness suites were re-run successfully after a normal `npm ci`; `helm` and `docker` were not available here so `scripts/validate-helm.sh`, `helm lint`/`helm template`, and `docker build`/`docker run` could not be executed in this environment and therefore should be run in CI or a local workstation using the commands from the verification checklist (e.g., `scripts/validate-helm.sh`, `helm lint charts/jobbot3000`, `helm template ... --set image.tag=main-TESTSHA`, `docker build -t jobbot3000:final-smoke .`, `docker run --rm -p 127.0.0.1:8080:8080 jobbot3000:final-smoke`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4612ceeb40832f8d47386361b06e49)