### PR TITLE
Rebuild tracker dashboard metrics

### DIFF
--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -8,10 +8,13 @@ const RESPONSE_EVENT_TYPES = new Set([
   "hiring_manager_reply",
   "written_assessment_requested",
   "recruiter_screen_scheduled",
+  "recruiter_screen_completed",
 ]);
 const ASSESSMENT_EVENT_TYPES = new Set([
+  "written_assessment",
   "written_assessment_requested",
   "written_assessment_submitted",
+  "take_home",
   "take_home_requested",
   "take_home_submitted",
 ]);
@@ -99,12 +102,16 @@ export const selectDashboardMetrics = (bundle = {}) => {
   const metadataByApplicationId = applicationMetadata(bundle);
   const responseApplicationIds = new Set();
   let compactOutreachReplies = 0;
+  const compactOutreachApplicationIds = new Set();
+  const outboundOutreachApplicationIds = new Set();
   const recruiterScreenKeys = new Set();
-  const assessmentKeys = new Set();
+  const assessmentApplicationIds = new Set();
 
   for (const application of applications) {
     const metadata = metadataByApplicationId.get(application.id) ?? {};
-    if (OUTREACH_REPLY_STATUSES.has(compactOutreachStatus(metadata))) {
+    const outreachStatus = compactOutreachStatus(metadata);
+    if (outreachStatus) compactOutreachApplicationIds.add(application.id);
+    if (OUTREACH_REPLY_STATUSES.has(outreachStatus)) {
       compactOutreachReplies += 1;
       addResponse(responseApplicationIds, application.id);
     }
@@ -112,18 +119,26 @@ export const selectDashboardMetrics = (bundle = {}) => {
       addResponse(responseApplicationIds, application.id);
     if (isAssessmentMetadata(metadata)) {
       addResponse(responseApplicationIds, application.id);
-      assessmentKeys.add(`metadata:${application.id}`);
+      assessmentApplicationIds.add(application.id);
     }
   }
 
   let outreachSent = 0;
   let outreachReplies = compactOutreachReplies;
   for (const message of outreachMessages) {
-    if (message.direction === "outbound") outreachSent += 1;
+    if (message.direction === "outbound") {
+      outreachSent += 1;
+      if (message.applicationId)
+        outboundOutreachApplicationIds.add(message.applicationId);
+    }
     if (message.direction === "inbound") {
       outreachReplies += 1;
       addResponse(responseApplicationIds, message.applicationId);
     }
+  }
+
+  for (const applicationId of compactOutreachApplicationIds) {
+    if (!outboundOutreachApplicationIds.has(applicationId)) outreachSent += 1;
   }
 
   for (const event of lifecycleEvents) {
@@ -134,10 +149,11 @@ export const selectDashboardMetrics = (bundle = {}) => {
       TERMINAL_EMPLOYER_STATUSES.has(status)
     )
       addResponse(responseApplicationIds, event.applicationId);
-    if (ASSESSMENT_EVENT_TYPES.has(eventType))
-      assessmentKeys.add(
-        event.id ?? `${event.applicationId}:${eventType}:${event.occurredAt}`,
-      );
+    if (ASSESSMENT_EVENT_TYPES.has(eventType)) {
+      addResponse(responseApplicationIds, event.applicationId);
+      if (event.applicationId)
+        assessmentApplicationIds.add(event.applicationId);
+    }
     if (
       RECRUITER_SCREEN_EVENT_TYPES.has(eventType) ||
       status === "recruiter_screen"
@@ -146,6 +162,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
   }
 
   for (const interview of interviews) {
+    addResponse(responseApplicationIds, interview.applicationId);
     if (interview.stage === "recruiter_screen")
       recruiterScreenKeys.add(recruiterScreenKey(interview));
   }
@@ -165,11 +182,12 @@ export const selectDashboardMetrics = (bundle = {}) => {
     outreachReplyRate: boundedPercentage(outreachReplies, outreachSent),
     recruiterScreens: recruiterScreenKeys.size,
     interviews: nonRecruiterInterviews.length,
-    assessments: assessmentKeys.size,
-    offers:
-      offers.length +
-      applications.filter(({ status }) =>
-        ["offer", "accepted"].includes(status),
-      ).length,
+    assessments: assessmentApplicationIds.size,
+    offers: new Set([
+      ...offers.map((offer) => offer.applicationId ?? offer.id).filter(Boolean),
+      ...applications
+        .filter(({ status }) => ["offer", "accepted"].includes(status))
+        .map(({ id }) => id),
+    ]).size,
   };
 };

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -180,7 +180,10 @@ export const selectDashboardMetrics = (bundle = {}) => {
       status === "recruiter_screen"
     )
       recruiterScreenKeys.add(recruiterScreenKey(event));
-    if (OFFER_EVENT_TYPES.has(eventType))
+    if (
+      OFFER_EVENT_TYPES.has(eventType) ||
+      ["offer", "accepted"].includes(status)
+    )
       offerApplicationIds.add(event.applicationId);
   }
 

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -103,7 +103,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
   const offers = bundle.offers ?? [];
   const metadataByApplicationId = applicationMetadata(bundle);
   const responseApplicationIds = new Set();
-  let compactOutreachReplies = 0;
+  const compactOutreachReplyApplicationIds = new Set();
   const compactOutreachApplicationIds = new Set();
   const outboundOutreachApplicationIds = new Set();
   const recruiterScreenKeys = new Set();
@@ -114,7 +114,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
     const outreachStatus = compactOutreachStatus(metadata);
     if (outreachStatus) compactOutreachApplicationIds.add(application.id);
     if (OUTREACH_REPLY_STATUSES.has(outreachStatus)) {
-      compactOutreachReplies += 1;
+      compactOutreachReplyApplicationIds.add(application.id);
       addResponse(responseApplicationIds, application.id);
     }
     if (TERMINAL_EMPLOYER_STATUSES.has(application.status))
@@ -126,7 +126,8 @@ export const selectDashboardMetrics = (bundle = {}) => {
   }
 
   let outreachSent = 0;
-  let outreachReplies = compactOutreachReplies;
+  let outreachReplies = 0;
+  const representedReplyApplicationIds = new Set();
   for (const message of outreachMessages) {
     const direction = normalize(message.direction);
     if (direction === "outbound") {
@@ -139,8 +140,15 @@ export const selectDashboardMetrics = (bundle = {}) => {
       OUTREACH_REPLY_STATUSES.has(normalize(message.status))
     ) {
       outreachReplies += 1;
+      if (message.applicationId)
+        representedReplyApplicationIds.add(message.applicationId);
       addResponse(responseApplicationIds, message.applicationId);
     }
+  }
+
+  for (const applicationId of compactOutreachReplyApplicationIds) {
+    if (!representedReplyApplicationIds.has(applicationId))
+      outreachReplies += 1;
   }
 
   for (const applicationId of compactOutreachApplicationIds) {

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -1,0 +1,175 @@
+const TERMINAL_EMPLOYER_STATUSES = new Set([
+  "offer",
+  "accepted",
+  "rejected",
+  "closed_archived",
+]);
+const RESPONSE_EVENT_TYPES = new Set([
+  "hiring_manager_reply",
+  "written_assessment_requested",
+  "recruiter_screen_scheduled",
+]);
+const ASSESSMENT_EVENT_TYPES = new Set([
+  "written_assessment_requested",
+  "written_assessment_submitted",
+  "take_home_requested",
+  "take_home_submitted",
+]);
+const RECRUITER_SCREEN_EVENT_TYPES = new Set([
+  "recruiter_screen_scheduled",
+  "recruiter_screen_completed",
+]);
+const OUTREACH_REPLY_STATUSES = new Set(["replied", "reply", "responded"]);
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+const normalize = (value) =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+export const readSpreadsheetMetadata = (notes) => {
+  const prefix = "Spreadsheet metadata:";
+  const line = String(notes ?? "")
+    .split("\n")
+    .find((item) => item.startsWith(prefix));
+  if (!line) return {};
+  try {
+    return JSON.parse(line.slice(prefix.length).trim());
+  } catch {
+    return {};
+  }
+};
+
+export const boundedPercentage = (numerator, denominator) => {
+  if (denominator <= 0 || numerator <= 0) return 0;
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator)) return 0;
+  return clamp(Math.round((numerator / denominator) * 100), 0, 100);
+};
+
+const applicationMetadata = (bundle) =>
+  new Map(
+    (bundle.applications ?? []).map((application) => [
+      application.id,
+      readSpreadsheetMetadata(application.notes),
+    ]),
+  );
+
+const compactStage = (metadata) =>
+  normalize(metadata.spreadsheet_interview_stage);
+const compactOutcome = (metadata) => normalize(metadata.spreadsheet_outcome);
+const compactOutreachStatus = (metadata) => normalize(metadata.outreach_status);
+
+const isAssessmentMetadata = (metadata) => {
+  const stage = compactStage(metadata);
+  const outcome = compactOutcome(metadata);
+  return (
+    stage.includes("written_assessment") ||
+    outcome.includes("written_assessment") ||
+    stage.includes("take_home") ||
+    outcome.includes("take_home")
+  );
+};
+
+const addResponse = (responses, applicationId) => {
+  if (applicationId) responses.add(applicationId);
+};
+const recruiterScreenKey = (record) =>
+  [
+    record.applicationId,
+    record.dueAt ?? record.startsAt ?? record.occurredAt ?? record.id,
+  ]
+    .filter(Boolean)
+    .join(":");
+
+/**
+ * Dashboard selector for imported tracker bundles.
+ * - applicationResponseRate is unique responding applications / total applications.
+ * - outreachReplyRate is inbound/replied outreach messages / outbound outreach messages.
+ * - recruiterScreens, interviews, and assessments are intentionally split so
+ *   assessment and hiring-manager-reply child records cannot inflate interviews.
+ */
+export const selectDashboardMetrics = (bundle = {}) => {
+  const applications = bundle.applications ?? [];
+  const outreachMessages = bundle.outreachMessages ?? [];
+  const lifecycleEvents = bundle.lifecycleEvents ?? [];
+  const interviews = bundle.interviews ?? [];
+  const offers = bundle.offers ?? [];
+  const metadataByApplicationId = applicationMetadata(bundle);
+  const responseApplicationIds = new Set();
+  let compactOutreachReplies = 0;
+  const recruiterScreenKeys = new Set();
+  const assessmentKeys = new Set();
+
+  for (const application of applications) {
+    const metadata = metadataByApplicationId.get(application.id) ?? {};
+    if (OUTREACH_REPLY_STATUSES.has(compactOutreachStatus(metadata))) {
+      compactOutreachReplies += 1;
+      addResponse(responseApplicationIds, application.id);
+    }
+    if (TERMINAL_EMPLOYER_STATUSES.has(application.status))
+      addResponse(responseApplicationIds, application.id);
+    if (isAssessmentMetadata(metadata)) {
+      addResponse(responseApplicationIds, application.id);
+      assessmentKeys.add(`metadata:${application.id}`);
+    }
+  }
+
+  let outreachSent = 0;
+  let outreachReplies = compactOutreachReplies;
+  for (const message of outreachMessages) {
+    if (message.direction === "outbound") outreachSent += 1;
+    if (message.direction === "inbound") {
+      outreachReplies += 1;
+      addResponse(responseApplicationIds, message.applicationId);
+    }
+  }
+
+  for (const event of lifecycleEvents) {
+    const eventType = normalize(event.eventType);
+    const status = normalize(event.status);
+    if (
+      RESPONSE_EVENT_TYPES.has(eventType) ||
+      TERMINAL_EMPLOYER_STATUSES.has(status)
+    )
+      addResponse(responseApplicationIds, event.applicationId);
+    if (ASSESSMENT_EVENT_TYPES.has(eventType))
+      assessmentKeys.add(
+        event.id ?? `${event.applicationId}:${eventType}:${event.occurredAt}`,
+      );
+    if (
+      RECRUITER_SCREEN_EVENT_TYPES.has(eventType) ||
+      status === "recruiter_screen"
+    )
+      recruiterScreenKeys.add(recruiterScreenKey(event));
+  }
+
+  for (const interview of interviews) {
+    if (interview.stage === "recruiter_screen")
+      recruiterScreenKeys.add(recruiterScreenKey(interview));
+  }
+  const nonRecruiterInterviews = interviews.filter(
+    (interview) => interview.stage !== "recruiter_screen",
+  );
+
+  return {
+    totalApplications: applications.length,
+    outreachSent,
+    outreachReplies,
+    applicationsWithResponse: responseApplicationIds.size,
+    applicationResponseRate: boundedPercentage(
+      responseApplicationIds.size,
+      applications.length,
+    ),
+    outreachReplyRate: boundedPercentage(outreachReplies, outreachSent),
+    recruiterScreens: recruiterScreenKeys.size,
+    interviews: nonRecruiterInterviews.length,
+    assessments: assessmentKeys.size,
+    offers:
+      offers.length +
+      applications.filter(({ status }) =>
+        ["offer", "accepted"].includes(status),
+      ).length,
+  };
+};

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -26,6 +26,7 @@ const RECRUITER_SCREEN_EVENT_TYPES = new Set([
 ]);
 const OFFER_EVENT_TYPES = new Set(["offer", "offer_received"]);
 const OUTREACH_REPLY_STATUSES = new Set(["replied", "reply", "responded"]);
+const OUTREACH_SENT_STATUSES = new Set(["sent", ...OUTREACH_REPLY_STATUSES]);
 const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
 const normalize = (value) =>
   String(value ?? "")
@@ -114,7 +115,8 @@ export const selectDashboardMetrics = (bundle = {}) => {
   for (const application of applications) {
     const metadata = metadataByApplicationId.get(application.id) ?? {};
     const outreachStatus = compactOutreachStatus(metadata);
-    if (outreachStatus) compactOutreachApplicationIds.add(application.id);
+    if (OUTREACH_SENT_STATUSES.has(outreachStatus))
+      compactOutreachApplicationIds.add(application.id);
     if (OUTREACH_REPLY_STATUSES.has(outreachStatus)) {
       compactOutreachReplyApplicationIds.add(application.id);
       addResponse(responseApplicationIds, application.id);
@@ -165,6 +167,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
       TERMINAL_EMPLOYER_STATUSES.has(status)
     )
       addResponse(responseApplicationIds, event.applicationId);
+    if (eventType === "hiring_manager_reply") outreachReplies += 1;
     if (ASSESSMENT_EVENT_TYPES.has(eventType)) {
       addResponse(responseApplicationIds, event.applicationId);
       if (event.applicationId)

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -132,6 +132,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
   let outreachSent = 0;
   let outreachReplies = 0;
   const representedReplyApplicationIds = new Set();
+  const lifecycleReplyApplicationIds = new Set();
   for (const message of outreachMessages) {
     const direction = normalize(message.direction);
     if (direction === "outbound") {
@@ -167,7 +168,8 @@ export const selectDashboardMetrics = (bundle = {}) => {
       TERMINAL_EMPLOYER_STATUSES.has(status)
     )
       addResponse(responseApplicationIds, event.applicationId);
-    if (eventType === "hiring_manager_reply") outreachReplies += 1;
+    if (eventType === "hiring_manager_reply" && event.applicationId)
+      lifecycleReplyApplicationIds.add(event.applicationId);
     if (ASSESSMENT_EVENT_TYPES.has(eventType)) {
       addResponse(responseApplicationIds, event.applicationId);
       if (event.applicationId)
@@ -180,6 +182,14 @@ export const selectDashboardMetrics = (bundle = {}) => {
       recruiterScreenKeys.add(recruiterScreenKey(event));
     if (OFFER_EVENT_TYPES.has(eventType))
       offerApplicationIds.add(event.applicationId);
+  }
+
+  for (const applicationId of lifecycleReplyApplicationIds) {
+    if (
+      !representedReplyApplicationIds.has(applicationId) &&
+      !compactOutreachReplyApplicationIds.has(applicationId)
+    )
+      outreachReplies += 1;
   }
 
   for (const interview of interviews) {

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -24,6 +24,7 @@ const RECRUITER_SCREEN_EVENT_TYPES = new Set([
   "recruiter_screen_scheduled",
   "recruiter_screen_completed",
 ]);
+const OFFER_EVENT_TYPES = new Set(["offer", "offer_received"]);
 const OUTREACH_REPLY_STATUSES = new Set(["replied", "reply", "responded"]);
 const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
 const normalize = (value) =>
@@ -108,6 +109,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
   const outboundOutreachApplicationIds = new Set();
   const recruiterScreenKeys = new Set();
   const assessmentApplicationIds = new Set();
+  const offerApplicationIds = new Set();
 
   for (const application of applications) {
     const metadata = metadataByApplicationId.get(application.id) ?? {};
@@ -173,6 +175,8 @@ export const selectDashboardMetrics = (bundle = {}) => {
       status === "recruiter_screen"
     )
       recruiterScreenKeys.add(recruiterScreenKey(event));
+    if (OFFER_EVENT_TYPES.has(eventType))
+      offerApplicationIds.add(event.applicationId);
   }
 
   for (const interview of interviews) {
@@ -197,11 +201,16 @@ export const selectDashboardMetrics = (bundle = {}) => {
     recruiterScreens: recruiterScreenKeys.size,
     interviews: nonRecruiterInterviews.length,
     assessments: assessmentApplicationIds.size,
-    offers: new Set([
-      ...offers.map((offer) => offer.applicationId ?? offer.id).filter(Boolean),
-      ...applications
-        .filter(({ status }) => ["offer", "accepted"].includes(status))
-        .map(({ id }) => id),
-    ]).size,
+    offers: new Set(
+      [
+        ...offers
+          .map((offer) => offer.applicationId ?? offer.id)
+          .filter(Boolean),
+        ...applications
+          .filter(({ status }) => ["offer", "accepted"].includes(status))
+          .map(({ id }) => id),
+        ...offerApplicationIds,
+      ].filter(Boolean),
+    ).size,
   };
 };

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -9,6 +9,8 @@ const RESPONSE_EVENT_TYPES = new Set([
   "written_assessment_requested",
   "recruiter_screen_scheduled",
   "recruiter_screen_completed",
+  "offer",
+  "offer_received",
 ]);
 const ASSESSMENT_EVENT_TYPES = new Set([
   "written_assessment",
@@ -126,12 +128,16 @@ export const selectDashboardMetrics = (bundle = {}) => {
   let outreachSent = 0;
   let outreachReplies = compactOutreachReplies;
   for (const message of outreachMessages) {
-    if (message.direction === "outbound") {
+    const direction = normalize(message.direction);
+    if (direction === "outbound") {
       outreachSent += 1;
       if (message.applicationId)
         outboundOutreachApplicationIds.add(message.applicationId);
     }
-    if (message.direction === "inbound") {
+    if (
+      direction === "inbound" ||
+      OUTREACH_REPLY_STATUSES.has(normalize(message.status))
+    ) {
       outreachReplies += 1;
       addResponse(responseApplicationIds, message.applicationId);
     }

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -11,6 +11,7 @@ import {
   importNdjsonBackup,
   previewSupplementalLifecycleCsvImport,
 } from "../import-export/spreadsheet.js";
+import { selectDashboardMetrics } from "./metrics.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
 const ARRAY_STORES = [
@@ -252,28 +253,38 @@ function renderNav() {
 }
 function renderDashboard() {
   const b = state.bundle;
-  const count = (s) => b.applications.filter((a) => a.status === s).length;
-  const outreach = b.outreachMessages.length,
-    interviews = b.interviews.length,
-    offers = b.offers.length,
-    total = b.applications.length;
-  const metrics = [
-    ["Total applications", total],
-    ["Outreach sent", outreach],
-    ["Recruiter screens", count("recruiter_screen")],
-    ["Interviews", interviews],
-    ["Offers", offers],
+  const metrics = selectDashboardMetrics(b);
+  const cards = [
+    ["Total applications", metrics.totalApplications, "Application records"],
+    ["Outreach sent", metrics.outreachSent, "Outbound outreach messages"],
     [
-      "Response rate",
-      total
-        ? `${Math.round(((outreach + interviews + offers) / total) * 100)}%`
-        : "0%",
+      "Outreach replies",
+      metrics.outreachReplies,
+      "Inbound or replied outreach messages",
+    ],
+    [
+      "Recruiter screens",
+      metrics.recruiterScreens,
+      "Recruiter-screen interviews/events",
+    ],
+    ["Interviews", metrics.interviews, "Non-recruiter-screen interviews"],
+    ["Assessments", metrics.assessments, "Written assessments/take-homes"],
+    ["Offers", metrics.offers, "Offer records or offer outcomes"],
+    [
+      "Application response rate",
+      `${metrics.applicationResponseRate}%`,
+      `${metrics.applicationsWithResponse} of ${metrics.totalApplications} applications`,
+    ],
+    [
+      "Outreach reply rate",
+      `${metrics.outreachReplyRate}%`,
+      `${metrics.outreachReplies} of ${metrics.outreachSent} outreach messages`,
     ],
   ];
-  $("[data-metrics]").innerHTML = metrics
+  $("[data-metrics]").innerHTML = cards
     .map(
-      ([k, v]) =>
-        `<div class="metric"><span>${k}</span><strong>${v}</strong></div>`,
+      ([label, value, help]) =>
+        `<div class="metric" aria-label="${esc(label)}: ${esc(value)} (${esc(help)})"><span>${esc(label)}</span><strong>${esc(value)}</strong><small class="muted">${esc(help)}</small></div>`,
     )
     .join("");
   const weeks = {};

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -271,6 +271,11 @@ function renderDashboard() {
     ["Assessments", metrics.assessments, "Written assessments/take-homes"],
     ["Offers", metrics.offers, "Offer records or offer outcomes"],
     [
+      "Application responses",
+      metrics.applicationsWithResponse,
+      "Applications with employer response signals",
+    ],
+    [
       "Application response rate",
       `${metrics.applicationResponseRate}%`,
       `${metrics.applicationsWithResponse} of ${metrics.totalApplications} applications`,

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -83,10 +83,6 @@ test.describe("browser application tracker", () => {
   test("imports compact CSV regression fixture with bounded dashboard metrics", async ({
     page,
   }) => {
-    test.fail(
-      true,
-      "Prompt 01 lands this red regression net; later prompts fix dashboard/import.",
-    );
     const csv = await regressionCsvFixture();
 
     await page.getByRole("button", { name: "Import/Export" }).click();
@@ -108,9 +104,11 @@ test.describe("browser application tracker", () => {
     await expect(metrics).toContainText("Recruiter screens0");
     await expect(metrics).toContainText("Interviews0");
     await expect(metrics).toContainText("Offers0");
-    await expect(metrics).toContainText("Application responses4");
+    await expect(metrics).toContainText("Assessments1");
     await expect(metrics).toContainText("Application response rate27%");
+    await expect(metrics).toContainText("4 of 15 applications");
     await expect(metrics).toContainText("Outreach reply rate29%");
+    await expect(metrics).toContainText("2 of 7 outreach messages");
   });
 
   test("imports CSV, shows list, edits detail, and renders follow-ups", async ({

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -105,6 +105,7 @@ test.describe("browser application tracker", () => {
     await expect(metrics).toContainText("Interviews0");
     await expect(metrics).toContainText("Offers0");
     await expect(metrics).toContainText("Assessments1");
+    await expect(metrics).toContainText("Application responses4");
     await expect(metrics).toContainText("Application response rate27%");
     await expect(metrics).toContainText("4 of 15 applications");
     await expect(metrics).toContainText("Outreach reply rate29%");

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -84,19 +84,51 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationsWithResponse).toBe(5);
   });
 
-  it("counts hiring-manager lifecycle replies as outreach replies", async () => {
-    const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
-      exportedAt,
+  it(
+    "dedupes hiring-manager lifecycle replies already represented by compact metadata",
+    async () => {
+      const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
+        exportedAt,
+      });
+      const lifecycle = importLifecycle(
+        await lifecycleFixture("employer-reply-lifecycle-regression.csv"),
+        bundle,
+      );
+
+      const metrics = selectDashboardMetrics(mergeBundle(bundle, lifecycle));
+
+      expect(metrics.outreachReplies).toBe(2);
+      expect(metrics.applicationsWithResponse).toBe(4);
+      expect(metrics.interviews).toBe(0);
+    },
+  );
+
+  it("counts lifecycle-only hiring-manager replies as outreach replies", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_lifecycle_reply",
+          company: "Lifecycle Reply",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_lifecycle_reply",
+          applicationId: "app_lifecycle_reply",
+          eventType: "hiring_manager_reply",
+          occurredAt: timestamp,
+          createdAt: timestamp,
+        },
+      ],
     });
-    const lifecycle = importLifecycle(
-      await lifecycleFixture("employer-reply-lifecycle-regression.csv"),
-      bundle,
-    );
 
-    const metrics = selectDashboardMetrics(mergeBundle(bundle, lifecycle));
-
-    expect(metrics.outreachReplies).toBe(4);
-    expect(metrics.applicationsWithResponse).toBe(4);
+    expect(metrics.outreachReplies).toBe(1);
+    expect(metrics.applicationsWithResponse).toBe(1);
     expect(metrics.interviews).toBe(0);
   });
 

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -84,7 +84,7 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationsWithResponse).toBe(5);
   });
 
-  it("counts hiring-manager replies as responses, not interviews", async () => {
+  it("counts hiring-manager lifecycle replies as outreach replies", async () => {
     const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
       exportedAt,
     });
@@ -95,6 +95,7 @@ describe("tracker dashboard metrics", () => {
 
     const metrics = selectDashboardMetrics(mergeBundle(bundle, lifecycle));
 
+    expect(metrics.outreachReplies).toBe(4);
     expect(metrics.applicationsWithResponse).toBe(4);
     expect(metrics.interviews).toBe(0);
   });
@@ -241,6 +242,27 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.outreachReplies).toBe(1);
     expect(metrics.outreachReplyRate).toBe(100);
     expect(metrics.applicationsWithResponse).toBe(1);
+  });
+
+  it("ignores non-outbound compact outreach statuses for sent outreach", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const applications = ["not_started", "pending", "", "snoozed"].map(
+      (status, index) => ({
+        id: `app_non_outbound_${index}`,
+        company: "Example",
+        role: "Engineer",
+        status: "applied",
+        notes: `Spreadsheet metadata: {"outreach_status":"${status}"}`,
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      }),
+    );
+
+    const metrics = selectDashboardMetrics({ applications });
+
+    expect(metrics.outreachSent).toBe(0);
+    expect(metrics.outreachReplies).toBe(0);
+    expect(metrics.outreachReplyRate).toBe(0);
   });
 
   it("dedupes compact reply metadata represented by inbound outreach", () => {
@@ -401,9 +423,9 @@ describe("tracker dashboard metrics", () => {
       ],
       interviews: [
         {
-          id: "interview_technical",
+          id: "interview_technical_screen",
           applicationId: "app_interview",
-          stage: "technical",
+          stage: "technical_screen",
           startsAt: timestamp,
           createdAt: timestamp,
         },

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -188,6 +188,14 @@ describe("tracker dashboard metrics", () => {
           createdAt: timestamp,
           updatedAt: timestamp,
         },
+        {
+          id: "app_offer_event",
+          company: "Offer Event",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
       ],
       offers: [
         { id: "offer_one", applicationId: "app_offer", createdAt: timestamp },
@@ -197,10 +205,19 @@ describe("tracker dashboard metrics", () => {
           createdAt: timestamp,
         },
       ],
+      lifecycleEvents: [
+        {
+          id: "event_offer_received",
+          applicationId: "app_offer_event",
+          eventType: "offer_received",
+          occurredAt: timestamp,
+          createdAt: timestamp,
+        },
+      ],
     });
 
     expect(metrics.offers).toBe(2);
-    expect(metrics.applicationsWithResponse).toBe(2);
+    expect(metrics.applicationsWithResponse).toBe(3);
   });
 
   it("counts compact replied outreach statuses as sent outreach when text is absent", () => {
@@ -256,21 +273,13 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationsWithResponse).toBe(1);
   });
 
-  it("counts recruiter-screen completions and interview records as responses", () => {
+  it("counts lifecycle-only recruiter-screen completions as responses", () => {
     const timestamp = "2026-01-01T00:00:00.000Z";
     const metrics = selectDashboardMetrics({
       applications: [
         {
           id: "app_screen",
           company: "Screen",
-          role: "Engineer",
-          status: "applied",
-          createdAt: timestamp,
-          updatedAt: timestamp,
-        },
-        {
-          id: "app_interview",
-          company: "Interview",
           role: "Engineer",
           status: "applied",
           createdAt: timestamp,
@@ -286,6 +295,67 @@ describe("tracker dashboard metrics", () => {
           createdAt: timestamp,
         },
       ],
+    });
+
+    expect(metrics.recruiterScreens).toBe(1);
+    expect(metrics.interviews).toBe(0);
+    expect(metrics.applicationsWithResponse).toBe(1);
+    expect(metrics.applicationResponseRate).toBe(100);
+  });
+
+  it("counts replied outreach records as outreach replies and application responses", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_outreach_reply",
+          company: "Outreach",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      outreachMessages: [
+        {
+          id: "message_outbound",
+          applicationId: "app_outreach_reply",
+          direction: "outbound",
+          channel: "email",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+        {
+          id: "message_reply",
+          applicationId: "app_outreach_reply",
+          direction: "outbound",
+          status: "replied",
+          channel: "email",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+    });
+
+    expect(metrics.outreachSent).toBe(2);
+    expect(metrics.outreachReplies).toBe(1);
+    expect(metrics.applicationsWithResponse).toBe(1);
+    expect(metrics.applicationResponseRate).toBe(100);
+  });
+
+  it("counts interview records as responses while preserving interview counts", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_interview",
+          company: "Interview",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
       interviews: [
         {
           id: "interview_technical",
@@ -297,10 +367,9 @@ describe("tracker dashboard metrics", () => {
       ],
     });
 
-    expect(metrics.recruiterScreens).toBe(1);
+    expect(metrics.recruiterScreens).toBe(0);
     expect(metrics.interviews).toBe(1);
-    expect(metrics.applicationsWithResponse).toBe(2);
-    expect(metrics.applicationResponseRate).toBe(100);
+    expect(metrics.applicationsWithResponse).toBe(1);
   });
 
   it("guards response percentages when child records exceed applications", () => {

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -229,6 +229,14 @@ describe("tracker dashboard metrics", () => {
           createdAt: timestamp,
           updatedAt: timestamp,
         },
+        {
+          id: "app_offer_status_event",
+          company: "Offer Status Event",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
       ],
       offers: [
         { id: "offer_one", applicationId: "app_offer", createdAt: timestamp },
@@ -246,11 +254,19 @@ describe("tracker dashboard metrics", () => {
           occurredAt: timestamp,
           createdAt: timestamp,
         },
+        {
+          id: "event_offer_status",
+          applicationId: "app_offer_status_event",
+          eventType: "status_change",
+          status: "accepted",
+          occurredAt: timestamp,
+          createdAt: timestamp,
+        },
       ],
     });
 
-    expect(metrics.offers).toBe(3);
-    expect(metrics.applicationsWithResponse).toBe(3);
+    expect(metrics.offers).toBe(4);
+    expect(metrics.applicationsWithResponse).toBe(4);
   });
 
   it("counts compact replied outreach statuses as sent outreach when text is absent", () => {

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -1,0 +1,211 @@
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  csvToBrowserApplicationExport,
+  lifecycleRowsToBrowserApplicationExport,
+  parseCsv,
+} from "../src/web/import-export/spreadsheet.js";
+import {
+  boundedPercentage,
+  selectDashboardMetrics,
+} from "../src/web/tracker/metrics.js";
+
+const exportedAt = "2026-03-10T00:00:00.000Z";
+const compactFixture = async () =>
+  readFile("test/fixtures/tracker-import/compact-main-regression.csv", "utf8");
+const lifecycleFixture = async (name) =>
+  readFile(`test/fixtures/tracker-import/${name}`, "utf8");
+const mergeBundle = (base, supplemental) => ({
+  ...base,
+  lifecycleEvents: [
+    ...(base.lifecycleEvents ?? []),
+    ...(supplemental.lifecycleEvents ?? []),
+  ],
+  interviews: [...(base.interviews ?? []), ...(supplemental.interviews ?? [])],
+  reminders: [...(base.reminders ?? []), ...(supplemental.reminders ?? [])],
+});
+const importLifecycle = (csv, existing) =>
+  lifecycleRowsToBrowserApplicationExport(parseCsv(csv), existing, {
+    exportedAt,
+  }).bundle;
+
+describe("tracker dashboard metrics", () => {
+  it("returns safe zero metrics for empty bundles", () => {
+    expect(selectDashboardMetrics({})).toMatchObject({
+      totalApplications: 0,
+      applicationResponseRate: 0,
+      outreachReplyRate: 0,
+      applicationsWithResponse: 0,
+    });
+    expect(boundedPercentage(1, 0)).toBe(0);
+    expect(boundedPercentage(Number.POSITIVE_INFINITY, 1)).toBe(0);
+    expect(boundedPercentage(-1, 1)).toBe(0);
+  });
+
+  it("computes compact fixture application and outreach rates separately", async () => {
+    const { bundle, errors } = csvToBrowserApplicationExport(
+      await compactFixture(),
+      { exportedAt },
+    );
+    expect(errors).toEqual([]);
+
+    const metrics = selectDashboardMetrics(bundle);
+
+    expect(metrics).toMatchObject({
+      totalApplications: 15,
+      outreachSent: 7,
+      outreachReplies: 2,
+      applicationsWithResponse: 4,
+      applicationResponseRate: 27,
+      outreachReplyRate: 29,
+      recruiterScreens: 0,
+      interviews: 0,
+      assessments: 1,
+      offers: 0,
+    });
+    expect(metrics.applicationResponseRate).toBeLessThanOrEqual(100);
+  });
+
+  it("counts assessment lifecycle events as assessments, not interviews", async () => {
+    const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
+      exportedAt,
+    });
+    const lifecycle = importLifecycle(
+      await lifecycleFixture("assessment-lifecycle-regression.csv"),
+      bundle,
+    );
+
+    const metrics = selectDashboardMetrics(mergeBundle(bundle, lifecycle));
+
+    expect(metrics.assessments).toBe(3);
+    expect(metrics.interviews).toBe(0);
+    expect(metrics.applicationsWithResponse).toBe(5);
+  });
+
+  it("counts hiring-manager replies as responses, not interviews", async () => {
+    const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
+      exportedAt,
+    });
+    const lifecycle = importLifecycle(
+      await lifecycleFixture("employer-reply-lifecycle-regression.csv"),
+      bundle,
+    );
+
+    const metrics = selectDashboardMetrics(mergeBundle(bundle, lifecycle));
+
+    expect(metrics.applicationsWithResponse).toBe(4);
+    expect(metrics.interviews).toBe(0);
+  });
+
+  it("splits recruiter screens from non-recruiter-screen interviews", async () => {
+    const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
+      exportedAt,
+    });
+    const lifecycle = importLifecycle(
+      await lifecycleFixture("recruiter-screen-lifecycle-regression.csv"),
+      bundle,
+    );
+
+    const metrics = selectDashboardMetrics(mergeBundle(bundle, lifecycle));
+
+    expect(metrics.recruiterScreens).toBe(1);
+    expect(metrics.interviews).toBe(0);
+    expect(metrics.applicationsWithResponse).toBe(4);
+  });
+
+  it("dedupes multiple response child records to one responding application", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_multi_response",
+          company: "Example",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      outreachMessages: [
+        {
+          id: "message_inbound",
+          applicationId: "app_multi_response",
+          direction: "inbound",
+          channel: "email",
+          receivedAt: timestamp,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_reply",
+          applicationId: "app_multi_response",
+          status: "outreach_sent",
+          eventType: "hiring_manager_reply",
+          occurredAt: timestamp,
+          source: "manual",
+          createdAt: timestamp,
+        },
+        {
+          id: "event_assessment",
+          applicationId: "app_multi_response",
+          status: "outreach_sent",
+          eventType: "written_assessment_requested",
+          occurredAt: timestamp,
+          source: "manual",
+          createdAt: timestamp,
+        },
+      ],
+      interviews: [],
+      offers: [],
+    });
+
+    expect(metrics.applicationsWithResponse).toBe(1);
+    expect(metrics.applicationResponseRate).toBe(100);
+    expect(metrics.outreachReplyRate).toBe(0);
+  });
+
+  it("guards response percentages when child records exceed applications", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const bundle = {
+      applications: [
+        {
+          id: "app_one",
+          company: "Example",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      outreachMessages: Array.from({ length: 5 }, (_, index) => ({
+        id: `message_${index}`,
+        applicationId: "app_one",
+        direction: index === 0 ? "outbound" : "inbound",
+        channel: "email",
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      })),
+      lifecycleEvents: Array.from({ length: 5 }, (_, index) => ({
+        id: `event_${index}`,
+        applicationId: "app_one",
+        status: "outreach_sent",
+        eventType: "hiring_manager_reply",
+        occurredAt: timestamp,
+        source: "manual",
+        createdAt: timestamp,
+      })),
+      interviews: [],
+      offers: [],
+    };
+
+    const metrics = selectDashboardMetrics(bundle);
+
+    expect(metrics.applicationsWithResponse).toBe(1);
+    expect(metrics.applicationResponseRate).toBe(100);
+    expect(metrics.outreachReplyRate).toBe(100);
+  });
+});

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -216,7 +216,7 @@ describe("tracker dashboard metrics", () => {
       ],
     });
 
-    expect(metrics.offers).toBe(2);
+    expect(metrics.offers).toBe(3);
     expect(metrics.applicationsWithResponse).toBe(3);
   });
 

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -79,7 +79,7 @@ describe("tracker dashboard metrics", () => {
 
     const metrics = selectDashboardMetrics(mergeBundle(bundle, lifecycle));
 
-    expect(metrics.assessments).toBe(3);
+    expect(metrics.assessments).toBe(2);
     expect(metrics.interviews).toBe(0);
     expect(metrics.applicationsWithResponse).toBe(5);
   });
@@ -166,6 +166,141 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationsWithResponse).toBe(1);
     expect(metrics.applicationResponseRate).toBe(100);
     expect(metrics.outreachReplyRate).toBe(0);
+  });
+
+  it("dedupes overlapping offer records and offer statuses by application", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_offer",
+          company: "Example",
+          role: "Engineer",
+          status: "offer",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+        {
+          id: "app_accepted",
+          company: "Accepted",
+          role: "Engineer",
+          status: "accepted",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      offers: [
+        { id: "offer_one", applicationId: "app_offer", createdAt: timestamp },
+        {
+          id: "offer_two",
+          applicationId: "app_accepted",
+          createdAt: timestamp,
+        },
+      ],
+    });
+
+    expect(metrics.offers).toBe(2);
+    expect(metrics.applicationsWithResponse).toBe(2);
+  });
+
+  it("counts compact replied outreach statuses as sent outreach when text is absent", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_reply",
+          company: "Example",
+          role: "Engineer",
+          status: "applied",
+          notes:
+            'Spreadsheet metadata: {"outreach_status":"replied","outreach_message_text":""}',
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+    });
+
+    expect(metrics.outreachSent).toBe(1);
+    expect(metrics.outreachReplies).toBe(1);
+    expect(metrics.outreachReplyRate).toBe(100);
+    expect(metrics.applicationsWithResponse).toBe(1);
+  });
+
+  it("dedupes compact and lifecycle assessment signals by application", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_assessment",
+          company: "Example",
+          role: "Engineer",
+          status: "applied",
+          notes:
+            'Spreadsheet metadata: {"spreadsheet_interview_stage":"Written assessment submitted"}',
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_assessment",
+          applicationId: "app_assessment",
+          eventType: "written_assessment",
+          occurredAt: timestamp,
+          createdAt: timestamp,
+        },
+      ],
+    });
+
+    expect(metrics.assessments).toBe(1);
+    expect(metrics.applicationsWithResponse).toBe(1);
+  });
+
+  it("counts recruiter-screen completions and interview records as responses", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_screen",
+          company: "Screen",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+        {
+          id: "app_interview",
+          company: "Interview",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_screen",
+          applicationId: "app_screen",
+          eventType: "recruiter_screen_completed",
+          occurredAt: timestamp,
+          createdAt: timestamp,
+        },
+      ],
+      interviews: [
+        {
+          id: "interview_technical",
+          applicationId: "app_interview",
+          stage: "technical",
+          startsAt: timestamp,
+          createdAt: timestamp,
+        },
+      ],
+    });
+
+    expect(metrics.recruiterScreens).toBe(1);
+    expect(metrics.interviews).toBe(1);
+    expect(metrics.applicationsWithResponse).toBe(2);
+    expect(metrics.applicationResponseRate).toBe(100);
   });
 
   it("guards response percentages when child records exceed applications", () => {

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -243,6 +243,49 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationsWithResponse).toBe(1);
   });
 
+  it("dedupes compact reply metadata represented by inbound outreach", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_reply_overlap",
+          company: "Overlap",
+          role: "Engineer",
+          status: "applied",
+          notes: [
+            "Spreadsheet metadata:",
+            '{"outreach_status":"replied","outreach_message_text":"Checking in"}',
+          ].join(" "),
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      outreachMessages: [
+        {
+          id: "message_outbound",
+          applicationId: "app_reply_overlap",
+          direction: "outbound",
+          channel: "email",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+        {
+          id: "message_inbound",
+          applicationId: "app_reply_overlap",
+          direction: "inbound",
+          channel: "email",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+    });
+
+    expect(metrics.outreachSent).toBe(1);
+    expect(metrics.outreachReplies).toBe(1);
+    expect(metrics.outreachReplyRate).toBe(100);
+    expect(metrics.applicationsWithResponse).toBe(1);
+  });
+
   it("dedupes compact and lifecycle assessment signals by application", () => {
     const timestamp = "2026-01-01T00:00:00.000Z";
     const metrics = selectDashboardMetrics({


### PR DESCRIPTION
### Motivation
- Make dashboard metric semantics explicit and deterministic so child-record counts cannot inflate application-level response rates.  
- Prevent impossible values (e.g. >100% response rates or `NaN%`) by clamping/guarding arithmetic and using unique-application deduping.  
- Surface distinct concepts (outreach messages, outreach replies, assessments, recruiter screens, interviews, offers) so UI cards are accurate and testable.  

### Description
- Added a pure, DOM-independent selector `selectDashboardMetrics` in `src/web/tracker/metrics.js` that computes `totalApplications`, `outreachSent`, `outreachReplies`, `applicationsWithResponse`, `applicationResponseRate`, `outreachReplyRate`, `recruiterScreens`, `interviews`, `assessments`, and `offers`, with deduping and bounded percentage guards.  
- Updated the tracker UI (`src/web/tracker/tracker.js`) to consume the selector output and render accessible numerator/denominator sublabels (for example `4 of 15 applications` and `2 of 7 outreach messages`).  
- Added fixture-backed unit tests in `test/web-tracker-metrics.test.js` covering empty bundles, compact-only fixtures, lifecycle-only child records, duplicate child records, and regression guards.  
- Updated the Playwright browser tracker test `test/playwright/browser-tracker.spec.js` to assert the corrected bounded dashboard cards instead of using the prior expected-failure marker.  

### Testing
- `npm ci` — passed.  
- `npx vitest run test/web-tracker-metrics.test.js` — passed (new metric unit tests).  
- `npx playwright install chromium && npx playwright test test/playwright/browser-tracker.spec.js --grep "bounded dashboard metrics"` — passed (browser E2E verifies dashboard cards).  
- `npm run build` — passed (static tracker built into `dist/`).  
- `npm run format:check` — ran and reported pre-existing repository-wide formatting drift unrelated to this focused change (not modified here).  
- `npm run lint` — passed after ignoring transient `dist/` build artifacts in the local run.  
- `npm run typecheck` — passed.  
- `npm run test:ci` — passed (full test suite).  

Notes: formatting drift reported by `format:check` is pre-existing and outside this focused change set; consider a separate formatting pass if desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4df20c8808832fa43b4b63a49e54c7)