### PR TITLE
Normalize compact CSV lifecycle labels without phantom interviews

### DIFF
--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -48,6 +48,13 @@ const KNOWN_STATUSES = new Set([
   "closed_archived",
 ]);
 const OUTREACH_SENT_STATUSES = new Set(["sent", "replied"]);
+const STATUS_LABELS = new Map([
+  ["applied", "applied"],
+  ["not_started", "applied"],
+  ["responded_to_inbound", "outreach_sent"],
+  ["interviewing", "recruiter_screen"],
+  ["application_rejected", "rejected"],
+]);
 const INTERVIEW_STAGES = new Map([
   ["recruiter_screen", "recruiter_screen"],
   ["phone_screen", "recruiter_screen"],
@@ -62,6 +69,7 @@ const OUTCOMES = new Map([
   ["withdrawn", "withdrawn"],
   ["closed", "closed_archived"],
   ["closed_archived", "closed_archived"],
+  ["application_rejected", "rejected"],
 ]);
 const ARTIFACT_DEFS = [
   ["resume", "resume_artifact", "resume_url", "Resume"],
@@ -99,6 +107,11 @@ const normalizeKey = (value) =>
   String(value ?? "")
     .trim()
     .toLowerCase();
+const normalizeLabelKey = (value) =>
+  normalizeKey(value)
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
 const compact = (value) => String(value ?? "").trim();
 const slug = (value) =>
   compact(value)
@@ -286,6 +299,9 @@ const metadataFromRow = (row) =>
       "fit_score_100",
       "outreach_status",
       "outreach_channel",
+      "status",
+      "interview_stage",
+      "outcome",
       "schema_version",
     ]
       .map((key) => [key, compact(row[key])])
@@ -320,13 +336,20 @@ const readMetadataFromNotes = (notes) => {
     return { notes: compact(notes), metadata: {} };
   }
 };
-const mapStatus = (row) => {
-  const status = normalizeKey(row.status);
+const normalizeCompactStatus = (value) => {
+  const status = normalizeKey(value);
   if (KNOWN_STATUSES.has(status)) return status;
-  const outcome = OUTCOMES.get(normalizeKey(row.outcome));
+  return STATUS_LABELS.get(normalizeLabelKey(value));
+};
+const normalizeCompactStage = (value) =>
+  INTERVIEW_STAGES.get(normalizeKey(value));
+const normalizeCompactOutcome = (value) =>
+  OUTCOMES.get(normalizeKey(value)) ?? OUTCOMES.get(normalizeLabelKey(value));
+const mapStatus = (row) => {
+  const status = normalizeCompactStatus(row.status);
+  if (status) return status;
+  const outcome = normalizeCompactOutcome(row.outcome);
   if (outcome) return outcome;
-  const stage = INTERVIEW_STAGES.get(normalizeKey(row.interview_stage));
-  if (stage) return stage;
   if (OUTREACH_SENT_STATUSES.has(normalizeKey(row.outreach_status)))
     return "outreach_sent";
   return "applied";
@@ -525,7 +548,7 @@ export const rowsToBrowserApplicationExport = (
         source: "csv_import",
         createdAt: exportedAt,
       });
-    const stage = INTERVIEW_STAGES.get(normalizeKey(row.interview_stage));
+    const stage = normalizeCompactStage(row.interview_stage);
     if (stage) {
       lifecycleEvents.push({
         id: stableId("event", id, stage),
@@ -536,18 +559,8 @@ export const rowsToBrowserApplicationExport = (
         note: compact(row.interview_stage),
         createdAt: exportedAt,
       });
-      interviews.push({
-        id: stableId("interview", id, stage),
-        applicationId: id,
-        contactIds: contactId ? [contactId] : [],
-        stage,
-        startsAt: outreachSentAt ?? appliedAt ?? timestamp,
-        outcome: "scheduled",
-        createdAt: timestamp,
-        updatedAt: exportedAt,
-      });
     }
-    const outcome = OUTCOMES.get(normalizeKey(row.outcome));
+    const outcome = normalizeCompactOutcome(row.outcome);
     if (outcome)
       lifecycleEvents.push({
         id: stableId("event", id, outcome),
@@ -613,11 +626,10 @@ export const browserApplicationExportToRows = (bundle) => {
         parsed.outreachMessages,
         (message) => message.applicationId === application.id,
       );
-      const interview =
-        firstBy(
-          parsed.interviews,
-          (record) => record.applicationId === application.id,
-        ) ?? {};
+      const interview = firstBy(
+        parsed.interviews,
+        (record) => record.applicationId === application.id,
+      );
       const interviewStageEvent = firstBy(
         parsed.lifecycleEvents,
         (event) =>
@@ -683,16 +695,17 @@ export const browserApplicationExportToRows = (bundle) => {
         outreach_sent_at: dateTime(outreach.sentAt),
         outreach_message_text: outreach.body ?? "",
         interview_stage:
-          interview.stage ??
-          interviewStageEvent.status ??
           metadata.interview_stage ??
+          interview?.stage ??
+          interviewStageEvent.status ??
           "",
         outcome:
+          metadata.outcome ??
           outcomeEvent.status ??
           (offer.status === "received" ? "offer" : offer.status) ??
-          metadata.outcome ??
           "",
       });
+      row.status = metadata.status ?? application.status;
       return row;
     });
 };

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -392,6 +392,79 @@ describe("spreadsheet import/export", () => {
     ]);
   });
 
+  it("normalizes compact display labels while preserving raw spreadsheet fields", () => {
+    const csv = serializeCsv([
+      {
+        application_id: "app_display_labels",
+        company: "Display Labels Inc",
+        role_title: "Lifecycle Engineer",
+        status: "Interviewing",
+        applied_at: "2026-02-01",
+        outreach_status: "replied",
+        outreach_channel: "email",
+        outreach_sent_at: "2026-02-02T12:00:00.000Z",
+        outreach_message_text: "Inbound reply with next steps.",
+        interview_stage: "Written assessment submitted",
+        outcome: "Application rejected",
+        notes: "Long note line one.\nLong note line two.",
+      },
+      {
+        application_id: "app_not_started",
+        company: "Not Started LLC",
+        role_title: "Spreadsheet Curator",
+        status: "Not started",
+        interview_stage: "Recruiter screen pending",
+      },
+    ]);
+
+    const { bundle, errors } = csvToBrowserApplicationExport(csv, {
+      exportedAt: "2026-03-01T00:00:00.000Z",
+    });
+
+    expect(errors).toEqual([]);
+    expect(bundle.applications).toEqual([
+      expect.objectContaining({
+        id: "app_display_labels",
+        status: "recruiter_screen",
+        notes: expect.stringContaining('"status":"Interviewing"'),
+      }),
+      expect.objectContaining({
+        id: "app_not_started",
+        status: "applied",
+        notes: expect.stringContaining(
+          '"interview_stage":"Recruiter screen pending"',
+        ),
+      }),
+    ]);
+    expect(bundle.interviews).toHaveLength(0);
+    expect(bundle.lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          applicationId: "app_display_labels",
+          status: "rejected",
+          note: "Application rejected",
+        }),
+      ]),
+    );
+
+    const rows = parseCsv(exportCompactCsv(bundle));
+    expect(rows).toEqual([
+      expect.objectContaining({
+        application_id: "app_display_labels",
+        status: "Interviewing",
+        outreach_status: "replied",
+        interview_stage: "Written assessment submitted",
+        outcome: "Application rejected",
+        notes: "Long note line one.\nLong note line two.",
+      }),
+      expect.objectContaining({
+        application_id: "app_not_started",
+        status: "Not started",
+        interview_stage: "Recruiter screen pending",
+      }),
+    ]);
+  });
+
   it("documents intended compact CSV regression metrics without phantom interviews", async () => {
     const csv = await readFile(
       "test/fixtures/tracker-import/compact-main-regression.csv",
@@ -451,6 +524,27 @@ describe("spreadsheet import/export", () => {
         (repliedOutreachRows.length / bundle.outreachMessages.length) * 100,
       ),
     ).toBe(29);
+
+    const roundTripRows = parseCsv(exportCompactCsv(bundle));
+    const roundTripRowsById = new Map(
+      roundTripRows.map((row) => [row.application_id, row]),
+    );
+    expect(roundTripRows).toHaveLength(rows.length);
+    for (const row of rows) {
+      expect(roundTripRowsById.get(row.application_id)).toMatchObject({
+        application_id: row.application_id,
+        status: row.status,
+        interview_stage: row.interview_stage,
+        outcome: row.outcome,
+        notes: row.notes,
+        compensation_min_usd: row.compensation_min_usd,
+        compensation_max_usd: row.compensation_max_usd,
+        outreach_status: row.outreach_status,
+        outreach_message_text: row.outreach_message_text,
+        applied_at: row.applied_at.slice(0, 10),
+        outreach_sent_at: row.outreach_sent_at,
+      });
+    }
   });
 
   it("keeps supplemental lifecycle fixtures safe", async () => {
@@ -811,9 +905,7 @@ describe("spreadsheet import/export", () => {
     expect(exported.outreachMessages[0].contactId).not.toContain(
       "app_regenerated",
     );
-    expect(exported.interviews[0].contactIds).toEqual(
-      expect.not.arrayContaining([expect.stringContaining("app_regenerated")]),
-    );
+    expect(exported.interviews).toHaveLength(0);
     const childCounts = Object.fromEntries(
       childStores.map((store) => [store, exported[store].length]),
     );


### PR DESCRIPTION
### Motivation
- The compact CSV format contains human spreadsheet labels that must not be treated as canonical lifecycle statuses or synthesized into interview records. 
- Preserve raw spreadsheet metadata so CSV → IndexedDB → CSV round trips keep human-readable labels and dashboard response facts intact. 
- Avoid creating phantom `interviews` from non-interview stage labels while still recording canonical lifecycle events and rejections.

### Description
- Add label-aware normalizers (`STATUS_LABELS`, `normalizeCompactStatus`, `normalizeCompactStage`, `normalizeCompactOutcome`) to map human display labels to canonical lifecycle values without losing the original labels. 
- Preserve raw `status`, `interview_stage`, and `outcome` values in spreadsheet metadata attached to `applications` and round-trip them through `appendMetadataToNotes` / `readMetadataFromNotes`. 
- Stop creating first-class `interviews` from compact CSV stage labels; canonical stages still generate `lifecycleEvents` but non-interview labels remain metadata. 
- Update CSV export to prefer preserved spreadsheet fields when present and add regression tests that validate label normalization, raw metadata retention, compact fixture round trips, outreach/rejection handling, and zero phantom interviews.

### Testing
- Ran `npm ci` which completed successfully (install completed; audit warnings noted). 
- Ran `npm run format:check` which reports pre-existing repository-wide Prettier warnings, but targeted formatting checks passed for the modified files. 
- Ran `npx prettier --check src/web/import-export/spreadsheet.js test/web-spreadsheet-import-export.test.js` which passed. 
- Ran `npm run lint` and `npm run typecheck` which completed without errors. 
- Ran the focused tests with `npm test -- --run test/web-spreadsheet-import-export.test.js` which passed (21 tests). 
- Ran full CI tests with `npm run test:ci` which passed (all tests passed in CI run reported). 
- Built static assets with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ca6140cfc832f9a1809b5450b1119)