### PR TITLE
Finalize production readiness checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,23 @@ Run the snippet with `node example.js` after saving it to a file in the project 
 
 Production deployments use the static, browser-local web build. The container serves static assets and `/healthz` and `/livez`; it does not own private tracker data, Secrets, or application data volumes.
 
+- [docs/production-readiness.md](docs/production-readiness.md) is the final production checklist for first use, first deploy, restore, rollback, and verification.
+- [docs/backup-restore-guide.md](docs/backup-restore-guide.md) explains CSV/JSON/NDJSON backup and restore choices.
+- [docs/import-current-spreadsheet.md](docs/import-current-spreadsheet.md) covers replacing the current Google Sheets tracker with jobbot3000.
 - [docs/release-ghcr.md](docs/release-ghcr.md) explains the GHCR image workflow and immutable image tags such as `ghcr.io/futuroptimist/jobbot3000:main-<short-sha>`.
 - [docs/release-helm.md](docs/release-helm.md) explains the app-owned Helm chart, OCI publishing workflow, and Sugarkube chart pin for `oci://ghcr.io/futuroptimist/charts/jobbot3000`.
 - [charts/jobbot3000/ci](charts/jobbot3000/ci) contains placeholder dev, staging, and production values examples for Sugarkube-owned environment configuration.
+
+### Deploy with Sugarkube
+
+Sugarkube owns environment-specific orchestration. Use the Sugarkube jobbot3000 runbook there rather than duplicating hosts, secrets, or cluster-specific values in this repo. High-level flow:
+
+1. Publish `ghcr.io/futuroptimist/jobbot3000:main-<short-sha>` for the static app build.
+2. Publish `oci://ghcr.io/futuroptimist/charts/jobbot3000` only when chart content changes.
+3. Deploy staging with the immutable image tag.
+4. Verify `/`, `/tracker`, `/healthz`, and `/livez`.
+5. Import the backup through the browser UI, then export JSON/NDJSON and CSV backups from the browser UI.
+6. Promote production with the same immutable tag after staging verification.
 
 Image tags and chart versions are intentionally separate: bump the image tag for a new static app build, and bump `charts/jobbot3000/Chart.yaml` `version` for Kubernetes packaging or default-value changes.
 
@@ -169,8 +183,9 @@ Image tags and chart versions are intentionally separate: bump the image tag for
 - [docs/privacy-and-security.md](docs/privacy-and-security.md) – browser-only production privacy model, backups, clearing data, quota caveats, and static security headers
 - [docs/indexeddb-persistence.md](docs/indexeddb-persistence.md) – browser IndexedDB persistence, backup/restore, and quota caveats
 - [docs/spreadsheet-replacement.md](docs/spreadsheet-replacement.md) – CSV/JSON/NDJSON import-export workflow for replacing the current spreadsheet
-- [docs/backup-restore-guide.md](docs/backup-restore-guide.md) – backup, restore, and verification
-  steps
+- [docs/import-current-spreadsheet.md](docs/import-current-spreadsheet.md) – step-by-step Google Sheets CSV migration and transition backup cadence
+- [docs/backup-restore-guide.md](docs/backup-restore-guide.md) – backup, restore, and verification steps
+- [docs/production-readiness.md](docs/production-readiness.md) – production safety, deploy, restore, rollback, and smoke-test checklists
 - [docs/web-ux-guidelines.md](docs/web-ux-guidelines.md) – layout, typography, and interaction guardrails
 - [GitHub Actions: web-screenshots.yml](https://github.com/futuroptimist/jobbot3000/actions/workflows/web-screenshots.yml) – captures the latest UI flows for regressions
 

--- a/charts/jobbot3000/ci/dev-values.yaml
+++ b/charts/jobbot3000/ci/dev-values.yaml
@@ -1,5 +1,5 @@
 image:
-  tag: main-latest
+  tag: main-TESTSHA
 
 ingress:
   enabled: true

--- a/charts/jobbot3000/values.yaml
+++ b/charts/jobbot3000/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/futuroptimist/jobbot3000
-  tag: main-latest
+  tag: main-TESTSHA
   pullPolicy: IfNotPresent
 
 nameOverride: ""

--- a/docs/backup-restore-guide.md
+++ b/docs/backup-restore-guide.md
@@ -100,3 +100,34 @@ Run a quick checklist before resuming normal operations:
   a sandbox directory.
 - Combine the NDJSON export and archive with offsite replication to stay ready
   for disaster recovery.
+
+## Browser IndexedDB production backups
+
+jobbot3000 production mode stores private tracker data in browser IndexedDB. Browser backups are explicit files generated in the browser. Real user data must never be baked into images, charts, Helm values, ConfigMaps, Secrets, PVCs, committed fixtures, screenshots, or public repositories.
+
+| Format | Shape                              | Use it for                                            | Limitations                                                             |
+| ------ | ---------------------------------- | ----------------------------------------------------- | ----------------------------------------------------------------------- |
+| CSV    | 32-column, one row per application | Google Sheets interchange, human editing, quick audit | Not full-fidelity for multiple events/interviews/offers per application |
+| JSON   | Canonical full-fidelity bundle     | Primary backup, restore, browser migration            | Less convenient for spreadsheet editing                                 |
+| NDJSON | Line-oriented full-fidelity stream | Line-based tooling, review, resilient archives        | Requires every line to be valid JSON                                    |
+
+### Verify a browser backup before clearing data
+
+1. Export JSON and NDJSON from the source browser.
+2. Export CSV if spreadsheet compatibility matters.
+3. Restore JSON or NDJSON into an empty dev/staging browser profile.
+4. Confirm record counts by store, application count, representative notes/outreach/interviews/offers/reminders, and settings.
+5. Re-export from the restore target and compare canonicalized records or counts.
+6. Only then clear the original browser data.
+
+### Restore into dev, staging, and production browsers
+
+Dev, staging, and production deployments are separate browser/storage profiles unless the user imports the same backup into each. To seed any environment, open the deployed app in that browser profile and import an anonymized JSON/NDJSON backup or fake seed data through the UI. Do not include Daniel's real data in committed fixtures, public repos, Docker images, chart packages, or Kubernetes manifests.
+
+### Browser production backup rules
+
+- Production deploys should use immutable image tags.
+- Kubernetes rollback changes the static app version only; it does not roll back IndexedDB.
+- Do not mount PVCs for application tracker data.
+- Do not create Secrets or ConfigMaps containing applications, contacts, outreach, notes, offers, artifacts, reminders, or private settings.
+- Keep real backups in private storage with an access model appropriate for sensitive job-search data.

--- a/docs/import-current-spreadsheet.md
+++ b/docs/import-current-spreadsheet.md
@@ -1,0 +1,39 @@
+# Import the current spreadsheet
+
+Use this guide to move from the current Google Sheets tracker to jobbot3000 while keeping CSV as the spreadsheet-compatible backup path and JSON/NDJSON as full-fidelity restore paths.
+
+## Export Google Sheets as CSV
+
+1. Open the current tracker spreadsheet.
+2. Select the tab that contains the 32-column application tracker.
+3. Choose **File → Download → Comma Separated Values (.csv)**.
+4. Save the file outside the repository and Docker build context.
+
+## Import CSV into jobbot3000
+
+1. Open `/tracker` in the browser profile that will own the data.
+2. Go to **Import/Export**.
+3. Select the CSV file and run **Preview/dry-run**.
+4. Confirm the row count matches the spreadsheet and review conflicts for duplicate application IDs or posting URLs.
+5. Apply the import only after the preview looks correct.
+6. Spot-check representative normalized records: company, role, status, applied date, posting URL, outreach, interview stage, outcome, and notes.
+
+## Export backups after import
+
+- Export CSV for a human-editable spreadsheet-compatible backup.
+- Export JSON as the canonical full-fidelity backup bundle.
+- Export NDJSON as a line-oriented full-fidelity backup stream.
+
+CSV is one row per application. It cannot fully represent multiple outreach messages, interviews, offers, artifacts, or reminders for the same application. Once you add richer tracker history, use JSON or NDJSON before clearing or moving browsers.
+
+## Restore JSON or NDJSON into an empty browser profile
+
+1. Open a new browser profile or clear local jobbot3000 data after saving a final backup.
+2. Open the deployed app and import the JSON or NDJSON backup through the browser UI.
+3. Review dry-run counts and conflicts.
+4. Apply the restore with replace confirmation.
+5. Re-export JSON/NDJSON and compare record counts before deleting old backups.
+
+## Transition backup cadence
+
+During the first two weeks after moving off the spreadsheet, export JSON and NDJSON after each tracking session and export CSV at least daily while you still want spreadsheet review. Keep backups in a private storage location, not in Git, Docker images, Helm values, ConfigMaps, Secrets, or PVCs.

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -1,0 +1,86 @@
+# Production readiness
+
+jobbot3000 production mode is a static, browser-local application tracker. The container, Helm chart, and Kubernetes deployment serve HTML, CSS, JavaScript, the web manifest, and health endpoints only. Private tracker data remains in the user's browser IndexedDB and moves between environments only when the user imports or exports files through the browser UI.
+
+## Architecture summary
+
+- Static server: serves `/`, `/tracker`, `/healthz`, `/livez`, `/manifest.webmanifest`, and static assets on port `8080`.
+- Browser storage: applications, contacts, outreach, lifecycle events, interviews, offers, artifacts, reminders, and settings live in IndexedDB database `jobbot3000`.
+- Backups: CSV, JSON, and NDJSON are generated client-side and downloaded by the browser.
+- Release artifacts: image `ghcr.io/futuroptimist/jobbot3000` and chart `oci://ghcr.io/futuroptimist/charts/jobbot3000` contain no user tracker data.
+
+## Safe to deploy publicly
+
+It is safe to publish the static production image, chart templates, default values, screenshots, and fake fixtures. The public deployment exposes only the static app shell and health checks. The production server does not require provider API tokens, SQLite, native CLI access, or user-data volumes.
+
+## Local-only data boundary
+
+The following data stays local to each browser profile unless the user exports it manually: application rows, notes, contacts, outreach message bodies, interview records, offers, artifacts, reminders, settings, and backup files selected through file inputs.
+
+Never store real tracker data in Kubernetes objects, Docker layers, static server logs, ConfigMaps, Secrets, PVCs, Helm values, committed fixtures, screenshots, or public issue/PR text.
+
+## Backup formats
+
+- CSV is the spreadsheet-compatible, one-row-per-application format. Use it for Google Sheets interchange and human review.
+- JSON is the canonical full-fidelity backup bundle. Use it before clearing data, migrating browsers, or promoting jobbot3000 as the primary tracker.
+- NDJSON is the line-oriented full-fidelity stream. Use it when line-based review, splitting, or resilient tooling is useful.
+
+CSV is not full-fidelity once a single application has multiple contacts, outreach messages, interviews, offers, artifacts, or reminders.
+
+## First-use checklist
+
+1. Open `/tracker` in the browser profile you will use as the primary tracker.
+2. Import the current spreadsheet CSV and confirm preview row counts and conflicts.
+3. Review representative applications, outreach, interviews, offers, and follow-up dates.
+4. Export JSON and NDJSON full-fidelity backups.
+5. Export CSV for spreadsheet-compatible backup.
+6. Store backups outside the repo, image build context, and Kubernetes manifests.
+
+## First production deploy checklist
+
+1. Publish an immutable image tag such as `main-<short-sha>`.
+2. Publish the Helm chart only when chart content changes.
+3. Deploy staging with that immutable image tag.
+4. Verify `/`, `/tracker`, `/healthz`, and `/livez`.
+5. Import an anonymized backup or fake seed data through the staging browser UI.
+6. Export a backup from staging to verify client-side import/export.
+7. Promote production with the same immutable image tag.
+
+## Restore checklist
+
+1. Use a fresh browser profile or clear local data after exporting a final backup.
+2. Prefer JSON for canonical restore; use NDJSON when restoring from a line-oriented archive.
+3. Dry-run or preview the restore when available and review record counts by store.
+4. Apply the replace restore only after explicitly confirming that existing IndexedDB data can be replaced.
+5. Re-export JSON/NDJSON and compare record counts and representative applications.
+
+## Rollback checklist
+
+- Roll back app deployment by redeploying the previous immutable image tag and chart version.
+- Browser data is independent of the deployment. Do not clear IndexedDB as part of a Kubernetes rollback.
+- If a bad import was applied, restore the last known-good JSON or NDJSON backup through the browser UI.
+
+## Verification checklist
+
+Run the repository checks from CI, then smoke the static artifact or container:
+
+```bash
+npm ci
+npm run format:check
+npm run lint
+npm run typecheck
+npm run test:ci
+npm run build
+scripts/validate-helm.sh
+helm lint charts/jobbot3000
+helm template jobbot3000 charts/jobbot3000 --set image.tag=main-TESTSHA
+```
+
+Container smoke should verify `/`, `/tracker`, `/healthz`, `/livez`, security headers, and app-shell cache behavior.
+
+## Known limitations and follow-ups
+
+- There is no server-side account sync or multi-user database by design.
+- Browser profiles are separate storage silos; dev, staging, and production see the same data only if the user imports the same backup into each.
+- Users must maintain manual backups; IndexedDB is not a disaster-recovery system.
+- CSV remains intentionally lossy for complex multi-event application histories.

--- a/scripts/build-static.js
+++ b/scripts/build-static.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from "node:fs/promises";
 import path from "node:path";
+import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -11,9 +12,39 @@ const assetsDir = path.join(distDir, "assets");
 await fs.rm(distDir, { recursive: true, force: true });
 await fs.mkdir(assetsDir, { recursive: true });
 
-await fs.copyFile(
+const packageJson = JSON.parse(
+  await fs.readFile(path.join(repoRoot, "package.json"), "utf8"),
+);
+const readGit = (args) => {
+  try {
+    return execFileSync("git", args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }).trim();
+  } catch {
+    return "unknown";
+  }
+};
+const buildInfo = {
+  version: packageJson.version || "unknown",
+  gitSha:
+    process.env.GITHUB_SHA || readGit(["rev-parse", "--short=12", "HEAD"]),
+  builtAt: process.env.SOURCE_DATE_EPOCH
+    ? new Date(Number(process.env.SOURCE_DATE_EPOCH) * 1000).toISOString()
+    : new Date().toISOString(),
+  mode: "static/browser-local",
+};
+const trackerTemplate = await fs.readFile(
   path.join(repoRoot, "src/web/tracker/index.html"),
+  "utf8",
+);
+await fs.writeFile(
   path.join(distDir, "tracker.html"),
+  trackerTemplate.replace(
+    "__JOBBOT_BUILD_INFO__",
+    `${buildInfo.mode} · v${buildInfo.version} · ${buildInfo.gitSha} · ${buildInfo.builtAt}`,
+  ),
+  "utf8",
 );
 await fs.copyFile(
   path.join(repoRoot, "src/web/tracker/tracker.js"),
@@ -66,6 +97,12 @@ const manifest = {
   background_color: "#0b0d0f",
   theme_color: "#38bdf8",
 };
+await fs.writeFile(
+  path.join(distDir, "build-info.json"),
+  `${JSON.stringify(buildInfo, null, 2)}\n`,
+  "utf8",
+);
+
 await fs.writeFile(
   path.join(distDir, "manifest.webmanifest"),
   `${JSON.stringify(manifest, null, 2)}\n`,

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -691,10 +691,37 @@ export const browserApplicationExportToRows = (bundle) => {
 };
 export const exportCompactCsv = (bundle) =>
   serializeCsv(browserApplicationExportToRows(bundle));
-export const exportJsonBackup = (bundle) =>
-  `${JSON.stringify(browserApplicationExportSchema.parse(bundle), null, 2)}\n`;
-export const exportNdjsonBackup = (bundle) => {
+const sortRecordsById = (records) =>
+  [...records].sort((a, b) => String(a.id).localeCompare(String(b.id)));
+
+const canonicalizeBundle = (bundle) => {
   const parsed = browserApplicationExportSchema.parse(bundle);
+  return {
+    backup_schema_version: parsed.schemaVersion,
+    source_database_version: 1,
+    ...parsed,
+    ...Object.fromEntries(
+      ARRAY_STORES.map((store) => [store, sortRecordsById(parsed[store])]),
+    ),
+  };
+};
+
+const normalizeBackupBundle = (data) => {
+  if (
+    data &&
+    typeof data === "object" &&
+    "backup_schema_version" in data &&
+    !("schemaVersion" in data)
+  ) {
+    return { ...data, schemaVersion: data.backup_schema_version };
+  }
+  return data;
+};
+
+export const exportJsonBackup = (bundle) =>
+  `${JSON.stringify(canonicalizeBundle(bundle), null, 2)}\n`;
+export const exportNdjsonBackup = (bundle) => {
+  const parsed = canonicalizeBundle(bundle);
   const stores = ARRAY_STORES;
   return (
     [
@@ -715,7 +742,7 @@ export const exportNdjsonBackup = (bundle) => {
   );
 };
 export const importJsonBackup = (text) =>
-  browserApplicationExportSchema.parse(JSON.parse(text));
+  browserApplicationExportSchema.parse(normalizeBackupBundle(JSON.parse(text)));
 export const importNdjsonBackup = (text) => {
   const bundle = {
     schemaVersion: 1,

--- a/src/web/tracker/index.html
+++ b/src/web/tracker/index.html
@@ -13,7 +13,8 @@
     <header>
       <p class="pill">
         <strong>jobbot3000</strong><span aria-hidden="true"> • </span
-        ><span>Browser-only tracker</span>
+        ><span>Browser-only tracker</span><span aria-hidden="true"> • </span
+        ><span data-build-info>__JOBBOT_BUILD_INFO__</span>
       </p>
       <h1>Application tracker</h1>
       <p>

--- a/test/docs-backup-restore.test.js
+++ b/test/docs-backup-restore.test.js
@@ -1,31 +1,67 @@
-import { readFileSync } from 'node:fs';
-import { describe, it, expect } from 'vitest';
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { describe, it, expect } from "vitest";
 
-const guidePath = new URL('../docs/backup-restore-guide.md', import.meta.url);
+const repoRoot = path.resolve(new URL("..", import.meta.url).pathname);
+const guidePath = new URL("../docs/backup-restore-guide.md", import.meta.url);
 
-describe('backup and restore guide', () => {
-  it('documents backup steps for the data directory and audit log', () => {
-    const contents = readFileSync(guidePath, 'utf8');
-    expect(contents).toContain('## Backup');
-    expect(contents).toContain('JOBBOT_DATA_DIR');
-    expect(contents).toContain('JOBBOT_AUDIT_LOG');
+describe("backup and restore guide", () => {
+  it("documents backup steps for the data directory and audit log", () => {
+    const contents = readFileSync(guidePath, "utf8");
+    expect(contents).toContain("## Backup");
+    expect(contents).toContain("JOBBOT_DATA_DIR");
+    expect(contents).toContain("JOBBOT_AUDIT_LOG");
     expect(contents).toMatch(/node scripts\/export-data\.js/);
     expect(contents).toMatch(/tar -czf .*jobbot-backup\.tgz/);
     expect(contents).toMatch(/Compress-Archive/);
   });
 
-  it('documents restore steps using the import script and archive extraction', () => {
-    const contents = readFileSync(guidePath, 'utf8');
-    expect(contents).toContain('## Restore');
+  it("documents restore steps using the import script and archive extraction", () => {
+    const contents = readFileSync(guidePath, "utf8");
+    expect(contents).toContain("## Restore");
     expect(contents).toMatch(/tar -xzf .*jobbot-backup\.tgz/);
     expect(contents).toMatch(/node scripts\/import-data\.js --source/);
     expect(contents).toMatch(/--dry-run/);
   });
 
-  it('explains verification commands for restored environments', () => {
-    const contents = readFileSync(guidePath, 'utf8');
-    expect(contents).toContain('## Verify');
+  it("explains verification commands for restored environments", () => {
+    const contents = readFileSync(guidePath, "utf8");
+    expect(contents).toContain("## Verify");
     expect(contents).toMatch(/jobbot analytics health --json/);
-    expect(contents).toMatch(/node scripts\/export-data\.js > \/tmp\/restore-check\.ndjson/);
+    expect(contents).toMatch(
+      /node scripts\/export-data\.js > \/tmp\/restore-check\.ndjson/,
+    );
+  });
+});
+
+describe("production readiness docs", () => {
+  it("links production readiness, spreadsheet migration, and backup boundaries", async () => {
+    const readiness = readFileSync(
+      path.join(repoRoot, "docs", "production-readiness.md"),
+      "utf8",
+    );
+    const migration = readFileSync(
+      path.join(repoRoot, "docs", "import-current-spreadsheet.md"),
+      "utf8",
+    );
+    const backup = readFileSync(
+      path.join(repoRoot, "docs", "backup-restore-guide.md"),
+      "utf8",
+    );
+    const readme = readFileSync(path.join(repoRoot, "README.md"), "utf8");
+
+    expect(readiness).toContain("static, browser-local application tracker");
+    expect(readiness).toContain(
+      "Never store real tracker data in Kubernetes objects",
+    );
+    expect(readiness).toContain("CSV is the spreadsheet-compatible");
+    expect(migration).toContain("File → Download → Comma Separated Values");
+    expect(migration).toContain("CSV is one row per application");
+    expect(backup).toContain(
+      "Dev, staging, and production deployments are separate browser/storage profiles",
+    );
+    expect(backup).toContain("Do not include Daniel's real data");
+    expect(readme).toContain("docs/production-readiness.md");
+    expect(readme).toContain("Deploy with Sugarkube");
   });
 });

--- a/test/web-deployment.test.js
+++ b/test/web-deployment.test.js
@@ -127,6 +127,70 @@ describe("web deployment artifacts", () => {
     expect(staticServer).not.toMatch(/writeFile|appendFile|createWriteStream/);
   });
 
+  it("exposes build metadata in static tracker artifacts", async () => {
+    const buildScript = await readFile(
+      path.join(repoRoot, "scripts", "build-static.js"),
+      "utf8",
+    );
+    const trackerHtml = await readFile(
+      path.join(repoRoot, "src", "web", "tracker", "index.html"),
+      "utf8",
+    );
+    expect(buildScript).toContain("build-info.json");
+    expect(buildScript).toContain("packageJson.version");
+    expect(buildScript).toContain("GITHUB_SHA");
+    expect(buildScript).toContain("static/browser-local");
+    expect(trackerHtml).toContain("data-build-info");
+    expect(trackerHtml).toContain("__JOBBOT_BUILD_INFO__");
+  });
+
+  it("regresses against server-side tracker PII persistence in static mode", async () => {
+    const trackerJs = await readFile(
+      path.join(repoRoot, "src", "web", "tracker", "tracker.js"),
+      "utf8",
+    );
+    const staticServer = await readFile(
+      path.join(repoRoot, "scripts", "static-server.js"),
+      "utf8",
+    );
+    const dockerignore = await readFile(
+      path.join(repoRoot, ".dockerignore"),
+      "utf8",
+    );
+    const dockerfile = await readFile(
+      path.join(repoRoot, "Dockerfile"),
+      "utf8",
+    );
+    const values = await readFile(
+      path.join(repoRoot, "charts", "jobbot3000", "values.yaml"),
+      "utf8",
+    );
+    const templates = await Promise.all(
+      ["deployment.yaml", "service.yaml", "ingress.yaml"].map((file) =>
+        readFile(
+          path.join(repoRoot, "charts", "jobbot3000", "templates", file),
+          "utf8",
+        ),
+      ),
+    );
+
+    expect(trackerJs).not.toMatch(/fetch\s*\(/);
+    expect(trackerJs).not.toMatch(/XMLHttpRequest|sendBeacon/);
+    expect(trackerJs).toContain("indexedDB.open");
+    expect(staticServer).not.toMatch(/app\.(post|put|patch|delete)\(/);
+    expect(staticServer).not.toMatch(/writeFile|appendFile|createWriteStream/);
+    expect(dockerignore).toMatch(/^data$/m);
+    expect(dockerignore).toMatch(/^\.env/m);
+    expect(dockerignore).toMatch(/^backups\/?$/m);
+    expect(dockerfile).not.toContain("COPY data");
+    expect(dockerfile).not.toContain(".env");
+    expect(values).toContain("repository: ghcr.io/futuroptimist/jobbot3000");
+    expect(values).not.toMatch(/latest|main-latest/);
+    for (const template of templates) {
+      expect(template).not.toMatch(/PersistentVolumeClaim|kind:\s*Secret/);
+    }
+  });
+
   it("documents static privacy boundaries and IndexedDB backup guidance", async () => {
     const doc = await readFile(
       path.join(repoRoot, "docs", "privacy-and-security.md"),

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -352,9 +352,7 @@ describe("spreadsheet import/export", () => {
       "app_regenerated",
     );
     expect(exported.interviews[0].contactIds).toEqual(
-      expect.not.arrayContaining([
-        expect.stringContaining("app_regenerated"),
-      ]),
+      expect.not.arrayContaining([expect.stringContaining("app_regenerated")]),
     );
     const childCounts = Object.fromEntries(
       childStores.map((store) => [store, exported[store].length]),
@@ -371,6 +369,234 @@ describe("spreadsheet import/export", () => {
         childStores.map((store) => [store, exportedAgain[store].length]),
       ),
     ).toEqual(childCounts);
+
+    repo.close();
+  });
+});
+
+describe("production backup and restore integrity", () => {
+  const canonical = (bundle) => ({
+    ...bundle,
+    exportedAt: "CANONICAL",
+    applications: [...bundle.applications].sort((a, b) =>
+      a.id.localeCompare(b.id),
+    ),
+    contacts: [...bundle.contacts].sort((a, b) => a.id.localeCompare(b.id)),
+    outreachMessages: [...bundle.outreachMessages].sort((a, b) =>
+      a.id.localeCompare(b.id),
+    ),
+    lifecycleEvents: [...bundle.lifecycleEvents].sort((a, b) =>
+      a.id.localeCompare(b.id),
+    ),
+    interviews: [...bundle.interviews].sort((a, b) => a.id.localeCompare(b.id)),
+    offers: [...bundle.offers].sort((a, b) => a.id.localeCompare(b.id)),
+    artifacts: [...bundle.artifacts].sort((a, b) => a.id.localeCompare(b.id)),
+    reminders: [...bundle.reminders].sort((a, b) => a.id.localeCompare(b.id)),
+  });
+
+  it("runs an end-to-end fake-data backup and restore smoke flow", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const csv = await fixture();
+    await importCompactCsv(csv, repo, { mode: "replace" });
+
+    const now = "2026-04-01T12:00:00.000Z";
+    const app = {
+      id: "app_manual_gamma_003",
+      company: "Demo Analytics",
+      role: "Principal Data Engineer",
+      status: "applied",
+      postingUrl: "https://jobs.example.test/demo-analytics/principal-data",
+      appliedAt: now,
+      followUpDate: "2026-04-08T00:00:00.000Z",
+      notes: "Fake manual application for production-readiness smoke tests.",
+      createdAt: now,
+      updatedAt: now,
+    };
+    const contact = {
+      id: "contact_manual_gamma_003",
+      applicationId: app.id,
+      name: "Taylor Fixture",
+      email: "taylor.fixture@example.test",
+      createdAt: now,
+      updatedAt: now,
+    };
+    const reminder = {
+      id: "reminder_manual_gamma_003",
+      applicationId: app.id,
+      contactId: contact.id,
+      dueAt: "2026-04-08T00:00:00.000Z",
+      summary: "Send a fake follow-up",
+      createdAt: now,
+      updatedAt: now,
+    };
+    await repo.createApplication(app);
+    await repo.updateApplication({
+      ...app,
+      status: "technical_screen",
+      updatedAt: "2026-04-02T12:00:00.000Z",
+    });
+    await repo.upsertContact(contact);
+    await repo.addOutreachMessage({
+      id: "message_manual_gamma_003",
+      applicationId: app.id,
+      contactId: contact.id,
+      direction: "outbound",
+      channel: "email",
+      subject: "Fake hello",
+      body: "This is anonymized fixture outreach.",
+      sentAt: "2026-04-02T13:00:00.000Z",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await repo.upsertInterview({
+      id: "interview_manual_gamma_003",
+      applicationId: app.id,
+      contactIds: [contact.id],
+      stage: "technical_screen",
+      startsAt: "2026-04-04T16:00:00.000Z",
+      outcome: "completed",
+      createdAt: now,
+      updatedAt: now,
+    });
+    await repo.upsertOffer({
+      id: "offer_manual_gamma_003",
+      applicationId: app.id,
+      status: "received",
+      baseSalaryMin: 180000,
+      baseSalaryMax: 210000,
+      currency: "USD",
+      createdAt: now,
+      updatedAt: now,
+    });
+    const withReminder = await repo.exportAllData();
+    await repo.importAllData(
+      { ...withReminder, reminders: [reminder] },
+      { allowOverwrite: true },
+    );
+    const completedReminder = {
+      ...reminder,
+      completedAt: "2026-04-03T00:00:00.000Z",
+      updatedAt: "2026-04-03T00:00:00.000Z",
+    };
+    await repo.importAllData(
+      { ...(await repo.exportAllData()), reminders: [completedReminder] },
+      { allowOverwrite: true },
+    );
+    await repo.importAllData(
+      { ...(await repo.exportAllData()), reminders: [reminder] },
+      { allowOverwrite: true },
+    );
+
+    const full = await repo.exportAllData();
+    expect(full.applications).toHaveLength(3);
+    expect(full.outreachMessages).toHaveLength(3);
+    expect(parseCsv(exportCompactCsv(full))[0]).toMatchObject({
+      application_id: "app_fake_alpha_001",
+    });
+    const json = exportJsonBackup(full);
+    const ndjson = exportNdjsonBackup(full);
+
+    await repo.clearAllData();
+    await repo.importAllData(importJsonBackup(json));
+    const restoredJson = await repo.exportAllData();
+    expect(restoredJson.offers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: "offer_manual_gamma_003" }),
+      ]),
+    );
+
+    await repo.clearAllData();
+    await repo.importAllData(importNdjsonBackup(ndjson));
+    const restoredNdjson = await repo.exportAllData();
+    expect(canonical(restoredNdjson)).toMatchObject(canonical(restoredJson));
+
+    repo.close();
+  });
+
+  it("exports deterministic metadata and rejects corrupt restores", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const csv = await fixture();
+    await importCompactCsv(csv, repo, { mode: "replace" });
+    const bundle = await repo.exportAllData();
+    const firstJson = exportJsonBackup(bundle);
+    const secondJson = exportJsonBackup({
+      ...bundle,
+      applications: [...bundle.applications].reverse(),
+    });
+    expect(firstJson).toBe(secondJson);
+    const parsed = JSON.parse(firstJson);
+    expect(parsed.backup_schema_version).toBe(1);
+    expect(parsed.source_database_version).toBe(1);
+    expect(
+      Object.fromEntries(
+        [
+          "applications",
+          "contacts",
+          "outreachMessages",
+          "lifecycleEvents",
+          "interviews",
+          "offers",
+          "artifacts",
+          "reminders",
+        ].map((store) => [store, parsed[store].length]),
+      ),
+    ).toMatchObject({ applications: 2, outreachMessages: 2 });
+    expect(exportNdjsonBackup(bundle)).toBe(
+      exportNdjsonBackup({
+        ...bundle,
+        applications: [...bundle.applications].reverse(),
+      }),
+    );
+    expect(exportCompactCsv(bundle).split("\n")[0]).toBe(
+      COMPACT_CSV_COLUMNS.join(","),
+    );
+
+    expect(() => importJsonBackup("{")).toThrow();
+    expect(() =>
+      importJsonBackup(JSON.stringify({ ...bundle, schemaVersion: 999 })),
+    ).toThrow();
+    expect(() =>
+      importJsonBackup(
+        JSON.stringify({
+          ...bundle,
+          applications: [bundle.applications[0], bundle.applications[0]],
+        }),
+      ),
+    ).toThrow(/Duplicate applications id/);
+    expect(() =>
+      importJsonBackup(
+        JSON.stringify({ schemaVersion: 1, exportedAt: bundle.exportedAt }),
+      ),
+    ).toThrow();
+    expect(() =>
+      importNdjsonBackup('{"type":"meta","schemaVersion":1}\nnot-json\n'),
+    ).toThrow();
+
+    const before = await repo.exportAllData();
+    await expect(
+      repo.importAllData(
+        {
+          ...bundle,
+          contacts: [{ ...bundle.contacts[0], applicationId: "missing" }],
+        },
+        { allowOverwrite: true },
+      ),
+    ).rejects.toMatchObject({ code: "schema_validation_failed" });
+    expect(canonical(await repo.exportAllData())).toMatchObject(
+      canonical(before),
+    );
+    const dryRun = await repo.importAllData(bundle, { dryRun: true });
+    expect(dryRun).toMatchObject({
+      imported: false,
+      hasExistingData: true,
+      conflicts: expect.any(Array),
+    });
+    expect(canonical(await repo.exportAllData())).toMatchObject(
+      canonical(before),
+    );
+    await expect(repo.importAllData(bundle)).rejects.toMatchObject({
+      code: "import_conflict",
+    });
 
     repo.close();
   });


### PR DESCRIPTION
### Motivation

- Finalize jobbot3000 for safe browser-local production use by tightening docs, backup/restore guidance, and smoke/integrity tests so the app can replace the spreadsheet as the primary tracker. 
- Ensure full-fidelity JSON/NDJSON backups are deterministic and restorable while keeping CSV as the spreadsheet-compatible, lossy interchange format. 
- Prove the static/server boundary (no server-side PII persistence) and add compact build/version visibility for deployed static artifacts. 
- Provide clear deploy guidance for GHCR/Helm and a Sugarkube-friendly flow that uses immutable image tags. 

### Description

- Added `docs/production-readiness.md`, `docs/import-current-spreadsheet.md`, and extended `docs/backup-restore-guide.md` with checklists, migration steps, backup format guidance, verification and seeding instructions. 
- Made JSON/NDJSON exports deterministic by canonicalizing store ordering and adding `backup_schema_version` and `source_database_version`, and accepted legacy `backup_schema_version` on import for compatibility (`src/web/import-export/spreadsheet.js`). 
- Injected compact build metadata into static build outputs and the tracker UI via `scripts/build-static.js` and the `tracker.html` template (package version, short git SHA fallback, build timestamp, and mode). 
- Added end-to-end fake-data backup/restore and import/export integrity tests, plus a regression test proving no private tracker data is sent or persisted server-side in static mode, and adjusted Helm example image tags to immutable-shaped `main-TESTSHA`. 

### Testing

- Ran `npm ci` successfully and installed test dependencies. 
- Ran `npm run lint` and `npm run typecheck` which passed, and ran focused tests with `npx vitest run test/web-deployment.test.js test/docs-backup-restore.test.js test/web-spreadsheet-import-export.test.js` which passed. 
- Built the static artifact with `npm run build` and captured UI screenshots with `npm run web:screenshots` which succeeded, and `git diff --check` reported no issues. 
- Not run / environment-limited: `npm run format:check` surfaced pre-existing formatting warnings across unrelated files, and Helm/Docker smoke checks (`scripts/validate-helm.sh`, `helm lint`/`helm template`, `docker build`/`docker run`, and subsequent `curl` checks) could not be executed because `helm` and `docker` are unavailable in this environment; reviewers should run those commands in CI or a local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4612d68608832f82f070c826805c4c)