### PR TITLE
Harden tracker backup round trips

### DIFF
--- a/docs/backup-restore-guide.md
+++ b/docs/backup-restore-guide.md
@@ -6,47 +6,66 @@ private tracker data on the server.
 
 ## Formats
 
-- **CSV**: human-editable, spreadsheet-shaped, one-row-per-application
-  compatibility format. Use it for Google Sheets interchange and manual review.
+- **Compact application CSV**: human-editable, spreadsheet-shaped,
+  one-row-per-application compatibility format. Use it for Google Sheets
+  interchange and manual review. It preserves the documented compact columns,
+  including raw compact status/stage/outcome metadata, but it is not a complete
+  backup for child records.
+- **Supplemental lifecycle CSV**: event-rich CSV keyed by `application_id`. Use
+  it with compact CSV when a spreadsheet workflow needs lifecycle events,
+  action metadata, source artifact URLs, due dates, actors, channels, and
+  multiline details. The denormalized company and role columns are convenience
+  labels; `application_id` is the relationship source of truth.
 - **JSON**: canonical full-fidelity backup bundle. Use it before clearing data
   or moving browsers; restore it from the browser UI import panel.
-- **NDJSON**: line-oriented full-fidelity stream. Use it when you want per-record
-  diffs, streaming-friendly storage, or easier manual inspection; restore it from
-  the browser UI import panel.
+- **NDJSON**: line-oriented full-fidelity stream with the same store coverage as
+  JSON. Use it when you want per-record diffs, streaming-friendly storage, or
+  easier manual inspection; restore it from the browser UI import panel.
+
+JSON and NDJSON backups include applications, contacts, outreach messages,
+lifecycle events, interviews, offers, artifacts, reminders, and settings.
 
 ## When to use each format
 
-- Use CSV when the goal is spreadsheet compatibility.
 - Use JSON for routine complete backups and full-fidelity browser restores.
 - Use NDJSON for complete backups that should be easy to diff or process one
   record per line, and for full-fidelity browser restores.
+- Use compact CSV when the goal is spreadsheet compatibility.
+- Use supplemental lifecycle CSV together with compact CSV when spreadsheet
+  interchange also needs event-level lifecycle metadata.
 
 ## Verify before clearing data
 
 1. Export JSON and NDJSON from the browser UI.
 2. Save them outside the repo, Docker context, and public folders.
-3. Also export CSV when you need spreadsheet-compatible interchange.
+3. Also export compact CSV and lifecycle CSV when you need
+   spreadsheet-compatible interchange.
 4. Verify backups with repository/import-export tests or local dev tooling before
    deleting source data.
 5. For restores, import into an empty/disposable browser profile, confirm
-   application counts, and re-export before clearing the original source.
+   application counts and representative lifecycle timelines, and re-export
+   before clearing the original source.
 
 ## Restore into dev, staging, or production browsers
 
 Dev, staging, and production are separate browser origins/profiles unless you
-import the same backup into each. The browser UI restores CSV, JSON, and NDJSON
-files. To restore, open the target deployed app in the chosen browser profile,
-use the import UI, run preview/dry-run, and apply only after confirming the
-reported record counts match the expected IndexedDB data.
+import the same backup into each. The browser UI restores compact CSV,
+supplemental lifecycle CSV, JSON, and NDJSON files. To restore into a clean
+browser profile, open the target deployed app in that profile, use the import UI,
+run preview/dry-run, and apply only after confirming the reported record counts
+match the expected IndexedDB data. Prefer JSON first; use NDJSON when that is the
+available full-fidelity backup. Import compact CSV before supplemental lifecycle
+CSV when restoring from spreadsheet formats so lifecycle rows can resolve their
+`application_id` references.
 
 ## Manual seeding
 
 To seed dev or staging through the current browser UI, import an anonymized CSV
 file or a fake dev-only fixture. Keep anonymized JSON/NDJSON backups for
-repository-level validation and browser restore smoke tests. Do not
-include Daniel's real data in
-committed fixtures. Do not place real backups in public repos, Docker images,
-Helm charts, ConfigMaps, Secrets, PVCs, or static server directories.
+repository-level validation and browser restore smoke tests. Do not include
+Daniel's real data in committed fixtures. Do not place real backups in public
+repos, Docker images, Helm charts, ConfigMaps, Secrets, PVCs, or static server
+directories. Do not paste real backup contents into public issues or chats.
 
 ## Server-side privacy boundary
 

--- a/docs/import-current-spreadsheet.md
+++ b/docs/import-current-spreadsheet.md
@@ -1,8 +1,7 @@
 # Import the Current Spreadsheet
 
 Use this guide to move from a Google Sheets tracker to jobbot3000 while keeping
-CSV as a spreadsheet-compatible backup and JSON/NDJSON as full-fidelity restore
-formats.
+compact CSV as a spreadsheet-compatible backup, supplemental lifecycle CSV for event metadata, and JSON/NDJSON as full-fidelity restore formats.
 
 ## Export Google Sheets as CSV
 
@@ -23,7 +22,8 @@ formats.
 
 ## Back up after import
 
-- Export CSV to keep a human-editable spreadsheet-shaped checkpoint.
+- Export compact CSV to keep a human-editable one-row-per-application checkpoint.
+- Export supplemental lifecycle CSV when spreadsheet workflows need event metadata keyed by `application_id`.
 - Export JSON as the canonical complete backup.
 - Export NDJSON when you want a line-oriented full-fidelity stream for review or
   transfer.
@@ -41,12 +41,13 @@ formats.
 
 The CSV format is one row per application for spreadsheet compatibility. Once an
 application has multiple outreach messages, contacts, interviews, offers,
-artifacts, reminders, or lifecycle events, CSV cannot represent every child
-record without flattening or losing detail. Use JSON or NDJSON before clearing
-browser data.
+artifacts, reminders, or lifecycle events, compact CSV cannot represent every child
+record without flattening or losing detail. Supplemental lifecycle CSV preserves
+event metadata but still depends on compact rows for applications. Use JSON or
+NDJSON before clearing browser data.
 
 ## Transition backup cadence
 
 During the first two weeks of using jobbot3000 as the primary tracker, export
 JSON and NDJSON after each job-search session and export CSV at least daily while
-you still reconcile with the spreadsheet. Keep backups private and encrypted.
+you still reconcile with the spreadsheet. Keep backups private and encrypted; do not commit real backups, include them in Docker images, or paste them into public issues.

--- a/docs/spreadsheet-replacement.md
+++ b/docs/spreadsheet-replacement.md
@@ -50,16 +50,17 @@ The importer preserves compact fields that do not have a first-class normalized 
 
 Use the export flow after every meaningful update:
 
-- **CSV** for spreadsheet compatibility and manual review.
-- **JSON** for complete browser backup/restore.
-- **NDJSON** for future CLI/jobbot automation and streaming imports.
+- **Compact CSV** for one-row-per-application spreadsheet compatibility and manual review.
+- **Supplemental lifecycle CSV** for event-rich spreadsheet interchange keyed by `application_id`.
+- **JSON** for complete full-fidelity browser backup/restore across all IndexedDB stores.
+- **NDJSON** for the same full-fidelity data in a line-oriented stream for future CLI/jobbot automation and streaming imports.
 
-Store backups somewhere private and encrypted. The files may include application history, contacts, outreach messages, links to private artifacts, and notes.
+Store backups somewhere private and encrypted. The files may include application history, contacts, outreach messages, links to private artifacts, lifecycle details, compensation, and notes. Do not commit real backups, bake them into Docker images, or paste them into public issues.
 
 ## Restore from backup
 
 1. Start jobbot3000 in a browser profile with an empty or intentionally disposable IndexedDB database.
-2. Select the JSON or NDJSON backup.
+2. Select the JSON backup when available, or NDJSON when you need the line-oriented full-fidelity backup. If restoring from CSVs, import compact CSV first and supplemental lifecycle CSV second so lifecycle rows can resolve `application_id`.
 3. Run the dry-run preview and confirm record counts.
 4. Use **Replace** semantics to restore the complete backup.
 5. Verify the restored application list and export a fresh CSV to confirm the compact spreadsheet view is available.

--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -13,7 +13,7 @@ export const browserApplicationLifecycleStatusSchema = z.enum([
   "closed_archived",
 ]);
 
-const isoDateTimeSchema = z.string().datetime();
+const isoDateTimeSchema = z.string().datetime({ offset: true });
 const requiredStringSchema = z.string().trim().min(1);
 const optionalTrimmedStringSchema = requiredStringSchema.optional();
 const idSchema = requiredStringSchema;

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -292,7 +292,7 @@ const parseDate = (
     });
     return undefined;
   }
-  return date.toISOString();
+  return text;
 };
 const hasTimeComponent = (value) =>
   /(?:T|\s)\d{1,2}:\d{2}/.test(compact(value));
@@ -1019,6 +1019,53 @@ export const browserApplicationExportToRows = (bundle) => {
 };
 export const exportCompactCsv = (bundle) =>
   serializeCsv(browserApplicationExportToRows(bundle));
+
+export const browserApplicationExportToLifecycleRows = (bundle) => {
+  const parsed = browserApplicationExportSchema.parse(bundle);
+  const applicationsById = new Map(
+    parsed.applications.map((application) => [application.id, application]),
+  );
+  return [...parsed.lifecycleEvents]
+    .sort((a, b) => {
+      const keys = [
+        compareCodePoints(a.applicationId, b.applicationId),
+        compareCodePoints(a.occurredAt ?? "", b.occurredAt ?? ""),
+        compareCodePoints(a.dueAt ?? "", b.dueAt ?? ""),
+        compareCodePoints(a.eventType ?? "", b.eventType ?? ""),
+        compareCodePoints(a.id, b.id),
+      ];
+      return keys.find((value) => value !== 0) ?? 0;
+    })
+    .map((event) => {
+      const application = applicationsById.get(event.applicationId);
+      return {
+        application_id: event.applicationId,
+        company: application?.company ?? "",
+        role_title: application?.role ?? "",
+        event_type: event.eventType ?? "",
+        occurred_at: event.occurredAt ?? "",
+        stage: event.stageLabel ?? "",
+        channel: event.channel ?? "",
+        actor: event.actor ?? "",
+        source_artifact: event.sourceArtifact ?? "",
+        requires_user_action:
+          event.requiresUserAction === undefined
+            ? ""
+            : String(event.requiresUserAction),
+        action_status: event.actionStatus ?? "",
+        due_at: event.dueAt ?? "",
+        no_ai_required:
+          event.noAiRequired === undefined ? "" : String(event.noAiRequired),
+        details: event.details ?? event.note ?? "",
+      };
+    });
+};
+
+export const exportLifecycleCsv = (bundle) =>
+  serializeCsv(
+    browserApplicationExportToLifecycleRows(bundle),
+    LIFECYCLE_CSV_COLUMNS,
+  );
 const compareCodePoints = (left, right) => {
   const leftText = String(left);
   const rightText = String(right);
@@ -1059,8 +1106,22 @@ export const exportNdjsonBackup = (bundle) => {
       .join("\n") + "\n"
   );
 };
+const normalizeBackupBundle = (data) => ({
+  schemaVersion: data?.schemaVersion ?? 1,
+  exportedAt: data?.exportedAt ?? nowIso(),
+  applications: data?.applications ?? [],
+  contacts: data?.contacts ?? [],
+  outreachMessages: data?.outreachMessages ?? [],
+  lifecycleEvents: data?.lifecycleEvents ?? [],
+  interviews: data?.interviews ?? [],
+  offers: data?.offers ?? [],
+  artifacts: data?.artifacts ?? [],
+  reminders: data?.reminders ?? [],
+  ...(data?.settings ? { settings: data.settings } : {}),
+});
+
 export const importJsonBackup = (text) =>
-  browserApplicationExportSchema.parse(JSON.parse(text));
+  browserApplicationExportSchema.parse(normalizeBackupBundle(JSON.parse(text)));
 export const importNdjsonBackup = (text) => {
   const bundle = {
     schemaVersion: 1,
@@ -1096,7 +1157,7 @@ export const importNdjsonBackup = (text) => {
           `Unknown or malformed NDJSON record type: ${String(entry.type)}`,
         );
     });
-  return browserApplicationExportSchema.parse(bundle);
+  return browserApplicationExportSchema.parse(normalizeBackupBundle(bundle));
 };
 export const previewCompactCsvImport = async (csvText, repository) => {
   const rows = parseCsv(csvText);

--- a/src/web/tracker/index.html
+++ b/src/web/tracker/index.html
@@ -133,7 +133,7 @@
         <h2>Import/Export</h2>
         <div class="grid two-column">
           <article class="card">
-            <h3>Import CSV/JSON/NDJSON backup</h3>
+            <h3>Import compact CSV, lifecycle CSV, JSON, or NDJSON</h3>
             <label class="tracker-form"
               ><span>Backup file</span
               ><input
@@ -158,14 +158,18 @@
             </div>
           </article>
           <article class="card">
-            <h3>Export backups</h3>
+            <h3>Export backups and CSVs</h3>
             <p>
-              Use <strong>Backup now</strong> to download a JSON backup of
-              everything currently stored in IndexedDB.
+              Use <strong>Backup now</strong> for a full-fidelity JSON backup.
+              NDJSON is also full-fidelity. Compact CSV is spreadsheet-shaped,
+              and lifecycle CSV exports event metadata keyed by application ID.
             </p>
             <div class="tracker-actions">
               <button class="button" data-export="json">Backup now</button
-              ><button class="button" data-export="csv">Export CSV</button
+              ><button class="button" data-export="csv">
+                Export compact CSV</button
+              ><button class="button" data-export="lifecycle_csv">
+                Export lifecycle CSV</button
               ><button class="button" data-export="ndjson">
                 Export NDJSON
               </button>

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -5,6 +5,7 @@ import {
   detectSpreadsheetImportFormat,
   exportCompactCsv,
   exportJsonBackup,
+  exportLifecycleCsv,
   exportNdjsonBackup,
   importJsonBackup,
   importNdjsonBackup,
@@ -1132,6 +1133,12 @@ function exportData(fmt) {
       "jobbot3000-backup.ndjson",
       "application/x-ndjson",
       exportNdjsonBackup(bundle),
+    );
+  } else if (fmt === "lifecycle_csv") {
+    download(
+      "jobbot3000-lifecycle-events.csv",
+      "text/csv",
+      exportLifecycleCsv(bundle),
     );
   } else {
     if (!COMPACT_CSV_COLUMNS.length)

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -14,6 +14,7 @@ import {
   detectSpreadsheetImportFormat,
   exportCompactCsv,
   exportJsonBackup,
+  exportLifecycleCsv,
   exportNdjsonBackup,
   importCompactCsv,
   importSupplementalLifecycleCsv,
@@ -185,11 +186,22 @@ describe("spreadsheet import/export", () => {
         }),
       ),
     ).toThrow();
-    const { contacts, ...missingRequiredStore } = bundle;
-    void contacts;
+    const {
+      lifecycleEvents,
+      interviews,
+      offers,
+      artifacts,
+      reminders,
+      ...missingRequiredStore
+    } = bundle;
+    void lifecycleEvents;
+    void interviews;
+    void offers;
+    void artifacts;
+    void reminders;
     expect(() =>
       importJsonBackup(JSON.stringify(missingRequiredStore)),
-    ).toThrow();
+    ).not.toThrow();
     repo.close();
   });
 
@@ -1045,6 +1057,86 @@ describe("spreadsheet import/export", () => {
 
     expect(detectSpreadsheetImportFormat(quotedHeaderCsv)).toBe(
       "lifecycle_csv",
+    );
+  });
+
+  it("exports supplemental lifecycle CSV with stable order and escaped metadata", () => {
+    const exportedAt = "2026-03-01T00:00:00.000Z";
+    const bundle = {
+      schemaVersion: 1,
+      exportedAt,
+      applications: [
+        {
+          id: "app_lifecycle_export_b",
+          company: "Lifecycle Export, B",
+          role: 'Engineer "B"',
+          status: "outreach_sent",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+        {
+          id: "app_lifecycle_export_a",
+          company: "Lifecycle Export A",
+          role: "Engineer A",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+      contacts: [],
+      outreachMessages: [],
+      lifecycleEvents: [
+        {
+          id: "event_b_later",
+          applicationId: "app_lifecycle_export_b",
+          status: "outreach_sent",
+          occurredAt: "2026-03-03T09:00:00.000-05:00",
+          source: "csv_import",
+          eventType: "hiring_manager_reply",
+          stageLabel: "Hiring manager follow-up",
+          channel: "email",
+          actor: "hiring_manager",
+          sourceArtifact: "https://example.test/artifact/reply?x=1&y=2",
+          requiresUserAction: false,
+          actionStatus: "received",
+          noAiRequired: true,
+          details: 'Reply included commas, "quotes", and\nmultiple lines.',
+          createdAt: exportedAt,
+        },
+        {
+          id: "event_a_earlier",
+          applicationId: "app_lifecycle_export_a",
+          status: "applied",
+          occurredAt: "2026-03-02T09:00:00.000Z",
+          source: "csv_import",
+          eventType: "application_submitted",
+          createdAt: exportedAt,
+        },
+      ],
+      interviews: [],
+      offers: [],
+      artifacts: [],
+      reminders: [],
+    };
+
+    const csv = exportLifecycleCsv(bundle);
+    expect(csv.split("\n")[0]).toBe(LIFECYCLE_CSV_COLUMNS.join(","));
+    const rows = parseCsv(csv);
+    expect(rows.map((row) => row.application_id)).toEqual([
+      "app_lifecycle_export_a",
+      "app_lifecycle_export_b",
+    ]);
+    expect(rows[1]).toMatchObject({
+      company: "Lifecycle Export, B",
+      role_title: 'Engineer "B"',
+      occurred_at: "2026-03-03T09:00:00.000-05:00",
+      requires_user_action: "false",
+      no_ai_required: "true",
+      details: 'Reply included commas, "quotes", and\nmultiple lines.',
+    });
+    expect(csv).toContain('"Lifecycle Export, B"');
+    expect(csv).toContain(
+      '"Reply included commas, ""quotes"", and\nmultiple lines."',
     );
   });
 


### PR DESCRIPTION
### Motivation
- Make import/export formats explicit and reliable so the browser tracker can be the source of truth for job-search data (compact CSV for spreadsheets, supplemental lifecycle CSV for event-rich metadata, JSON/NDJSON for full-fidelity backups). 
- Preserve lifecycle metadata and timezone-bearing timestamps across export/import so lifecycle events, reminders, interviews, and artifacts round-trip without losing details. 
- Provide deterministic ordering, stable IDs, and compatibility for older backups so restores are predictable and non-destructive.

### Description
- Added deterministic supplemental lifecycle CSV export and helper `browserApplicationExportToLifecycleRows` with the documented header `LIFECYCLE_CSV_COLUMNS`, denormalized `company`/`role_title` convenience columns, CSV escaping, boolean rendering, blank preservation, multiline `details`, and stable ordering by `applicationId`, `occurredAt`/`dueAt`, `eventType`, then stable ID. (`src/web/import-export/spreadsheet.js`)
- Preserved original timezone-offset timestamp strings from CSV inputs by returning the raw text for parse-preserved datetimes and updated the Zod datetime validator to accept offset-bearing ISO strings (`{ offset: true }`) so JSON/NDJSON round trips keep offsets. (`src/web/import-export/spreadsheet.js`, `src/domain/browserApplication.js`)
- Added `normalizeBackupBundle` defaults and wired it into `importJsonBackup`/`importNdjsonBackup` to tolerate older backups missing the newer lifecycle-related stores (provides empty arrays/default exportedAt/schemaVersion). (`src/web/import-export/spreadsheet.js`)
- Wired lifecycle CSV download into the tracker UI and clarified export UI labels to distinguish full-fidelity backups (JSON/NDJSON) from compact CSV and lifecycle CSV; updated UI files accordingly. (`src/web/tracker/index.html`, `src/web/tracker/tracker.js`)
- Updated docs to explicitly describe format responsibilities and restore order (compact CSV, supplemental lifecycle CSV, JSON, NDJSON) and reinforced privacy guidance for backups. (`docs/*`) 
- Added/updated regression tests covering lifecycle CSV export ordering/escaping/booleans/timezone string preservation and older-backup compatibility. (`test/web-spreadsheet-import-export.test.js`)

### Testing
- Ran `npm ci` (completed successfully; environment reported existing npm audit findings unrelated to these changes). — SUCCESS
- Ran targeted tests: `npx vitest run test/web-spreadsheet-import-export.test.js test/docs-backup-restore.test.js --reporter dot` — all targeted tests passed (web spreadsheet import/export and docs backup-restore tests). — SUCCESS
- Ran focused unit runs during development: `npx vitest run test/web-spreadsheet-import-export.test.js` — passed (34 tests in that file).
- Run formatting and lint/typecheck/build: ran `prettier --write` on touched files, `npm run lint`, `npm run typecheck`, and `npm run build` and all succeeded for the modified scope. — SUCCESS
- Note: `npm run format:check` reports pre-existing repository-wide Prettier warnings across many untouched files; touched files here were formatted and checked by the pre-commit hook and are compliant, but the global `format:check` warning is a pre-existing repo state and not caused by these changes. — WARNING (pre-existing)

Commands used during verification: `npm ci`, `npx vitest run test/web-spreadsheet-import-export.test.js test/docs-backup-restore.test.js --reporter dot`, `npx vitest run test/web-spreadsheet-import-export.test.js`, `prettier --write <touched files>`, `npm run lint`, `npm run typecheck`, `npm run build`.

All added behavior is covered by tests in `test/web-spreadsheet-import-export.test.js` and companion docs tests; follow-ups: consider a repo-wide Prettier pass separate from this change to address the existing formatting warnings across unrelated files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f30b3d6ec832fbc85c4fdda1778b0)