### PR TITLE
Use canonical CSV imports in browser tracker

### DIFF
--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -2,6 +2,7 @@
 /* eslint-disable max-len */
 import {
   COMPACT_CSV_COLUMNS,
+  csvToBrowserApplicationExport,
   exportCompactCsv,
   exportJsonBackup,
   exportNdjsonBackup,
@@ -183,44 +184,6 @@ const state = {
   current: null,
   detailSave: Promise.resolve(),
 };
-function parseCsv(text) {
-  const rows = [];
-  let row = [],
-    field = "",
-    q = false;
-  const input = String(text).replace(/^\uFEFF/, "");
-  for (let i = 0; i < input.length; i += 1) {
-    const ch = input[i];
-    if (q) {
-      if (ch === '"' && input[i + 1] === '"') {
-        field += '"';
-        i += 1;
-      } else if (ch === '"') q = false;
-      else field += ch;
-    } else if (ch === '"') q = true;
-    else if (ch === ",") {
-      row.push(field);
-      field = "";
-    } else if (ch === "\n") {
-      row.push(field);
-      rows.push(row);
-      row = [];
-      field = "";
-    } else if (ch !== "\r") field += ch;
-  }
-  row.push(field);
-  if (row.some(Boolean)) rows.push(row);
-  const head = (rows.shift() || []).map((h) => h.trim().toLowerCase());
-  return rows
-    .filter((r) => r.some(Boolean))
-    .map((r) => Object.fromEntries(head.map((h, i) => [h, r[i] ?? ""])));
-}
-
-function safeIsoDate(value, fallback) {
-  if (!value) return fallback;
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? fallback : date.toISOString();
-}
 function weekBucket(value) {
   const d = day(value);
   if (!d) return "";
@@ -250,84 +213,6 @@ function linkForArtifact(artifact) {
 }
 function fitScore(notes) {
   return String(notes || "").match(/fit_score_100[":\s]+([\d.]+)/)?.[1] || "";
-}
-function rowToRecords(r) {
-  const ts = now(),
-    appId = r.application_id || id("app");
-  const app = {
-    id: appId,
-    company: r.company || "Unknown company",
-    role: r.role_title || r.role || "Unknown role",
-    status: STATUSES.includes(r.status) ? r.status : "applied",
-    source: r.application_channel || undefined,
-    postingUrl: r.posting_url || undefined,
-    appliedAt: safeIsoDate(r.applied_at, ts),
-    followUpDate: safeIsoDate(r.follow_up_date, undefined),
-    notes: r.notes || undefined,
-    createdAt: ts,
-    updatedAt: ts,
-  };
-  const records = {
-    applications: [app],
-    contacts: [],
-    outreachMessages: [],
-    lifecycleEvents: [
-      {
-        id: id("event"),
-        applicationId: appId,
-        status: app.status,
-        occurredAt: app.appliedAt,
-        source: "csv_import",
-        createdAt: ts,
-      },
-    ],
-    interviews: [],
-    offers: [],
-    artifacts: [],
-    reminders: [],
-  };
-  if (r.posting_url)
-    records.artifacts.push({
-      id: id("artifact"),
-      applicationId: appId,
-      kind: "job_posting",
-      name: "Posting",
-      url: r.posting_url,
-      private: true,
-      createdAt: ts,
-      updatedAt: ts,
-    });
-  if (r.outreach_message_text)
-    records.outreachMessages.push({
-      id: id("msg"),
-      applicationId: appId,
-      direction: "outbound",
-      channel: r.outreach_channel || "other",
-      body: r.outreach_message_text,
-      sentAt: safeIsoDate(r.outreach_sent_at, ts),
-      createdAt: ts,
-      updatedAt: ts,
-    });
-  if (r.interview_stage)
-    records.interviews.push({
-      id: id("interview"),
-      applicationId: appId,
-      contactIds: [],
-      stage: r.interview_stage,
-      outcome: "scheduled",
-      startsAt: ts,
-      createdAt: ts,
-      updatedAt: ts,
-    });
-  if (r.outcome === "offer")
-    records.offers.push({
-      id: id("offer"),
-      applicationId: appId,
-      status: "received",
-      createdAt: ts,
-      updatedAt: ts,
-    });
-  return records;
 }
 async function refresh() {
   state.bundle = await repo.exportAll();
@@ -689,23 +574,7 @@ async function newApplication() {
   openUnsavedDetail(app);
 }
 function previewBundleFromCsv(text) {
-  const rows = parseCsv(text);
-  const bundle = {
-    applications: [],
-    contacts: [],
-    outreachMessages: [],
-    lifecycleEvents: [],
-    interviews: [],
-    offers: [],
-    artifacts: [],
-    reminders: [],
-  };
-  for (const row of rows) {
-    const records = rowToRecords(row);
-    for (const store of Object.keys(bundle))
-      bundle[store].push(...records[store]);
-  }
-  return bundle;
+  return csvToBrowserApplicationExport(text).bundle;
 }
 function bundleForIndexedDb(bundle) {
   return {

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -7,10 +7,10 @@ import { startWebServer } from "../../src/web/server.js";
 
 const csvFixture = [
   "application_id,company,role_title,status,applied_at,posting_url," +
-    "application_channel,follow_up_date,outreach_channel,outreach_message_text," +
-    "interview_stage,outcome,notes",
+    "application_channel,follow_up_date,outreach_status,outreach_channel," +
+    "outreach_message_text,interview_stage,outcome,notes",
   "fake_app_1,Example Labs,Frontend Engineer,applied,2026-01-02," +
-    "https://example.test/jobs/frontend,direct,2026-01-09,email," +
+    "https://example.test/jobs/frontend,direct,2026-01-09,sent,email," +
     "Following up on my application,recruiter_screen,,fit_score_100: 82",
 ].join("\n");
 
@@ -65,10 +65,6 @@ test.describe("browser application tracker", () => {
   test("previews compact CSV regression fixture without phantom interviews", async ({
     page,
   }) => {
-    test.fail(
-      true,
-      "Prompt 01 lands this red regression net; later prompts fix tracker import.",
-    );
     const csv = await regressionCsvFixture();
 
     await page.getByRole("button", { name: "Import/Export" }).click();
@@ -89,7 +85,7 @@ test.describe("browser application tracker", () => {
   }) => {
     test.fail(
       true,
-      "Prompt 01 lands this red regression net; later prompts fix dashboard/import.",
+      "Prompt 02 fixes canonical import; later dashboard prompts define bounded metrics.",
     );
     const csv = await regressionCsvFixture();
 
@@ -316,7 +312,7 @@ test.describe("browser application tracker", () => {
     await expect(page.locator('[name="company"]')).toHaveValue(
       "Example Labs Updated",
     );
-    await expect(page.locator(".timeline li")).toHaveCount(1);
+    await expect(page.locator(".timeline li")).toHaveCount(2);
 
     await page
       .locator('[data-core-form] [name="status"]')


### PR DESCRIPTION
### Motivation
- The tracker contained a browser-local CSV parser and `rowToRecords` mapper that duplicated logic from the canonical spreadsheet pipeline and created phantom interview records for arbitrary `interview_stage` text. 
- The goal is to make the static tracker import/preview use the shared canonical import/export implementation so tests and browser behaviour are consistent. 
- Preserve the browser-only boundary (no server calls) and keep the IndexedDB bundle shape and conflict detection unchanged.

### Description
- Replaced the tracker-local CSV path by importing `csvToBrowserApplicationExport` from `src/web/import-export/spreadsheet.js` and removed the duplicate `parseCsv` and `rowToRecords` logic in `src/web/tracker/tracker.js`.
- Updated `previewBundleFromCsv` to return the canonical `bundle` produced by `csvToBrowserApplicationExport` and kept `bundleForIndexedDb` to normalize the bundle into the expected IndexedDB store arrays.
- Kept JSON/NDJSON import helpers (`importJsonBackup`, `importNdjsonBackup`) and preserved conflict detection via `detectImportConflicts` and dry-run counts that derive from the canonical bundle.
- Adjusted browser E2E smoke fixture and expectations in `test/playwright/browser-tracker.spec.js` to exercise the canonical compact CSV semantics (compact CSV outreach/status fields and timeline assertions).

### Testing
- Ran `npm ci` and dependency setup (succeeded).
- Ran `npm run format:check` which reported pre-existing repository-wide Prettier warnings, and ran `npx prettier --check src/web/tracker/tracker.js test/playwright/browser-tracker.spec.js` which passed for the modified files.
- Ran `npm run lint` and `npm run typecheck` (both succeeded).
- Ran the full unit test CI harness with `npm run test:ci` (result: succeeded; recorded output showed 138 test files and 987 tests passing).
- Ran the browser smoke tests with `npx playwright test test/playwright/browser-tracker.spec.js --reporter=line` and verified the tracker Playwright scenarios for the modified flow (result: succeeded; all Playwright tracker tests passed after the change).
- Built the static tracker with `npm run build` (succeeded).

Residual risks and follow-ups: dashboard metric definitions and taxonomy normalization are intentionally scoped to a later task; confirm dashboard metric semantics in the follow-up prompt before changing metric calculations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c717dce7c832f89a4e3c501ba64a3)