### PR TITLE
Fix tracker dashboard metric semantics

### DIFF
--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -1,0 +1,189 @@
+const EMPTY_ARRAY = Object.freeze([]);
+const TERMINAL_RESPONSE_STATUSES = new Set([
+  "offer",
+  "accepted",
+  "rejected",
+  "withdrawn",
+  "closed_archived",
+]);
+const ASSESSMENT_EVENT_TYPES = new Set([
+  "written_assessment_requested",
+  "written_assessment_submitted",
+  "take_home_requested",
+  "take_home_submitted",
+]);
+const EMPLOYER_RESPONSE_EVENT_TYPES = new Set([
+  "hiring_manager_reply",
+  "written_assessment_requested",
+  "recruiter_screen_scheduled",
+  "recruiter_screen_completed",
+  "offer_received",
+]);
+const RECRUITER_SCREEN_EVENT_TYPES = new Set([
+  "recruiter_screen_scheduled",
+  "recruiter_screen_completed",
+]);
+const LOCAL_ONLY_EVENT_TYPES = new Set([
+  "application_submitted",
+  "next_tracking_step",
+  "follow_up_reminder",
+  "note",
+  "user_note",
+]);
+const CSV_METADATA_PREFIX = "Spreadsheet metadata:";
+
+const normalizeKey = (value) =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase();
+const normalizeLabelKey = (value) =>
+  normalizeKey(value)
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+const arrays = (bundle = {}) => ({
+  applications: bundle.applications ?? EMPTY_ARRAY,
+  outreachMessages: bundle.outreachMessages ?? EMPTY_ARRAY,
+  lifecycleEvents: bundle.lifecycleEvents ?? EMPTY_ARRAY,
+  interviews: bundle.interviews ?? EMPTY_ARRAY,
+  offers: bundle.offers ?? EMPTY_ARRAY,
+});
+const percent = (numerator, denominator) => {
+  if (!denominator || denominator < 0) return 0;
+  const value = Math.round((Math.max(0, numerator) / denominator) * 100);
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(100, Math.max(0, value));
+};
+
+export const formatMetricPercent = (value) =>
+  `${Math.min(100, Math.max(0, Number.isFinite(value) ? value : 0))}%`;
+
+const metadataFromNotes = (notes) => {
+  const line = String(notes ?? "")
+    .split("\n")
+    .find((entry) => entry.startsWith(CSV_METADATA_PREFIX));
+  if (!line) return {};
+  try {
+    return JSON.parse(line.slice(CSV_METADATA_PREFIX.length).trim());
+  } catch {
+    return {};
+  }
+};
+const isAssessmentLabel = (value) => {
+  const key = normalizeLabelKey(value);
+  return (
+    key === "written_assessment" ||
+    key.startsWith("written_assessment_") ||
+    key === "take_home" ||
+    key.startsWith("take_home_")
+  );
+};
+const isEmployerLifecycleResponse = (event) => {
+  const eventType = normalizeLabelKey(event.eventType);
+  if (LOCAL_ONLY_EVENT_TYPES.has(eventType)) return false;
+  return (
+    EMPLOYER_RESPONSE_EVENT_TYPES.has(eventType) ||
+    TERMINAL_RESPONSE_STATUSES.has(event.status) ||
+    isAssessmentLabel(event.stageLabel)
+  );
+};
+const add = (set, id) => {
+  if (id) set.add(id);
+};
+
+/**
+ * Dashboard metric definitions:
+ * - Application response rate is unique applications with employer responses
+ *   or terminal outcomes / total applications.
+ * - Outreach reply rate is reply signals / outbound outreach messages.
+ * - Recruiter screens, non-recruiter interviews, assessments, and offers are distinct concepts.
+ * Percentages are rounded and guarded so impossible values never render above
+ * 100%, negative, NaN%, or Infinity%.
+ */
+export const selectDashboardMetrics = (bundle = {}) => {
+  const {
+    applications,
+    outreachMessages,
+    lifecycleEvents,
+    interviews,
+    offers,
+  } = arrays(bundle);
+  const applicationsWithResponse = new Set();
+  const assessmentApplications = new Set();
+  const recruiterScreenApplications = new Set();
+  const interviewApplications = new Set();
+  const offerApplications = new Set();
+
+  const outreachSent = outreachMessages.filter(
+    ({ direction }) => direction !== "inbound",
+  ).length;
+  let outreachReplies = outreachMessages.filter(
+    ({ direction }) => direction === "inbound",
+  ).length;
+
+  for (const app of applications) {
+    const metadata = metadataFromNotes(app.notes);
+    if (normalizeLabelKey(metadata.outreach_status) === "replied") {
+      add(applicationsWithResponse, app.id);
+      outreachReplies += 1;
+    }
+    if (TERMINAL_RESPONSE_STATUSES.has(app.status))
+      add(applicationsWithResponse, app.id);
+    if (["offer", "accepted"].includes(app.status))
+      add(offerApplications, app.id);
+    if (
+      TERMINAL_RESPONSE_STATUSES.has(
+        normalizeLabelKey(metadata.spreadsheet_outcome),
+      )
+    )
+      add(applicationsWithResponse, app.id);
+    if (isAssessmentLabel(metadata.spreadsheet_interview_stage)) {
+      add(applicationsWithResponse, app.id);
+      add(assessmentApplications, app.id);
+    }
+  }
+
+  for (const message of outreachMessages) {
+    if (message.direction === "inbound")
+      add(applicationsWithResponse, message.applicationId);
+  }
+  for (const event of lifecycleEvents) {
+    const eventType = normalizeLabelKey(event.eventType);
+    if (isEmployerLifecycleResponse(event))
+      add(applicationsWithResponse, event.applicationId);
+    if (eventType === "hiring_manager_reply") outreachReplies += 1;
+    if (
+      ASSESSMENT_EVENT_TYPES.has(eventType) ||
+      isAssessmentLabel(event.stageLabel)
+    )
+      add(assessmentApplications, event.applicationId);
+    if (RECRUITER_SCREEN_EVENT_TYPES.has(eventType))
+      add(recruiterScreenApplications, event.applicationId);
+  }
+  for (const interview of interviews) {
+    if (interview.stage === "recruiter_screen")
+      add(recruiterScreenApplications, interview.applicationId);
+    else add(interviewApplications, interview.applicationId);
+  }
+  for (const offer of offers) {
+    add(applicationsWithResponse, offer.applicationId);
+    add(offerApplications, offer.applicationId);
+  }
+
+  const totalApplications = applications.length;
+  return {
+    totalApplications,
+    outreachSent,
+    outreachReplies,
+    applicationsWithResponse: applicationsWithResponse.size,
+    applicationResponseRate: percent(
+      applicationsWithResponse.size,
+      totalApplications,
+    ),
+    outreachReplyRate: percent(outreachReplies, outreachSent),
+    recruiterScreens: recruiterScreenApplications.size,
+    interviews: interviewApplications.size,
+    assessments: assessmentApplications.size,
+    offers: offerApplications.size,
+  };
+};

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -11,6 +11,7 @@ import {
   importNdjsonBackup,
   previewSupplementalLifecycleCsvImport,
 } from "../import-export/spreadsheet.js";
+import { formatMetricPercent, selectDashboardMetrics } from "./metrics.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
 const ARRAY_STORES = [
@@ -252,28 +253,39 @@ function renderNav() {
 }
 function renderDashboard() {
   const b = state.bundle;
-  const count = (s) => b.applications.filter((a) => a.status === s).length;
-  const outreach = b.outreachMessages.length,
-    interviews = b.interviews.length,
-    offers = b.offers.length,
-    total = b.applications.length;
+  const dashboardMetrics = selectDashboardMetrics(b);
   const metrics = [
-    ["Total applications", total],
-    ["Outreach sent", outreach],
-    ["Recruiter screens", count("recruiter_screen")],
-    ["Interviews", interviews],
-    ["Offers", offers],
+    ["Total applications", dashboardMetrics.totalApplications],
     [
-      "Response rate",
-      total
-        ? `${Math.round(((outreach + interviews + offers) / total) * 100)}%`
-        : "0%",
+      "Outreach sent",
+      dashboardMetrics.outreachSent,
+      "outbound outreach messages",
+    ],
+    ["Outreach replies", dashboardMetrics.outreachReplies],
+    ["Application responses", dashboardMetrics.applicationsWithResponse],
+    ["Recruiter screens", dashboardMetrics.recruiterScreens],
+    ["Interviews", dashboardMetrics.interviews, "excludes recruiter screens"],
+    [
+      "Assessments",
+      dashboardMetrics.assessments,
+      "written assessments/take-homes",
+    ],
+    ["Offers", dashboardMetrics.offers],
+    [
+      "Application response rate",
+      formatMetricPercent(dashboardMetrics.applicationResponseRate),
+      `${dashboardMetrics.applicationsWithResponse} of ${dashboardMetrics.totalApplications} applications`,
+    ],
+    [
+      "Outreach reply rate",
+      formatMetricPercent(dashboardMetrics.outreachReplyRate),
+      `${dashboardMetrics.outreachReplies} of ${dashboardMetrics.outreachSent} outreach messages`,
     ],
   ];
   $("[data-metrics]").innerHTML = metrics
     .map(
-      ([k, v]) =>
-        `<div class="metric"><span>${k}</span><strong>${v}</strong></div>`,
+      ([k, v, sublabel]) =>
+        `<div class="metric"><span>${k}</span><strong>${v}</strong>${sublabel ? `<small>${esc(sublabel)}</small>` : ""}</div>`,
     )
     .join("");
   const weeks = {};

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -83,10 +83,6 @@ test.describe("browser application tracker", () => {
   test("imports compact CSV regression fixture with bounded dashboard metrics", async ({
     page,
   }) => {
-    test.fail(
-      true,
-      "Prompt 01 lands this red regression net; later prompts fix dashboard/import.",
-    );
     const csv = await regressionCsvFixture();
 
     await page.getByRole("button", { name: "Import/Export" }).click();
@@ -109,8 +105,15 @@ test.describe("browser application tracker", () => {
     await expect(metrics).toContainText("Interviews0");
     await expect(metrics).toContainText("Offers0");
     await expect(metrics).toContainText("Application responses4");
-    await expect(metrics).toContainText("Application response rate27%");
-    await expect(metrics).toContainText("Outreach reply rate29%");
+    await expect(metrics).toContainText("Assessments1");
+    await expect(metrics).toContainText(
+      "Application response rate27%4 of 15 applications",
+    );
+    await expect(metrics).toContainText(
+      "Outreach reply rate29%2 of 7 outreach messages",
+    );
+    await expect(metrics).not.toContainText("NaN%");
+    await expect(metrics).not.toContainText("Infinity%");
   });
 
   test("imports CSV, shows list, edits detail, and renders follow-ups", async ({

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -1,0 +1,157 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  csvToBrowserApplicationExport,
+  csvToSupplementalLifecycleExport,
+} from "../src/web/import-export/spreadsheet.js";
+import {
+  formatMetricPercent,
+  selectDashboardMetrics,
+} from "../src/web/tracker/metrics.js";
+
+const exportedAt = "2026-03-10T00:00:00.000Z";
+const fixture = (name) =>
+  readFile(`test/fixtures/tracker-import/${name}`, "utf8");
+const compactBundle = async () => {
+  const { bundle, errors } = csvToBrowserApplicationExport(
+    await fixture("compact-main-regression.csv"),
+    { exportedAt },
+  );
+  expect(errors).toEqual([]);
+  return bundle;
+};
+const withLifecycle = async (name) => {
+  const base = await compactBundle();
+  const { bundle: supplement, errors } = csvToSupplementalLifecycleExport(
+    await fixture(name),
+    base,
+    { exportedAt },
+  );
+  expect(errors).toEqual([]);
+  return {
+    ...base,
+    lifecycleEvents: [...base.lifecycleEvents, ...supplement.lifecycleEvents],
+    interviews: [...base.interviews, ...supplement.interviews],
+    reminders: [...base.reminders, ...supplement.reminders],
+  };
+};
+
+describe("tracker dashboard metric selectors", () => {
+  it("returns safe zero metrics for empty data", () => {
+    expect(selectDashboardMetrics()).toMatchObject({
+      totalApplications: 0,
+      applicationsWithResponse: 0,
+      applicationResponseRate: 0,
+      outreachReplyRate: 0,
+      recruiterScreens: 0,
+      interviews: 0,
+      assessments: 0,
+      offers: 0,
+    });
+    expect(formatMetricPercent(Number.NaN)).toBe("0%");
+    expect(formatMetricPercent(Number.POSITIVE_INFINITY)).toBe("0%");
+    expect(formatMetricPercent(-50)).toBe("0%");
+    expect(formatMetricPercent(150)).toBe("100%");
+  });
+
+  it("computes compact regression fixture metrics without phantom interviews", async () => {
+    const metrics = selectDashboardMetrics(await compactBundle());
+
+    expect(metrics).toMatchObject({
+      totalApplications: 15,
+      outreachSent: 7,
+      outreachReplies: 2,
+      applicationsWithResponse: 4,
+      applicationResponseRate: 27,
+      outreachReplyRate: 29,
+      recruiterScreens: 0,
+      interviews: 0,
+      assessments: 1,
+      offers: 0,
+    });
+    expect(metrics.applicationResponseRate).toBeLessThanOrEqual(100);
+  });
+
+  it("counts written assessment lifecycle events as assessments, not interviews", async () => {
+    const metrics = selectDashboardMetrics(
+      await withLifecycle("assessment-lifecycle-regression.csv"),
+    );
+
+    expect(metrics.assessments).toBe(2);
+    expect(metrics.interviews).toBe(0);
+    expect(metrics.applicationsWithResponse).toBe(5);
+  });
+
+  it("counts hiring-manager replies as responses, not interviews", async () => {
+    const metrics = selectDashboardMetrics(
+      await withLifecycle("employer-reply-lifecycle-regression.csv"),
+    );
+
+    expect(metrics.applicationsWithResponse).toBe(4);
+    expect(metrics.interviews).toBe(0);
+    expect(metrics.outreachReplies).toBe(4);
+  });
+
+  it("counts recruiter screens separately from non-recruiter interviews", async () => {
+    const metrics = selectDashboardMetrics(
+      await withLifecycle("recruiter-screen-lifecycle-regression.csv"),
+    );
+
+    expect(metrics.recruiterScreens).toBe(1);
+    expect(metrics.interviews).toBe(0);
+    expect(metrics.applicationsWithResponse).toBe(4);
+  });
+
+  it("dedupes child records and clamps impossible percentages", () => {
+    const bundle = {
+      applications: [
+        {
+          id: "app_one",
+          company: "Example",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+      outreachMessages: [
+        { id: "m1", applicationId: "app_one", direction: "outbound" },
+        { id: "m2", applicationId: "app_one", direction: "inbound" },
+        { id: "m3", applicationId: "app_one", direction: "inbound" },
+      ],
+      lifecycleEvents: [
+        {
+          id: "e1",
+          applicationId: "app_one",
+          eventType: "hiring_manager_reply",
+        },
+        {
+          id: "e2",
+          applicationId: "app_one",
+          eventType: "written_assessment_requested",
+        },
+        {
+          id: "e3",
+          applicationId: "app_one",
+          eventType: "recruiter_screen_scheduled",
+        },
+      ],
+      interviews: [
+        { id: "i1", applicationId: "app_one", stage: "recruiter_screen" },
+        { id: "i2", applicationId: "app_one", stage: "technical_screen" },
+      ],
+      offers: [{ id: "o1", applicationId: "app_one", status: "received" }],
+    };
+
+    const metrics = selectDashboardMetrics(bundle);
+
+    expect(metrics.applicationsWithResponse).toBe(1);
+    expect(metrics.applicationResponseRate).toBe(100);
+    expect(metrics.outreachReplyRate).toBe(100);
+    expect(metrics.recruiterScreens).toBe(1);
+    expect(metrics.interviews).toBe(1);
+    expect(metrics.assessments).toBe(1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure dashboard metrics are computed from the canonical imported bundle with explicit definitions and unique-application deduping so child-record counts cannot inflate application-level response numerators.
- Prevent impossible percentage displays (NaN, Infinity, negative, or >100%) and separate outreach reply rate from application response rate while distinguishing recruiter screens, interviews, assessments, and offers.

### Description
- Add a pure, DOM-independent selector `selectDashboardMetrics` in `src/web/tracker/metrics.js` that accepts the current bundle and returns named metrics with deduping, event-type classification, assessment detection, and percentage guards.
- Update `src/web/tracker/tracker.js` to render metrics exclusively from the selector and add numerator/denominator sublabels on rate cards (for example `4 of 15 applications` and `2 of 7 outreach messages`).
- Add fixture-driven unit tests in `test/web-tracker-metrics.test.js` using the anonymized CSV and lifecycle fixtures to verify compact-only behavior, lifecycle supplements, recruiter-screen splitting, assessment detection, deduping, and bounded percentages, and tighten the Playwright regression in `test/playwright/browser-tracker.spec.js`.
- Keep the metric module independent of the DOM and compatible with the existing CSV/lifecycle import/export pipeline without adding new runtime dependencies.

### Testing
- Ran verification commands: `npm ci` (success), `npm run format:check` (Prettier run; target files formatted), `npm run lint` (staged/modified files linted successfully), `npm run typecheck` (success), `npm run test -- --run test/web-tracker-metrics.test.js test/web-spreadsheet-import-export.test.js` (both targeted test files passed), `npm run build` (success), and `npm run test:ci` (full automated test suite including Playwright browser tracker tests passed in CI after browser installation).
- New/targeted automated tests: `test/web-tracker-metrics.test.js` (unit cases for empty data, compact-only fixtures, lifecycle supplements, duplicate child records, and clamped percentages) — all tests passed; Playwright regression asserting corrected dashboard labels and bounded percentages in `test/playwright/browser-tracker.spec.js` passed under CI.
- Residual risks and follow-ups: CI environments must ensure Playwright browsers are installed (`npx playwright install`) to run browser tests in isolated runners, and a follow-up could add lightweight UI help text/localization for the metric definitions if desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4df208af34832fae679ecbc185e70e)