### PR TITLE
Add supplemental lifecycle CSV import support

### DIFF
--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -59,6 +59,16 @@ export const browserApplicationLifecycleEventSchema = z.object({
     "sqlite_migration",
   ]),
   note: optionalTrimmedStringSchema,
+  eventType: optionalTrimmedStringSchema,
+  stageLabel: optionalTrimmedStringSchema,
+  channel: optionalTrimmedStringSchema,
+  actor: optionalTrimmedStringSchema,
+  sourceArtifact: optionalTrimmedStringSchema,
+  requiresUserAction: z.boolean().optional(),
+  actionStatus: optionalTrimmedStringSchema,
+  dueAt: isoDateTimeSchema.optional(),
+  noAiRequired: z.boolean().optional(),
+  details: optionalTrimmedStringSchema,
   createdAt: isoDateTimeSchema,
 });
 

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -34,6 +34,22 @@ export const COMPACT_CSV_COLUMNS = [
   "notes",
   "schema_version",
 ];
+export const LIFECYCLE_CSV_COLUMNS = [
+  "application_id",
+  "company",
+  "role_title",
+  "event_type",
+  "occurred_at",
+  "stage",
+  "channel",
+  "actor",
+  "source_artifact",
+  "requires_user_action",
+  "action_status",
+  "due_at",
+  "no_ai_required",
+  "details",
+];
 
 const KNOWN_STATUSES = new Set([
   "applied",
@@ -226,6 +242,27 @@ export const parseCsv = (text) => {
       ),
     );
 };
+export const csvHeaders = (text) => {
+  const input = String(text ?? "").replace(/^\uFEFF/, "");
+  const firstLine = input.split(/\r?\n/, 1)[0] ?? "";
+  return parseCsv(`${firstLine}\n`).length
+    ? []
+    : firstLine.split(",").map(normalizeKey);
+};
+export const detectCsvImportFormat = (text) => {
+  const headers = csvHeaders(text);
+  if (
+    headers.length === LIFECYCLE_CSV_COLUMNS.length &&
+    headers.every((header, index) => header === LIFECYCLE_CSV_COLUMNS[index])
+  )
+    return "lifecycle_csv";
+  if (
+    headers.length === COMPACT_CSV_COLUMNS.length &&
+    headers.every((header, index) => header === COMPACT_CSV_COLUMNS[index])
+  )
+    return "compact_csv";
+  return "csv";
+};
 
 const serializeField = (value) => {
   const text = String(value ?? "");
@@ -276,6 +313,19 @@ const parseNumber = (value, field, rowNumber, errors) => {
     return undefined;
   }
   return number;
+};
+const parseBoolean = (value, field, rowNumber, errors) => {
+  const text = normalizeKey(value);
+  if (!text) return undefined;
+  if (["true", "yes", "y", "1"].includes(text)) return true;
+  if (["false", "no", "n", "0"].includes(text)) return false;
+  errors.push({
+    rowNumber,
+    field,
+    code: "malformed_boolean",
+    message: `${field} is not a valid boolean.`,
+  });
+  return undefined;
 };
 const WEB_URL_PROTOCOLS = new Set(["http:", "https:"]);
 
@@ -690,6 +740,159 @@ export const rowsToBrowserApplicationExport = (
 export const csvToBrowserApplicationExport = (csvText, options) =>
   rowsToBrowserApplicationExport(parseCsv(csvText), options);
 
+const LIFECYCLE_STATUS_BY_EVENT_TYPE = new Map([
+  ["application_submitted", "applied"],
+  ["written_assessment_requested", "applied"],
+  ["written_assessment_submitted", "applied"],
+  ["hiring_manager_reply", "outreach_sent"],
+  ["next_tracking_step", "applied"],
+  ["recruiter_screen_scheduled", "recruiter_screen"],
+]);
+const lifecycleEventId = (row, applicationId) =>
+  stableId(
+    "event",
+    applicationId,
+    row.event_type,
+    row.occurred_at,
+    row.stage,
+    row.due_at,
+  );
+const lifecycleInterviewId = (eventId) => stableId("interview", eventId);
+const lifecycleReminderId = (eventId) => stableId("reminder", eventId);
+const lifecycleArtifactId = (eventId) => stableId("artifact", eventId);
+export const lifecycleRowsToBrowserApplicationExport = (
+  rows,
+  existing,
+  { exportedAt = nowIso() } = {},
+) => {
+  const errors = [];
+  const existingApplications = new Map(
+    (existing?.applications ?? []).map((application) => [
+      application.id,
+      application,
+    ]),
+  );
+  const lifecycleEvents = [],
+    interviews = [],
+    artifacts = [],
+    reminders = [];
+  rows.forEach((sourceRow, index) => {
+    const rowNumber = index + 2;
+    const row = Object.fromEntries(
+      LIFECYCLE_CSV_COLUMNS.map((key) => [key, compact(sourceRow[key])]),
+    );
+    const applicationId = row.application_id;
+    if (!applicationId || !existingApplications.has(applicationId)) {
+      errors.push({
+        rowNumber,
+        field: "application_id",
+        code: "missing_application",
+        value: applicationId,
+        message:
+          `application_id ${applicationId || "(blank)"} does not match ` +
+          "an existing application.",
+      });
+      return;
+    }
+    const occurredAt = parseDate(
+      row.occurred_at,
+      "occurred_at",
+      rowNumber,
+      errors,
+    );
+    const dueAt = parseDate(row.due_at, "due_at", rowNumber, errors);
+    const requiresUserAction = parseBoolean(
+      row.requires_user_action,
+      "requires_user_action",
+      rowNumber,
+      errors,
+    );
+    const noAiRequired = parseBoolean(
+      row.no_ai_required,
+      "no_ai_required",
+      rowNumber,
+      errors,
+    );
+    const eventType = normalizeLabelKey(row.event_type);
+    const eventId = lifecycleEventId(row, applicationId);
+    lifecycleEvents.push({
+      id: eventId,
+      applicationId,
+      status: LIFECYCLE_STATUS_BY_EVENT_TYPE.get(eventType) ?? "applied",
+      occurredAt: occurredAt ?? exportedAt,
+      source: "csv_import",
+      note: row.details || row.stage || undefined,
+      eventType: eventType || undefined,
+      stageLabel: row.stage || undefined,
+      channel: row.channel || undefined,
+      actor: row.actor || undefined,
+      sourceArtifact: row.source_artifact || undefined,
+      requiresUserAction,
+      actionStatus: row.action_status || undefined,
+      dueAt,
+      noAiRequired,
+      details: row.details || undefined,
+      createdAt: exportedAt,
+    });
+    if (row.source_artifact)
+      artifacts.push({
+        id: lifecycleArtifactId(eventId),
+        applicationId,
+        kind: "link",
+        name: row.source_artifact,
+        url: validUrl(
+          row.source_artifact,
+          "source_artifact",
+          rowNumber,
+          errors,
+        ),
+        private: true,
+        createdAt: occurredAt ?? exportedAt,
+        updatedAt: exportedAt,
+      });
+    if (eventType === "next_tracking_step" && dueAt)
+      reminders.push({
+        id: lifecycleReminderId(eventId),
+        applicationId,
+        dueAt,
+        summary: row.details || row.stage || "Next tracking step",
+        createdAt: exportedAt,
+        updatedAt: exportedAt,
+      });
+    if (eventType === "recruiter_screen_scheduled" && dueAt)
+      interviews.push({
+        id: lifecycleInterviewId(eventId),
+        applicationId,
+        contactIds: [],
+        stage: "recruiter_screen",
+        startsAt: dueAt,
+        outcome: "scheduled",
+        preparationNotes: row.details || undefined,
+        createdAt: exportedAt,
+        updatedAt: exportedAt,
+      });
+  });
+  const bundle = {
+    schemaVersion: 1,
+    exportedAt,
+    applications: [],
+    contacts: [],
+    outreachMessages: [],
+    lifecycleEvents,
+    interviews,
+    offers: [],
+    artifacts,
+    reminders,
+  };
+  return { bundle, errors };
+};
+export const lifecycleCsvToBrowserApplicationExport = (
+  csvText,
+  existing,
+  options,
+) =>
+  lifecycleRowsToBrowserApplicationExport(parseCsv(csvText), existing, options);
+
 const dateOnly = (value) => (value ? String(value).slice(0, 10) : "");
 const dateTime = (value) => (value ? String(value) : "");
 const firstBy = (records, predicate) => records.find(predicate) ?? {};
@@ -1008,6 +1211,88 @@ export const importCompactCsv = async (
             ...incoming,
           ]
         : [...existing[store], ...incoming];
+  }
+  return {
+    imported: true,
+    preview,
+    result: await repository.importAllData(merged, { allowOverwrite: true }),
+  };
+};
+
+export const previewLifecycleCsvImport = async (csvText, repository) => {
+  const rows = parseCsv(csvText);
+  const existing = repository
+    ? await repository.exportAllData()
+    : { applications: [] };
+  const { bundle, errors } = lifecycleRowsToBrowserApplicationExport(
+    rows,
+    existing,
+  );
+  const existingKeys = new Set(
+    ARRAY_STORES.flatMap((store) =>
+      (existing[store] ?? []).map(({ id }) => `${store}:${id}`),
+    ),
+  );
+  const incomingKeys = new Set();
+  const conflicts = [];
+  for (const store of ARRAY_STORES) {
+    (bundle[store] ?? []).forEach((record) => {
+      const key = `${store}:${record.id}`;
+      if (incomingKeys.has(key))
+        conflicts.push({
+          rowNumber: null,
+          field: "id",
+          code: "duplicate_in_file",
+          value: record.id,
+          store,
+        });
+      if (existingKeys.has(key))
+        conflicts.push({
+          rowNumber: null,
+          field: "id",
+          code: "duplicate_existing",
+          value: record.id,
+          store,
+        });
+      incomingKeys.add(key);
+    });
+  }
+  return {
+    format: "lifecycle_csv",
+    rowCount: rows.length,
+    validRowCount: Math.max(
+      0,
+      rows.length -
+        new Set(
+          errors
+            .map((error) => error.rowNumber)
+            .filter((rowNumber) => Number.isInteger(rowNumber)),
+        ).size,
+    ),
+    errors,
+    conflicts,
+    bundle,
+  };
+};
+
+export const importLifecycleCsv = async (csvText, repository) => {
+  const preview = await previewLifecycleCsvImport(csvText, repository);
+  if (preview.errors.length > 0) return { imported: false, preview };
+  const existing = await repository.exportAllData();
+  const merged = { ...existing, exportedAt: nowIso() };
+  for (const store of [
+    "lifecycleEvents",
+    "interviews",
+    "artifacts",
+    "reminders",
+  ]) {
+    const incoming = preview.bundle[store] ?? [];
+    merged[store] = [
+      ...(existing[store] ?? []).filter(
+        (record) => !incoming.some(({ id }) => id === record.id),
+      ),
+      ...incoming,
+    ];
   }
   return {
     imported: true,

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -3,9 +3,11 @@
 import {
   COMPACT_CSV_COLUMNS,
   csvToBrowserApplicationExport,
+  detectCsvImportFormat,
   exportCompactCsv,
   exportJsonBackup,
   exportNdjsonBackup,
+  lifecycleCsvToBrowserApplicationExport,
   importJsonBackup,
   importNdjsonBackup,
 } from "../import-export/spreadsheet.js";
@@ -574,7 +576,11 @@ async function newApplication() {
   openUnsavedDetail(app);
 }
 function previewBundleFromCsv(text) {
-  const { bundle, errors } = csvToBrowserApplicationExport(text);
+  const format = detectCsvImportFormat(text);
+  const { bundle, errors } =
+    format === "lifecycle_csv"
+      ? lifecycleCsvToBrowserApplicationExport(text, state.bundle)
+      : csvToBrowserApplicationExport(text);
   if (errors.length) {
     throw new Error(
       errors
@@ -586,7 +592,26 @@ function previewBundleFromCsv(text) {
         .join("; "),
     );
   }
-  return bundle;
+  return { bundle, format };
+}
+function mergeSupplementalLifecycleBundle(existing, incoming) {
+  const merged = { ...existing, exportedAt: now() };
+  for (const store of [
+    "lifecycleEvents",
+    "interviews",
+    "artifacts",
+    "reminders",
+  ]) {
+    const rows = incoming[store] ?? [];
+    merged[store] = [
+      ...(existing[store] ?? []).filter(
+        (record) =>
+          !rows.some(({ id: incomingId }) => incomingId === record.id),
+      ),
+      ...rows,
+    ];
+  }
+  return merged;
 }
 function bundleForIndexedDb(bundle) {
   return {
@@ -623,21 +648,30 @@ async function previewImport() {
   try {
     const text = await file.text();
     const format = importFormatForFile(file);
-    const bundle =
+    const parsed =
       format === "json"
-        ? importJsonBackup(text)
+        ? { bundle: importJsonBackup(text), format: "json" }
         : format === "ndjson"
-          ? importNdjsonBackup(text)
+          ? { bundle: importNdjsonBackup(text), format: "ndjson" }
           : previewBundleFromCsv(text);
+    const bundle =
+      parsed.format === "lifecycle_csv"
+        ? mergeSupplementalLifecycleBundle(state.bundle, parsed.bundle)
+        : parsed.bundle;
     state.preview = bundleForIndexedDb(bundle);
     state.previewConflicts = await detectImportConflicts(state.preview);
     const totalRecords = Object.values(state.preview).reduce(
       (count, rows) => count + rows.length,
       0,
     );
-    const formatLabel = format === "csv" ? "" : ` (${format.toUpperCase()})`;
+    const formatLabel =
+      parsed.format === "lifecycle_csv"
+        ? " (lifecycle CSV)"
+        : format === "csv"
+          ? " (compact CSV)"
+          : ` (${format.toUpperCase()})`;
     $("[data-import-result]").textContent =
-      `Dry-run OK${formatLabel}: ${(bundle.applications ?? []).length} applications, ${(bundle.outreachMessages ?? []).length} outreach messages, ${(bundle.interviews ?? []).length} interviews. ${totalRecords} total records. ${state.previewConflicts.length} existing record conflicts.`;
+      `Dry-run OK${formatLabel}: ${(bundle.applications ?? []).length} applications, ${(bundle.lifecycleEvents ?? []).length} lifecycle events, ${(bundle.outreachMessages ?? []).length} outreach messages, ${(bundle.interviews ?? []).length} interviews, ${(bundle.reminders ?? []).length} reminders. ${totalRecords} total records. ${state.previewConflicts.length} existing record conflicts.`;
     $("[data-import-apply]").disabled = false;
   } catch (err) {
     state.preview = null;

--- a/test/fixtures/tracker-import/canonical-lifecycle-regression.csv
+++ b/test/fixtures/tracker-import/canonical-lifecycle-regression.csv
@@ -1,4 +1,4 @@
-application_id,event_type,event_status,occurred_at,source,contact_name,artifact_url,notes,schema_version
-app_reg_beta_002,outreach_reply,replied,2026-02-05T12:00:00.000Z,email,Casey Beta,https://example.test/artifact/beta/reply.eml,Fake reply metadata.,1
-app_reg_zeta_006,outreach_reply,replied,2026-02-12T12:00:00.000Z,email,Alex Zeta,https://example.test/artifact/zeta/reply.eml,Fake reply metadata.,1
-app_reg_gamma_003,decision,rejected,2026-02-10T09:00:00.000Z,portal,,https://example.test/artifact/gamma/rejection.html,Fake rejection metadata.,1
+application_id,company,role_title,event_type,occurred_at,stage,channel,actor,source_artifact,requires_user_action,action_status,due_at,no_ai_required,details
+app_reg_delta_004,Company Delta,ML Infrastructure Engineer,written_assessment_requested,2026-02-07T18:00:00.000Z,Written assessment,email,Recruiting Team,https://example.test/artifact/delta/request.eml,true,pending,2026-02-09T23:59:59.000Z,true,"Fake written assessment request.
+Includes multiline details."
+app_reg_delta_004,Company Delta,ML Infrastructure Engineer,written_assessment_submitted,2026-02-08T20:00:00.000Z,Written assessment submitted,portal,Candidate,https://example.test/artifact/delta/assessment.pdf,false,submitted,,true,Fake assessment submitted metadata.

--- a/test/fixtures/tracker-import/loft-lifecycle-regression.csv
+++ b/test/fixtures/tracker-import/loft-lifecycle-regression.csv
@@ -1,2 +1,3 @@
-application_id,event_type,event_status,occurred_at,source,contact_name,artifact_url,notes,schema_version
-app_reg_delta_004,assessment,written_assessment_submitted,2026-02-08T20:00:00.000Z,loft,,https://example.test/artifact/delta/assessment.pdf,Fake Loft-style supplemental lifecycle row.,1
+application_id,company,role_title,event_type,occurred_at,stage,channel,actor,source_artifact,requires_user_action,action_status,due_at,no_ai_required,details
+app_reg_beta_002,Company Beta,Backend Systems Engineer,hiring_manager_reply,2026-02-05T12:00:00.000Z,Hiring manager follow-up,email,Hiring Manager,https://example.test/artifact/beta/reply.eml,false,replied,,,Fake hiring-manager reply metadata.
+app_reg_zeta_006,Company Zeta,Security Engineer,hiring_manager_reply,2026-02-12T12:00:00.000Z,Hiring manager follow-up,email,Hiring Manager,https://example.test/artifact/zeta/reply.eml,false,replied,,,Fake reply metadata.

--- a/test/fixtures/tracker-import/reducto-lifecycle-regression.csv
+++ b/test/fixtures/tracker-import/reducto-lifecycle-regression.csv
@@ -1,2 +1,2 @@
-application_id,event_type,event_status,occurred_at,source,contact_name,artifact_url,notes,schema_version
-app_reg_epsilon_005,scheduler,recruiter_screen_pending,2026-02-10T16:00:00.000Z,reducto,Riley Epsilon,https://example.test/artifact/epsilon/scheduler.html,Fake Reducto-style supplemental lifecycle row.,1
+application_id,company,role_title,event_type,occurred_at,stage,channel,actor,source_artifact,requires_user_action,action_status,due_at,no_ai_required,details
+app_reg_epsilon_005,Company Epsilon,Developer Tools Engineer,recruiter_screen_scheduled,2026-02-10T16:00:00.000Z,Recruiter screen,email,Recruiter,https://example.test/artifact/epsilon/scheduler.html,false,scheduled,2026-02-12T17:30:00.000Z,false,Fake recruiter screen scheduled metadata.

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -9,16 +9,21 @@ import {
 } from "../src/web/storage/indexedDbRepository.js";
 import {
   COMPACT_CSV_COLUMNS,
+  LIFECYCLE_CSV_COLUMNS,
   csvToBrowserApplicationExport,
+  detectCsvImportFormat,
   exportCompactCsv,
   exportJsonBackup,
   exportNdjsonBackup,
   importCompactCsv,
+  importLifecycleCsv,
   importJsonBackup,
   importNdjsonBackup,
+  lifecycleCsvToBrowserApplicationExport,
   parseCsv,
   serializeCsv,
   previewCompactCsvImport,
+  previewLifecycleCsvImport,
 } from "../src/web/import-export/spreadsheet.js";
 
 const deleteDatabase = () =>
@@ -893,7 +898,7 @@ describe("spreadsheet import/export", () => {
     ).toBe(true);
     expect(
       lifecycleRows.every((row) =>
-        row.artifact_url.startsWith("https://example.test/artifact/"),
+        row.source_artifact.startsWith("https://example.test/artifact/"),
       ),
     ).toBe(true);
 
@@ -904,6 +909,210 @@ describe("spreadsheet import/export", () => {
     expect(lifecycleText).not.toMatch(
       /(?:gmail|outlook|yahoo|hotmail|linkedin|greenhouse|lever|ashby|workday)\.com/i,
     );
+  });
+
+  it("detects compact and supplemental lifecycle CSV formats", async () => {
+    expect(
+      detectCsvImportFormat(
+        await readFile(
+          "test/fixtures/tracker-import/compact-main-regression.csv",
+          "utf8",
+        ),
+      ),
+    ).toBe("compact_csv");
+    expect(
+      detectCsvImportFormat(
+        await readFile(
+          "test/fixtures/tracker-import/canonical-lifecycle-regression.csv",
+          "utf8",
+        ),
+      ),
+    ).toBe("lifecycle_csv");
+    expect(LIFECYCLE_CSV_COLUMNS.join(",")).toBe(
+      [
+        "application_id",
+        "company",
+        "role_title",
+        "event_type",
+        "occurred_at",
+        "stage",
+        "channel",
+        "actor",
+        "source_artifact",
+        "requires_user_action",
+        "action_status",
+        "due_at",
+        "no_ai_required",
+        "details",
+      ].join(","),
+    );
+  });
+
+  it("parses lifecycle booleans, dates, multiline details, blanks, and unknown types", async () => {
+    const mainCsv = await readFile(
+      "test/fixtures/tracker-import/compact-main-regression.csv",
+      "utf8",
+    );
+    const { bundle: existing } = csvToBrowserApplicationExport(mainCsv, {
+      exportedAt: "2026-03-10T00:00:00.000Z",
+    });
+    const csv = serializeCsv(
+      [
+        {
+          application_id: "app_reg_alpha_001",
+          event_type: "custom_vendor_signal",
+          occurred_at: "2026-02-03",
+          stage: "Custom stage",
+          channel: "portal",
+          actor: "",
+          source_artifact: "https://example.test/artifact/alpha/custom.html",
+          requires_user_action: "yes",
+          action_status: "",
+          due_at: "",
+          no_ai_required: "no",
+          details: "Line one\nLine two",
+        },
+      ],
+      LIFECYCLE_CSV_COLUMNS,
+    );
+
+    const { bundle, errors } = lifecycleCsvToBrowserApplicationExport(
+      csv,
+      existing,
+      { exportedAt: "2026-03-11T00:00:00.000Z" },
+    );
+
+    expect(errors).toEqual([]);
+    expect(bundle.lifecycleEvents).toEqual([
+      expect.objectContaining({
+        applicationId: "app_reg_alpha_001",
+        status: "applied",
+        eventType: "custom_vendor_signal",
+        occurredAt: "2026-02-03T00:00:00.000Z",
+        stageLabel: "Custom stage",
+        channel: "portal",
+        requiresUserAction: true,
+        noAiRequired: false,
+        details: "Line one\nLine two",
+      }),
+    ]);
+  });
+
+  it("imports supplemental lifecycle fixtures without phantom interviews", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const mainCsv = await readFile(
+      "test/fixtures/tracker-import/compact-main-regression.csv",
+      "utf8",
+    );
+    await importCompactCsv(mainCsv, repo, { mode: "replace" });
+
+    const canonicalCsv = await readFile(
+      "test/fixtures/tracker-import/canonical-lifecycle-regression.csv",
+      "utf8",
+    );
+    const loftCsv = await readFile(
+      "test/fixtures/tracker-import/loft-lifecycle-regression.csv",
+      "utf8",
+    );
+    const reductoCsv = await readFile(
+      "test/fixtures/tracker-import/reducto-lifecycle-regression.csv",
+      "utf8",
+    );
+
+    await importLifecycleCsv(canonicalCsv, repo);
+    await importLifecycleCsv(loftCsv, repo);
+    let bundle = await repo.exportAllData();
+    expect(bundle.applications).toHaveLength(15);
+    expect(bundle.interviews).toHaveLength(0);
+    expect(bundle.lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "written_assessment_requested",
+          noAiRequired: true,
+        }),
+        expect.objectContaining({ eventType: "written_assessment_submitted" }),
+        expect.objectContaining({ eventType: "hiring_manager_reply" }),
+      ]),
+    );
+
+    await importLifecycleCsv(reductoCsv, repo);
+    bundle = await repo.exportAllData();
+    expect(bundle.interviews).toEqual([
+      expect.objectContaining({
+        applicationId: "app_reg_epsilon_005",
+        stage: "recruiter_screen",
+        startsAt: "2026-02-12T17:30:00.000Z",
+      }),
+    ]);
+
+    await importLifecycleCsv(reductoCsv, repo);
+    const secondBundle = await repo.exportAllData();
+    expect(secondBundle.interviews).toHaveLength(1);
+    expect(
+      secondBundle.lifecycleEvents.filter(
+        ({ eventType }) => eventType === "recruiter_screen_scheduled",
+      ),
+    ).toHaveLength(1);
+
+    const roundTrip = importNdjsonBackup(exportNdjsonBackup(secondBundle));
+    expect(roundTrip.lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "written_assessment_requested",
+          noAiRequired: true,
+        }),
+      ]),
+    );
+    expect(
+      importJsonBackup(exportJsonBackup(secondBundle)).lifecycleEvents,
+    ).toEqual(roundTrip.lifecycleEvents);
+    repo.close();
+  });
+
+  it("reports missing lifecycle application IDs without orphan records", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const mainCsv = await readFile(
+      "test/fixtures/tracker-import/compact-main-regression.csv",
+      "utf8",
+    );
+    await importCompactCsv(mainCsv, repo, { mode: "replace" });
+    const csv = serializeCsv(
+      [
+        {
+          application_id: "app_missing_999",
+          event_type: "hiring_manager_reply",
+          occurred_at: "2026-02-03T00:00:00.000Z",
+          details: "Should not import.",
+        },
+      ],
+      LIFECYCLE_CSV_COLUMNS,
+    );
+
+    const preview = await previewLifecycleCsvImport(csv, repo);
+    expect(preview.errors).toEqual([
+      expect.objectContaining({
+        rowNumber: 2,
+        field: "application_id",
+        code: "missing_application",
+        value: "app_missing_999",
+      }),
+    ]);
+    expect(preview.bundle.lifecycleEvents).toHaveLength(0);
+
+    const result = await importLifecycleCsv(csv, repo);
+    expect(result.imported).toBe(false);
+    const bundle = await repo.exportAllData();
+    expect(
+      bundle.lifecycleEvents.some(
+        ({ applicationId }) => applicationId === "app_missing_999",
+      ),
+    ).toBe(false);
+    expect(
+      bundle.interviews.some(
+        ({ applicationId }) => applicationId === "app_missing_999",
+      ),
+    ).toBe(false);
+    repo.close();
   });
 
   it("imports the fake compact CSV fixture into IndexedDB and exports stable CSV", async () => {


### PR DESCRIPTION
### Motivation
- Allow importing supplemental lifecycle CSVs that attach event-level metadata to existing applications without creating orphan records or misclassifying non-interview events as interviews.
- Preserve per-event metadata (assessment requests/submissions, hiring-manager replies, reminders, recruiter-screen scheduling, artifact URLs, no-AI flags) while keeping compact CSV behavior unchanged and maintaining browser-only privacy boundaries.

### Description
- Added an exact supplemental lifecycle CSV header (`LIFECYCLE_CSV_COLUMNS`) and `detectCsvImportFormat` to the shared import/export layer so lifecycle CSVs are routed through the canonical pipeline instead of ad-hoc parsing. (`src/web/import-export/spreadsheet.js`)
- Implemented `lifecycleRowsToBrowserApplicationExport` / `lifecycleCsvToBrowserApplicationExport`, deterministic stable IDs for lifecycle-derived records, idempotent import merging, conflict detection, and preview helpers (`previewLifecycleCsvImport` / `importLifecycleCsv`). (`src/web/import-export/spreadsheet.js`)
- Extended `browserApplicationLifecycleEventSchema` with optional lifecycle metadata fields: `eventType`, `stageLabel`, `channel`, `actor`, `sourceArtifact`, `requiresUserAction`, `actionStatus`, `dueAt`, `noAiRequired`, and `details`. (`src/domain/browserApplication.js`)
- Updated the browser tracker import preview and apply logic to detect compact CSV vs lifecycle CSV vs JSON/NDJSON backups and to merge supplemental lifecycle bundles into the current IndexedDB bundle for dry-run previews and apply. (`src/web/tracker/tracker.js`)
- Added anonymized lifecycle fixtures matching the exact supplemental header and regression tests covering format detection, boolean/date parsing, multiline details, missing-application handling, idempotency, non-interview assessment/reply preservation, recruiter-screen interview creation (only when scheduled time present), and JSON/NDJSON round-trip compatibility. (`test/fixtures/tracker-import/*.csv`, `test/web-spreadsheet-import-export.test.js`)

### Testing
- `npm ci` — ran and completed (dependencies installed).
- `npx prettier --check src/domain/browserApplication.js src/web/import-export/spreadsheet.js src/web/tracker/tracker.js test/web-spreadsheet-import-export.test.js` — passed for the modified files.
- `npm run format:check` — reported repo-wide pre-existing formatting warnings outside the touched files (known unrelated warnings), not changed by this PR.
- `npm run lint` — lint run against staged changes and modified files passed for source files touched by this change.
- `npm run typecheck` (`tsc -p tsconfig.json`) — passed.
- `npx vitest run test/web-spreadsheet-import-export.test.js` — focused spreadsheet/import-export test file passed (30 tests passed).
- `npm run build` — static tracker build succeeded and `dist/` was generated.
- `npm run test:ci` — broader CI run was started but the full suite was terminated/hung in this environment; the focused lifecycle/import tests passed as noted above.

Residual risks and follow-ups: watch CI for unrelated repo-wide formatting/lint rules (pre-existing warnings surfaced by `format:check`), and monitor downstream dashboard/metrics work to ensure lifecycle records are consumed as intended (Prompt 05 scope).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4dd609c88c832fb0344672a270c5dd)