### PR TITLE
Add supplemental lifecycle CSV import support

### DIFF
--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -59,6 +59,16 @@ export const browserApplicationLifecycleEventSchema = z.object({
     "sqlite_migration",
   ]),
   note: optionalTrimmedStringSchema,
+  eventType: optionalTrimmedStringSchema,
+  stageLabel: optionalTrimmedStringSchema,
+  channel: optionalTrimmedStringSchema,
+  actor: optionalTrimmedStringSchema,
+  sourceArtifact: optionalTrimmedStringSchema,
+  requiresUserAction: z.boolean().optional(),
+  actionStatus: optionalTrimmedStringSchema,
+  dueAt: isoDateTimeSchema.optional(),
+  noAiRequired: z.boolean().optional(),
+  details: optionalTrimmedStringSchema,
   createdAt: isoDateTimeSchema,
 });
 

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -35,6 +35,23 @@ export const COMPACT_CSV_COLUMNS = [
   "schema_version",
 ];
 
+export const LIFECYCLE_CSV_COLUMNS = [
+  "application_id",
+  "company",
+  "role_title",
+  "event_type",
+  "occurred_at",
+  "stage",
+  "channel",
+  "actor",
+  "source_artifact",
+  "requires_user_action",
+  "action_status",
+  "due_at",
+  "no_ai_required",
+  "details",
+];
+
 const KNOWN_STATUSES = new Set([
   "applied",
   "outreach_sent",
@@ -109,6 +126,25 @@ const ARRAY_STORES = [
   "reminders",
 ];
 const ARRAY_STORE_SET = new Set(ARRAY_STORES);
+const LIFECYCLE_EVENT_TYPES = new Set([
+  "application_submitted",
+  "written_assessment_requested",
+  "written_assessment_submitted",
+  "hiring_manager_reply",
+  "next_tracking_step",
+  "recruiter_screen_scheduled",
+]);
+
+export const detectCsvImportKind = (csvText) => {
+  const input = String(csvText ?? "").replace(/^\uFEFF/, "");
+  const firstLineEnd = input.search(/\r?\n/);
+  const headerLine = firstLineEnd === -1 ? input : input.slice(0, firstLineEnd);
+  const headers = headerLine.split(",").map(normalizeKey);
+  if (headers.join(",") === LIFECYCLE_CSV_COLUMNS.join(","))
+    return "lifecycle_csv";
+  if (headers.join(",") === COMPACT_CSV_COLUMNS.join(",")) return "compact_csv";
+  return "unknown_csv";
+};
 
 const blankRow = () =>
   Object.fromEntries(COMPACT_CSV_COLUMNS.map((key) => [key, ""]));
@@ -871,6 +907,266 @@ export const importNdjsonBackup = (text) => {
     });
   return browserApplicationExportSchema.parse(bundle);
 };
+const parseBoolean = (value, field, rowNumber, errors) => {
+  const text = normalizeKey(value);
+  if (!text) return undefined;
+  if (["true", "t", "yes", "y", "1"].includes(text)) return true;
+  if (["false", "f", "no", "n", "0"].includes(text)) return false;
+  errors.push({
+    rowNumber,
+    field,
+    code: "malformed_boolean",
+    message: `${field} is not a valid boolean.`,
+  });
+  return undefined;
+};
+const lifecycleStatusForEvent = (eventType, stage) => {
+  if (eventType === "recruiter_screen_scheduled") return "recruiter_screen";
+  if (eventType === "application_submitted") return "applied";
+  if (normalizeLabelKey(stage) === "rejected") return "rejected";
+  return "applied";
+};
+export const rowsToSupplementalLifecycleExport = (
+  rows,
+  existing,
+  { exportedAt = nowIso() } = {},
+) => {
+  const errors = [];
+  const warnings = [];
+  const lifecycleEvents = [];
+  const interviews = [];
+  const reminders = [];
+  const existingIds = new Set(
+    (existing?.applications ?? []).map(({ id }) => id),
+  );
+  rows.forEach((sourceRow, index) => {
+    const rowNumber = index + 2;
+    const row = Object.fromEntries(
+      LIFECYCLE_CSV_COLUMNS.map((column) => [
+        column,
+        compact(sourceRow[column]),
+      ]),
+    );
+    if (!row.application_id) {
+      errors.push({
+        rowNumber,
+        field: "application_id",
+        code: "required",
+        message: "application_id is required.",
+      });
+      return;
+    }
+    if (!existingIds.has(row.application_id)) {
+      errors.push({
+        rowNumber,
+        field: "application_id",
+        code: "missing_application",
+        value: row.application_id,
+        message: `No existing application found for application_id ${row.application_id}.`,
+      });
+      return;
+    }
+    const occurredAt =
+      parseDate(row.occurred_at, "occurred_at", rowNumber, errors) ??
+      exportedAt;
+    const dueAt = parseDate(row.due_at, "due_at", rowNumber, errors);
+    const eventType = normalizeLabelKey(row.event_type);
+    if (!eventType)
+      errors.push({
+        rowNumber,
+        field: "event_type",
+        code: "required",
+        message: "event_type is required.",
+      });
+    else if (!LIFECYCLE_EVENT_TYPES.has(eventType))
+      warnings.push({
+        rowNumber,
+        field: "event_type",
+        code: "unknown_event_type",
+        value: row.event_type,
+        message: `Unknown lifecycle event_type preserved as metadata: ${row.event_type}.`,
+      });
+    const requiresUserAction = parseBoolean(
+      row.requires_user_action,
+      "requires_user_action",
+      rowNumber,
+      errors,
+    );
+    const noAiRequired = parseBoolean(
+      row.no_ai_required,
+      "no_ai_required",
+      rowNumber,
+      errors,
+    );
+    const eventId = stableId(
+      "event",
+      row.application_id,
+      eventType || row.event_type,
+      occurredAt,
+      row.stage,
+      row.due_at,
+      row.details,
+    );
+    const event = {
+      id: eventId,
+      applicationId: row.application_id,
+      status: lifecycleStatusForEvent(eventType, row.stage),
+      occurredAt,
+      source: "csv_import",
+      note: row.details || undefined,
+      eventType: eventType || row.event_type || undefined,
+      stageLabel: row.stage || undefined,
+      channel: row.channel || undefined,
+      actor: row.actor || undefined,
+      sourceArtifact: row.source_artifact || undefined,
+      requiresUserAction,
+      actionStatus: row.action_status || undefined,
+      dueAt,
+      noAiRequired,
+      details: row.details || undefined,
+      createdAt: exportedAt,
+    };
+    lifecycleEvents.push(event);
+    if (eventType === "recruiter_screen_scheduled" && dueAt) {
+      interviews.push({
+        id: stableId(
+          "interview",
+          row.application_id,
+          "recruiter_screen",
+          dueAt,
+        ),
+        applicationId: row.application_id,
+        contactIds: [],
+        stage: "recruiter_screen",
+        startsAt: dueAt,
+        outcome: "scheduled",
+        preparationNotes: row.details || undefined,
+        createdAt: exportedAt,
+        updatedAt: exportedAt,
+      });
+    }
+    if (eventType === "next_tracking_step" && dueAt) {
+      reminders.push({
+        id: stableId(
+          "reminder",
+          row.application_id,
+          eventType,
+          dueAt,
+          row.details,
+        ),
+        applicationId: row.application_id,
+        dueAt,
+        summary: row.details || row.stage || "Follow up on application",
+        notes: row.action_status || undefined,
+        createdAt: exportedAt,
+        updatedAt: exportedAt,
+      });
+    }
+  });
+  const bundle = {
+    schemaVersion: 1,
+    exportedAt,
+    applications: existing?.applications ?? [],
+    contacts: existing?.contacts ?? [],
+    outreachMessages: existing?.outreachMessages ?? [],
+    lifecycleEvents,
+    interviews,
+    offers: existing?.offers ?? [],
+    artifacts: existing?.artifacts ?? [],
+    reminders,
+    settings: existing?.settings,
+  };
+  const parsed = browserApplicationExportSchema.safeParse(bundle);
+  if (!parsed.success)
+    errors.push({
+      rowNumber: null,
+      field: "bundle",
+      code: "schema_validation_failed",
+      message: parsed.error.message,
+    });
+  return {
+    bundle: {
+      ...bundle,
+      applications: [],
+      contacts: [],
+      outreachMessages: [],
+      offers: [],
+      artifacts: [],
+    },
+    errors,
+    warnings,
+  };
+};
+export const previewSupplementalLifecycleCsvImport = async (
+  csvText,
+  repository,
+) => {
+  const rows = parseCsv(csvText);
+  const existing = repository
+    ? await repository.exportAllData()
+    : { applications: [] };
+  const { bundle, errors, warnings } = rowsToSupplementalLifecycleExport(
+    rows,
+    existing,
+  );
+  const conflicts = [];
+  const existingByStore = Object.fromEntries(
+    ARRAY_STORES.map((store) => [
+      store,
+      new Set((existing[store] ?? []).map(({ id }) => id)),
+    ]),
+  );
+  for (const store of ["lifecycleEvents", "interviews", "reminders"]) {
+    const seen = new Set();
+    for (const record of bundle[store]) {
+      if (seen.has(record.id))
+        conflicts.push({
+          storeName: store,
+          id: record.id,
+          code: "duplicate_in_file",
+        });
+      if (existingByStore[store]?.has(record.id))
+        conflicts.push({
+          storeName: store,
+          id: record.id,
+          code: "duplicate_existing",
+        });
+      seen.add(record.id);
+    }
+  }
+  return {
+    kind: "lifecycle_csv",
+    rowCount: rows.length,
+    errors,
+    warnings,
+    conflicts,
+    bundle,
+  };
+};
+export const importSupplementalLifecycleCsv = async (csvText, repository) => {
+  const preview = await previewSupplementalLifecycleCsvImport(
+    csvText,
+    repository,
+  );
+  if (preview.errors.length > 0) return { imported: false, preview };
+  const existing = await repository.exportAllData();
+  const merged = { ...existing, exportedAt: nowIso() };
+  for (const store of ["lifecycleEvents", "interviews", "reminders"]) {
+    const incoming = preview.bundle[store] ?? [];
+    merged[store] = [
+      ...existing[store].filter(
+        (record) => !incoming.some(({ id }) => id === record.id),
+      ),
+      ...incoming,
+    ];
+  }
+  return {
+    imported: true,
+    preview,
+    result: await repository.importAllData(merged, { allowOverwrite: true }),
+  };
+};
+
 export const previewCompactCsvImport = async (csvText, repository) => {
   const rows = parseCsv(csvText);
   const { bundle, errors } = rowsToBrowserApplicationExport(rows);

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -3,11 +3,13 @@
 import {
   COMPACT_CSV_COLUMNS,
   csvToBrowserApplicationExport,
+  detectCsvImportKind,
   exportCompactCsv,
   exportJsonBackup,
   exportNdjsonBackup,
   importJsonBackup,
   importNdjsonBackup,
+  previewSupplementalLifecycleCsvImport,
 } from "../import-export/spreadsheet.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
@@ -573,7 +575,27 @@ async function newApplication() {
   };
   openUnsavedDetail(app);
 }
-function previewBundleFromCsv(text) {
+async function previewBundleFromCsv(text) {
+  if (detectCsvImportKind(text) === "lifecycle_csv") {
+    const preview = await previewSupplementalLifecycleCsvImport(text, repo);
+    if (preview.errors.length) {
+      throw new Error(
+        preview.errors
+          .map((error) =>
+            error.rowNumber
+              ? `Row ${error.rowNumber} ${error.field}: ${error.message}`
+              : `${error.field}: ${error.message}`,
+          )
+          .join("; "),
+      );
+    }
+    return {
+      ...preview.bundle,
+      __importKind: "lifecycle_csv",
+      __warnings: preview.warnings,
+      __conflicts: preview.conflicts,
+    };
+  }
   const { bundle, errors } = csvToBrowserApplicationExport(text);
   if (errors.length) {
     throw new Error(
@@ -628,16 +650,30 @@ async function previewImport() {
         ? importJsonBackup(text)
         : format === "ndjson"
           ? importNdjsonBackup(text)
-          : previewBundleFromCsv(text);
+          : await previewBundleFromCsv(text);
     state.preview = bundleForIndexedDb(bundle);
     state.previewConflicts = await detectImportConflicts(state.preview);
     const totalRecords = Object.values(state.preview).reduce(
       (count, rows) => count + rows.length,
       0,
     );
-    const formatLabel = format === "csv" ? "" : ` (${format.toUpperCase()})`;
+    const isLifecycleCsv = bundle.__importKind === "lifecycle_csv";
+    const formatLabel =
+      format === "csv"
+        ? isLifecycleCsv
+          ? " lifecycle CSV"
+          : ""
+        : ` (${format.toUpperCase()})`;
+    const warnings = bundle.__warnings?.length
+      ? ` ${bundle.__warnings.length} warnings.`
+      : "";
+    const conflicts =
+      bundle.__conflicts?.length ?? state.previewConflicts.length;
+    const lifecycleSummary = isLifecycleCsv
+      ? `, ${(bundle.lifecycleEvents ?? []).length} lifecycle events, ${(bundle.reminders ?? []).length} reminders`
+      : "";
     $("[data-import-result]").textContent =
-      `Dry-run OK${formatLabel}: ${(bundle.applications ?? []).length} applications, ${(bundle.outreachMessages ?? []).length} outreach messages, ${(bundle.interviews ?? []).length} interviews. ${totalRecords} total records. ${state.previewConflicts.length} existing record conflicts.`;
+      `Dry-run OK${formatLabel}: ${(bundle.applications ?? []).length} applications, ${(bundle.outreachMessages ?? []).length} outreach messages, ${(bundle.interviews ?? []).length} interviews${lifecycleSummary}. ${totalRecords} total records. ${conflicts} existing record conflicts.${warnings}`;
     $("[data-import-apply]").disabled = false;
   } catch (err) {
     state.preview = null;

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -9,16 +9,20 @@ import {
 } from "../src/web/storage/indexedDbRepository.js";
 import {
   COMPACT_CSV_COLUMNS,
+  LIFECYCLE_CSV_COLUMNS,
   csvToBrowserApplicationExport,
+  detectCsvImportKind,
   exportCompactCsv,
   exportJsonBackup,
   exportNdjsonBackup,
   importCompactCsv,
+  importSupplementalLifecycleCsv,
   importJsonBackup,
   importNdjsonBackup,
   parseCsv,
   serializeCsv,
   previewCompactCsvImport,
+  previewSupplementalLifecycleCsvImport,
 } from "../src/web/import-export/spreadsheet.js";
 
 const deleteDatabase = () =>
@@ -36,6 +40,175 @@ afterEach(async () => {
 const fixture = () => readFile("test/fixtures/fake-applications.csv", "utf8");
 
 describe("spreadsheet import/export", () => {
+  it("detects and imports supplemental lifecycle CSVs idempotently", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const mainCsv = await readFile(
+      "test/fixtures/tracker-import/compact-main-regression.csv",
+      "utf8",
+    );
+    await importCompactCsv(mainCsv, repo, { mode: "replace" });
+    let exported = await repo.exportAllData();
+    expect(exported.applications).toHaveLength(15);
+    expect(exported.interviews).toHaveLength(0);
+
+    const lifecycleCsv = serializeCsv(
+      [
+        {
+          application_id: "app_reg_delta_004",
+          company: "Company Delta",
+          role_title: "ML Infrastructure Engineer",
+          event_type: "written_assessment_submitted",
+          occurred_at: "2026-02-08T20:00:00.000Z",
+          stage: "assessment",
+          channel: "portal",
+          actor: "candidate",
+          source_artifact: "https://example.test/artifact/delta/assessment.pdf",
+          requires_user_action: "false",
+          action_status: "submitted",
+          due_at: "",
+          no_ai_required: "true",
+          details: "Fake assessment details with\nmultiple lines.",
+        },
+        {
+          application_id: "app_reg_zeta_006",
+          company: "Company Zeta",
+          role_title: "Staff Full Stack Engineer",
+          event_type: "hiring_manager_reply",
+          occurred_at: "2026-02-12T12:00:00.000Z",
+          stage: "reply",
+          channel: "email",
+          actor: "hiring_manager",
+          source_artifact: "reply.eml",
+          requires_user_action: "yes",
+          action_status: "pending",
+          due_at: "2026-02-18",
+          no_ai_required: "no",
+          details: "Fake hiring manager reply metadata.",
+        },
+        {
+          application_id: "app_reg_epsilon_005",
+          company: "Company Epsilon",
+          role_title: "Developer Tools Engineer",
+          event_type: "recruiter_screen_scheduled",
+          occurred_at: "2026-02-10T16:00:00.000Z",
+          stage: "recruiter_screen",
+          channel: "scheduler",
+          actor: "recruiter",
+          source_artifact:
+            "https://example.test/artifact/epsilon/scheduler.html",
+          requires_user_action: "0",
+          action_status: "scheduled",
+          due_at: "2026-02-15T18:30:00.000Z",
+          no_ai_required: "1",
+          details: "Fake scheduled recruiter screen.",
+        },
+      ],
+      LIFECYCLE_CSV_COLUMNS,
+    );
+    expect(detectCsvImportKind(lifecycleCsv)).toBe("lifecycle_csv");
+    expect(detectCsvImportKind(mainCsv)).toBe("compact_csv");
+
+    const preview = await previewSupplementalLifecycleCsvImport(
+      lifecycleCsv,
+      repo,
+    );
+    expect(preview.errors).toEqual([]);
+    expect(preview.bundle.lifecycleEvents).toHaveLength(3);
+    expect(preview.bundle.interviews).toHaveLength(1);
+    expect(preview.bundle.lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          applicationId: "app_reg_delta_004",
+          eventType: "written_assessment_submitted",
+          noAiRequired: true,
+          details: "Fake assessment details with\nmultiple lines.",
+        }),
+        expect.objectContaining({
+          applicationId: "app_reg_zeta_006",
+          eventType: "hiring_manager_reply",
+          requiresUserAction: true,
+          dueAt: "2026-02-18T00:00:00.000Z",
+        }),
+      ]),
+    );
+
+    await importSupplementalLifecycleCsv(lifecycleCsv, repo);
+    exported = await repo.exportAllData();
+    expect(exported.lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ eventType: "written_assessment_submitted" }),
+        expect.objectContaining({ eventType: "hiring_manager_reply" }),
+      ]),
+    );
+    expect(exported.interviews).toHaveLength(1);
+    expect(exported.interviews[0]).toMatchObject({
+      applicationId: "app_reg_epsilon_005",
+      stage: "recruiter_screen",
+      startsAt: "2026-02-15T18:30:00.000Z",
+    });
+
+    await importSupplementalLifecycleCsv(lifecycleCsv, repo);
+    const exportedAgain = await repo.exportAllData();
+    expect(exportedAgain.lifecycleEvents).toHaveLength(
+      exported.lifecycleEvents.length,
+    );
+    expect(exportedAgain.interviews).toHaveLength(1);
+
+    const json = exportJsonBackup(exportedAgain);
+    const ndjson = exportNdjsonBackup(exportedAgain);
+    expect(importJsonBackup(json).lifecycleEvents).toEqual(
+      exportedAgain.lifecycleEvents,
+    );
+    expect(importNdjsonBackup(ndjson).lifecycleEvents).toEqual(
+      exportedAgain.lifecycleEvents,
+    );
+    repo.close();
+  });
+
+  it("reports missing supplemental lifecycle applications without creating orphans", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const mainCsv = await readFile(
+      "test/fixtures/tracker-import/compact-main-regression.csv",
+      "utf8",
+    );
+    await importCompactCsv(mainCsv, repo, { mode: "replace" });
+    const missingCsv = serializeCsv(
+      [
+        {
+          application_id: "app_missing_999",
+          company: "Missing Co",
+          role_title: "Missing Role",
+          event_type: "written_assessment_requested",
+          occurred_at: "2026-02-08T20:00:00.000Z",
+          stage: "assessment",
+          details: "Should not import.",
+        },
+      ],
+      LIFECYCLE_CSV_COLUMNS,
+    );
+    const result = await importSupplementalLifecycleCsv(missingCsv, repo);
+    expect(result.imported).toBe(false);
+    expect(result.preview.errors).toEqual([
+      expect.objectContaining({
+        rowNumber: 2,
+        field: "application_id",
+        code: "missing_application",
+        value: "app_missing_999",
+      }),
+    ]);
+    const exported = await repo.exportAllData();
+    expect(
+      exported.lifecycleEvents.every(
+        (event) => event.applicationId !== "app_missing_999",
+      ),
+    ).toBe(true);
+    expect(
+      exported.interviews.every(
+        (event) => event.applicationId !== "app_missing_999",
+      ),
+    ).toBe(true);
+    repo.close();
+  });
   it("runs a fake full-fidelity backup/restore smoke flow", async () => {
     const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
     const csv = await fixture();


### PR DESCRIPTION
### Motivation
- Support a second CSV import lane that attaches event-level lifecycle metadata to existing compact application rows without creating orphan applications or misclassifying non-interview events as interviews. 
- Preserve additional per-event fields (assessments, replies, reminders, recruiter-screen schedules, artifact URLs, and boolean flags) in browser-only backups and imports while keeping compatibility with existing JSON/NDJSON exports. 

### Description
- Extend the browser export schema to accept optional lifecycle event metadata fields: `eventType`, `stageLabel`, `channel`, `actor`, `sourceArtifact`, `requiresUserAction`, `actionStatus`, `dueAt`, `noAiRequired`, and `details` in `browserApplicationLifecycleEventSchema`. 
- Add exact header detection for supplemental lifecycle CSVs (`LIFECYCLE_CSV_COLUMNS`) and a new `detectCsvImportKind` helper so the shared import/export pipeline distinguishes compact CSV vs lifecycle CSV. 
- Implement lifecycle CSV parsing (`rowsToSupplementalLifecycleExport`), deterministic/event ids, idempotent import merging (`importSupplementalLifecycleCsv`), conflict checks, missing-application dry-run errors, and selective creation of recruiter-screen interview records only when a real `due_at` is present. 
- Wire lifecycle CSV dry-run/preview and apply flows into the tracker UI import path so the browser preview shows lifecycle event counts, warnings, and conflicts while preserving JSON/NDJSON behavior. 
- Add targeted tests covering format detection, lifecycle parsing and edge cases, idempotent imports, recruiter-screen interview creation, missing-application handling, and JSON/NDJSON round-trips. 

### Testing
- Ran focused unit tests for the spreadsheet import/export changes with `npx vitest run test/web-spreadsheet-import-export.test.js`, which passed (28 tests passed). 
- Verified full CI suite with `npm run test:ci` (includes unit and Playwright browser tests) and `npm run build`, both completed successfully in this environment. 
- Lint and type checks: `npm run lint` and `npm run typecheck` completed successfully. 
- Formatting: `npm run format:check` initially reported repository-wide formatting warnings unrelated to these changes; touched files were formatted with `npx prettier --write` before committing (note: repo-wide Prettier warnings remain outside this patch). 

Residual risks and follow-ups: browser-only import logic was intentionally kept client-side (no server changes); artifact modeling was preserved as a URL/string on lifecycle events for now and can be expanded in a follow-up prompt to create/link artifact records more richly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4dd5efcba4832f8be06e58d52598b1)