### PR TITLE
Polish browser tracker import and lifecycle UX

### DIFF
--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -490,6 +490,7 @@ export const lifecycleRowsToBrowserApplicationExport = (
   const lifecycleEvents = [];
   const interviews = [];
   const reminders = [];
+  const warnings = [];
   rows.forEach((sourceRow, index) => {
     const rowNumber = index + 2;
     const row = { ...blankLifecycleRow(), ...sourceRow };
@@ -507,7 +508,8 @@ export const lifecycleRowsToBrowserApplicationExport = (
       });
       return;
     }
-    const eventType = normalizeLabelKey(row.event_type) || "lifecycle_event";
+    const rawEventType = compact(row.event_type);
+    const eventType = normalizeLabelKey(rawEventType) || "lifecycle_event";
     const occurredAt = parseDate(
       row.occurred_at,
       "occurred_at",
@@ -517,8 +519,20 @@ export const lifecycleRowsToBrowserApplicationExport = (
     const dueAt = parseDate(row.due_at, "due_at", rowNumber, errors);
     const eventOccurredAt = occurredAt ?? dueAt ?? "1970-01-01T00:00:00.000Z";
     const stageLabel = compact(row.stage) || undefined;
+    const knownLifecycleStatus = lifecycleStatusForEvent(eventType);
+    if (
+      !knownLifecycleStatus &&
+      !["lifecycle_event", "next_tracking_step"].includes(eventType)
+    )
+      warnings.push({
+        rowNumber,
+        field: "event_type",
+        code: "unsupported_event_type",
+        value: rawEventType || eventType,
+        message: "Imported as a generic lifecycle event.",
+      });
     const status =
-      lifecycleStatusForEvent(eventType) ??
+      knownLifecycleStatus ??
       mapStatus({ status: "", interview_stage: stageLabel ?? "", outcome: "" });
     const sourceArtifact = compact(row.source_artifact) || undefined;
     const details = compact(row.details) || undefined;
@@ -604,7 +618,7 @@ export const lifecycleRowsToBrowserApplicationExport = (
     artifacts: [],
     reminders,
   };
-  return { bundle, errors };
+  return { bundle, errors, warnings };
 };
 
 export const csvToSupplementalLifecycleExport = (csvText, existing, options) =>
@@ -615,6 +629,7 @@ export const rowsToBrowserApplicationExport = (
   { exportedAt = nowIso() } = {},
 ) => {
   const errors = [];
+  const warnings = [];
   const applications = [],
     contacts = [],
     outreachMessages = [],
@@ -827,6 +842,14 @@ export const rowsToBrowserApplicationExport = (
         updatedAt: exportedAt,
       });
     } else if (NON_INTERVIEW_STAGE_LABELS.has(stageLabel)) {
+      warnings.push({
+        rowNumber: index + 2,
+        field: "interview_stage",
+        code: "ignored_non_interview_stage",
+        value: compact(row.interview_stage),
+        message:
+          "Non-interview stage label preserved in metadata without creating an interview.",
+      });
       const nonInterviewStatus =
         stageLabel === "application_rejected" ? "rejected" : undefined;
       if (nonInterviewStatus)
@@ -888,7 +911,7 @@ export const rowsToBrowserApplicationExport = (
       code: "schema_validation_failed",
       message: parsed.error.message,
     });
-  return { bundle, errors };
+  return { bundle, errors, warnings };
 };
 
 export const csvToBrowserApplicationExport = (csvText, options) =>
@@ -1077,7 +1100,7 @@ export const importNdjsonBackup = (text) => {
 };
 export const previewCompactCsvImport = async (csvText, repository) => {
   const rows = parseCsv(csvText);
-  const { bundle, errors } = rowsToBrowserApplicationExport(rows);
+  const { bundle, errors, warnings } = rowsToBrowserApplicationExport(rows);
   const existing = repository
     ? await repository.exportAllData()
     : { applications: [] };
@@ -1121,6 +1144,28 @@ export const previewCompactCsvImport = async (csvText, repository) => {
         value: application.postingUrl,
       });
   });
+  for (const store of [
+    "applications",
+    "contacts",
+    "outreachMessages",
+    "lifecycleEvents",
+    "interviews",
+    "offers",
+    "artifacts",
+    "reminders",
+  ]) {
+    const seen = new Set();
+    bundle[store] = (bundle[store] ?? []).filter((record) => {
+      if (seen.has(record.id)) return false;
+      seen.add(record.id);
+      return true;
+    });
+  }
+  const blockingErrors = conflicts.some(
+    (conflict) => conflict.code === "duplicate_in_file",
+  )
+    ? errors.filter((error) => error.code !== "schema_validation_failed")
+    : errors;
   return {
     rowCount: rows.length,
     validRowCount: Math.max(
@@ -1132,8 +1177,9 @@ export const previewCompactCsvImport = async (csvText, repository) => {
             .filter((rowNumber) => Number.isInteger(rowNumber)),
         ).size,
     ),
-    errors,
+    errors: blockingErrors,
     conflicts,
+    warnings,
     bundle,
   };
 };
@@ -1237,7 +1283,7 @@ export const previewSupplementalLifecycleCsvImport = async (
 ) => {
   const rows = parseCsv(csvText);
   const existing = await repository.exportAllData();
-  const { bundle, errors } = csvToSupplementalLifecycleExport(
+  const { bundle, errors, warnings } = csvToSupplementalLifecycleExport(
     csvText,
     existing,
   );
@@ -1286,6 +1332,7 @@ export const previewSupplementalLifecycleCsvImport = async (
     ),
     errors,
     conflicts,
+    warnings,
     bundle,
   };
 };

--- a/src/web/tracker/index.html
+++ b/src/web/tracker/index.html
@@ -64,6 +64,36 @@
               <option>withdrawn</option>
               <option>closed_archived</option>
             </select></label
+          ><label
+            ><span>Response</span
+            ><select data-filter="response">
+              <option value="">All response states</option>
+              <option value="responded">Employer responded</option>
+              <option value="no_response">No response yet</option>
+            </select></label
+          ><label
+            ><span>Outreach</span
+            ><select data-filter="outreach">
+              <option value="">All outreach states</option>
+              <option value="sent">Outreach sent</option>
+              <option value="none">No outreach</option>
+            </select></label
+          ><label
+            ><span>Follow-up</span
+            ><select data-filter="follow-up">
+              <option value="">All follow-ups</option>
+              <option value="due">Due or overdue</option>
+              <option value="scheduled">Scheduled later</option>
+              <option value="none">No follow-up</option>
+            </select></label
+          ><label
+            ><span>Activity</span
+            ><select data-filter="activity">
+              <option value="">All activity</option>
+              <option value="assessment">Assessments/take-homes</option>
+              <option value="recruiter_screen">Recruiter screens</option>
+              <option value="terminal">Terminal outcomes</option>
+            </select></label
           >
         </form>
         <p data-empty-state class="muted">
@@ -117,7 +147,15 @@
                 Apply import
               </button>
             </div>
-            <pre data-import-result class="muted"></pre>
+            <div
+              data-import-result
+              class="import-preview muted"
+              role="status"
+              aria-live="polite"
+            >
+              Select Preview/dry-run to validate the selected file before
+              applying.
+            </div>
           </article>
           <article class="card">
             <h3>Export backups</h3>

--- a/src/web/tracker/tracker.css
+++ b/src/web/tracker/tracker.css
@@ -31,6 +31,18 @@
   padding: 1rem;
   background: var(--card-surface, #111827);
 }
+.metric-screen {
+  border-color: rgba(56, 189, 248, 0.6);
+}
+.metric-interview {
+  border-color: rgba(167, 139, 250, 0.65);
+}
+.metric-assessment {
+  border-color: rgba(251, 191, 36, 0.7);
+}
+.metric-offer {
+  border-color: rgba(74, 222, 128, 0.65);
+}
 .metric strong {
   display: block;
   font-size: 1.6rem;
@@ -74,6 +86,31 @@
 .tracker-table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
+}
+.table-container {
+  overflow-x: auto;
+}
+.tracker-table td {
+  overflow-wrap: anywhere;
+}
+.table-note {
+  display: block;
+  max-width: 36rem;
+}
+.clip-cell {
+  max-width: 18rem;
+}
+.chip {
+  display: inline-block;
+  border: 1px solid var(--card-border, #334155);
+  border-radius: 999px;
+  padding: 0.12rem 0.45rem;
+  margin: 0.1rem;
+  background: rgba(148, 163, 184, 0.12);
+}
+.chip-warning {
+  border-color: rgba(251, 191, 36, 0.7);
 }
 .tracker-view[hidden],
 .hidden {
@@ -84,10 +121,67 @@
   grid-template-columns: minmax(260px, 1fr) minmax(260px, 1fr);
   gap: 1rem;
 }
+.wide-card {
+  grid-column: 1 / -1;
+}
 .timeline {
   display: grid;
   gap: 0.5rem;
-  padding-left: 1.25rem;
+  padding-left: 0;
+  list-style: none;
+}
+.timeline-item {
+  border-left: 4px solid var(--card-border, #334155);
+  border-radius: 0.75rem;
+  padding: 0.75rem;
+  background: rgba(15, 23, 42, 0.45);
+}
+.timeline-recruiter {
+  border-left-color: #38bdf8;
+}
+.timeline-assessment {
+  border-left-color: #fbbf24;
+}
+.timeline-meta {
+  display: grid;
+  gap: 0.25rem;
+  margin-top: 0.4rem;
+}
+.metadata-list {
+  display: grid;
+  gap: 0.45rem;
+}
+.metadata-list div {
+  display: grid;
+  grid-template-columns: minmax(9rem, 0.45fr) 1fr;
+  gap: 0.5rem;
+}
+.metadata-list dt {
+  color: var(--muted, #94a3b8);
+}
+.metadata-list dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+.import-preview {
+  white-space: normal;
+}
+.import-preview ul {
+  margin-top: 0.25rem;
+}
+.button:disabled,
+.tracker-nav button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+.button:focus-visible,
+.tracker-nav button:focus-visible,
+.tracker-form input:focus-visible,
+.tracker-form select:focus-visible,
+.tracker-form textarea:focus-visible,
+.tracker-table th button:focus-visible {
+  outline: 3px solid var(--accent, #38bdf8);
+  outline-offset: 2px;
 }
 .muted {
   color: var(--muted, #94a3b8);

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -264,19 +264,42 @@ const hasMetadataAssessmentSignal = (metadata = {}) =>
       normalize(value).includes("assessment") ||
       normalize(value).includes("take_home"),
   );
+const TERMINAL_EMPLOYER_STATUSES = new Set([
+  "offer",
+  "accepted",
+  "rejected",
+  "closed_archived",
+]);
+const COMPACT_OUTREACH_REPLY_STATUSES = new Set([
+  "replied",
+  "reply",
+  "responded",
+]);
+const RESPONSE_EVENT_TYPES = new Set([
+  "hiring_manager_reply",
+  "written_assessment_requested",
+  "recruiter_screen_scheduled",
+  "recruiter_screen_completed",
+  "offer",
+  "offer_received",
+]);
 const hasMetadataResponseSignal = (metadata = {}) =>
-  [metadata.outreach_status, metadata.spreadsheet_interview_stage].some(
-    (value) =>
-      [
-        "replied",
-        "responded",
-        "response_received",
-        "written_assessment_submitted",
-        "written_assessment_requested",
-        "recruiter_screen_scheduled",
-        "interview_scheduled",
-      ].includes(normalize(value)),
-  );
+  COMPACT_OUTREACH_REPLY_STATUSES.has(normalize(metadata.outreach_status)) ||
+  hasMetadataAssessmentSignal(metadata);
+const hasListResponseSignal = (app, meta, metadata = {}) =>
+  TERMINAL_EMPLOYER_STATUSES.has(app.status) ||
+  meta.interviews.length > 0 ||
+  meta.outreach.some(
+    (x) =>
+      normalize(x.direction) === "inbound" ||
+      COMPACT_OUTREACH_REPLY_STATUSES.has(normalize(x.status)),
+  ) ||
+  meta.lifecycle.some(
+    (x) =>
+      RESPONSE_EVENT_TYPES.has(normalize(x.eventType)) ||
+      TERMINAL_EMPLOYER_STATUSES.has(normalize(x.status)),
+  ) ||
+  hasMetadataResponseSignal(metadata);
 function metadataEntries(app) {
   const metadata = readSpreadsheetMetadata(app.notes);
   return Object.entries({
@@ -440,17 +463,7 @@ function renderList() {
   let rows = state.apps.filter((a) => {
     const m = appMeta(a);
     const metadata = readSpreadsheetMetadata(a.notes);
-    const hasResponse =
-      ["offer", "accepted", "rejected", "closed_archived"].includes(a.status) ||
-      m.outreach.some((x) => x.direction === "inbound") ||
-      m.lifecycle.some((x) =>
-        [
-          "hiring_manager_reply",
-          "written_assessment_requested",
-          "recruiter_screen_scheduled",
-        ].includes(normalize(x.eventType)),
-      ) ||
-      hasMetadataResponseSignal(metadata);
+    const hasResponse = hasListResponseSignal(a, m, metadata);
     const outreachState =
       m.outreach.length || metadata.outreach_status ? "sent" : "none";
     const dueState =

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -11,7 +11,7 @@ import {
   importNdjsonBackup,
   previewSupplementalLifecycleCsvImport,
 } from "../import-export/spreadsheet.js";
-import { selectDashboardMetrics } from "./metrics.js";
+import { readSpreadsheetMetadata, selectDashboardMetrics } from "./metrics.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
 const ARRAY_STORES = [
@@ -214,9 +214,69 @@ function linkForArtifact(artifact) {
     ? `<a href="${esc(href)}" rel="noopener noreferrer">${esc(artifact.name)}</a>`
     : esc(artifact.name);
 }
+function safeArtifactLink(value, label = value) {
+  const raw = String(value ?? "").trim();
+  if (!raw) return "";
+  let href = "";
+  try {
+    const url = new URL(raw);
+    if (["http:", "https:"].includes(url.protocol)) href = url.toString();
+  } catch {
+    href = "";
+  }
+  return href
+    ? `<a href="${esc(href)}" rel="noopener noreferrer" target="_blank">${esc(label)}</a>`
+    : esc(raw);
+}
 function fitScore(notes) {
   return String(notes || "").match(/fit_score_100[":\s]+([\d.]+)/)?.[1] || "";
 }
+const normalize = (value) =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+const isAssessmentEvent = (record = {}) =>
+  [
+    record.eventType,
+    record.stageLabel,
+    record.status,
+    record.note,
+    record.details,
+  ]
+    .map(normalize)
+    .some(
+      (value) => value.includes("assessment") || value.includes("take_home"),
+    );
+const isRecruiterScreen = (record = {}) =>
+  normalize(record.stage) === "recruiter_screen" ||
+  normalize(record.status) === "recruiter_screen" ||
+  normalize(record.eventType).startsWith("recruiter_screen");
+function metadataEntries(app) {
+  const metadata = readSpreadsheetMetadata(app.notes);
+  return Object.entries({
+    "Raw status": metadata.spreadsheet_status,
+    "Raw stage": metadata.spreadsheet_interview_stage,
+    "Raw outcome": metadata.spreadsheet_outcome,
+    "Outreach status": metadata.outreach_status,
+    "Outreach channel": metadata.outreach_channel,
+    "Follow-up date": day(app.followUpDate),
+    "Application URL": metadata.application_url,
+    "Posting ID": metadata.posting_id,
+    "Work model": metadata.work_model,
+    "Compensation min": metadata.compensation_min_usd,
+    "Compensation max": metadata.compensation_max_usd,
+    "Cover letter submitted": metadata.cover_letter_submitted,
+    "Fit score": metadata.fit_score_100,
+    "Schema version": metadata.schema_version,
+  }).filter(([, value]) => value !== undefined && value !== "");
+}
+const metadataText = (app) =>
+  metadataEntries(app)
+    .map(([label, value]) => `${label}: ${value}`)
+    .join(" · ");
 async function refresh() {
   state.bundle = await repo.exportAll();
   state.apps = state.bundle.applications.sort((a, b) =>
@@ -255,41 +315,66 @@ function renderDashboard() {
   const b = state.bundle;
   const metrics = selectDashboardMetrics(b);
   const cards = [
-    ["Total applications", metrics.totalApplications, "Application records"],
-    ["Outreach sent", metrics.outreachSent, "Outbound outreach messages"],
+    [
+      "Total applications",
+      metrics.totalApplications,
+      "Applications being tracked",
+      "volume",
+    ],
+    [
+      "Outreach sent",
+      metrics.outreachSent,
+      "Outbound outreach messages",
+      "outreach",
+    ],
     [
       "Outreach replies",
       metrics.outreachReplies,
-      "Inbound or replied outreach messages",
+      `${metrics.outreachReplies} of ${metrics.outreachSent} outreach messages`,
+      "outreach",
     ],
     [
       "Recruiter screens",
       metrics.recruiterScreens,
-      "Recruiter-screen interviews/events",
+      "Recruiter-screen events, separate from interviews",
+      "screen",
     ],
-    ["Interviews", metrics.interviews, "Non-recruiter-screen interviews"],
-    ["Assessments", metrics.assessments, "Written assessments/take-homes"],
-    ["Offers", metrics.offers, "Offer records or offer outcomes"],
+    [
+      "Interviews",
+      metrics.interviews,
+      "Technical, onsite, or other non-recruiter interviews",
+      "interview",
+    ],
+    [
+      "Assessments",
+      metrics.assessments,
+      "Written assessments and take-homes, not interviews",
+      "assessment",
+    ],
+    ["Offers", metrics.offers, "Offer records or offer outcomes", "offer"],
     [
       "Application responses",
       metrics.applicationsWithResponse,
-      "Applications with employer response signals",
+      `${metrics.applicationsWithResponse} of ${metrics.totalApplications} applications`,
+      "response",
     ],
     [
       "Application response rate",
       `${metrics.applicationResponseRate}%`,
       `${metrics.applicationsWithResponse} of ${metrics.totalApplications} applications`,
+      "response",
     ],
     [
       "Outreach reply rate",
       `${metrics.outreachReplyRate}%`,
       `${metrics.outreachReplies} of ${metrics.outreachSent} outreach messages`,
+      "outreach",
     ],
   ];
   $("[data-metrics]").innerHTML = cards
     .map(
-      ([label, value, help]) =>
-        `<div class="metric" aria-label="${esc(label)}: ${esc(value)} (${esc(help)})"><span>${esc(label)}</span><strong>${esc(value)}</strong><small class="muted">${esc(help)}</small></div>`,
+      ([label, value, help, kind]) =>
+        `<div class="metric metric-${esc(kind)}" aria-label="${esc(label)}: ${esc(value)} (${esc(help)})"><span>${esc(label)}</span><strong>${esc(value)}</strong><small class="muted">${esc(help || "No records yet")}</small></div>`,
     )
     .join("");
   const weeks = {};
@@ -307,6 +392,7 @@ function appMeta(app) {
   const b = state.bundle;
   return {
     outreach: b.outreachMessages.filter((x) => x.applicationId === app.id),
+    lifecycle: b.lifecycleEvents.filter((x) => x.applicationId === app.id),
     interviews: b.interviews.filter((x) => x.applicationId === app.id),
     offers: b.offers.filter((x) => x.applicationId === app.id),
     artifacts: b.artifacts.filter((x) => x.applicationId === app.id),
@@ -319,19 +405,64 @@ function outcomeForApp(app, meta = appMeta(app)) {
 function renderList() {
   const q = $('[data-filter="query"]').value.toLowerCase(),
     st = $('[data-filter="status"]').value,
-    out = $('[data-filter="outcome"]').value;
-  const hasActiveFilters = Boolean(q || st || out);
+    out = $('[data-filter="outcome"]').value,
+    response = $('[data-filter="response"]').value,
+    outreach = $('[data-filter="outreach"]').value,
+    followUp = $('[data-filter="follow-up"]').value,
+    activity = $('[data-filter="activity"]').value;
+  const today = day(now());
+  const hasActiveFilters = Boolean(
+    q || st || out || response || outreach || followUp || activity,
+  );
   let rows = state.apps.filter((a) => {
     const m = appMeta(a);
+    const metadata = readSpreadsheetMetadata(a.notes);
+    const hasResponse =
+      ["offer", "accepted", "rejected", "closed_archived"].includes(a.status) ||
+      m.outreach.some((x) => x.direction === "inbound") ||
+      m.lifecycle.some((x) =>
+        [
+          "hiring_manager_reply",
+          "written_assessment_requested",
+          "recruiter_screen_scheduled",
+        ].includes(normalize(x.eventType)),
+      );
+    const outreachState =
+      m.outreach.length || metadata.outreach_status ? "sent" : "none";
+    const dueState =
+      a.followUpDate && day(a.followUpDate) <= today
+        ? "due"
+        : a.followUpDate
+          ? "scheduled"
+          : "none";
+    const hasAssessment =
+      m.lifecycle.some(isAssessmentEvent) ||
+      [metadata.spreadsheet_interview_stage, metadata.spreadsheet_outcome].some(
+        (x) =>
+          normalize(x).includes("assessment") ||
+          normalize(x).includes("take_home"),
+      );
+    const hasRecruiter =
+      m.interviews.some(isRecruiterScreen) ||
+      m.lifecycle.some(isRecruiterScreen);
+    const terminal =
+      OUTCOMES.has(a.status) || OUTCOMES.has(outcomeForApp(a, m));
     return (
       (!q ||
-        [a.company, a.role, a.status, a.notes].some((x) =>
+        [a.company, a.role, a.status, a.notes, metadataText(a)].some((x) =>
           String(x || "")
             .toLowerCase()
             .includes(q),
         )) &&
       (!st || a.status === st) &&
-      (!out || outcomeForApp(a, m) === out)
+      (!out || outcomeForApp(a, m) === out) &&
+      (!response || (response === "responded" ? hasResponse : !hasResponse)) &&
+      (!outreach || outreachState === outreach) &&
+      (!followUp || dueState === followUp) &&
+      (!activity ||
+        (activity === "assessment" && hasAssessment) ||
+        (activity === "recruiter_screen" && hasRecruiter) ||
+        (activity === "terminal" && terminal))
     );
   });
   rows.sort(
@@ -348,7 +479,15 @@ function renderList() {
   $("[data-applications-table] tbody").innerHTML = rows
     .map((a) => {
       const m = appMeta(a);
-      return `<tr><td><button class="button" data-open="${esc(a.id)}">${esc(a.company)}</button></td><td>${esc(a.role)}</td><td>${esc(a.status)}</td><td>${day(a.appliedAt)}</td><td>${day(a.followUpDate)}</td><td>${m.outreach.length ? "sent" : "none"}</td><td>${esc(m.interviews.at(-1)?.stage || "")}</td><td>${esc(outcomeForApp(a, m))}</td><td>${esc(fitScore(a.notes))}</td><td>${m.artifacts.map(linkForArtifact).join(", ")}</td></tr>`;
+      const metadata = metadataText(a);
+      const latestInterview = m.interviews
+        .filter((item) => !isRecruiterScreen(item))
+        .at(-1);
+      const recruiterCount =
+        m.interviews.filter(isRecruiterScreen).length +
+        m.lifecycle.filter(isRecruiterScreen).length;
+      const assessmentCount = m.lifecycle.filter(isAssessmentEvent).length;
+      return `<tr><td><button class="button" data-open="${esc(a.id)}">${esc(a.company)}</button>${metadata ? `<small class="muted table-note">${esc(metadata)}</small>` : ""}</td><td>${esc(a.role)}</td><td><span class="chip">${esc(a.status)}</span></td><td>${day(a.appliedAt)}</td><td>${day(a.followUpDate) || "—"}</td><td>${esc(readSpreadsheetMetadata(a.notes).outreach_status || (m.outreach.length ? "sent" : "none"))}</td><td>${recruiterCount ? `<span class="chip">Recruiter screen ×${recruiterCount}</span>` : ""}${latestInterview ? `<span class="chip">Interview: ${esc(latestInterview.stage)}</span>` : ""}${assessmentCount ? `<span class="chip chip-warning">Assessment ×${assessmentCount}</span>` : ""}</td><td>${esc(outcomeForApp(a, m) || "—")}</td><td>${esc(fitScore(a.notes) || readSpreadsheetMetadata(a.notes).fit_score_100 || "")}</td><td class="clip-cell">${m.artifacts.map(linkForArtifact).join(", ")}</td></tr>`;
     })
     .join("");
   $$("[data-open]").forEach(
@@ -405,17 +544,74 @@ function renderAll() {
   renderFollowups();
   renderOutreach();
 }
+function sortedLifecycleEvents(appId) {
+  return [...state.bundle.lifecycleEvents]
+    .filter((e) => e.applicationId === appId)
+    .sort((a, b) => {
+      const left = a.occurredAt || a.dueAt || "";
+      const right = b.occurredAt || b.dueAt || "";
+      return (
+        left.localeCompare(right) || String(a.id).localeCompare(String(b.id))
+      );
+    });
+}
+function eventDetails(e) {
+  return Object.entries({
+    Type: e.eventType,
+    Stage: e.stageLabel,
+    Channel: e.channel,
+    Actor: e.actor,
+    "Source artifact": e.sourceArtifact
+      ? safeArtifactLink(e.sourceArtifact)
+      : "",
+    "Requires action":
+      e.requiresUserAction === undefined
+        ? ""
+        : e.requiresUserAction
+          ? "yes"
+          : "no",
+    "Action status": e.actionStatus,
+    "Due date": day(e.dueAt),
+    "No AI required":
+      e.noAiRequired === undefined ? "" : e.noAiRequired ? "yes" : "no",
+    Details: e.details || e.note,
+  })
+    .filter(([, value]) => value !== undefined && value !== "")
+    .map(
+      ([label, value]) =>
+        `<span><strong>${esc(label)}:</strong> ${label === "Source artifact" ? value : esc(value)}</span>`,
+    )
+    .join("");
+}
+function timelineItem(e) {
+  const kind = isAssessmentEvent(e)
+    ? "assessment"
+    : isRecruiterScreen(e)
+      ? "recruiter"
+      : "event";
+  const label =
+    kind === "assessment"
+      ? "Assessment/take-home"
+      : kind === "recruiter"
+        ? "Recruiter screen"
+        : "Lifecycle event";
+  return `<li class="timeline-item timeline-${kind}"><div><strong>${esc(label)}</strong> <span class="chip">${esc(e.status || e.eventType || "event")}</span></div><time>${esc(day(e.occurredAt) || day(e.dueAt) || "No date")}</time><div class="timeline-meta">${eventDetails(e)}</div></li>`;
+}
+function metadataSection(app) {
+  const entries = metadataEntries(app);
+  if (!entries.length)
+    return '<p class="muted">No compact CSV metadata for this application yet.</p>';
+  return `<dl class="metadata-list">${entries.map(([label, value]) => `<div><dt>${esc(label)}</dt><dd>${label.includes("URL") ? safeArtifactLink(value) : esc(value)}</dd></div>`).join("")}</dl>`;
+}
 function detailForm(app) {
   const m = appMeta(app);
-  return `<div class="tracker-detail"><article class="card"><h2>${esc(app.company || "New application")} — ${esc(app.role || "Unsaved")}</h2><form class="tracker-form" data-core-form>${input("company", app.company, true)}${input("role", app.role, true)}${input("postingUrl", app.postingUrl, "url")}<label>Status<select name="status" required>${STATUSES.map((s) => `<option ${app.status === s ? "selected" : ""}>${s}</option>`).join("")}</select></label>${input("source", app.source, "text")}${input("appliedAt", day(app.appliedAt), "date", true)}${input("followUpDate", day(app.followUpDate), "date")}<label>Notes<textarea name="notes">${esc(app.notes)}</textarea></label><button class="button">Save application</button></form></article><article class="card"><h3>Lifecycle timeline</h3><ul class="timeline">${
-    state.bundle.lifecycleEvents
-      .filter((e) => e.applicationId === app.id)
-      .map(
-        (e) =>
-          `<li>${day(e.occurredAt)} ${esc(e.status)} ${esc(e.note || "")}</li>`,
-      )
-      .join("") || "<li>No events yet.</li>"
-  }</ul></article><article class="card"><h3>Links/artifacts</h3><form class="tracker-form" data-artifact-form>${input("name", "", true)}${input("url", "")}<button class="button">Add link/artifact</button></form><ul>${m.artifacts.map((a) => `<li>${linkForArtifact(a)}</li>`).join("")}</ul></article><article class="card"><h3>Outreach messages</h3><form class="tracker-form" data-outreach-form><label>Channel<select name="channel"><option>email</option><option>linkedin</option><option>phone</option><option>sms</option><option>other</option></select></label><label>Message<textarea name="body" required></textarea></label><button class="button">Add outreach</button></form><ul>${m.outreach.map((o) => `<li>${day(o.sentAt)} ${esc(o.channel)} ${esc(o.body)}</li>`).join("")}</ul></article><article class="card"><h3>Interviews</h3><form class="tracker-form" data-interview-form><label>Stage<select name="stage"><option>recruiter_screen</option><option>technical_screen</option><option>onsite_loop</option><option>other</option></select></label>${input("startsAt", day(now()), "date")}<button class="button">Log interview</button></form><ul>${m.interviews.map((i) => `<li>${day(i.startsAt)} ${esc(i.stage)} ${esc(i.outcome)}</li>`).join("")}</ul></article><article class="card"><h3>Offers</h3><form class="tracker-form" data-offer-form><label>Status<select name="status"><option>received</option><option>negotiating</option><option>accepted</option><option>declined</option></select></label>${input("notes", "")}<button class="button">Log offer</button></form><ul>${m.offers.map((o) => `<li>${esc(o.status)} ${esc(o.notes || "")}</li>`).join("")}</ul></article></div>`;
+  const events = sortedLifecycleEvents(app.id);
+  const recruiterScreens = m.interviews.filter(isRecruiterScreen);
+  const otherInterviews = m.interviews.filter(
+    (item) => !isRecruiterScreen(item),
+  );
+  const assessments = events.filter(isAssessmentEvent);
+  return `<div class="tracker-detail"><article class="card"><h2>${esc(app.company || "New application")} — ${esc(app.role || "Unsaved")}</h2><form class="tracker-form" data-core-form>${input("company", app.company, true)}${input("role", app.role, true)}${input("postingUrl", app.postingUrl, "url")}<label>Status<select name="status" required>${STATUSES.map((s) => `<option ${app.status === s ? "selected" : ""}>${s}</option>`).join("")}</select></label>${input("source", app.source, "text")}${input("appliedAt", day(app.appliedAt), "date", true)}${input("followUpDate", day(app.followUpDate), "date")}<label>Notes<textarea name="notes">${esc(app.notes)}</textarea></label><button class="button">Save application</button></form></article><article class="card"><h3>Compact CSV metadata</h3>${metadataSection(app)}</article><article class="card wide-card"><h3>Lifecycle timeline</h3><p class="muted">Events are sorted by occurred date, then due date, then stable ID. All data stays local in this browser.</p><ul class="timeline">${events.map(timelineItem).join("") || '<li class="muted">No lifecycle events for this application yet.</li>'}</ul></article><article class="card"><h3>Assessments/take-homes</h3>${assessments.length ? `<ul>${assessments.map((e) => `<li>${esc(day(e.occurredAt) || day(e.dueAt))} ${esc(e.stageLabel || e.eventType || e.details || "assessment")}</li>`).join("")}</ul>` : '<p class="muted">No written assessments or take-homes yet.</p>'}</article><article class="card"><h3>Recruiter screens</h3>${recruiterScreens.length ? `<ul>${recruiterScreens.map((i) => `<li>${day(i.startsAt)} ${esc(i.outcome)}</li>`).join("")}</ul>` : '<p class="muted">No recruiter screens yet.</p>'}</article><article class="card"><h3>Interviews</h3><form class="tracker-form" data-interview-form><label>Stage<select name="stage"><option>recruiter_screen</option><option>technical_screen</option><option>onsite_loop</option><option>other</option></select></label>${input("startsAt", day(now()), "date")}<button class="button">Log interview</button></form><ul>${otherInterviews.map((i) => `<li>${day(i.startsAt)} ${esc(i.stage)} ${esc(i.outcome)}</li>`).join("") || '<li class="muted">No non-recruiter interviews yet.</li>'}</ul></article><article class="card"><h3>Links/artifacts</h3><form class="tracker-form" data-artifact-form>${input("name", "", true)}${input("url", "")}<button class="button">Add link/artifact</button></form><ul>${m.artifacts.map((a) => `<li>${linkForArtifact(a)}</li>`).join("")}</ul></article><article class="card"><h3>Outreach messages</h3><form class="tracker-form" data-outreach-form><label>Channel<select name="channel"><option>email</option><option>linkedin</option><option>phone</option><option>sms</option><option>other</option></select></label><label>Message<textarea name="body" required></textarea></label><button class="button">Add outreach</button></form><ul>${m.outreach.map((o) => `<li>${day(o.sentAt)} ${esc(o.channel)} ${esc(o.body)}</li>`).join("")}</ul></article><article class="card"><h3>Offers</h3><form class="tracker-form" data-offer-form><label>Status<select name="status"><option>received</option><option>negotiating</option><option>accepted</option><option>declined</option></select></label>${input("notes", "")}<button class="button">Log offer</button></form><ul>${m.offers.map((o) => `<li>${esc(o.status)} ${esc(o.notes || "")}</li>`).join("")}</ul></article></div>`;
 }
 function input(n, v = "", type = "text", required = false) {
   const req = type === true || required ? "required" : "";
@@ -635,6 +831,67 @@ function importFormatForFile(file) {
   if (name.endsWith(".ndjson") || name.endsWith(".jsonl")) return "ndjson";
   return "csv";
 }
+function detectedFormatLabel(format, text, lifecyclePreview) {
+  if (lifecyclePreview) return "supplemental lifecycle CSV";
+  if (format === "json") return "JSON backup";
+  if (format === "ndjson") return "NDJSON backup";
+  return detectSpreadsheetImportFormat(text) === "compact_csv"
+    ? "compact application CSV"
+    : "CSV";
+}
+function countByStore(recordsByStore) {
+  const rows = {
+    applications: recordsByStore.applications?.length ?? 0,
+    contacts: recordsByStore.contacts?.length ?? 0,
+    outreachMessages: recordsByStore.outreachMessages?.length ?? 0,
+    lifecycleEvents: recordsByStore.lifecycleEvents?.length ?? 0,
+    recruiterScreens:
+      (recordsByStore.interviews ?? []).filter(isRecruiterScreen).length +
+      (recordsByStore.lifecycleEvents ?? []).filter(isRecruiterScreen).length,
+    interviews: (recordsByStore.interviews ?? []).filter(
+      (item) => !isRecruiterScreen(item),
+    ).length,
+    assessments:
+      (recordsByStore.lifecycleEvents ?? []).filter(isAssessmentEvent).length +
+      (recordsByStore.applications ?? []).filter((application) => {
+        const metadata = readSpreadsheetMetadata(application.notes);
+        return [
+          metadata.spreadsheet_interview_stage,
+          metadata.spreadsheet_outcome,
+        ].some(
+          (value) =>
+            normalize(value).includes("assessment") ||
+            normalize(value).includes("take_home"),
+        );
+      }).length,
+    offers: recordsByStore.offers?.length ?? 0,
+    artifacts: recordsByStore.artifacts?.length ?? 0,
+    reminders: recordsByStore.reminders?.length ?? 0,
+    settings: recordsByStore.settings?.length ?? 0,
+  };
+  return Object.entries(rows).filter(([, count]) => count > 0);
+}
+function formatIssue(issue) {
+  const where = issue.rowNumber
+    ? `Row ${issue.rowNumber}`
+    : issue.storeName || issue.store || "Import";
+  const field = issue.field ? ` ${issue.field}` : "";
+  return `${where}${field}: ${[issue.code, issue.message || issue.id].filter(Boolean).join(": ")}`;
+}
+function renderImportPreview({
+  label,
+  recordsByStore,
+  conflicts = [],
+  warnings = [],
+  errors = [],
+  blocking = false,
+}) {
+  const counts = countByStore(recordsByStore);
+  const totalRecords = counts.reduce((sum, [, count]) => sum + count, 0);
+  const compactSummary = `Dry-run OK: ${recordsByStore.applications?.length ?? 0} applications, ${recordsByStore.outreachMessages?.length ?? 0} outreach messages, ${(recordsByStore.interviews ?? []).filter((item) => !isRecruiterScreen(item)).length} interviews`;
+  $("[data-import-result]").innerHTML =
+    `<h4>${blocking ? "Import preview needs attention" : "Dry-run succeeded"}</h4>${blocking ? "" : `<p>${esc(compactSummary)}</p>`}<p><strong>Detected format:</strong> ${esc(label)}.</p><p>${blocking ? "Apply import is disabled until blocking errors are fixed." : "Data remains local in this browser until you choose Apply import; no tracker details are sent to a server."}</p><h5>Record counts</h5><ul>${counts.map(([store, count]) => `<li>${esc(store)}: ${count}</li>`).join("") || "<li>No records detected.</li>"}</ul><p><strong>Total records:</strong> ${totalRecords}</p><h5>Conflicts</h5><ul>${conflicts.map((conflict) => `<li>${esc(conflict.storeName || conflict.store || "record")} ${esc(conflict.id || conflict.value || "")}</li>`).join("") || "<li>No existing record conflicts in local browser data.</li>"}</ul>${warnings.length ? `<h5>Warnings</h5><ul>${warnings.map((warning) => `<li>${esc(formatIssue(warning))}</li>`).join("")}</ul>` : ""}${errors.length ? `<h5>Blocking errors</h5><ul>${errors.map((error) => `<li>${esc(formatIssue(error))}</li>`).join("")}</ul>` : ""}`;
+}
 async function previewImport() {
   const file = $("[data-import-file]").files[0];
   if (!file) return;
@@ -648,28 +905,7 @@ async function previewImport() {
             exportAllData: repo.exportAll,
           })
         : null;
-    if (lifecyclePreview?.errors.length) {
-      throw new Error(
-        lifecyclePreview.errors
-          .map((error) =>
-            error.rowNumber
-              ? `Row ${error.rowNumber} ${error.field}: ${error.message}`
-              : `${error.field}: ${error.message}`,
-          )
-          .join("; "),
-      );
-    }
-    if (lifecyclePreview?.conflicts.length) {
-      throw new Error(
-        lifecyclePreview.conflicts
-          .map((conflict) =>
-            conflict.rowNumber
-              ? `Row ${conflict.rowNumber} ${conflict.field}: ${conflict.code}`
-              : `${conflict.store ?? "record"} ${conflict.field}: ${conflict.code}`,
-          )
-          .join("; "),
-      );
-    }
+    if (lifecyclePreview?.errors.length) throw lifecyclePreview;
     const bundle = lifecyclePreview
       ? lifecyclePreview.bundle
       : format === "json"
@@ -687,41 +923,37 @@ async function previewImport() {
     state.previewConflicts =
       lifecyclePreview?.conflicts ??
       (await detectImportConflicts(state.preview));
-    const totalRecords = Object.values(state.preview).reduce(
-      (count, rows) => count + rows.length,
-      0,
-    );
-    const formatLabel = lifecyclePreview
-      ? " (lifecycle CSV)"
-      : format === "csv"
-        ? ""
-        : ` (${format.toUpperCase()})`;
-    const previewCounts = {
-      applications: state.preview.applications?.length ?? 0,
-      lifecycleEvents: state.preview.lifecycleEvents?.length ?? 0,
-      outreachMessages: state.preview.outreachMessages?.length ?? 0,
-      interviews: state.preview.interviews?.length ?? 0,
-      reminders: state.preview.reminders?.length ?? 0,
-    };
-    const lifecycleSummary = lifecyclePreview
-      ? `${previewCounts.lifecycleEvents} lifecycle events, `
-      : "";
-    $("[data-import-result]").textContent =
-      `Dry-run OK${formatLabel}: ${previewCounts.applications} applications, ${lifecycleSummary}${previewCounts.outreachMessages} outreach messages, ${previewCounts.interviews} interviews, ${previewCounts.reminders} reminders. ${totalRecords} total records. ${state.previewConflicts.length} existing record conflicts.`;
+    renderImportPreview({
+      label: detectedFormatLabel(format, text, lifecyclePreview),
+      recordsByStore: state.preview,
+      conflicts: state.previewConflicts,
+      warnings: lifecyclePreview?.warnings ?? [],
+    });
     $("[data-import-apply]").disabled = false;
   } catch (err) {
     state.preview = null;
     state.previewConflicts = [];
     $("[data-import-apply]").disabled = true;
-    $("[data-import-result]").textContent =
-      `Import preview failed: ${err?.message ?? err}`;
+    if (err?.errors) {
+      renderImportPreview({
+        label: "supplemental lifecycle CSV",
+        recordsByStore: {},
+        conflicts: err.conflicts ?? [],
+        warnings: err.warnings ?? [],
+        errors: err.errors,
+        blocking: true,
+      });
+    } else {
+      $("[data-import-result]").textContent =
+        `Import preview failed: ${err?.message ?? err}`;
+    }
   }
 }
 function resetImportPreview() {
   state.preview = null;
   state.previewConflicts = [];
   $("[data-import-apply]").disabled = true;
-  $("[data-import-result]").textContent =
+  $("[data-import-result]").innerHTML =
     "Select Preview/dry-run to validate the selected file before applying.";
 }
 async function applyImport() {
@@ -745,7 +977,8 @@ async function applyImport() {
       `Import failed: ${err?.message ?? err}`;
     return;
   }
-  $("[data-import-result]").textContent = "Import applied.";
+  $("[data-import-result]").textContent =
+    "Import applied successfully. Your tracker data remains local in this browser.";
   $("[data-import-apply]").disabled = true;
   await refresh();
 }

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -250,10 +250,14 @@ const isAssessmentEvent = (record = {}) =>
     .some(
       (value) => value.includes("assessment") || value.includes("take_home"),
     );
+const RECRUITER_SCREEN_EVENT_TYPES = new Set([
+  "recruiter_screen_scheduled",
+  "recruiter_screen_completed",
+]);
 const isRecruiterScreen = (record = {}) =>
   normalize(record.stage) === "recruiter_screen" ||
   normalize(record.status) === "recruiter_screen" ||
-  normalize(record.eventType).startsWith("recruiter_screen");
+  RECRUITER_SCREEN_EVENT_TYPES.has(normalize(record.eventType));
 const hasMetadataAssessmentSignal = (metadata = {}) =>
   [metadata.spreadsheet_interview_stage, metadata.spreadsheet_outcome].some(
     (value) =>
@@ -502,8 +506,11 @@ function renderList() {
       const recruiterCount =
         m.interviews.filter(isRecruiterScreen).length +
         m.lifecycle.filter(isRecruiterScreen).length;
-      const assessmentCount = m.lifecycle.filter(isAssessmentEvent).length;
-      return `<tr><td><button class="button" data-open="${esc(a.id)}">${esc(a.company)}</button>${metadata ? `<small class="muted table-note">${esc(metadata)}</small>` : ""}</td><td>${esc(a.role)}</td><td><span class="chip">${esc(a.status)}</span></td><td>${day(a.appliedAt)}</td><td>${day(a.followUpDate) || "—"}</td><td>${esc(readSpreadsheetMetadata(a.notes).outreach_status || (m.outreach.length ? "sent" : "none"))}</td><td>${recruiterCount ? `<span class="chip">Recruiter screen ×${recruiterCount}</span>` : ""}${latestInterview ? `<span class="chip">Interview: ${esc(latestInterview.stage)}</span>` : ""}${assessmentCount ? `<span class="chip chip-warning">Assessment ×${assessmentCount}</span>` : ""}</td><td>${esc(outcomeForApp(a, m) || "—")}</td><td>${esc(fitScore(a.notes) || readSpreadsheetMetadata(a.notes).fit_score_100 || "")}</td><td class="clip-cell">${m.artifacts.map(linkForArtifact).join(", ")}</td></tr>`;
+      const rowMetadata = readSpreadsheetMetadata(a.notes);
+      const assessmentCount =
+        m.lifecycle.filter(isAssessmentEvent).length +
+        (hasMetadataAssessmentSignal(rowMetadata) ? 1 : 0);
+      return `<tr><td><button class="button" data-open="${esc(a.id)}">${esc(a.company)}</button>${metadata ? `<small class="muted table-note">${esc(metadata)}</small>` : ""}</td><td>${esc(a.role)}</td><td><span class="chip">${esc(a.status)}</span></td><td>${day(a.appliedAt)}</td><td>${day(a.followUpDate) || "—"}</td><td>${esc(rowMetadata.outreach_status || (m.outreach.length ? "sent" : "none"))}</td><td>${recruiterCount ? `<span class="chip">Recruiter screen ×${recruiterCount}</span>` : ""}${latestInterview ? `<span class="chip">Interview: ${esc(latestInterview.stage)}</span>` : ""}${assessmentCount ? `<span class="chip chip-warning">Assessment ×${assessmentCount}</span>` : ""}</td><td>${esc(outcomeForApp(a, m) || "—")}</td><td>${esc(fitScore(a.notes) || rowMetadata.fit_score_100 || "")}</td><td class="clip-cell">${m.artifacts.map(linkForArtifact).join(", ")}</td></tr>`;
     })
     .join("");
   $$("[data-open]").forEach(

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -2,13 +2,13 @@
 /* eslint-disable max-len */
 import {
   COMPACT_CSV_COLUMNS,
-  csvToBrowserApplicationExport,
   detectSpreadsheetImportFormat,
   exportCompactCsv,
   exportJsonBackup,
   exportNdjsonBackup,
   importJsonBackup,
   importNdjsonBackup,
+  previewCompactCsvImport,
   previewSupplementalLifecycleCsvImport,
 } from "../import-export/spreadsheet.js";
 import { readSpreadsheetMetadata, selectDashboardMetrics } from "./metrics.js";
@@ -564,11 +564,9 @@ function sortedLifecycleEvents(appId) {
   return [...state.bundle.lifecycleEvents]
     .filter((e) => e.applicationId === appId)
     .sort((a, b) => {
-      const primary = (a.occurredAt || a.dueAt || "").localeCompare(
-        b.occurredAt || b.dueAt || "",
-      );
+      const occurred = (a.occurredAt || "").localeCompare(b.occurredAt || "");
       const due = (a.dueAt || "").localeCompare(b.dueAt || "");
-      return primary || due || String(a.id).localeCompare(String(b.id));
+      return occurred || due || String(a.id).localeCompare(String(b.id));
     });
 }
 function eventDetails(e) {
@@ -829,21 +827,6 @@ async function newApplication() {
   };
   openUnsavedDetail(app);
 }
-function previewBundleFromCsv(text) {
-  const { bundle, errors } = csvToBrowserApplicationExport(text);
-  if (errors.length) {
-    throw new Error(
-      errors
-        .map((error) =>
-          error.rowNumber
-            ? `Row ${error.rowNumber} ${error.field}: ${error.message}`
-            : `${error.field}: ${error.message}`,
-        )
-        .join("; "),
-    );
-  }
-  return bundle;
-}
 function bundleForIndexedDb(bundle) {
   return {
     ...Object.fromEntries(
@@ -911,7 +894,13 @@ function formatIssue(issue) {
     ? `Row ${issue.rowNumber}`
     : issue.storeName || issue.store || "Import";
   const field = issue.field ? ` ${issue.field}` : "";
-  return `${where}${field}: ${[issue.code, issue.message || issue.id].filter(Boolean).join(": ")}`;
+  const details = [
+    issue.code,
+    issue.message || issue.reason,
+    issue.value ? `value ${issue.value}` : "",
+    issue.id ? `ID ${issue.id}` : "",
+  ].filter(Boolean);
+  return `${where}${field}: ${details.join(": ")}`;
 }
 function renderImportPreview({
   label,
@@ -935,7 +924,7 @@ function renderImportPreview({
   ].reduce((sum, store) => sum + (recordsByStore[store]?.length ?? 0), 0);
   const compactSummary = `Dry-run OK: ${recordsByStore.applications?.length ?? 0} applications, ${recordsByStore.outreachMessages?.length ?? 0} outreach messages, ${(recordsByStore.interviews ?? []).filter((item) => !isRecruiterScreen(item)).length} interviews`;
   $("[data-import-result]").innerHTML =
-    `<h4>${blocking ? "Import preview needs attention" : "Dry-run succeeded"}</h4>${blocking ? "" : `<p>${esc(compactSummary)}</p>`}<p><strong>Detected format:</strong> ${esc(label)}.</p><p>${blocking ? "Apply import is disabled until blocking errors are fixed." : "Data remains local in this browser until you choose Apply import; no tracker details are sent to a server."}</p><h5>Record counts</h5><ul>${counts.map(([store, count]) => `<li>${esc(store)}: ${count}</li>`).join("") || "<li>No records detected.</li>"}</ul><p><strong>Total records:</strong> ${totalRecords}</p><h5>Conflicts</h5><ul>${conflicts.map((conflict) => `<li>${esc(conflict.storeName || conflict.store || "record")} ${esc(conflict.id || conflict.value || "")}</li>`).join("") || "<li>No existing record conflicts in local browser data.</li>"}</ul>${warnings.length ? `<h5>Warnings</h5><ul>${warnings.map((warning) => `<li>${esc(formatIssue(warning))}</li>`).join("")}</ul>` : ""}${errors.length ? `<h5>Blocking errors</h5><ul>${errors.map((error) => `<li>${esc(formatIssue(error))}</li>`).join("")}</ul>` : ""}`;
+    `<h4>${blocking ? "Import preview needs attention" : "Dry-run succeeded"}</h4>${blocking ? "" : `<p>${esc(compactSummary)}</p>`}<p><strong>Detected format:</strong> ${esc(label)}.</p><p>${blocking ? "Apply import is disabled until blocking errors are fixed." : "Data remains local in this browser until you choose Apply import; no tracker details are sent to a server."}</p><h5>Record counts</h5><ul>${counts.map(([store, count]) => `<li>${esc(store)}: ${count}</li>`).join("") || "<li>No records detected.</li>"}</ul><p><strong>Total records:</strong> ${totalRecords}</p><h5>Conflicts</h5><ul>${conflicts.map((conflict) => `<li>${esc(formatIssue(conflict))}</li>`).join("") || "<li>No existing record conflicts in local browser data.</li>"}</ul>${warnings.length ? `<h5>Warnings</h5><ul>${warnings.map((warning) => `<li>${esc(formatIssue(warning))}</li>`).join("")}</ul>` : ""}${errors.length ? `<h5>Blocking errors</h5><ul>${errors.map((error) => `<li>${esc(formatIssue(error))}</li>`).join("")}</ul>` : ""}`;
 }
 async function previewImport() {
   const file = $("[data-import-file]").files[0];
@@ -964,13 +953,33 @@ async function previewImport() {
       $("[data-import-apply]").disabled = true;
       return;
     }
+    const compactPreview =
+      !lifecyclePreview && format === "csv"
+        ? await previewCompactCsvImport(text, {
+            exportAllData: repo.exportAll,
+          })
+        : null;
+    if (compactPreview?.errors.length) {
+      renderImportPreview({
+        label: "compact application CSV",
+        recordsByStore: compactPreview.bundle ?? {},
+        conflicts: compactPreview.conflicts ?? [],
+        warnings: compactPreview.warnings ?? [],
+        errors: compactPreview.errors ?? [],
+        blocking: true,
+      });
+      state.preview = null;
+      state.previewConflicts = [];
+      $("[data-import-apply]").disabled = true;
+      return;
+    }
     const bundle = lifecyclePreview
       ? lifecyclePreview.bundle
-      : format === "json"
-        ? importJsonBackup(text)
-        : format === "ndjson"
-          ? importNdjsonBackup(text)
-          : previewBundleFromCsv(text);
+      : compactPreview
+        ? compactPreview.bundle
+        : format === "json"
+          ? importJsonBackup(text)
+          : importNdjsonBackup(text);
     state.preview = lifecyclePreview
       ? {
           lifecycleEvents: bundle.lifecycleEvents ?? [],
@@ -980,12 +989,13 @@ async function previewImport() {
       : bundleForIndexedDb(bundle);
     state.previewConflicts =
       lifecyclePreview?.conflicts ??
+      compactPreview?.conflicts ??
       (await detectImportConflicts(state.preview));
     renderImportPreview({
       label: detectedFormatLabel(format, text, lifecyclePreview),
       recordsByStore: state.preview,
       conflicts: state.previewConflicts,
-      warnings: lifecyclePreview?.warnings ?? [],
+      warnings: lifecyclePreview?.warnings ?? compactPreview?.warnings ?? [],
     });
     $("[data-import-apply]").disabled = false;
   } catch (err) {

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -258,6 +258,39 @@ const isRecruiterScreen = (record = {}) =>
   normalize(record.stage) === "recruiter_screen" ||
   normalize(record.status) === "recruiter_screen" ||
   RECRUITER_SCREEN_EVENT_TYPES.has(normalize(record.eventType));
+const recruiterScreenKey = (record = {}) =>
+  [
+    record.applicationId,
+    record.dueAt ?? record.startsAt ?? record.occurredAt ?? record.id,
+  ]
+    .filter(Boolean)
+    .join(":");
+const uniqueRecruiterScreens = (meta, events = meta.lifecycle) => {
+  const screens = [];
+  const seen = new Set();
+  for (const item of [
+    ...events.filter(isRecruiterScreen).map((event) => ({
+      key: recruiterScreenKey(event),
+      date: day(event.occurredAt) || day(event.dueAt),
+      label:
+        event.stageLabel ||
+        event.eventType ||
+        event.details ||
+        "recruiter screen",
+    })),
+    ...meta.interviews.filter(isRecruiterScreen).map((interview) => ({
+      key: recruiterScreenKey(interview),
+      date: day(interview.startsAt),
+      label: interview.outcome || interview.stage || "recruiter screen",
+    })),
+  ]) {
+    const key = item.key || `${item.date}:${item.label}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    screens.push(item);
+  }
+  return screens;
+};
 const hasMetadataAssessmentSignal = (metadata = {}) =>
   [metadata.spreadsheet_interview_stage, metadata.spreadsheet_outcome].some(
     (value) =>
@@ -475,9 +508,7 @@ function renderList() {
     const hasAssessment =
       m.lifecycle.some(isAssessmentEvent) ||
       hasMetadataAssessmentSignal(metadata);
-    const hasRecruiter =
-      m.interviews.some(isRecruiterScreen) ||
-      m.lifecycle.some(isRecruiterScreen);
+    const hasRecruiter = uniqueRecruiterScreens(m).length > 0;
     const terminal =
       OUTCOMES.has(a.status) || OUTCOMES.has(outcomeForApp(a, m));
     return (
@@ -516,9 +547,7 @@ function renderList() {
       const latestInterview = m.interviews
         .filter((item) => !isRecruiterScreen(item))
         .at(-1);
-      const recruiterCount =
-        m.interviews.filter(isRecruiterScreen).length +
-        m.lifecycle.filter(isRecruiterScreen).length;
+      const recruiterCount = uniqueRecruiterScreens(m).length;
       const rowMetadata = readSpreadsheetMetadata(a.notes);
       const assessmentCount =
         m.lifecycle.filter(isAssessmentEvent).length +
@@ -641,20 +670,7 @@ function detailForm(app) {
   const m = appMeta(app);
   const events = sortedLifecycleEvents(app.id);
   const metadata = readSpreadsheetMetadata(app.notes);
-  const recruiterScreens = [
-    ...m.interviews.filter(isRecruiterScreen).map((item) => ({
-      date: day(item.startsAt),
-      label: item.outcome || item.stage || "recruiter screen",
-    })),
-    ...events.filter(isRecruiterScreen).map((event) => ({
-      date: day(event.occurredAt) || day(event.dueAt),
-      label:
-        event.stageLabel ||
-        event.eventType ||
-        event.details ||
-        "recruiter screen",
-    })),
-  ];
+  const recruiterScreens = uniqueRecruiterScreens(m, events);
   const otherInterviews = m.interviews.filter(
     (item) => !isRecruiterScreen(item),
   );

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -254,6 +254,25 @@ const isRecruiterScreen = (record = {}) =>
   normalize(record.stage) === "recruiter_screen" ||
   normalize(record.status) === "recruiter_screen" ||
   normalize(record.eventType).startsWith("recruiter_screen");
+const hasMetadataAssessmentSignal = (metadata = {}) =>
+  [metadata.spreadsheet_interview_stage, metadata.spreadsheet_outcome].some(
+    (value) =>
+      normalize(value).includes("assessment") ||
+      normalize(value).includes("take_home"),
+  );
+const hasMetadataResponseSignal = (metadata = {}) =>
+  [metadata.outreach_status, metadata.spreadsheet_interview_stage].some(
+    (value) =>
+      [
+        "replied",
+        "responded",
+        "response_received",
+        "written_assessment_submitted",
+        "written_assessment_requested",
+        "recruiter_screen_scheduled",
+        "interview_scheduled",
+      ].includes(normalize(value)),
+  );
 function metadataEntries(app) {
   const metadata = readSpreadsheetMetadata(app.notes);
   return Object.entries({
@@ -426,7 +445,8 @@ function renderList() {
           "written_assessment_requested",
           "recruiter_screen_scheduled",
         ].includes(normalize(x.eventType)),
-      );
+      ) ||
+      hasMetadataResponseSignal(metadata);
     const outreachState =
       m.outreach.length || metadata.outreach_status ? "sent" : "none";
     const dueState =
@@ -437,11 +457,7 @@ function renderList() {
           : "none";
     const hasAssessment =
       m.lifecycle.some(isAssessmentEvent) ||
-      [metadata.spreadsheet_interview_stage, metadata.spreadsheet_outcome].some(
-        (x) =>
-          normalize(x).includes("assessment") ||
-          normalize(x).includes("take_home"),
-      );
+      hasMetadataAssessmentSignal(metadata);
     const hasRecruiter =
       m.interviews.some(isRecruiterScreen) ||
       m.lifecycle.some(isRecruiterScreen);
@@ -548,11 +564,11 @@ function sortedLifecycleEvents(appId) {
   return [...state.bundle.lifecycleEvents]
     .filter((e) => e.applicationId === appId)
     .sort((a, b) => {
-      const left = a.occurredAt || a.dueAt || "";
-      const right = b.occurredAt || b.dueAt || "";
-      return (
-        left.localeCompare(right) || String(a.id).localeCompare(String(b.id))
+      const primary = (a.occurredAt || a.dueAt || "").localeCompare(
+        b.occurredAt || b.dueAt || "",
       );
+      const due = (a.dueAt || "").localeCompare(b.dueAt || "");
+      return primary || due || String(a.id).localeCompare(String(b.id));
     });
 }
 function eventDetails(e) {
@@ -606,12 +622,38 @@ function metadataSection(app) {
 function detailForm(app) {
   const m = appMeta(app);
   const events = sortedLifecycleEvents(app.id);
-  const recruiterScreens = m.interviews.filter(isRecruiterScreen);
+  const metadata = readSpreadsheetMetadata(app.notes);
+  const recruiterScreens = [
+    ...m.interviews.filter(isRecruiterScreen).map((item) => ({
+      date: day(item.startsAt),
+      label: item.outcome || item.stage || "recruiter screen",
+    })),
+    ...events.filter(isRecruiterScreen).map((event) => ({
+      date: day(event.occurredAt) || day(event.dueAt),
+      label:
+        event.stageLabel ||
+        event.eventType ||
+        event.details ||
+        "recruiter screen",
+    })),
+  ];
   const otherInterviews = m.interviews.filter(
     (item) => !isRecruiterScreen(item),
   );
-  const assessments = events.filter(isAssessmentEvent);
-  return `<div class="tracker-detail"><article class="card"><h2>${esc(app.company || "New application")} — ${esc(app.role || "Unsaved")}</h2><form class="tracker-form" data-core-form>${input("company", app.company, true)}${input("role", app.role, true)}${input("postingUrl", app.postingUrl, "url")}<label>Status<select name="status" required>${STATUSES.map((s) => `<option ${app.status === s ? "selected" : ""}>${s}</option>`).join("")}</select></label>${input("source", app.source, "text")}${input("appliedAt", day(app.appliedAt), "date", true)}${input("followUpDate", day(app.followUpDate), "date")}<label>Notes<textarea name="notes">${esc(app.notes)}</textarea></label><button class="button">Save application</button></form></article><article class="card"><h3>Compact CSV metadata</h3>${metadataSection(app)}</article><article class="card wide-card"><h3>Lifecycle timeline</h3><p class="muted">Events are sorted by occurred date, then due date, then stable ID. All data stays local in this browser.</p><ul class="timeline">${events.map(timelineItem).join("") || '<li class="muted">No lifecycle events for this application yet.</li>'}</ul></article><article class="card"><h3>Assessments/take-homes</h3>${assessments.length ? `<ul>${assessments.map((e) => `<li>${esc(day(e.occurredAt) || day(e.dueAt))} ${esc(e.stageLabel || e.eventType || e.details || "assessment")}</li>`).join("")}</ul>` : '<p class="muted">No written assessments or take-homes yet.</p>'}</article><article class="card"><h3>Recruiter screens</h3>${recruiterScreens.length ? `<ul>${recruiterScreens.map((i) => `<li>${day(i.startsAt)} ${esc(i.outcome)}</li>`).join("")}</ul>` : '<p class="muted">No recruiter screens yet.</p>'}</article><article class="card"><h3>Interviews</h3><form class="tracker-form" data-interview-form><label>Stage<select name="stage"><option>recruiter_screen</option><option>technical_screen</option><option>onsite_loop</option><option>other</option></select></label>${input("startsAt", day(now()), "date")}<button class="button">Log interview</button></form><ul>${otherInterviews.map((i) => `<li>${day(i.startsAt)} ${esc(i.stage)} ${esc(i.outcome)}</li>`).join("") || '<li class="muted">No non-recruiter interviews yet.</li>'}</ul></article><article class="card"><h3>Links/artifacts</h3><form class="tracker-form" data-artifact-form>${input("name", "", true)}${input("url", "")}<button class="button">Add link/artifact</button></form><ul>${m.artifacts.map((a) => `<li>${linkForArtifact(a)}</li>`).join("")}</ul></article><article class="card"><h3>Outreach messages</h3><form class="tracker-form" data-outreach-form><label>Channel<select name="channel"><option>email</option><option>linkedin</option><option>phone</option><option>sms</option><option>other</option></select></label><label>Message<textarea name="body" required></textarea></label><button class="button">Add outreach</button></form><ul>${m.outreach.map((o) => `<li>${day(o.sentAt)} ${esc(o.channel)} ${esc(o.body)}</li>`).join("")}</ul></article><article class="card"><h3>Offers</h3><form class="tracker-form" data-offer-form><label>Status<select name="status"><option>received</option><option>negotiating</option><option>accepted</option><option>declined</option></select></label>${input("notes", "")}<button class="button">Log offer</button></form><ul>${m.offers.map((o) => `<li>${esc(o.status)} ${esc(o.notes || "")}</li>`).join("")}</ul></article></div>`;
+  const assessments = events.filter(isAssessmentEvent).map((event) => ({
+    date: day(event.occurredAt) || day(event.dueAt),
+    label: event.stageLabel || event.eventType || event.details || "assessment",
+  }));
+  if (hasMetadataAssessmentSignal(metadata)) {
+    assessments.push({
+      date: day(app.appliedAt),
+      label:
+        metadata.spreadsheet_interview_stage ||
+        metadata.spreadsheet_outcome ||
+        "Compact CSV assessment signal",
+    });
+  }
+  return `<div class="tracker-detail"><article class="card"><h2>${esc(app.company || "New application")} — ${esc(app.role || "Unsaved")}</h2><form class="tracker-form" data-core-form>${input("company", app.company, true)}${input("role", app.role, true)}${input("postingUrl", app.postingUrl, "url")}<label>Status<select name="status" required>${STATUSES.map((s) => `<option ${app.status === s ? "selected" : ""}>${s}</option>`).join("")}</select></label>${input("source", app.source, "text")}${input("appliedAt", day(app.appliedAt), "date", true)}${input("followUpDate", day(app.followUpDate), "date")}<label>Notes<textarea name="notes">${esc(app.notes)}</textarea></label><button class="button">Save application</button></form></article><article class="card"><h3>Compact CSV metadata</h3>${metadataSection(app)}</article><article class="card wide-card"><h3>Lifecycle timeline</h3><p class="muted">Events are sorted by occurred date, then due date, then stable ID. All data stays local in this browser.</p><ul class="timeline">${events.map(timelineItem).join("") || '<li class="muted">No lifecycle events for this application yet.</li>'}</ul></article><article class="card"><h3>Assessments/take-homes</h3>${assessments.length ? `<ul>${assessments.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No written assessments or take-homes yet.</p>'}</article><article class="card"><h3>Recruiter screens</h3>${recruiterScreens.length ? `<ul>${recruiterScreens.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No recruiter screens yet.</p>'}</article><article class="card"><h3>Interviews</h3><form class="tracker-form" data-interview-form><label>Stage<select name="stage"><option>recruiter_screen</option><option>technical_screen</option><option>onsite_loop</option><option>other</option></select></label>${input("startsAt", day(now()), "date")}<button class="button">Log interview</button></form><ul>${otherInterviews.map((i) => `<li>${day(i.startsAt)} ${esc(i.stage)} ${esc(i.outcome)}</li>`).join("") || '<li class="muted">No non-recruiter interviews yet.</li>'}</ul></article><article class="card"><h3>Links/artifacts</h3><form class="tracker-form" data-artifact-form>${input("name", "", true)}${input("url", "")}<button class="button">Add link/artifact</button></form><ul>${m.artifacts.map((a) => `<li>${linkForArtifact(a)}</li>`).join("")}</ul></article><article class="card"><h3>Outreach messages</h3><form class="tracker-form" data-outreach-form><label>Channel<select name="channel"><option>email</option><option>linkedin</option><option>phone</option><option>sms</option><option>other</option></select></label><label>Message<textarea name="body" required></textarea></label><button class="button">Add outreach</button></form><ul>${m.outreach.map((o) => `<li>${day(o.sentAt)} ${esc(o.channel)} ${esc(o.body)}</li>`).join("")}</ul></article><article class="card"><h3>Offers</h3><form class="tracker-form" data-offer-form><label>Status<select name="status"><option>received</option><option>negotiating</option><option>accepted</option><option>declined</option></select></label>${input("notes", "")}<button class="button">Log offer</button></form><ul>${m.offers.map((o) => `<li>${esc(o.status)} ${esc(o.notes || "")}</li>`).join("")}</ul></article></div>`;
 }
 function input(n, v = "", type = "text", required = false) {
   const req = type === true || required ? "required" : "";
@@ -855,14 +897,7 @@ function countByStore(recordsByStore) {
       (recordsByStore.lifecycleEvents ?? []).filter(isAssessmentEvent).length +
       (recordsByStore.applications ?? []).filter((application) => {
         const metadata = readSpreadsheetMetadata(application.notes);
-        return [
-          metadata.spreadsheet_interview_stage,
-          metadata.spreadsheet_outcome,
-        ].some(
-          (value) =>
-            normalize(value).includes("assessment") ||
-            normalize(value).includes("take_home"),
-        );
+        return hasMetadataAssessmentSignal(metadata);
       }).length,
     offers: recordsByStore.offers?.length ?? 0,
     artifacts: recordsByStore.artifacts?.length ?? 0,
@@ -887,7 +922,17 @@ function renderImportPreview({
   blocking = false,
 }) {
   const counts = countByStore(recordsByStore);
-  const totalRecords = counts.reduce((sum, [, count]) => sum + count, 0);
+  const totalRecords = [
+    "applications",
+    "contacts",
+    "outreachMessages",
+    "lifecycleEvents",
+    "interviews",
+    "offers",
+    "artifacts",
+    "reminders",
+    "settings",
+  ].reduce((sum, store) => sum + (recordsByStore[store]?.length ?? 0), 0);
   const compactSummary = `Dry-run OK: ${recordsByStore.applications?.length ?? 0} applications, ${recordsByStore.outreachMessages?.length ?? 0} outreach messages, ${(recordsByStore.interviews ?? []).filter((item) => !isRecruiterScreen(item)).length} interviews`;
   $("[data-import-result]").innerHTML =
     `<h4>${blocking ? "Import preview needs attention" : "Dry-run succeeded"}</h4>${blocking ? "" : `<p>${esc(compactSummary)}</p>`}<p><strong>Detected format:</strong> ${esc(label)}.</p><p>${blocking ? "Apply import is disabled until blocking errors are fixed." : "Data remains local in this browser until you choose Apply import; no tracker details are sent to a server."}</p><h5>Record counts</h5><ul>${counts.map(([store, count]) => `<li>${esc(store)}: ${count}</li>`).join("") || "<li>No records detected.</li>"}</ul><p><strong>Total records:</strong> ${totalRecords}</p><h5>Conflicts</h5><ul>${conflicts.map((conflict) => `<li>${esc(conflict.storeName || conflict.store || "record")} ${esc(conflict.id || conflict.value || "")}</li>`).join("") || "<li>No existing record conflicts in local browser data.</li>"}</ul>${warnings.length ? `<h5>Warnings</h5><ul>${warnings.map((warning) => `<li>${esc(formatIssue(warning))}</li>`).join("")}</ul>` : ""}${errors.length ? `<h5>Blocking errors</h5><ul>${errors.map((error) => `<li>${esc(formatIssue(error))}</li>`).join("")}</ul>` : ""}`;
@@ -905,7 +950,20 @@ async function previewImport() {
             exportAllData: repo.exportAll,
           })
         : null;
-    if (lifecyclePreview?.errors.length) throw lifecyclePreview;
+    if (lifecyclePreview?.errors.length || lifecyclePreview?.conflicts.length) {
+      renderImportPreview({
+        label: "supplemental lifecycle CSV",
+        recordsByStore: lifecyclePreview.bundle ?? {},
+        conflicts: lifecyclePreview.conflicts ?? [],
+        warnings: lifecyclePreview.warnings ?? [],
+        errors: lifecyclePreview.errors ?? [],
+        blocking: true,
+      });
+      state.preview = null;
+      state.previewConflicts = [];
+      $("[data-import-apply]").disabled = true;
+      return;
+    }
     const bundle = lifecyclePreview
       ? lifecyclePreview.bundle
       : format === "json"

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -88,6 +88,78 @@ test.describe("browser application tracker", () => {
     );
   });
 
+  test("shows compact metadata assessments as list chips", async ({ page }) => {
+    const csv = await regressionCsvFixture();
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await page.setInputFiles("[data-import-file]", {
+      name: "compact-main-regression.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(csv),
+    });
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+    await page.getByRole("button", { name: "Apply import" }).click();
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    const deltaRow = page
+      .locator("[data-applications-table] tbody tr")
+      .filter({ hasText: "Company Delta" });
+    await expect(deltaRow).toContainText("Assessment ×1");
+  });
+
+  test("does not show generic recruiter_screen lifecycle rows as recruiter chips", async ({
+    page,
+  }) => {
+    await page.evaluate(
+      () =>
+        new Promise((resolve, reject) => {
+          const request = indexedDB.open("jobbot3000", 1);
+          request.onerror = () => reject(request.error);
+          request.onsuccess = () => {
+            const db = request.result;
+            const tx = db.transaction(
+              ["applications", "lifecycleEvents"],
+              "readwrite",
+            );
+            tx.objectStore("applications").put({
+              id: "generic_recruiter_app",
+              company: "Generic Recruiter Co",
+              role: "Frontend Engineer",
+              status: "applied",
+              appliedAt: "2026-01-02",
+              createdAt: "2026-01-02T00:00:00.000Z",
+              updatedAt: "2026-01-02T00:00:00.000Z",
+            });
+            tx.objectStore("lifecycleEvents").put({
+              id: "generic_recruiter_event",
+              applicationId: "generic_recruiter_app",
+              eventType: "recruiter_screen",
+              occurredAt: "2026-01-03T00:00:00.000Z",
+              createdAt: "2026-01-03T00:00:00.000Z",
+              updatedAt: "2026-01-03T00:00:00.000Z",
+            });
+            tx.oncomplete = () => {
+              db.close();
+              resolve();
+            };
+            tx.onerror = () => reject(tx.error);
+          };
+        }),
+    );
+    await page.reload();
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    const row = page
+      .locator("[data-applications-table] tbody tr")
+      .filter({ hasText: "Generic Recruiter Co" });
+    await expect(row).toBeVisible();
+    await expect(row).not.toContainText("Recruiter screen ×1");
+  });
+
   test("previews supplemental lifecycle CSV counts and missing application errors", async ({
     page,
   }) => {

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -160,6 +160,62 @@ test.describe("browser application tracker", () => {
     await expect(row).not.toContainText("Recruiter screen ×1");
   });
 
+  test("deduplicates paired recruiter screen lifecycle and interview records", async ({
+    page,
+  }) => {
+    const csv = [
+      "application_id,company,role_title,status,applied_at,posting_url",
+      "paired_recruiter_app,Paired Recruiter Co,Frontend Engineer,applied," +
+        "2026-01-02,https://example.test/paired",
+    ].join("\n");
+    const lifecycle = [
+      "application_id,company,role_title,event_type,occurred_at,stage," +
+        "channel,actor,source_artifact,requires_user_action,action_status," +
+        "due_at,no_ai_required,details",
+      "paired_recruiter_app,Paired Recruiter Co,Frontend Engineer," +
+        "recruiter_screen_scheduled,2026-01-03,recruiter_screen," +
+        "email,recruiter,,,,2026-01-10T15:30:00.000Z,,Intro call",
+    ].join("\n");
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await page.setInputFiles("[data-import-file]", {
+      name: "paired-recruiter-app.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(csv),
+    });
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+    await page.getByRole("button", { name: "Apply import" }).click();
+
+    await page.setInputFiles("[data-import-file]", {
+      name: "paired-recruiter-lifecycle.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(lifecycle),
+    });
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+    await page.getByRole("button", { name: "Apply import" }).click();
+
+    await page.getByRole("button", { name: "Dashboard" }).click();
+    await expect(page.locator("[data-metrics]")).toContainText(
+      "Recruiter screens1",
+    );
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    const row = page
+      .locator("[data-applications-table] tbody tr")
+      .filter({ hasText: "Paired Recruiter Co" });
+    await expect(row).toContainText("Recruiter screen ×1");
+    await expect(row).not.toContainText("Recruiter screen ×2");
+
+    await page.getByRole("button", { name: "Paired Recruiter Co" }).click();
+    const recruiterSection = page.locator("[data-detail] article").filter({
+      has: page.getByRole("heading", { name: "Recruiter screens" }),
+    });
+    await expect(recruiterSection.locator("li")).toHaveCount(1);
+    await expect(recruiterSection).toContainText("recruiter_screen");
+  });
+
   test("previews supplemental lifecycle CSV counts and missing application errors", async ({
     page,
   }) => {

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -282,6 +282,60 @@ test.describe("browser application tracker", () => {
     ).toBeDisabled();
   });
 
+  test("filters compact response signals like dashboard responses", async ({
+    page,
+  }) => {
+    const csv = [
+      "application_id,company,role_title,status,applied_at,posting_url," +
+        "outreach_status,interview_stage,notes",
+      "compact_reply_app,Reply Signal Co,Frontend Engineer,applied," +
+        "2026-01-02,https://example.test/reply,reply,,",
+      "compact_interview_app,Interview Signal Co,Backend Engineer,applied," +
+        "2026-01-03,https://example.test/interview,,technical_screen,",
+      "compact_quiet_app,Quiet Signal Co,Data Engineer,applied," +
+        "2026-01-04,https://example.test/quiet,,,",
+    ].join("\n");
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await page.setInputFiles("[data-import-file]", {
+      name: "compact-response-signals.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(csv),
+    });
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+    await page.getByRole("button", { name: "Apply import" }).click();
+
+    await page.getByRole("button", { name: "Dashboard" }).click();
+    await expect(page.locator("[data-metrics]")).toContainText(
+      "Application responses2",
+    );
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.locator('[data-filter="response"]').selectOption("responded");
+    await expect(page.locator("[data-applications-table]")).toContainText(
+      "Reply Signal Co",
+    );
+    await expect(page.locator("[data-applications-table]")).toContainText(
+      "Interview Signal Co",
+    );
+    await expect(page.locator("[data-applications-table]")).not.toContainText(
+      "Quiet Signal Co",
+    );
+
+    await page.locator('[data-filter="response"]').selectOption("no_response");
+    await expect(page.locator("[data-applications-table]")).toContainText(
+      "Quiet Signal Co",
+    );
+    await expect(page.locator("[data-applications-table]")).not.toContainText(
+      "Reply Signal Co",
+    );
+    await expect(page.locator("[data-applications-table]")).not.toContainText(
+      "Interview Signal Co",
+    );
+  });
+
   test("imports compact CSV regression fixture with bounded dashboard metrics", async ({
     page,
   }) => {

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -139,6 +139,77 @@ test.describe("browser application tracker", () => {
     ).toBeDisabled();
   });
 
+  test("surfaces compact CSV conflicts and non-interview stage warnings", async ({
+    page,
+  }) => {
+    const duplicateCompactCsv = [
+      "application_id,company,role_title,status,applied_at,posting_url,interview_stage,notes",
+      "dup_app_1,Duplicate One,Engineer,applied,2026-01-02," +
+        "https://example.test/dup-a,written_assessment_submitted,first",
+      "dup_app_1,Duplicate Two,Engineer,applied,2026-01-03,https://example.test/dup-b,,second",
+    ].join("\n");
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await page.setInputFiles("[data-import-file]", {
+      name: "duplicate-compact.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(duplicateCompactCsv),
+    });
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+
+    const preview = page.locator("[data-import-result]");
+    await expect(preview).toContainText("duplicate_in_file");
+    await expect(preview).toContainText("application_id");
+    await expect(preview).toContainText("ignored_non_interview_stage");
+    await expect(preview).toContainText("written_assessment_submitted");
+    await expect(
+      page.getByRole("button", { name: "Apply import" }),
+    ).toBeEnabled();
+  });
+
+  test("surfaces lifecycle warnings and blocking date/application errors", async ({
+    page,
+  }) => {
+    const csv = await regressionCsvFixture();
+    const lifecycleHeader =
+      "application_id,company,role_title,event_type,occurred_at,stage," +
+      "channel,actor,source_artifact,requires_user_action,action_status," +
+      "due_at,no_ai_required,details";
+    const lifecycle = [
+      lifecycleHeader,
+      "app_reg_alpha_001,Company Alpha,Engineer,bespoke_vendor_ping," +
+        "2026-03-01,,,,,,,,,Imported as generic",
+      "app_reg_alpha_001,Company Alpha,Engineer,hiring_manager_reply," +
+        "not-a-date,,,,,,,,,Bad date",
+      "missing_app_999,Missing,Engineer,hiring_manager_reply,2026-03-02,,,,,,,,,Missing app",
+    ].join("\n");
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await page.setInputFiles("[data-import-file]", {
+      name: "compact-main-regression.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(csv),
+    });
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+    await page.getByRole("button", { name: "Apply import" }).click();
+
+    await page.setInputFiles("[data-import-file]", {
+      name: "warning-and-error-lifecycle.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(lifecycle),
+    });
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+
+    const preview = page.locator("[data-import-result]");
+    await expect(preview).toContainText("unsupported_event_type");
+    await expect(preview).toContainText("bespoke_vendor_ping");
+    await expect(preview).toContainText("malformed_date");
+    await expect(preview).toContainText("unknown_application");
+    await expect(
+      page.getByRole("button", { name: "Apply import" }),
+    ).toBeDisabled();
+  });
+
   test("imports compact CSV regression fixture with bounded dashboard metrics", async ({
     page,
   }) => {
@@ -296,7 +367,7 @@ test.describe("browser application tracker", () => {
     await page.getByRole("button", { name: "Preview/dry-run" }).click();
 
     await expect(page.locator("[data-import-result]")).toContainText(
-      "Row 2 posting_url: posting_url is not a valid http(s) URL.",
+      "Row 2 posting_url: malformed_url: posting_url is not a valid http(s) URL.",
     );
     await expect(
       page.getByRole("button", { name: "Apply import" }),
@@ -398,6 +469,49 @@ test.describe("browser application tracker", () => {
     ).toBeVisible();
     await expect(page.locator("[data-weekly-counts]")).toHaveText(
       "2026-01-05: 2 • 2026-01-12: 1",
+    );
+  });
+
+  test("sorts lifecycle timeline by occurred date, due date, then stable id", async ({
+    page,
+  }) => {
+    const lifecycleHeader =
+      "application_id,company,role_title,event_type,occurred_at,stage," +
+      "channel,actor,source_artifact,requires_user_action,action_status," +
+      "due_at,no_ai_required,details";
+    const lifecycle = [
+      lifecycleHeader,
+      "fake_app_1,Example Labs,Frontend Engineer,next_tracking_step," +
+        "2026-02-01,,,,,,,2026-02-20,,Later due date",
+      "fake_app_1,Example Labs,Frontend Engineer,next_tracking_step," +
+        "2026-02-01,,,,,,,2026-02-10,,Earlier due date",
+    ].join("\n");
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await page.setInputFiles("[data-import-file]", {
+      name: "fake-applications.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(csvFixture),
+    });
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+    await page.getByRole("button", { name: "Apply import" }).click();
+    await page.setInputFiles("[data-import-file]", {
+      name: "lifecycle-sorting.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(lifecycle),
+    });
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+    await page.getByRole("button", { name: "Apply import" }).click();
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Example Labs" }).click();
+    await expect(page.locator(".timeline li").nth(2)).toContainText(
+      "Earlier due date",
+    );
+    await expect(page.locator(".timeline li").nth(3)).toContainText(
+      "Later due date",
     );
   });
 

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -29,6 +29,8 @@ const weeklyCsvFixture = [
 
 const regressionCsvFixture = () =>
   readFile("test/fixtures/tracker-import/compact-main-regression.csv", "utf8");
+const lifecycleFixture = (name) =>
+  readFile(`test/fixtures/tracker-import/${name}`, "utf8");
 
 test.describe("browser application tracker", () => {
   let server;
@@ -78,6 +80,63 @@ test.describe("browser application tracker", () => {
     await expect(page.locator("[data-import-result]")).toContainText(
       "Dry-run OK: 15 applications, 7 outreach messages, 0 interviews",
     );
+    await expect(page.locator("[data-import-result]")).toContainText(
+      "Detected format: compact application CSV",
+    );
+    await expect(page.locator("[data-import-result]")).toContainText(
+      "assessments: 1",
+    );
+  });
+
+  test("previews supplemental lifecycle CSV counts and missing application errors", async ({
+    page,
+  }) => {
+    const csv = await regressionCsvFixture();
+    const lifecycle = await lifecycleFixture(
+      "assessment-lifecycle-regression.csv",
+    );
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await page.setInputFiles("[data-import-file]", {
+      name: "compact-main-regression.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(csv),
+    });
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+    await page.getByRole("button", { name: "Apply import" }).click();
+
+    await page.setInputFiles("[data-import-file]", {
+      name: "assessment-lifecycle-regression.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(lifecycle),
+    });
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+    await expect(page.locator("[data-import-result]")).toContainText(
+      "Detected format: supplemental lifecycle CSV",
+    );
+    await expect(page.locator("[data-import-result]")).toContainText(
+      "lifecycleEvents: 2",
+    );
+    await expect(page.locator("[data-import-result]")).toContainText(
+      "assessments: 2",
+    );
+
+    const unknownApplicationLifecycle = lifecycle.replace(
+      "app_reg_alpha_001",
+      "missing_app_999",
+    );
+    await page.setInputFiles("[data-import-file]", {
+      name: "unknown-lifecycle.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(unknownApplicationLifecycle),
+    });
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+    await expect(page.locator("[data-import-result]")).toContainText(
+      "unknown_application",
+    );
+    await expect(
+      page.getByRole("button", { name: "Apply import" }),
+    ).toBeDisabled();
   });
 
   test("imports compact CSV regression fixture with bounded dashboard metrics", async ({
@@ -110,6 +169,71 @@ test.describe("browser application tracker", () => {
     await expect(metrics).toContainText("4 of 15 applications");
     await expect(metrics).toContainText("Outreach reply rate29%");
     await expect(metrics).toContainText("2 of 7 outreach messages");
+  });
+
+  test("shows compact metadata and lifecycle metadata in application detail", async ({
+    page,
+  }) => {
+    const csv = await regressionCsvFixture();
+    const assessmentLifecycle = await lifecycleFixture(
+      "assessment-lifecycle-regression.csv",
+    );
+    const recruiterLifecycle = await lifecycleFixture(
+      "recruiter-screen-lifecycle-regression.csv",
+    );
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await page.setInputFiles("[data-import-file]", {
+      name: "compact-main-regression.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(csv),
+    });
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+    await page.getByRole("button", { name: "Apply import" }).click();
+    for (const [name, buffer] of [
+      ["assessment-lifecycle-regression.csv", assessmentLifecycle],
+      ["recruiter-screen-lifecycle-regression.csv", recruiterLifecycle],
+    ]) {
+      await page.setInputFiles("[data-import-file]", {
+        name,
+        mimeType: "text/csv",
+        buffer: Buffer.from(buffer),
+      });
+      await page.getByRole("button", { name: "Preview/dry-run" }).click();
+      await page.getByRole("button", { name: "Apply import" }).click();
+    }
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await expect(page.locator("[data-applications-table]")).toContainText(
+      "Raw status: applied",
+    );
+    await page.getByRole("button", { name: "Company Alpha" }).click();
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Compact CSV metadata",
+    );
+    await expect(page.locator("[data-detail]")).toContainText("Raw status");
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Assessment/take-home",
+    );
+    await expect(page.locator("[data-detail]")).toContainText(
+      "No AI required: yes",
+    );
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Source artifact:",
+    );
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Company Gamma" }).click();
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Recruiter screens",
+    );
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Recruiter screen",
+    );
   });
 
   test("imports CSV, shows list, edits detail, and renders follow-ups", async ({


### PR DESCRIPTION
### Motivation
- Make the tracker UI reflect corrected import semantics (compact CSV vs supplemental lifecycle CSV vs JSON/NDJSON backups) and surface per-type counts, conflicts, warnings, and blocking errors before applying an import. 
- Keep dashboard metrics semantically correct and readable by splitting recruiter screens, non‑recruiter interviews, and written assessments, and exposing numerator/denominator context. 
- Improve application list/detail UX to preserve compact CSV metadata, show stable lifecycle timelines with event metadata, and make artifact links safe and accessible without sending any data to a server.

### Description
- Import preview: detect `compact application CSV`, `supplemental lifecycle CSV`, `JSON backup`, and `NDJSON backup`; show record counts per store, conflict lists, warnings/errors, and clear dry-run messaging that data remains local; disable `Apply import` when preview has blocking lifecycle errors (changes in `src/web/tracker/tracker.js`).
- Dashboard & metrics: updated metric cards with compact sublabels and numerator/denominator context; distinct visual/semantic buckets for recruiter screens, interviews, assessments, offers, and response rates (changes in `src/web/tracker/tracker.js` and `src/web/tracker/tracker.css`).
- Application list & detail: added filters for response/outreach/follow-up/activity and preserved compact CSV metadata in list rows; detail view shows a labeled compact CSV metadata section, a lifecycle timeline sorted by `occurredAt`, `dueAt`, then stable ID, separate sections/styling for assessments and recruiter screens, and safe artifact link rendering (changes in `src/web/tracker/index.html`, `src/web/tracker/tracker.js`, `src/web/tracker/tracker.css`).
- Accessibility/responsive polish: focus-visible outlines, disabled control styling, screen-reader `role="status"` and `aria-live` for import preview, table overflow handling, chips and timeline visual cues (CSS changes only). 
- Tests: extended Playwright coverage and updated browser-tracker tests to assert format detection, per-type counts, missing-application lifecycle errors, metadata visibility, and timeline rendering (changes in `test/playwright/browser-tracker.spec.js`).

### Testing
- `npm ci` — ran to install dev deps and Playwright binaries when needed; succeeded.  
- `npx prettier --check src/web/tracker/tracker.js src/web/tracker/index.html src/web/tracker/tracker.css test/playwright/browser-tracker.spec.js` — targeted formatting check passed.  
- `npm run lint` — ESLint passed for staged files; overall lint completed successfully.  
- `npm run typecheck` — `tsc` passed.  
- `npm run test:ci` (unit/integration Vitest suite) — passed (including `test/web-spreadsheet-import-export.test.js` and `test/web-tracker-metrics.test.js`).  
- `npx playwright test test/playwright/browser-tracker.spec.js` — Playwright tests executed (browsers downloaded as part of the run) and all browser-tracker specs passed.  
- `npm run build` — static build completed and produced `dist/`.  
- `npm run web:screenshots` — generated tracker screenshots successfully.  

All modified tests and added assertions passed in CI runs; unrelated repo-wide `prettier --check` warnings exist in files outside this change set but targeted files here are formatted.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ef8ec846c832f986520aa22f3a951)