### PR TITLE
Fix compact CSV taxonomy normalization

### DIFF
--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -48,6 +48,17 @@ const KNOWN_STATUSES = new Set([
   "closed_archived",
 ]);
 const OUTREACH_SENT_STATUSES = new Set(["sent", "replied"]);
+const STATUS_LABELS = new Map([
+  ["applied", "applied"],
+  ["application rejected", "rejected"],
+  ["rejected", "rejected"],
+  ["withdrawn", "withdrawn"],
+  ["offer", "offer"],
+  ["accepted", "accepted"],
+  ["closed", "closed_archived"],
+  ["closed archived", "closed_archived"],
+  ["closed_archived", "closed_archived"],
+]);
 const INTERVIEW_STAGES = new Map([
   ["recruiter_screen", "recruiter_screen"],
   ["phone_screen", "recruiter_screen"],
@@ -56,6 +67,7 @@ const INTERVIEW_STAGES = new Map([
   ["onsite", "onsite_loop"],
 ]);
 const OUTCOMES = new Map([
+  ["application rejected", "rejected"],
   ["offer", "offer"],
   ["accepted", "accepted"],
   ["rejected", "rejected"],
@@ -286,6 +298,9 @@ const metadataFromRow = (row) =>
       "fit_score_100",
       "outreach_status",
       "outreach_channel",
+      "status",
+      "interview_stage",
+      "outcome",
       "schema_version",
     ]
       .map((key) => [key, compact(row[key])])
@@ -320,12 +335,21 @@ const readMetadataFromNotes = (notes) => {
     return { notes: compact(notes), metadata: {} };
   }
 };
+export const normalizeCompactStatusLabel = (value) => {
+  const status = normalizeKey(value);
+  return KNOWN_STATUSES.has(status) ? status : STATUS_LABELS.get(status);
+};
+export const normalizeCompactInterviewStageLabel = (value) =>
+  INTERVIEW_STAGES.get(normalizeKey(value));
+export const normalizeCompactOutcomeLabel = (value) =>
+  OUTCOMES.get(normalizeKey(value));
+
 const mapStatus = (row) => {
-  const status = normalizeKey(row.status);
-  if (KNOWN_STATUSES.has(status)) return status;
-  const outcome = OUTCOMES.get(normalizeKey(row.outcome));
+  const status = normalizeCompactStatusLabel(row.status);
+  if (status) return status;
+  const outcome = normalizeCompactOutcomeLabel(row.outcome);
   if (outcome) return outcome;
-  const stage = INTERVIEW_STAGES.get(normalizeKey(row.interview_stage));
+  const stage = normalizeCompactInterviewStageLabel(row.interview_stage);
   if (stage) return stage;
   if (OUTREACH_SENT_STATUSES.has(normalizeKey(row.outreach_status)))
     return "outreach_sent";
@@ -525,7 +549,7 @@ export const rowsToBrowserApplicationExport = (
         source: "csv_import",
         createdAt: exportedAt,
       });
-    const stage = INTERVIEW_STAGES.get(normalizeKey(row.interview_stage));
+    const stage = normalizeCompactInterviewStageLabel(row.interview_stage);
     if (stage) {
       lifecycleEvents.push({
         id: stableId("event", id, stage),
@@ -536,18 +560,8 @@ export const rowsToBrowserApplicationExport = (
         note: compact(row.interview_stage),
         createdAt: exportedAt,
       });
-      interviews.push({
-        id: stableId("interview", id, stage),
-        applicationId: id,
-        contactIds: contactId ? [contactId] : [],
-        stage,
-        startsAt: outreachSentAt ?? appliedAt ?? timestamp,
-        outcome: "scheduled",
-        createdAt: timestamp,
-        updatedAt: exportedAt,
-      });
     }
-    const outcome = OUTCOMES.get(normalizeKey(row.outcome));
+    const outcome = normalizeCompactOutcomeLabel(row.outcome);
     if (outcome)
       lifecycleEvents.push({
         id: stableId("event", id, outcome),
@@ -643,7 +657,7 @@ export const browserApplicationExportToRows = (bundle) => {
         application_id: application.id,
         company: application.company,
         role_title: application.role,
-        status: application.status,
+        status: metadata.status ?? application.status,
         applied_at: dateOnly(application.appliedAt),
         posting_url: application.postingUrl ?? "",
         application_channel: application.source ?? "",
@@ -683,14 +697,16 @@ export const browserApplicationExportToRows = (bundle) => {
         outreach_sent_at: dateTime(outreach.sentAt),
         outreach_message_text: outreach.body ?? "",
         interview_stage:
-          interview.stage ??
-          interviewStageEvent.status ??
           metadata.interview_stage ??
+          interview.stage ??
+          interviewStageEvent.note ??
+          interviewStageEvent.status ??
           "",
         outcome:
+          metadata.outcome ??
+          outcomeEvent.note ??
           outcomeEvent.status ??
           (offer.status === "received" ? "offer" : offer.status) ??
-          metadata.outcome ??
           "",
       });
       return row;

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -15,6 +15,9 @@ import {
   exportNdjsonBackup,
   importCompactCsv,
   importJsonBackup,
+  normalizeCompactInterviewStageLabel,
+  normalizeCompactOutcomeLabel,
+  normalizeCompactStatusLabel,
   importNdjsonBackup,
   parseCsv,
   serializeCsv,
@@ -453,6 +456,67 @@ describe("spreadsheet import/export", () => {
     ).toBe(29);
   });
 
+  it("normalizes compact display labels while preserving raw spreadsheet metadata", () => {
+    const csv = serializeCsv([
+      {
+        application_id: "app_label_metadata",
+        company: "Label Metadata Co",
+        role_title: "Lifecycle Engineer",
+        status: "Responded to inbound",
+        applied_at: "2026-02-01T08:00:00.000Z",
+        posting_url: "https://example.test/jobs/label-metadata",
+        outreach_status: "replied",
+        outreach_channel: "email",
+        outreach_sent_at: "2026-02-02T09:00:00.000Z",
+        outreach_message_text: "Line one\nLine two with, comma",
+        interview_stage: "Written assessment submitted",
+        outcome: "Application rejected",
+        notes: "Long note line one\nLong note line two",
+        schema_version: "1",
+      },
+    ]);
+
+    expect(normalizeCompactStatusLabel("Applied")).toBe("applied");
+    expect(normalizeCompactStatusLabel("Responded to inbound")).toBeUndefined();
+    expect(
+      normalizeCompactInterviewStageLabel("Written assessment"),
+    ).toBeUndefined();
+    expect(normalizeCompactOutcomeLabel("Application rejected")).toBe(
+      "rejected",
+    );
+
+    const { bundle, errors } = csvToBrowserApplicationExport(csv, {
+      exportedAt: "2026-03-10T00:00:00.000Z",
+    });
+    expect(errors).toEqual([]);
+    expect(bundle.applications[0].status).toBe("rejected");
+    expect(bundle.interviews).toHaveLength(0);
+    expect(bundle.lifecycleEvents).toEqual(
+      expect.arrayContaining([expect.objectContaining({ status: "rejected" })]),
+    );
+    expect(bundle.applications[0].notes).toContain(
+      '"status":"Responded to inbound"',
+    );
+    expect(bundle.applications[0].notes).toContain(
+      '"interview_stage":"Written assessment submitted"',
+    );
+    expect(bundle.applications[0].notes).toContain(
+      '"outcome":"Application rejected"',
+    );
+
+    const [roundTripped] = parseCsv(exportCompactCsv(bundle));
+    expect(roundTripped).toMatchObject({
+      status: "Responded to inbound",
+      outreach_status: "replied",
+      interview_stage: "Written assessment submitted",
+      outcome: "Application rejected",
+      notes: "Long note line one\nLong note line two",
+      outreach_message_text: "Line one\nLine two with, comma",
+      compensation_min_usd: "",
+      compensation_max_usd: "",
+    });
+  });
+
   it("keeps supplemental lifecycle fixtures safe", async () => {
     // Prompt 01 only validates supplemental lifecycle fixture safety; importing
     // these lifecycle CSVs is intentionally deferred to Prompt 04.
@@ -811,9 +875,7 @@ describe("spreadsheet import/export", () => {
     expect(exported.outreachMessages[0].contactId).not.toContain(
       "app_regenerated",
     );
-    expect(exported.interviews[0].contactIds).toEqual(
-      expect.not.arrayContaining([expect.stringContaining("app_regenerated")]),
-    );
+    expect(exported.interviews).toHaveLength(0);
     const childCounts = Object.fromEntries(
       childStores.map((store) => [store, exported[store].length]),
     );


### PR DESCRIPTION
### Motivation
- Compact CSV rows include human spreadsheet labels that should be preserved as metadata but must not be misinterpreted as canonical lifecycle statuses or create phantom interview records.
- The import/export round trip must retain raw spreadsheet `status`, `interview_stage`, and `outcome` labels for dashboard metrics and backups while still mapping supported canonical values to domain fields.

### Description
- Added explicit compact CSV normalizers: `normalizeCompactStatusLabel`, `normalizeCompactInterviewStageLabel`, and `normalizeCompactOutcomeLabel` to centralize label → canonical mapping and exported them for tests. (`src/web/import-export/spreadsheet.js`).
- Preserve raw spreadsheet fields (`status`, `interview_stage`, `outcome`) in the CSV metadata appended to `applications.notes` so CSV → IndexedDB → CSV round trips retain human-readable labels and multiline notes/messages.
- Stop creating first-class `interview` records from compact CSV stage labels alone; stage labels can still produce canonical `lifecycleEvents`, but interviews are only created when sufficient scheduling metadata exists.
- Adjusted compact CSV export to prefer preserved spreadsheet metadata for `status`, `interview_stage`, and `outcome` when present so exported CSV matches original human labels.
- Added regression test coverage and a new test that validates normalization while preserving raw metadata and round-trip fidelity, and updated merging expectations to assert no phantom interviews. (`test/web-spreadsheet-import-export.test.js`).

### Testing
- Ran `npm ci` which completed successfully.
- Ran `npm run format:check` which reported pre-existing formatting drift outside this patch and therefore did not pass (intentional — unrelated files); `prettier` warnings were observed.
- Ran `npm run lint` which completed successfully and `npm run typecheck` which passed with no type errors.
- Ran the focused test file with `npm test -- --run test/web-spreadsheet-import-export.test.js` and it passed (new and existing assertions; 21 tests passed).
- Ran the full CI suite with `npm run test:ci` which completed successfully (test run reported all tests passing in this environment) and `npm run build` which produced the static build into `dist/`.
- Verified the compact-main regression fixture behaviour in tests: import yields 15 applications and 0 interviews as expected, and CSV export round-trips preserved human-readable `status`, `interview_stage`, and `outcome` labels.

Residual risks / follow-ups: run `prettier --write` or run `npm run format:fix` in a separate cosmetic PR to fix existing repo-wide formatting drift; no schema changes were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ca603c088832faafd5bed62e1a693)