### PR TITLE
Harden lifecycle CSV backup exports

### DIFF
--- a/docs/backup-restore-guide.md
+++ b/docs/backup-restore-guide.md
@@ -6,8 +6,12 @@ private tracker data on the server.
 
 ## Formats
 
-- **CSV**: human-editable, spreadsheet-shaped, one-row-per-application
+- **Compact application CSV**: human-editable, spreadsheet-shaped, one-row-per-application
   compatibility format. Use it for Google Sheets interchange and manual review.
+- **Supplemental lifecycle CSV**: event-rich CSV keyed by `application_id`. It
+  preserves per-application lifecycle metadata such as stage labels, actor,
+  channel, source artifact, action status, due date, `no_ai_required`, and
+  multiline details, while using application ID as the relationship source of truth.
 - **JSON**: canonical full-fidelity backup bundle. Use it before clearing data
   or moving browsers; restore it from the browser UI import panel.
 - **NDJSON**: line-oriented full-fidelity stream. Use it when you want per-record
@@ -16,7 +20,8 @@ private tracker data on the server.
 
 ## When to use each format
 
-- Use CSV when the goal is spreadsheet compatibility.
+- Use compact CSV when the goal is one-row-per-application spreadsheet compatibility.
+- Use supplemental lifecycle CSV with compact CSV when you need spreadsheet-readable event metadata.
 - Use JSON for routine complete backups and full-fidelity browser restores.
 - Use NDJSON for complete backups that should be easy to diff or process one
   record per line, and for full-fidelity browser restores.
@@ -25,7 +30,7 @@ private tracker data on the server.
 
 1. Export JSON and NDJSON from the browser UI.
 2. Save them outside the repo, Docker context, and public folders.
-3. Also export CSV when you need spreadsheet-compatible interchange.
+3. Also export compact CSV and lifecycle CSV when you need spreadsheet-compatible interchange or event review.
 4. Verify backups with repository/import-export tests or local dev tooling before
    deleting source data.
 5. For restores, import into an empty/disposable browser profile, confirm
@@ -34,7 +39,7 @@ private tracker data on the server.
 ## Restore into dev, staging, or production browsers
 
 Dev, staging, and production are separate browser origins/profiles unless you
-import the same backup into each. The browser UI restores CSV, JSON, and NDJSON
+import the same backup into each. The browser UI restores compact CSV, supplemental lifecycle CSV, JSON, and NDJSON
 files. To restore, open the target deployed app in the chosen browser profile,
 use the import UI, run preview/dry-run, and apply only after confirming the
 reported record counts match the expected IndexedDB data.
@@ -45,7 +50,7 @@ To seed dev or staging through the current browser UI, import an anonymized CSV
 file or a fake dev-only fixture. Keep anonymized JSON/NDJSON backups for
 repository-level validation and browser restore smoke tests. Do not
 include Daniel's real data in
-committed fixtures. Do not place real backups in public repos, Docker images,
+committed fixtures. Do not paste real backups into public issues or place them in public repos, Docker images,
 Helm charts, ConfigMaps, Secrets, PVCs, or static server directories.
 
 ## Server-side privacy boundary

--- a/docs/import-current-spreadsheet.md
+++ b/docs/import-current-spreadsheet.md
@@ -1,7 +1,7 @@
 # Import the Current Spreadsheet
 
 Use this guide to move from a Google Sheets tracker to jobbot3000 while keeping
-CSV as a spreadsheet-compatible backup and JSON/NDJSON as full-fidelity restore
+compact CSV as a spreadsheet-compatible backup, supplemental lifecycle CSV for event metadata, and JSON/NDJSON as full-fidelity restore
 formats.
 
 ## Export Google Sheets as CSV
@@ -23,7 +23,8 @@ formats.
 
 ## Back up after import
 
-- Export CSV to keep a human-editable spreadsheet-shaped checkpoint.
+- Export compact CSV to keep a human-editable spreadsheet-shaped checkpoint.
+- Export supplemental lifecycle CSV if you want spreadsheet-readable event metadata keyed by `application_id`.
 - Export JSON as the canonical complete backup.
 - Export NDJSON when you want a line-oriented full-fidelity stream for review or
   transfer.
@@ -37,16 +38,20 @@ formats.
    offers, notes, artifacts, and reminders.
 5. Re-export JSON/NDJSON and compare record counts before deleting the old source.
 
-## Why CSV is not full fidelity
+## How the two CSV formats work together
 
-The CSV format is one row per application for spreadsheet compatibility. Once an
-application has multiple outreach messages, contacts, interviews, offers,
-artifacts, reminders, or lifecycle events, CSV cannot represent every child
-record without flattening or losing detail. Use JSON or NDJSON before clearing
-browser data.
+Compact CSV is one row per application for spreadsheet compatibility. Supplemental lifecycle CSV is one row per lifecycle event and uses `application_id` to attach events back to applications. Import compact CSV first, then lifecycle CSV, so lifecycle rows cannot create orphan child records.
+
+## Why JSON/NDJSON are preferred for full-fidelity backup
+
+The CSV formats are reviewable and spreadsheet-friendly, but they are not complete backups of every current IndexedDB store. JSON and NDJSON preserve applications, contacts, outreach messages, lifecycle events, interviews, offers, artifacts, reminders, settings, IDs, timestamps, and relationships. Use JSON or NDJSON before clearing browser data.
 
 ## Transition backup cadence
 
 During the first two weeks of using jobbot3000 as the primary tracker, export
 JSON and NDJSON after each job-search session and export CSV at least daily while
 you still reconcile with the spreadsheet. Keep backups private and encrypted.
+
+## Privacy expectations
+
+Real exports can contain private job-search data, notes, source artifact links, and contacts. Do not commit them, bake them into Docker images, or paste them into public issues. Keep real backups private and encrypted.

--- a/docs/spreadsheet-replacement.md
+++ b/docs/spreadsheet-replacement.md
@@ -46,15 +46,24 @@ After import, spot-check a few rows in the application tracker:
 
 The importer preserves compact fields that do not have a first-class normalized field as a `Spreadsheet metadata:` line in application notes, so values such as posting IDs, fit scores, and application URLs are not silently dropped.
 
+## Supplemental lifecycle CSV columns
+
+Lifecycle CSV is the event-rich companion format. It is keyed by `application_id`; the denormalized company and role title columns are convenience labels only. Export order is deterministic by application ID, occurred/due time, event type, and stable ID.
+
+```text
+application_id,company,role_title,event_type,occurred_at,stage,channel,actor,source_artifact,requires_user_action,action_status,due_at,no_ai_required,details
+```
+
 ## Export a backup
 
 Use the export flow after every meaningful update:
 
-- **CSV** for spreadsheet compatibility and manual review.
-- **JSON** for complete browser backup/restore.
-- **NDJSON** for future CLI/jobbot automation and streaming imports.
+- **Compact CSV** for one-row-per-application spreadsheet compatibility and manual review.
+- **Lifecycle CSV** for spreadsheet-readable event metadata keyed by `application_id`.
+- **JSON** for complete full-fidelity browser backup/restore.
+- **NDJSON** for full-fidelity line-oriented backups, future CLI/jobbot automation, and streaming imports.
 
-Store backups somewhere private and encrypted. The files may include application history, contacts, outreach messages, links to private artifacts, and notes.
+Store backups somewhere private and encrypted. The files may include application history, contacts, outreach messages, links to private artifacts, and notes. Do not commit real backups, embed them in Docker images, or paste them into public issues.
 
 ## Restore from backup
 

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1019,6 +1019,52 @@ export const browserApplicationExportToRows = (bundle) => {
 };
 export const exportCompactCsv = (bundle) =>
   serializeCsv(browserApplicationExportToRows(bundle));
+
+export const browserApplicationExportToLifecycleRows = (bundle) => {
+  const parsed = browserApplicationExportSchema.parse(bundle);
+  const applicationsById = new Map(
+    parsed.applications.map((application) => [application.id, application]),
+  );
+  return [...parsed.lifecycleEvents]
+    .sort((a, b) => {
+      const keys = [
+        compareCodePoints(a.applicationId, b.applicationId),
+        compareCodePoints(a.occurredAt ?? "", b.occurredAt ?? ""),
+        compareCodePoints(a.dueAt ?? "", b.dueAt ?? ""),
+        compareCodePoints(a.eventType ?? "", b.eventType ?? ""),
+        compareCodePoints(a.id, b.id),
+      ];
+      return keys.find((value) => value !== 0) ?? 0;
+    })
+    .map((event) => {
+      const application = applicationsById.get(event.applicationId);
+      return {
+        application_id: event.applicationId,
+        company: application?.company ?? "",
+        role_title: application?.role ?? "",
+        event_type: event.eventType ?? "",
+        occurred_at: event.occurredAt ?? "",
+        stage: event.stageLabel ?? "",
+        channel: event.channel ?? "",
+        actor: event.actor ?? "",
+        source_artifact: event.sourceArtifact ?? "",
+        requires_user_action:
+          event.requiresUserAction === undefined
+            ? ""
+            : String(event.requiresUserAction),
+        action_status: event.actionStatus ?? "",
+        due_at: event.dueAt ?? "",
+        no_ai_required:
+          event.noAiRequired === undefined ? "" : String(event.noAiRequired),
+        details: event.details ?? event.note ?? "",
+      };
+    });
+};
+export const exportLifecycleCsv = (bundle) =>
+  serializeCsv(
+    browserApplicationExportToLifecycleRows(bundle),
+    LIFECYCLE_CSV_COLUMNS,
+  );
 const compareCodePoints = (left, right) => {
   const leftText = String(left);
   const rightText = String(right);

--- a/src/web/tracker/index.html
+++ b/src/web/tracker/index.html
@@ -160,12 +160,17 @@
           <article class="card">
             <h3>Export backups</h3>
             <p>
-              Use <strong>Backup now</strong> to download a JSON backup of
-              everything currently stored in IndexedDB.
+              Use <strong>Backup now</strong> to download a full-fidelity JSON
+              backup of everything currently stored in IndexedDB. JSON/NDJSON
+              are complete backups; compact CSV is spreadsheet-friendly;
+              lifecycle CSV is event metadata keyed by application ID.
             </p>
             <div class="tracker-actions">
               <button class="button" data-export="json">Backup now</button
-              ><button class="button" data-export="csv">Export CSV</button
+              ><button class="button" data-export="csv">
+                Export compact CSV</button
+              ><button class="button" data-export="lifecycle-csv">
+                Export lifecycle CSV</button
               ><button class="button" data-export="ndjson">
                 Export NDJSON
               </button>

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -5,6 +5,7 @@ import {
   detectSpreadsheetImportFormat,
   exportCompactCsv,
   exportJsonBackup,
+  exportLifecycleCsv,
   exportNdjsonBackup,
   importJsonBackup,
   importNdjsonBackup,
@@ -1132,6 +1133,12 @@ function exportData(fmt) {
       "jobbot3000-backup.ndjson",
       "application/x-ndjson",
       exportNdjsonBackup(bundle),
+    );
+  } else if (fmt === "lifecycle-csv") {
+    download(
+      "jobbot3000-lifecycle.csv",
+      "text/csv",
+      exportLifecycleCsv(bundle),
     );
   } else {
     if (!COMPACT_CSV_COLUMNS.length)

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -14,6 +14,7 @@ import {
   detectSpreadsheetImportFormat,
   exportCompactCsv,
   exportJsonBackup,
+  exportLifecycleCsv,
   exportNdjsonBackup,
   importCompactCsv,
   importSupplementalLifecycleCsv,
@@ -216,6 +217,7 @@ describe("spreadsheet import/export", () => {
     expect(tracker).toContain("COMPACT_CSV_COLUMNS");
     expect(tracker).toContain("exportCompactCsv");
     expect(tracker).toContain("exportJsonBackup");
+    expect(tracker).toContain("exportLifecycleCsv");
     expect(tracker).toContain("exportNdjsonBackup");
     expect(tracker).toContain("../import-export/spreadsheet.js");
     const legacyHeader = [
@@ -1034,6 +1036,171 @@ describe("spreadsheet import/export", () => {
         }),
       ]),
     );
+    repo.close();
+  });
+
+  it("exports supplemental lifecycle CSV with stable order and full metadata", () => {
+    const exportedAt = "2026-03-01T00:00:00.000Z";
+    const bundle = {
+      schemaVersion: 1,
+      exportedAt,
+      applications: [
+        {
+          id: "app_b",
+          company: "Lifecycle B",
+          role: "Backend Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+        {
+          id: "app_a",
+          company: "Lifecycle A",
+          role: "Frontend Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+      contacts: [],
+      outreachMessages: [],
+      lifecycleEvents: [
+        {
+          id: "event_b_late",
+          applicationId: "app_b",
+          status: "outreach_sent",
+          occurredAt: "2026-03-05T12:00:00.000Z",
+          source: "csv_import",
+          eventType: "hiring_manager_reply",
+          stageLabel: "Hiring manager follow-up",
+          channel: "email",
+          actor: "hiring_manager",
+          sourceArtifact: "https://example.test/artifact/reply,b",
+          requiresUserAction: false,
+          actionStatus: "received",
+          noAiRequired: true,
+          details: [
+            'Reply includes comma, "quote", URL',
+            "https://example.test/path?a=1,b=2\nand a second line.",
+          ].join(" "),
+          createdAt: exportedAt,
+        },
+        {
+          id: "event_a_due",
+          applicationId: "app_a",
+          status: "applied",
+          occurredAt: "2026-03-04T17:00:00.000Z",
+          source: "csv_import",
+          eventType: "written_assessment_requested",
+          stageLabel: "Written assessment",
+          channel: "portal",
+          actor: "employer",
+          sourceArtifact: "https://example.test/artifact/assessment-a",
+          requiresUserAction: true,
+          actionStatus: "pending",
+          dueAt: "2026-03-07T22:00:00.000Z",
+          noAiRequired: false,
+          details: "Assessment details",
+          createdAt: exportedAt,
+        },
+      ],
+      interviews: [],
+      offers: [],
+      artifacts: [],
+      reminders: [],
+    };
+
+    const csv = exportLifecycleCsv(bundle);
+    expect(csv.split("\n")[0]).toBe(LIFECYCLE_CSV_COLUMNS.join(","));
+    expect(csv).toContain('"https://example.test/artifact/reply,b"');
+    expect(csv).toContain('"Reply includes comma, ""quote"", URL');
+    const rows = parseCsv(csv);
+    expect(rows.map(({ application_id }) => application_id)).toEqual([
+      "app_a",
+      "app_b",
+    ]);
+    expect(rows[0]).toMatchObject({
+      application_id: "app_a",
+      company: "Lifecycle A",
+      role_title: "Frontend Engineer",
+      event_type: "written_assessment_requested",
+      occurred_at: "2026-03-04T17:00:00.000Z",
+      due_at: "2026-03-07T22:00:00.000Z",
+      requires_user_action: "true",
+      no_ai_required: "false",
+    });
+    expect(rows[1]).toMatchObject({
+      application_id: "app_b",
+      source_artifact: "https://example.test/artifact/reply,b",
+      requires_user_action: "false",
+      no_ai_required: "true",
+      details:
+        'Reply includes comma, "quote", URL https://example.test/path?a=1,b=2\nand a second line.',
+    });
+  });
+
+  it("round-trips supplemental lifecycle CSV exports through import", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await importCompactCsv(
+      serializeCsv([
+        {
+          application_id: "app_lifecycle_export_roundtrip",
+          company: "Lifecycle Export Roundtrip",
+          role_title: "Engineer",
+          applied_at: "2026-01-01",
+          schema_version: "1",
+        },
+      ]),
+      repo,
+      { mode: "replace" },
+    );
+    const lifecycleCsv = serializeCsv(
+      [
+        {
+          application_id: "app_lifecycle_export_roundtrip",
+          company: "Lifecycle Export Roundtrip",
+          role_title: "Engineer",
+          event_type: "next_tracking_step",
+          occurred_at: "2026-01-02T09:00:00.000Z",
+          stage: "Follow up",
+          channel: "email",
+          actor: "candidate",
+          source_artifact: "https://example.test/artifact/follow-up",
+          requires_user_action: "true",
+          action_status: "pending",
+          due_at: "2026-01-05T17:00:00.000Z",
+          no_ai_required: "false",
+          details: "Follow up with a multiline note.\nSecond line.",
+        },
+      ],
+      LIFECYCLE_CSV_COLUMNS,
+    );
+    expect(
+      (await importSupplementalLifecycleCsv(lifecycleCsv, repo)).imported,
+    ).toBe(true);
+    const exportedCsv = exportLifecycleCsv(await repo.exportAllData());
+    const preview = await previewSupplementalLifecycleCsvImport(
+      exportedCsv,
+      repo,
+    );
+    expect(preview.errors).toEqual([]);
+    expect(preview.conflicts).toEqual([]);
+    expect(
+      preview.bundle.lifecycleEvents.filter(
+        ({ eventType }) => eventType === "next_tracking_step",
+      ),
+    ).toEqual([
+      expect.objectContaining({
+        applicationId: "app_lifecycle_export_roundtrip",
+        eventType: "next_tracking_step",
+        sourceArtifact: "https://example.test/artifact/follow-up",
+        requiresUserAction: true,
+        actionStatus: "pending",
+        dueAt: "2026-01-05T17:00:00.000Z",
+        noAiRequired: false,
+        details: "Follow up with a multiline note.\nSecond line.",
+      }),
+    ]);
     repo.close();
   });
 


### PR DESCRIPTION
### Motivation
- Make export/backup behavior deterministic and lossless for supplemental lifecycle CSV so compact CSV + lifecycle CSV + JSON/NDJSON can round-trip tracker data without creating orphan records. 
- Clarify format responsibilities in the UI/docs so users know when to use compact CSV, lifecycle CSV, JSON, and NDJSON. 

### Description
- Added a canonical lifecycle CSV exporter and helper `browserApplicationExportToLifecycleRows` and `exportLifecycleCsv` that emit rows with header `application_id,company,role_title,event_type,occurred_at,stage,channel,actor,source_artifact,requires_user_action,action_status,due_at,no_ai_required,details` and deterministic ordering by `applicationId`, `occurredAt`, `dueAt`, `eventType`, then stable id. 
- Serialized boolean and blank values consistently, preserved multiline `details`, `sourceArtifact`, `actionStatus`, `requiresUserAction`, `noAiRequired`, and denormalized `company`/`role_title` for convenience while keeping `application_id` as the relationship source of truth. 
- Wired tracker UI to offer a lifecycle CSV download alongside the existing compact CSV/JSON/NDJSON exports and added user-facing text describing format tradeoffs. 
- Added regression tests covering lifecycle CSV header, quoting/escaping, multiline details, booleans/blanks, deterministic ordering, and import/export/import round-trip idempotency, and updated docs to explain the two-CSV workflow and privacy expectations. 

### Testing
- `npm ci` — passed. 
- `npx prettier --check src/web/import-export/spreadsheet.js src/web/tracker/tracker.js src/web/tracker/index.html test/web-spreadsheet-import-export.test.js docs/backup-restore-guide.md docs/import-current-spreadsheet.md docs/spreadsheet-replacement.md` — passed for changed files. 
- `npm run format:check` — failed on repository-wide pre-existing formatting baseline (reported many unrelated files), which is outside this change; targeted files were formatted. 
- `npx vitest run test/web-spreadsheet-import-export.test.js` — passed (all tests in that file passed). 
- `npm run lint && npm run typecheck && npm run build` — passed after rebuilding to avoid a transient `dist/` lint artifact. 
- `npm run test:ci` — full CI test run completed successfully (large test suite passed). 
- Static export UI smoke: started static server and used Playwright to capture a screenshot of the Import/Export panel (screenshot saved at `/tmp/jobbot-lifecycle-export-ui.png`), with `npx playwright install` performed where required. 

Residual risks and follow-ups: update any external documentation consumers if they relied on legacy CSV headers, and address the repo-wide Prettier baseline separately (the changed files are formatted). No new runtime dependencies were added and no private data was committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f30b9f408832f8b4d338e0a880ee6)