### PR TITLE
Extract pure metrics selector and fix dashboard response-rate guards

### DIFF
--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -1,0 +1,177 @@
+const TERMINAL_EMPLOYER_OUTCOME_STATUSES = new Set([
+  "offer",
+  "accepted",
+  "rejected",
+  "closed_archived",
+]);
+const RESPONSE_LIFECYCLE_EVENT_TYPES = new Set([
+  "hiring_manager_reply",
+  "written_assessment_requested",
+  "recruiter_screen_scheduled",
+  "offer",
+]);
+const ASSESSMENT_EVENT_TYPES = new Set([
+  "written_assessment_requested",
+  "written_assessment_submitted",
+  "take_home_requested",
+  "take_home_submitted",
+]);
+const ASSESSMENT_LABEL_PATTERN =
+  /\b(?:written[_\s-]*assessment|take[_\s-]*home)\b/i;
+const CSV_METADATA_PREFIX = "Spreadsheet metadata:";
+
+const asArray = (value) => (Array.isArray(value) ? value : []);
+const normalizeKey = (value) =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+const clampCount = (value) => Math.max(0, Number.isFinite(value) ? value : 0);
+
+export const formatMetricPercent = (numerator, denominator) => {
+  const safeNumerator = clampCount(numerator);
+  const safeDenominator = clampCount(denominator);
+  if (safeDenominator === 0) return "0%";
+  const percent = Math.round((safeNumerator / safeDenominator) * 100);
+  return `${Math.min(100, Math.max(0, Number.isFinite(percent) ? percent : 0))}%`;
+};
+
+const readSpreadsheetMetadata = (notes) => {
+  const metadataLine = String(notes ?? "")
+    .split("\n")
+    .find((line) => line.startsWith(CSV_METADATA_PREFIX));
+  if (!metadataLine) return {};
+  try {
+    return JSON.parse(metadataLine.slice(CSV_METADATA_PREFIX.length).trim());
+  } catch {
+    return {};
+  }
+};
+
+const applicationHasResponseSignal = (application, scoped) => {
+  const metadata = readSpreadsheetMetadata(application.notes);
+  if (normalizeKey(metadata.outreach_status) === "replied") return true;
+  if (TERMINAL_EMPLOYER_OUTCOME_STATUSES.has(normalizeKey(application.status)))
+    return true;
+  if (ASSESSMENT_LABEL_PATTERN.test(metadata.spreadsheet_interview_stage))
+    return true;
+  if (
+    scoped.outreachMessages.some(
+      (message) =>
+        message.direction === "inbound" ||
+        normalizeKey(message.direction) === "replied",
+    )
+  )
+    return true;
+  if (
+    scoped.lifecycleEvents.some((event) =>
+      RESPONSE_LIFECYCLE_EVENT_TYPES.has(normalizeKey(event.eventType)),
+    )
+  )
+    return true;
+  return scoped.offers.length > 0;
+};
+
+/**
+ * Computes dashboard metrics from the browser IndexedDB export bundle.
+ * Application response rate is intentionally application-level: one application
+ * with many child reply/assessment/screen/offer records contributes one
+ * applicationsWithResponse numerator. Outreach reply rate is message-level.
+ */
+export const computeTrackerMetrics = (bundle = {}) => {
+  const applications = asArray(bundle.applications);
+  const outreachMessages = asArray(bundle.outreachMessages);
+  const lifecycleEvents = asArray(bundle.lifecycleEvents);
+  const interviews = asArray(bundle.interviews);
+  const offers = asArray(bundle.offers);
+  const byApplication = new Map(
+    applications.map((application) => [
+      application.id,
+      { outreachMessages: [], lifecycleEvents: [], interviews: [], offers: [] },
+    ]),
+  );
+  const scope = (record, store) => {
+    const scoped = byApplication.get(record.applicationId);
+    if (scoped) scoped[store].push(record);
+  };
+  outreachMessages.forEach((record) => scope(record, "outreachMessages"));
+  lifecycleEvents.forEach((record) => scope(record, "lifecycleEvents"));
+  interviews.forEach((record) => scope(record, "interviews"));
+  offers.forEach((record) => scope(record, "offers"));
+
+  const responseApplicationIds = new Set(
+    applications
+      .filter((application) =>
+        applicationHasResponseSignal(
+          application,
+          byApplication.get(application.id),
+        ),
+      )
+      .map(({ id }) => id),
+  );
+  const compactOutreachReplies = applications.filter(
+    (application) =>
+      normalizeKey(
+        readSpreadsheetMetadata(application.notes).outreach_status,
+      ) === "replied",
+  ).length;
+  const outreachSent = outreachMessages.filter(
+    ({ direction }) => direction === "outbound",
+  ).length;
+  const outreachReplies =
+    compactOutreachReplies +
+    outreachMessages.filter(
+      ({ direction }) => direction === "inbound" || direction === "replied",
+    ).length +
+    lifecycleEvents.filter(
+      ({ eventType }) => normalizeKey(eventType) === "hiring_manager_reply",
+    ).length;
+  const recruiterScreenKeys = new Set();
+  interviews
+    .filter(({ stage }) => stage === "recruiter_screen")
+    .forEach(({ applicationId, startsAt }) =>
+      recruiterScreenKeys.add(`${applicationId}:${startsAt ?? "scheduled"}`),
+    );
+  lifecycleEvents
+    .filter(
+      ({ eventType }) =>
+        normalizeKey(eventType) === "recruiter_screen_scheduled",
+    )
+    .forEach(({ applicationId, dueAt, occurredAt }) =>
+      recruiterScreenKeys.add(
+        `${applicationId}:${dueAt ?? occurredAt ?? "scheduled"}`,
+      ),
+    );
+  const recruiterScreens = recruiterScreenKeys.size;
+  const assessments = lifecycleEvents.filter(({ eventType, stageLabel }) => {
+    const normalizedType = normalizeKey(eventType);
+    return (
+      ASSESSMENT_EVENT_TYPES.has(normalizedType) ||
+      ASSESSMENT_LABEL_PATTERN.test(stageLabel)
+    );
+  }).length;
+  const offerCount =
+    offers.length +
+    applications.filter(({ status }) => ["offer", "accepted"].includes(status))
+      .length;
+
+  return {
+    totalApplications: applications.length,
+    outreachSent,
+    outreachReplies,
+    applicationsWithResponse: responseApplicationIds.size,
+    applicationResponseRate: formatMetricPercent(
+      responseApplicationIds.size,
+      applications.length,
+    ),
+    outreachReplyRate: formatMetricPercent(outreachReplies, outreachSent),
+    recruiterScreens,
+    interviews: interviews.filter(({ stage }) => stage !== "recruiter_screen")
+      .length,
+    assessments,
+    offers: offerCount,
+  };
+};

--- a/src/web/tracker/tracker.css
+++ b/src/web/tracker/tracker.css
@@ -108,3 +108,8 @@
   background: rgba(127, 29, 29, 0.35);
   color: #fecaca;
 }
+.metric small {
+  display: block;
+  margin-top: 0.35rem;
+  color: var(--muted, #94a3b8);
+}

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -11,6 +11,7 @@ import {
   importNdjsonBackup,
   previewSupplementalLifecycleCsvImport,
 } from "../import-export/spreadsheet.js";
+import { computeTrackerMetrics } from "./metrics.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
 const ARRAY_STORES = [
@@ -252,28 +253,43 @@ function renderNav() {
 }
 function renderDashboard() {
   const b = state.bundle;
-  const count = (s) => b.applications.filter((a) => a.status === s).length;
-  const outreach = b.outreachMessages.length,
-    interviews = b.interviews.length,
-    offers = b.offers.length,
-    total = b.applications.length;
+  const metricValues = computeTrackerMetrics(b);
   const metrics = [
-    ["Total applications", total],
-    ["Outreach sent", outreach],
-    ["Recruiter screens", count("recruiter_screen")],
-    ["Interviews", interviews],
-    ["Offers", offers],
+    ["Total applications", metricValues.totalApplications],
     [
-      "Response rate",
-      total
-        ? `${Math.round(((outreach + interviews + offers) / total) * 100)}%`
-        : "0%",
+      "Outreach sent",
+      metricValues.outreachSent,
+      "Outbound outreach messages, counted as messages rather than unique applications.",
+    ],
+    ["Outreach replies", metricValues.outreachReplies],
+    ["Application responses", metricValues.applicationsWithResponse],
+    ["Recruiter screens", metricValues.recruiterScreens],
+    [
+      "Interviews",
+      metricValues.interviews,
+      "Non-recruiter-screen interviews only.",
+    ],
+    [
+      "Assessments",
+      metricValues.assessments,
+      "Written assessments and take-homes; not counted as interviews.",
+    ],
+    ["Offers", metricValues.offers],
+    [
+      "Application response rate",
+      metricValues.applicationResponseRate,
+      `${metricValues.applicationsWithResponse} of ${metricValues.totalApplications} applications`,
+    ],
+    [
+      "Outreach reply rate",
+      metricValues.outreachReplyRate,
+      `${metricValues.outreachReplies} of ${metricValues.outreachSent} outreach messages`,
     ],
   ];
   $("[data-metrics]").innerHTML = metrics
     .map(
-      ([k, v]) =>
-        `<div class="metric"><span>${k}</span><strong>${v}</strong></div>`,
+      ([k, v, help]) =>
+        `<div class="metric"><span>${k}</span><strong>${v}</strong>${help ? `<small>${esc(help)}</small>` : ""}</div>`,
     )
     .join("");
   const weeks = {};

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -83,10 +83,6 @@ test.describe("browser application tracker", () => {
   test("imports compact CSV regression fixture with bounded dashboard metrics", async ({
     page,
   }) => {
-    test.fail(
-      true,
-      "Prompt 01 lands this red regression net; later prompts fix dashboard/import.",
-    );
     const csv = await regressionCsvFixture();
 
     await page.getByRole("button", { name: "Import/Export" }).click();

--- a/test/tracker-metrics.test.js
+++ b/test/tracker-metrics.test.js
@@ -1,0 +1,140 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  csvToBrowserApplicationExport,
+  lifecycleRowsToBrowserApplicationExport,
+  parseCsv,
+} from "../src/web/import-export/spreadsheet.js";
+import {
+  computeTrackerMetrics,
+  formatMetricPercent,
+} from "../src/web/tracker/metrics.js";
+
+const fixture = (name) =>
+  readFile(`test/fixtures/tracker-import/${name}`, "utf8");
+const mergeBundle = (base, supplemental) => ({
+  ...base,
+  lifecycleEvents: [...base.lifecycleEvents, ...supplemental.lifecycleEvents],
+  interviews: [...base.interviews, ...supplemental.interviews],
+  reminders: [...base.reminders, ...supplemental.reminders],
+});
+const compactBundle = async () => {
+  const { bundle, errors } = csvToBrowserApplicationExport(
+    await fixture("compact-main-regression.csv"),
+  );
+  expect(errors).toEqual([]);
+  return bundle;
+};
+const supplementalBundle = async (name, existing) =>
+  lifecycleRowsToBrowserApplicationExport(
+    parseCsv(await fixture(name)),
+    existing,
+  ).bundle;
+
+describe("tracker dashboard metrics", () => {
+  it("returns safe zero values for empty bundles", () => {
+    expect(computeTrackerMetrics({})).toMatchObject({
+      totalApplications: 0,
+      applicationsWithResponse: 0,
+      applicationResponseRate: "0%",
+      outreachReplyRate: "0%",
+    });
+    expect(formatMetricPercent(3, 0)).toBe("0%");
+    expect(formatMetricPercent(99, 3)).toBe("100%");
+    expect(formatMetricPercent(Number.NaN, Number.POSITIVE_INFINITY)).toBe(
+      "0%",
+    );
+  });
+
+  it("computes compact metrics without phantom interviews or impossible rates", async () => {
+    const metrics = computeTrackerMetrics(await compactBundle());
+    expect(metrics).toMatchObject({
+      totalApplications: 15,
+      outreachSent: 7,
+      outreachReplies: 2,
+      applicationsWithResponse: 4,
+      applicationResponseRate: "27%",
+      outreachReplyRate: "29%",
+      recruiterScreens: 0,
+      interviews: 0,
+      offers: 0,
+    });
+  });
+
+  it("counts written assessments as assessments and responses, not interviews", async () => {
+    const base = await compactBundle();
+    const metrics = computeTrackerMetrics(
+      mergeBundle(
+        base,
+        await supplementalBundle("assessment-lifecycle-regression.csv", base),
+      ),
+    );
+    expect(metrics.assessments).toBe(2);
+    expect(metrics.interviews).toBe(0);
+    expect(metrics.applicationsWithResponse).toBe(5);
+  });
+
+  it("counts hiring-manager replies as responses, not interviews", async () => {
+    const base = await compactBundle();
+    const metrics = computeTrackerMetrics(
+      mergeBundle(
+        base,
+        await supplementalBundle(
+          "employer-reply-lifecycle-regression.csv",
+          base,
+        ),
+      ),
+    );
+    expect(metrics.outreachReplies).toBe(4);
+    expect(metrics.interviews).toBe(0);
+    expect(metrics.applicationsWithResponse).toBe(4);
+  });
+
+  it("dedupes recruiter screens and application response signals", async () => {
+    const base = await compactBundle();
+    const metrics = computeTrackerMetrics(
+      mergeBundle(
+        base,
+        await supplementalBundle(
+          "recruiter-screen-lifecycle-regression.csv",
+          base,
+        ),
+      ),
+    );
+    expect(metrics.recruiterScreens).toBe(1);
+    expect(metrics.outreachReplies).toBe(2);
+    expect(metrics.interviews).toBe(0);
+    expect(metrics.applicationsWithResponse).toBe(4);
+  });
+
+  it("clamps application response rates when child records exceed application count", () => {
+    const bundle = {
+      applications: [{ id: "app_1", status: "applied" }],
+      outreachMessages: [
+        { id: "out_1", applicationId: "app_1", direction: "outbound" },
+        { id: "in_1", applicationId: "app_1", direction: "inbound" },
+        { id: "in_2", applicationId: "app_1", direction: "inbound" },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_1",
+          applicationId: "app_1",
+          eventType: "hiring_manager_reply",
+        },
+        {
+          id: "event_2",
+          applicationId: "app_1",
+          eventType: "written_assessment_requested",
+        },
+      ],
+      interviews: [],
+      offers: [],
+    };
+    const metrics = computeTrackerMetrics(bundle);
+    expect(metrics.applicationsWithResponse).toBe(1);
+    expect(metrics.applicationResponseRate).toBe("100%");
+    expect(metrics.outreachReplyRate).toBe("100%");
+  });
+});


### PR DESCRIPTION
### Motivation

- Eliminate ad-hoc DOM-local arithmetic that mixed child-record counts into application-level numerators and caused impossible rates (e.g. >100%).
- Make metric definitions explicit, testable, and independent of the UI so response signals are deduped at the application level.
- Surface distinct concepts (outreach messages, outreach replies, applicationsWithResponse, recruiter-screens, interviews, assessments, offers) and ensure percent metrics are clamped and safe.

### Description

- Add a pure metrics module `src/web/tracker/metrics.js` exporting `computeTrackerMetrics` and `formatMetricPercent` that computes named metrics from an exported IndexedDB bundle and enforces deduping and clamped percentages.
- Update the dashboard rendering in `src/web/tracker/tracker.js` to consume the selector output, display separate cards (including numerator/denominator help text for response cards), and avoid reusing child-record counts as application-level numerators.
- Add fixture-backed unit tests in `test/tracker-metrics.test.js` that cover empty bundles, compact-only fixtures, supplemental lifecycle fixtures (assessments, hiring-manager replies, recruiter screens), deduping, and impossible-value guards.
- Minor UI polish: add helper sublabel styling in `src/web/tracker/tracker.css` and re-enable the Playwright regression that validates bounded dashboard metrics in `test/playwright/browser-tracker.spec.js`.

### Testing

- Ran `npm ci` (passed) to install dependencies.
- Ran `npm run lint` (passed) and `npm run typecheck` (passed) to validate code quality and types.
- Ran the focused unit tests with `npm run test -- test/tracker-metrics.test.js` (passed) and the full CI suite with `npm run test:ci` (all tests passed: 1009 tests reported passing in this run).
- Ran `npm run build` (passed) to produce the static tracker assets.
- Ran `npm run format:check` which reported repository-wide Prettier warnings from pre-existing formatting drift (changed files were formatted as part of the work); this is a repo-wide issue and not caused by the metric changes.

Notes and follow-ups: metric semantics and fixtures were implemented to match the expected behaviors described in the regression fixtures; no new runtime dependencies were added and sensitive data/fixtures remain anonymized per the existing test fixtures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4df1eaaeb4832f93f1409449056cfd)