### PR TITLE
Add supplemental lifecycle CSV import support

### DIFF
--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -59,6 +59,16 @@ export const browserApplicationLifecycleEventSchema = z.object({
     "sqlite_migration",
   ]),
   note: optionalTrimmedStringSchema,
+  eventType: optionalTrimmedStringSchema,
+  stageLabel: optionalTrimmedStringSchema,
+  channel: optionalTrimmedStringSchema,
+  actor: optionalTrimmedStringSchema,
+  sourceArtifact: optionalTrimmedStringSchema,
+  requiresUserAction: z.boolean().optional(),
+  actionStatus: optionalTrimmedStringSchema,
+  dueAt: isoDateTimeSchema.optional(),
+  noAiRequired: z.boolean().optional(),
+  details: optionalTrimmedStringSchema,
   createdAt: isoDateTimeSchema,
 });
 

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -35,6 +35,23 @@ export const COMPACT_CSV_COLUMNS = [
   "schema_version",
 ];
 
+export const LIFECYCLE_CSV_COLUMNS = [
+  "application_id",
+  "company",
+  "role_title",
+  "event_type",
+  "occurred_at",
+  "stage",
+  "channel",
+  "actor",
+  "source_artifact",
+  "requires_user_action",
+  "action_status",
+  "due_at",
+  "no_ai_required",
+  "details",
+];
+
 const KNOWN_STATUSES = new Set([
   "applied",
   "outreach_sent",
@@ -238,6 +255,49 @@ export const serializeCsv = (rows, columns = COMPACT_CSV_COLUMNS) =>
       columns.map((column) => serializeField(row[column])).join(","),
     ),
   ].join("\n");
+
+const headersFromCsv = (text) => {
+  const input = String(text ?? "").replace(/^\uFEFF/, "");
+  const [headerLine = ""] = input.split(/\r?\n/, 1);
+  return parseCsv(`${headerLine}\n`).length === 0
+    ? headerLine.split(",").map(normalizeKey)
+    : Object.keys(parseCsv(`${headerLine}\n_`).at(0) ?? {});
+};
+export const detectSpreadsheetImportFormat = (text) => {
+  const headers = headersFromCsv(text);
+  const same = (columns) =>
+    headers.length === columns.length &&
+    columns.every((column, index) => headers[index] === column);
+  if (same(LIFECYCLE_CSV_COLUMNS)) return "lifecycle_csv";
+  if (same(COMPACT_CSV_COLUMNS)) return "compact_csv";
+  return "unknown_csv";
+};
+const parseBoolean = (value, field, rowNumber, errors) => {
+  const text = normalizeKey(value);
+  if (!text) return undefined;
+  if (["true", "yes", "y", "1"].includes(text)) return true;
+  if (["false", "no", "n", "0"].includes(text)) return false;
+  errors.push({
+    rowNumber,
+    field,
+    code: "malformed_boolean",
+    message: `${field} is not a valid boolean.`,
+  });
+  return undefined;
+};
+const EVENT_STATUS = new Map([
+  ["application_submitted", "applied"],
+  ["recruiter_screen_scheduled", "recruiter_screen"],
+  ["rejected", "rejected"],
+  ["application_rejected", "rejected"],
+  ["offer", "offer"],
+  ["accepted", "accepted"],
+  ["withdrawn", "withdrawn"],
+]);
+const statusForLifecycleRow = (row) =>
+  EVENT_STATUS.get(normalizeLabelKey(row.event_type)) ??
+  EVENT_STATUS.get(normalizeLabelKey(row.stage)) ??
+  "applied";
 
 const parseDate = (
   value,
@@ -690,6 +750,171 @@ export const rowsToBrowserApplicationExport = (
 export const csvToBrowserApplicationExport = (csvText, options) =>
   rowsToBrowserApplicationExport(parseCsv(csvText), options);
 
+export const lifecycleRowsToBrowserApplicationExport = (
+  rows,
+  existingBundle = { applications: [] },
+  { exportedAt = nowIso() } = {},
+) => {
+  const errors = [];
+  const warnings = [];
+  const applicationsById = new Map(
+    (existingBundle.applications ?? []).map((application) => [
+      application.id,
+      application,
+    ]),
+  );
+  const lifecycleEvents = [];
+  const interviews = [];
+  const reminders = [];
+  rows.forEach((sourceRow, index) => {
+    const rowNumber = index + 2;
+    const row = Object.fromEntries(
+      LIFECYCLE_CSV_COLUMNS.map((key) => [key, compact(sourceRow[key])]),
+    );
+    if (!row.application_id) {
+      errors.push({
+        rowNumber,
+        field: "application_id",
+        code: "required",
+        message: "application_id is required.",
+      });
+      return;
+    }
+    if (!applicationsById.has(row.application_id)) {
+      errors.push({
+        rowNumber,
+        field: "application_id",
+        code: "missing_application",
+        value: row.application_id,
+        message: `application_id ${row.application_id} does not match an existing application.`,
+      });
+      return;
+    }
+    const occurredAt =
+      parseDate(row.occurred_at, "occurred_at", rowNumber, errors) ??
+      exportedAt;
+    const dueAt = parseDate(row.due_at, "due_at", rowNumber, errors);
+    const requiresUserAction = parseBoolean(
+      row.requires_user_action,
+      "requires_user_action",
+      rowNumber,
+      errors,
+    );
+    const noAiRequired = parseBoolean(
+      row.no_ai_required,
+      "no_ai_required",
+      rowNumber,
+      errors,
+    );
+    const eventType = normalizeLabelKey(row.event_type) || "lifecycle_event";
+    const stageLabel = compact(row.stage) || undefined;
+    if (
+      !EVENT_STATUS.has(eventType) &&
+      ![
+        "written_assessment_requested",
+        "written_assessment_submitted",
+        "hiring_manager_reply",
+        "next_tracking_step",
+      ].includes(eventType)
+    )
+      warnings.push({
+        rowNumber,
+        field: "event_type",
+        code: "unknown_event_type",
+        value: row.event_type,
+      });
+    lifecycleEvents.push({
+      id: stableId(
+        "event",
+        row.application_id,
+        eventType,
+        occurredAt,
+        row.due_at,
+        row.source_artifact,
+      ),
+      applicationId: row.application_id,
+      status: statusForLifecycleRow(row),
+      occurredAt,
+      source: "csv_import",
+      note: row.details || undefined,
+      eventType,
+      stageLabel,
+      channel: row.channel || undefined,
+      actor: row.actor || undefined,
+      sourceArtifact: row.source_artifact || undefined,
+      requiresUserAction,
+      actionStatus: row.action_status || undefined,
+      dueAt,
+      noAiRequired,
+      details: row.details || undefined,
+      createdAt: exportedAt,
+    });
+    if (eventType === "recruiter_screen_scheduled" && dueAt)
+      interviews.push({
+        id: stableId(
+          "interview",
+          row.application_id,
+          "recruiter_screen",
+          dueAt,
+        ),
+        applicationId: row.application_id,
+        contactIds: [],
+        stage: "recruiter_screen",
+        startsAt: dueAt,
+        location: row.channel || undefined,
+        preparationNotes: row.details || undefined,
+        outcome: "scheduled",
+        createdAt: exportedAt,
+        updatedAt: exportedAt,
+      });
+    if (eventType === "next_tracking_step" && dueAt)
+      reminders.push({
+        id: stableId("reminder", row.application_id, dueAt, row.details),
+        applicationId: row.application_id,
+        dueAt,
+        summary: row.action_status || row.details || "Follow up on application",
+        notes: row.details || undefined,
+        createdAt: exportedAt,
+        updatedAt: exportedAt,
+      });
+  });
+  const bundle = {
+    schemaVersion: 1,
+    exportedAt,
+    applications: [],
+    contacts: [],
+    outreachMessages: [],
+    lifecycleEvents,
+    interviews,
+    offers: [],
+    artifacts: [],
+    reminders,
+  };
+  const parsed = browserApplicationExportSchema.safeParse({
+    ...bundle,
+    applications: existingBundle.applications ?? [],
+    contacts: existingBundle.contacts ?? [],
+  });
+  if (!parsed.success)
+    errors.push({
+      rowNumber: null,
+      field: "bundle",
+      code: "schema_validation_failed",
+      message: parsed.error.message,
+    });
+  return { bundle, errors, warnings };
+};
+export const csvToLifecycleBrowserApplicationExport = (
+  csvText,
+  existingBundle,
+  options,
+) =>
+  lifecycleRowsToBrowserApplicationExport(
+    parseCsv(csvText),
+    existingBundle,
+    options,
+  );
+
 const dateOnly = (value) => (value ? String(value).slice(0, 10) : "");
 const dateTime = (value) => (value ? String(value) : "");
 const firstBy = (records, predicate) => records.find(predicate) ?? {};
@@ -871,6 +1096,73 @@ export const importNdjsonBackup = (text) => {
     });
   return browserApplicationExportSchema.parse(bundle);
 };
+
+export const previewLifecycleCsvImport = async (csvText, repository) => {
+  const rows = parseCsv(csvText);
+  const existing = repository
+    ? await repository.exportAllData()
+    : { applications: [] };
+  const { bundle, errors, warnings } = lifecycleRowsToBrowserApplicationExport(
+    rows,
+    existing,
+  );
+  const conflicts = [];
+  for (const store of ["lifecycleEvents", "interviews", "reminders"]) {
+    const existingIds = new Set((existing[store] ?? []).map(({ id }) => id));
+    for (const record of bundle[store] ?? []) {
+      if (existingIds.has(record.id))
+        conflicts.push({
+          storeName: store,
+          id: record.id,
+          code: "duplicate_existing",
+        });
+    }
+    const seen = new Set();
+    for (const record of bundle[store] ?? []) {
+      if (seen.has(record.id))
+        conflicts.push({
+          storeName: store,
+          id: record.id,
+          code: "duplicate_in_file",
+        });
+      seen.add(record.id);
+    }
+  }
+  return {
+    format: "lifecycle_csv",
+    rowCount: rows.length,
+    validRowCount: Math.max(
+      0,
+      rows.length -
+        new Set(errors.map((e) => e.rowNumber).filter(Number.isInteger)).size,
+    ),
+    errors,
+    warnings,
+    conflicts,
+    bundle,
+  };
+};
+export const importLifecycleCsv = async (csvText, repository) => {
+  const preview = await previewLifecycleCsvImport(csvText, repository);
+  if (preview.errors.length > 0) return { imported: false, preview };
+  const existing = await repository.exportAllData();
+  const merged = { ...existing, exportedAt: nowIso() };
+  for (const store of ["lifecycleEvents", "interviews", "reminders"]) {
+    const incoming = preview.bundle[store] ?? [];
+    merged[store] = [
+      ...(existing[store] ?? []).filter(
+        (record) => !incoming.some(({ id }) => id === record.id),
+      ),
+      ...incoming,
+    ];
+  }
+  return {
+    imported: true,
+    preview,
+    result: await repository.importAllData(merged, { allowOverwrite: true }),
+  };
+};
+
 export const previewCompactCsvImport = async (csvText, repository) => {
   const rows = parseCsv(csvText);
   const { bundle, errors } = rowsToBrowserApplicationExport(rows);

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -3,11 +3,13 @@
 import {
   COMPACT_CSV_COLUMNS,
   csvToBrowserApplicationExport,
+  detectSpreadsheetImportFormat,
   exportCompactCsv,
   exportJsonBackup,
   exportNdjsonBackup,
   importJsonBackup,
   importNdjsonBackup,
+  previewLifecycleCsvImport,
 } from "../import-export/spreadsheet.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
@@ -573,7 +575,30 @@ async function newApplication() {
   };
   openUnsavedDetail(app);
 }
-function previewBundleFromCsv(text) {
+async function previewBundleFromCsv(text) {
+  const format = detectSpreadsheetImportFormat(text);
+  if (format === "lifecycle_csv") {
+    const preview = await previewLifecycleCsvImport(text, {
+      exportAllData: () => repo.exportAll(),
+    });
+    const problems = [...preview.errors, ...preview.warnings];
+    if (preview.errors.length) {
+      throw new Error(
+        problems
+          .map((error) =>
+            error.rowNumber
+              ? `Row ${error.rowNumber} ${error.field}: ${error.message ?? error.code}`
+              : `${error.field}: ${error.message ?? error.code}`,
+          )
+          .join("; "),
+      );
+    }
+    return {
+      bundle: preview.bundle,
+      importKind: "supplemental lifecycle CSV",
+      warnings: preview.warnings,
+    };
+  }
   const { bundle, errors } = csvToBrowserApplicationExport(text);
   if (errors.length) {
     throw new Error(
@@ -586,7 +611,7 @@ function previewBundleFromCsv(text) {
         .join("; "),
     );
   }
-  return bundle;
+  return { bundle, importKind: "compact application CSV", warnings: [] };
 }
 function bundleForIndexedDb(bundle) {
   return {
@@ -623,21 +648,26 @@ async function previewImport() {
   try {
     const text = await file.text();
     const format = importFormatForFile(file);
-    const bundle =
+    const parsed =
       format === "json"
         ? importJsonBackup(text)
         : format === "ndjson"
           ? importNdjsonBackup(text)
-          : previewBundleFromCsv(text);
+          : await previewBundleFromCsv(text);
+    const bundle = parsed.bundle ?? parsed;
+    const importKind = parsed.importKind ?? format.toUpperCase();
+    const warnings = parsed.warnings ?? [];
     state.preview = bundleForIndexedDb(bundle);
     state.previewConflicts = await detectImportConflicts(state.preview);
     const totalRecords = Object.values(state.preview).reduce(
       (count, rows) => count + rows.length,
       0,
     );
-    const formatLabel = format === "csv" ? "" : ` (${format.toUpperCase()})`;
+    const formatLabel =
+      format === "csv" ? ` (${importKind})` : ` (${format.toUpperCase()})`;
+    const warningLabel = warnings.length ? ` ${warnings.length} warnings.` : "";
     $("[data-import-result]").textContent =
-      `Dry-run OK${formatLabel}: ${(bundle.applications ?? []).length} applications, ${(bundle.outreachMessages ?? []).length} outreach messages, ${(bundle.interviews ?? []).length} interviews. ${totalRecords} total records. ${state.previewConflicts.length} existing record conflicts.`;
+      `Dry-run OK${formatLabel}: ${(bundle.applications ?? []).length} applications, ${(bundle.lifecycleEvents ?? []).length} lifecycle events, ${(bundle.outreachMessages ?? []).length} outreach messages, ${(bundle.interviews ?? []).length} interviews, ${(bundle.reminders ?? []).length} reminders. ${totalRecords} total records. ${state.previewConflicts.length} existing record conflicts.${warningLabel}`;
     $("[data-import-apply]").disabled = false;
   } catch (err) {
     state.preview = null;

--- a/test/fixtures/tracker-import/canonical-lifecycle-regression.csv
+++ b/test/fixtures/tracker-import/canonical-lifecycle-regression.csv
@@ -1,4 +1,3 @@
-application_id,event_type,event_status,occurred_at,source,contact_name,artifact_url,notes,schema_version
-app_reg_beta_002,outreach_reply,replied,2026-02-05T12:00:00.000Z,email,Casey Beta,https://example.test/artifact/beta/reply.eml,Fake reply metadata.,1
-app_reg_zeta_006,outreach_reply,replied,2026-02-12T12:00:00.000Z,email,Alex Zeta,https://example.test/artifact/zeta/reply.eml,Fake reply metadata.,1
-app_reg_gamma_003,decision,rejected,2026-02-10T09:00:00.000Z,portal,,https://example.test/artifact/gamma/rejection.html,Fake rejection metadata.,1
+application_id,company,role_title,event_type,occurred_at,stage,channel,actor,source_artifact,requires_user_action,action_status,due_at,no_ai_required,details
+app_reg_beta_002,Company Beta,Backend Systems Engineer,written_assessment_requested,2026-02-05T12:00:00.000Z,assessment,email,Casey Beta,https://example.test/artifact/beta/assessment.eml,true,pending,2026-02-07T17:00:00.000Z,true,"Fake assessment request metadata."
+app_reg_zeta_006,Company Zeta,Infrastructure Engineer,written_assessment_submitted,2026-02-12T12:00:00.000Z,assessment,portal,Alex Zeta,https://example.test/artifact/zeta/assessment.txt,false,submitted,,true,"Fake assessment submission metadata."

--- a/test/fixtures/tracker-import/loft-lifecycle-regression.csv
+++ b/test/fixtures/tracker-import/loft-lifecycle-regression.csv
@@ -1,2 +1,2 @@
-application_id,event_type,event_status,occurred_at,source,contact_name,artifact_url,notes,schema_version
-app_reg_delta_004,assessment,written_assessment_submitted,2026-02-08T20:00:00.000Z,loft,,https://example.test/artifact/delta/assessment.pdf,Fake Loft-style supplemental lifecycle row.,1
+application_id,company,role_title,event_type,occurred_at,stage,channel,actor,source_artifact,requires_user_action,action_status,due_at,no_ai_required,details
+app_reg_delta_004,Company Delta,Product Engineer,hiring_manager_reply,2026-02-08T20:00:00.000Z,hiring_manager_follow_up,email,Hiring Manager,https://example.test/artifact/delta/reply.eml,false,replied,,,"Fake Loft-style supplemental lifecycle row."

--- a/test/fixtures/tracker-import/reducto-lifecycle-regression.csv
+++ b/test/fixtures/tracker-import/reducto-lifecycle-regression.csv
@@ -1,2 +1,2 @@
-application_id,event_type,event_status,occurred_at,source,contact_name,artifact_url,notes,schema_version
-app_reg_epsilon_005,scheduler,recruiter_screen_pending,2026-02-10T16:00:00.000Z,reducto,Riley Epsilon,https://example.test/artifact/epsilon/scheduler.html,Fake Reducto-style supplemental lifecycle row.,1
+application_id,company,role_title,event_type,occurred_at,stage,channel,actor,source_artifact,requires_user_action,action_status,due_at,no_ai_required,details
+app_reg_epsilon_005,Company Epsilon,ML Engineer,recruiter_screen_scheduled,2026-02-10T16:00:00.000Z,recruiter_screen,video,Riley Epsilon,https://example.test/artifact/epsilon/scheduler.html,true,scheduled,2026-02-14T18:30:00.000Z,false,"Fake Reducto-style supplemental lifecycle row."

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -9,16 +9,20 @@ import {
 } from "../src/web/storage/indexedDbRepository.js";
 import {
   COMPACT_CSV_COLUMNS,
+  LIFECYCLE_CSV_COLUMNS,
   csvToBrowserApplicationExport,
+  detectSpreadsheetImportFormat,
   exportCompactCsv,
   exportJsonBackup,
   exportNdjsonBackup,
   importCompactCsv,
+  importLifecycleCsv,
   importJsonBackup,
   importNdjsonBackup,
   parseCsv,
   serializeCsv,
   previewCompactCsvImport,
+  previewLifecycleCsvImport,
 } from "../src/web/import-export/spreadsheet.js";
 
 const deleteDatabase = () =>
@@ -35,7 +39,200 @@ afterEach(async () => {
 
 const fixture = () => readFile("test/fixtures/fake-applications.csv", "utf8");
 
+const createLifecycleTestRepository = () =>
+  createIndexedDbRepository({
+    databaseName: `jobbot3000_lifecycle_${Date.now()}_${Math.random()}`,
+    indexedDb: indexedDB,
+  });
+
 describe("spreadsheet import/export", () => {
+  it("detects compact and supplemental lifecycle CSV formats", async () => {
+    const compact = await readFile(
+      "test/fixtures/tracker-import/compact-main-regression.csv",
+      "utf8",
+    );
+    const lifecycle = await readFile(
+      "test/fixtures/tracker-import/canonical-lifecycle-regression.csv",
+      "utf8",
+    );
+    expect(detectSpreadsheetImportFormat(compact)).toBe("compact_csv");
+    expect(detectSpreadsheetImportFormat(lifecycle)).toBe("lifecycle_csv");
+    expect(lifecycle.split(/\r?\n/, 1)[0]).toBe(
+      LIFECYCLE_CSV_COLUMNS.join(","),
+    );
+  });
+
+  it("imports supplemental lifecycle assessment rows without creating interviews", async () => {
+    const repo = await createLifecycleTestRepository();
+    const compact = await readFile(
+      "test/fixtures/tracker-import/compact-main-regression.csv",
+      "utf8",
+    );
+    await importCompactCsv(compact, repo, { mode: "replace" });
+    let exported = await repo.exportAllData();
+    expect(exported.applications).toHaveLength(15);
+    expect(exported.interviews).toHaveLength(0);
+
+    const lifecycle = await readFile(
+      "test/fixtures/tracker-import/canonical-lifecycle-regression.csv",
+      "utf8",
+    );
+    const preview = await previewLifecycleCsvImport(lifecycle, repo);
+    expect(preview.errors).toEqual([]);
+    expect(preview.bundle.lifecycleEvents).toHaveLength(2);
+    expect(preview.bundle.interviews).toHaveLength(0);
+    await importLifecycleCsv(lifecycle, repo);
+    exported = await repo.exportAllData();
+    expect(
+      exported.lifecycleEvents.filter((event) =>
+        event.eventType?.startsWith("written_assessment"),
+      ),
+    ).toHaveLength(2);
+    expect(
+      exported.lifecycleEvents.find(
+        (event) => event.eventType === "written_assessment_requested",
+      ).noAiRequired,
+    ).toBe(true);
+    expect(exported.interviews).toHaveLength(0);
+  });
+
+  it("imports hiring-manager replies without creating interviews", async () => {
+    const repo = await createLifecycleTestRepository();
+    await importCompactCsv(
+      await readFile(
+        "test/fixtures/tracker-import/compact-main-regression.csv",
+        "utf8",
+      ),
+      repo,
+      { mode: "replace" },
+    );
+    await importLifecycleCsv(
+      await readFile(
+        "test/fixtures/tracker-import/loft-lifecycle-regression.csv",
+        "utf8",
+      ),
+      repo,
+    );
+    const exported = await repo.exportAllData();
+    expect(
+      exported.lifecycleEvents.some(
+        (event) => event.eventType === "hiring_manager_reply",
+      ),
+    ).toBe(true);
+    expect(exported.interviews).toHaveLength(0);
+  });
+
+  it("creates one scheduled recruiter-screen interview idempotently", async () => {
+    const repo = await createLifecycleTestRepository();
+    await importCompactCsv(
+      await readFile(
+        "test/fixtures/tracker-import/compact-main-regression.csv",
+        "utf8",
+      ),
+      repo,
+      { mode: "replace" },
+    );
+    const lifecycle = await readFile(
+      "test/fixtures/tracker-import/reducto-lifecycle-regression.csv",
+      "utf8",
+    );
+    await importLifecycleCsv(lifecycle, repo);
+    await importLifecycleCsv(lifecycle, repo);
+    const exported = await repo.exportAllData();
+    expect(
+      exported.lifecycleEvents.filter(
+        (event) => event.eventType === "recruiter_screen_scheduled",
+      ),
+    ).toHaveLength(1);
+    expect(exported.interviews).toHaveLength(1);
+    expect(exported.interviews[0]).toMatchObject({
+      applicationId: "app_reg_epsilon_005",
+      stage: "recruiter_screen",
+      startsAt: "2026-02-14T18:30:00.000Z",
+    });
+  });
+
+  it("reports missing lifecycle application references without creating orphans", async () => {
+    const repo = await createLifecycleTestRepository();
+    await importCompactCsv(
+      await readFile(
+        "test/fixtures/tracker-import/compact-main-regression.csv",
+        "utf8",
+      ),
+      repo,
+      { mode: "replace" },
+    );
+    const csv = [
+      LIFECYCLE_CSV_COLUMNS.join(","),
+      [
+        "app_missing_999",
+        "Missing Co",
+        "Missing Role",
+        "hiring_manager_reply",
+        "2026-02-01T00:00:00.000Z",
+        "reply",
+        "email",
+        "Actor",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "Missing details",
+      ].join(","),
+    ].join("\n");
+    const preview = await previewLifecycleCsvImport(csv, repo);
+    expect(preview.errors).toContainEqual(
+      expect.objectContaining({
+        rowNumber: 2,
+        field: "application_id",
+        code: "missing_application",
+        value: "app_missing_999",
+      }),
+    );
+    const result = await importLifecycleCsv(csv, repo);
+    expect(result.imported).toBe(false);
+    const exported = await repo.exportAllData();
+    expect(
+      exported.lifecycleEvents.every(
+        (event) => event.applicationId !== "app_missing_999",
+      ),
+    ).toBe(true);
+  });
+
+  it("preserves lifecycle metadata through JSON and NDJSON backups", async () => {
+    const repo = await createLifecycleTestRepository();
+    await importCompactCsv(
+      await readFile(
+        "test/fixtures/tracker-import/compact-main-regression.csv",
+        "utf8",
+      ),
+      repo,
+      { mode: "replace" },
+    );
+    await importLifecycleCsv(
+      await readFile(
+        "test/fixtures/tracker-import/canonical-lifecycle-regression.csv",
+        "utf8",
+      ),
+      repo,
+    );
+    const exported = await repo.exportAllData();
+    const fromJson = importJsonBackup(exportJsonBackup(exported));
+    const fromNdjson = importNdjsonBackup(exportNdjsonBackup(exported));
+    for (const bundle of [fromJson, fromNdjson]) {
+      const assessment = bundle.lifecycleEvents.find(
+        (event) => event.eventType === "written_assessment_requested",
+      );
+      expect(assessment).toMatchObject({
+        sourceArtifact: "https://example.test/artifact/beta/assessment.eml",
+        requiresUserAction: true,
+        actionStatus: "pending",
+        dueAt: "2026-02-07T17:00:00.000Z",
+        noAiRequired: true,
+      });
+    }
+  });
   it("runs a fake full-fidelity backup/restore smoke flow", async () => {
     const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
     const csv = await fixture();
@@ -893,7 +1090,7 @@ describe("spreadsheet import/export", () => {
     ).toBe(true);
     expect(
       lifecycleRows.every((row) =>
-        row.artifact_url.startsWith("https://example.test/artifact/"),
+        row.source_artifact.startsWith("https://example.test/artifact/"),
       ),
     ).toBe(true);
 


### PR DESCRIPTION
### Motivation
- Support supplemental lifecycle CSVs keyed by `application_id` so compact application imports can be enriched with event-level metadata without creating phantom interviews or orphaned child records.
- Keep import/export logic shared between tracker UI and tests to preserve the static/browser-only privacy boundary and maintain backup compatibility.

### Description
- Add exact-header detection and a new `LIFECYCLE_CSV_COLUMNS` shape plus `detectSpreadsheetImportFormat` to the shared import/export layer and a `parseBoolean` helper for boolean fields.  
- Implement lifecycle CSV parser/mapper `lifecycleRowsToBrowserApplicationExport` and public helpers `previewLifecycleCsvImport` and `importLifecycleCsv` that attach events by `application_id`, validate missing-application references, emit warnings/errors, and produce deterministic stable IDs for idempotent imports.  
- Extend `browserApplicationLifecycleEventSchema` with optional supplemental metadata fields (`eventType`, `stageLabel`, `channel`, `actor`, `sourceArtifact`, `requiresUserAction`, `actionStatus`, `dueAt`, `noAiRequired`, `details`) while keeping old data compatible.  
- Update browser tracker UI import flow to detect compact vs lifecycle CSVs, show lifecycle/reminder counts and warnings in the dry-run preview, and reuse the shared import pipeline; refresh anonymized fixture CSVs and add regression tests covering detection, assessments, hiring-manager replies, scheduled recruiter screens (idempotent), missing application references, and JSON/NDJSON round trips.

### Testing
- Ran `npm ci` which completed successfully.  
- Ran `npm run lint` which passed for changed files.  
- Ran `npm run typecheck` (`tsc -p tsconfig.json`) which passed.  
- Ran the focused spreadsheet tests with `npm test -- test/web-spreadsheet-import-export.test.js` and all tests in that file passed (`32/32` passed).  
- Ran repository checks: `npm exec prettier -- --check src/domain/browserApplication.js src/web/import-export/spreadsheet.js src/web/tracker/tracker.js test/web-spreadsheet-import-export.test.js` and `git diff --check` which succeeded for modified files.  
- Ran `npm run build` which produced the static build successfully.  
- Note: `npm run format:check` reported pre-existing repository-wide formatting warnings outside this change set, and `npm run test:ci` exercised the suite but failed in CI with a Vitest worker timeout after reporting a large number of passing tests (observed as a worker `Timeout calling "onTaskUpdate"`); no lifecycle-import regressions were reported before that timeout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4dd5fd37b8832f991dad6b52e354a8)