### PR TITLE
Harden tracker backup round trips

### DIFF
--- a/docs/backup-restore-guide.md
+++ b/docs/backup-restore-guide.md
@@ -32,9 +32,9 @@ private tracker data on the server.
 ## Restore into dev, staging, or production browsers
 
 Dev, staging, and production are separate browser origins/profiles unless you
-import the same backup into each. The browser UI restores CSV, JSON, and NDJSON
+import the same backup into each. The browser UI restores compact CSV, supplemental lifecycle CSV, JSON, and NDJSON
 files. To restore, open the target deployed app in the chosen browser profile,
-use the import UI, run preview/dry-run, and apply only after confirming the reported record counts match the expected IndexedDB data. For a clean restore, create a new browser profile (or clear local tracker data after saving a verified backup), import JSON first when available, use NDJSON as the equivalent full-fidelity fallback, and then spot-check lifecycle timelines, recruiter screens, reminders, artifacts, and settings before deleting the original profile.
+use the import UI, run preview/dry-run, and apply only after confirming the reported record counts match the expected IndexedDB data. For a clean restore, create a new browser profile (or clear local tracker data after saving a verified backup), import JSON first when available, use NDJSON as the equivalent full-fidelity fallback, or import compact CSV followed by supplemental lifecycle CSV for spreadsheet interchange; then spot-check lifecycle timelines, recruiter screens, reminders, artifacts, and settings before deleting the original profile.
 
 ## Manual seeding
 

--- a/docs/backup-restore-guide.md
+++ b/docs/backup-restore-guide.md
@@ -6,26 +6,24 @@ private tracker data on the server.
 
 ## Formats
 
-- **CSV**: human-editable, spreadsheet-shaped, one-row-per-application
-  compatibility format. Use it for Google Sheets interchange and manual review.
-- **JSON**: canonical full-fidelity backup bundle. Use it before clearing data
-  or moving browsers; restore it from the browser UI import panel.
-- **NDJSON**: line-oriented full-fidelity stream. Use it when you want per-record
-  diffs, streaming-friendly storage, or easier manual inspection; restore it from
-  the browser UI import panel.
+- **Compact application CSV**: human-editable, spreadsheet-shaped, one-row-per-application compatibility format. Use it for Google Sheets interchange and manual review; it preserves documented compact metadata but is not the complete backup format.
+- **Supplemental lifecycle CSV**: event-rich CSV keyed by `application_id`. Use it with compact CSV when a spreadsheet workflow needs lifecycle events, action metadata, source artifacts, due dates, and multiline details.
+- **JSON**: canonical full-fidelity backup bundle for complete browser restores. It includes applications, contacts, outreach messages, lifecycle events, interviews, offers, artifacts, reminders, and settings. Use it for routine backups, before clearing data, or when moving browsers.
+- **NDJSON**: line-oriented full-fidelity stream with stable record types and version metadata. Use it when you want per-record diffs, streaming-friendly storage, or easier manual inspection; restore it from the browser UI import panel.
 
 ## When to use each format
 
-- Use CSV when the goal is spreadsheet compatibility.
+- Use compact CSV when the goal is spreadsheet compatibility.
+- Use supplemental lifecycle CSV alongside compact CSV when the spreadsheet workflow needs event metadata; `application_id` is the relationship source of truth.
 - Use JSON for routine complete backups and full-fidelity browser restores.
 - Use NDJSON for complete backups that should be easy to diff or process one
   record per line, and for full-fidelity browser restores.
 
 ## Verify before clearing data
 
-1. Export JSON and NDJSON from the browser UI.
+1. Export JSON and NDJSON from the browser UI; prefer JSON as the everyday backup.
 2. Save them outside the repo, Docker context, and public folders.
-3. Also export CSV when you need spreadsheet-compatible interchange.
+3. Also export compact CSV and lifecycle CSV when you need spreadsheet-compatible interchange or event review.
 4. Verify backups with repository/import-export tests or local dev tooling before
    deleting source data.
 5. For restores, import into an empty/disposable browser profile, confirm
@@ -36,8 +34,7 @@ private tracker data on the server.
 Dev, staging, and production are separate browser origins/profiles unless you
 import the same backup into each. The browser UI restores CSV, JSON, and NDJSON
 files. To restore, open the target deployed app in the chosen browser profile,
-use the import UI, run preview/dry-run, and apply only after confirming the
-reported record counts match the expected IndexedDB data.
+use the import UI, run preview/dry-run, and apply only after confirming the reported record counts match the expected IndexedDB data. For a clean restore, create a new browser profile (or clear local tracker data after saving a verified backup), import JSON first when available, use NDJSON as the equivalent full-fidelity fallback, and then spot-check lifecycle timelines, recruiter screens, reminders, artifacts, and settings before deleting the original profile.
 
 ## Manual seeding
 
@@ -45,7 +42,7 @@ To seed dev or staging through the current browser UI, import an anonymized CSV
 file or a fake dev-only fixture. Keep anonymized JSON/NDJSON backups for
 repository-level validation and browser restore smoke tests. Do not
 include Daniel's real data in
-committed fixtures. Do not place real backups in public repos, Docker images,
+committed fixtures. Real backups may contain private names, companies, URLs, notes, outreach text, and artifact links; do not paste them into public issues or support chats. Do not place real backups in public repos, Docker images,
 Helm charts, ConfigMaps, Secrets, PVCs, or static server directories.
 
 ## Server-side privacy boundary

--- a/docs/import-current-spreadsheet.md
+++ b/docs/import-current-spreadsheet.md
@@ -1,8 +1,7 @@
 # Import the Current Spreadsheet
 
 Use this guide to move from a Google Sheets tracker to jobbot3000 while keeping
-CSV as a spreadsheet-compatible backup and JSON/NDJSON as full-fidelity restore
-formats.
+compact CSV as a spreadsheet-compatible backup, supplemental lifecycle CSV as the event-rich spreadsheet companion, and JSON/NDJSON as full-fidelity restore formats.
 
 ## Export Google Sheets as CSV
 
@@ -23,7 +22,8 @@ formats.
 
 ## Back up after import
 
-- Export CSV to keep a human-editable spreadsheet-shaped checkpoint.
+- Export compact CSV to keep a human-editable spreadsheet-shaped checkpoint.
+- Export lifecycle CSV if you imported or maintain event metadata outside the compact sheet.
 - Export JSON as the canonical complete backup.
 - Export NDJSON when you want a line-oriented full-fidelity stream for review or
   transfer.
@@ -39,14 +39,10 @@ formats.
 
 ## Why CSV is not full fidelity
 
-The CSV format is one row per application for spreadsheet compatibility. Once an
-application has multiple outreach messages, contacts, interviews, offers,
-artifacts, reminders, or lifecycle events, CSV cannot represent every child
-record without flattening or losing detail. Use JSON or NDJSON before clearing
-browser data.
+Compact CSV is one row per application for spreadsheet compatibility. Supplemental lifecycle CSV adds one row per event keyed by `application_id`, but JSON/NDJSON remain preferred for full-fidelity backups because they preserve every current store, relationship, ID, setting, and child record without flattening. Use JSON or NDJSON before clearing browser data.
 
 ## Transition backup cadence
 
 During the first two weeks of using jobbot3000 as the primary tracker, export
 JSON and NDJSON after each job-search session and export CSV at least daily while
-you still reconcile with the spreadsheet. Keep backups private and encrypted.
+you still reconcile with the spreadsheet. Keep backups private and encrypted, and never commit real backups, embed them in Docker images, or paste them into public issues.

--- a/docs/spreadsheet-replacement.md
+++ b/docs/spreadsheet-replacement.md
@@ -1,6 +1,6 @@
 # Replacing the Google Sheets application tracker
 
-jobbot3000 can import the compact CSV tracker into the browser-first IndexedDB data model and export durable backups. Use only fake/test data in the repository; keep real application records in private browser backups.
+jobbot3000 can import the compact CSV tracker into the browser-first IndexedDB data model and export durable backups. Compact CSV is the spreadsheet-compatible one-row-per-application format, supplemental lifecycle CSV carries event metadata keyed by `application_id`, and JSON/NDJSON are full-fidelity backup/restore formats. Use only fake/test data in the repository; keep real application records in private browser backups.
 
 ## Supported compact CSV columns
 
@@ -50,11 +50,12 @@ The importer preserves compact fields that do not have a first-class normalized 
 
 Use the export flow after every meaningful update:
 
-- **CSV** for spreadsheet compatibility and manual review.
-- **JSON** for complete browser backup/restore.
-- **NDJSON** for future CLI/jobbot automation and streaming imports.
+- **Compact CSV** for spreadsheet compatibility and manual review.
+- **Lifecycle CSV** when you need event rows, source artifacts, action status, due dates, and multiline details tied back to applications by `application_id`.
+- **JSON** for complete browser backup/restore; this is the preferred everyday backup.
+- **NDJSON** for equivalent full-fidelity backup/restore with one typed record per line.
 
-Store backups somewhere private and encrypted. The files may include application history, contacts, outreach messages, links to private artifacts, and notes.
+Store backups somewhere private and encrypted. The files may include application history, contacts, outreach messages, links to private artifacts, private URLs, company names, and notes. Do not commit real backups, bake them into Docker images, or paste them into public issues.
 
 ## Restore from backup
 

--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -13,7 +13,7 @@ export const browserApplicationLifecycleStatusSchema = z.enum([
   "closed_archived",
 ]);
 
-const isoDateTimeSchema = z.string().datetime();
+const isoDateTimeSchema = z.string().datetime({ offset: true });
 const requiredStringSchema = z.string().trim().min(1);
 const optionalTrimmedStringSchema = requiredStringSchema.optional();
 const idSchema = requiredStringSchema;

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -271,6 +271,71 @@ export const serializeCsv = (rows, columns = COMPACT_CSV_COLUMNS) =>
     ),
   ].join("\n");
 
+const ISO_OFFSET_DATE_TIME =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|([+-])(\d{2}):(\d{2}))$/;
+
+const isValidIsoOffsetDateTime = (text) => {
+  const match = ISO_OFFSET_DATE_TIME.exec(text);
+  if (!match) return false;
+  const [
+    ,
+    yearText,
+    monthText,
+    dayText,
+    hourText,
+    minuteText,
+    secondText,
+    fractionText = "0",
+    offsetText,
+    offsetSign,
+    offsetHourText = "0",
+    offsetMinuteText = "0",
+  ] = match;
+  const year = Number(yearText);
+  const month = Number(monthText);
+  const day = Number(dayText);
+  const hour = Number(hourText);
+  const minute = Number(minuteText);
+  const second = Number(secondText);
+  const millisecond = Number(fractionText.padEnd(3, "0").slice(0, 3));
+  const offsetHour = Number(offsetHourText);
+  const offsetMinute = Number(offsetMinuteText);
+  if (
+    month < 1 ||
+    month > 12 ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59 ||
+    offsetHour > 23 ||
+    offsetMinute > 59
+  )
+    return false;
+  const offsetMultiplier = offsetText === "Z" || offsetSign === "+" ? 1 : -1;
+  const offsetMinutes = offsetMultiplier * (offsetHour * 60 + offsetMinute);
+  const instantMs =
+    Date.UTC(year, month - 1, day, hour, minute, second, millisecond) -
+    offsetMinutes * 60_000;
+  const local = new Date(instantMs + offsetMinutes * 60_000);
+  return (
+    local.getUTCFullYear() === year &&
+    local.getUTCMonth() === month - 1 &&
+    local.getUTCDate() === day &&
+    local.getUTCHours() === hour &&
+    local.getUTCMinutes() === minute &&
+    local.getUTCSeconds() === second &&
+    local.getUTCMilliseconds() === millisecond
+  );
+};
+
+const pushMalformedDateError = (errors, field, rowNumber) => {
+  errors.push({
+    rowNumber,
+    field,
+    code: "malformed_date",
+    message: `${field} is not a valid date.`,
+  });
+};
+
 const parseDate = (
   value,
   field,
@@ -282,24 +347,19 @@ const parseDate = (
   if (!text) return undefined;
   if (/^\d{4}-\d{2}-\d{2}$/.test(text))
     return `${text}T${endOfDay ? "23:59:59.000" : "00:00:00.000"}Z`;
-  const date = new Date(text);
-  if (Number.isNaN(date.getTime())) {
-    errors.push({
-      rowNumber,
-      field,
-      code: "malformed_date",
-      message: `${field} is not a valid date.`,
-    });
+  // Preserve explicit ISO date/time strings exactly enough for backup round
+  // trips, including timezone offsets, while still rejecting impossible
+  // calendar datetimes as field-level malformed_date import errors.
+  if (ISO_OFFSET_DATE_TIME.test(text)) {
+    if (isValidIsoOffsetDateTime(text)) return text;
+    pushMalformedDateError(errors, field, rowNumber);
     return undefined;
   }
-  // Preserve explicit ISO date/time strings exactly enough for backup round trips,
-  // including timezone offsets, while normalizing other Date-parseable inputs.
-  if (
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(
-      text,
-    )
-  )
-    return text;
+  const date = new Date(text);
+  if (Number.isNaN(date.getTime())) {
+    pushMalformedDateError(errors, field, rowNumber);
+    return undefined;
+  }
   return date.toISOString();
 };
 const hasTimeComponent = (value) =>
@@ -482,6 +542,7 @@ const lifecycleStatusForEvent = (eventType) => {
   if (eventType === "hiring_manager_reply") return "outreach_sent";
   if (eventType === "recruiter_screen_scheduled") return "recruiter_screen";
   if (eventType === "application_submitted") return "applied";
+  if (KNOWN_STATUSES.has(eventType)) return eventType;
   return undefined;
 };
 
@@ -932,6 +993,18 @@ const compareCodePoints = (left, right) => {
   const rightText = String(right);
   return leftText < rightText ? -1 : leftText > rightText ? 1 : 0;
 };
+const compareIsoDateTimes = (left, right) => {
+  const leftText = left ?? "";
+  const rightText = right ?? "";
+  const leftTime = leftText ? new Date(leftText).getTime() : Number.NaN;
+  const rightTime = rightText ? new Date(rightText).getTime() : Number.NaN;
+  const leftValid = Number.isFinite(leftTime);
+  const rightValid = Number.isFinite(rightTime);
+  if (leftValid && rightValid && leftTime !== rightTime)
+    return leftTime - rightTime;
+  if (leftValid !== rightValid) return leftValid ? 1 : -1;
+  return compareCodePoints(leftText, rightText);
+};
 const firstBy = (records, predicate) => records.find(predicate) ?? {};
 export const browserApplicationExportToRows = (bundle) => {
   const parsed = browserApplicationExportSchema.parse(bundle);
@@ -1039,14 +1112,13 @@ export const browserApplicationExportToLifecycleRows = (bundle) => {
   );
   return [...parsed.lifecycleEvents]
     .sort((a, b) => {
-      for (const [left, right] of [
-        [a.applicationId, b.applicationId],
-        [a.occurredAt ?? "", b.occurredAt ?? ""],
-        [a.dueAt ?? "", b.dueAt ?? ""],
-        [a.eventType ?? "", b.eventType ?? ""],
-        [a.id, b.id],
+      for (const compared of [
+        compareCodePoints(a.applicationId, b.applicationId),
+        compareIsoDateTimes(a.occurredAt, b.occurredAt),
+        compareIsoDateTimes(a.dueAt, b.dueAt),
+        compareCodePoints(a.eventType ?? "", b.eventType ?? ""),
+        compareCodePoints(a.id, b.id),
       ]) {
-        const compared = compareCodePoints(left, right);
         if (compared !== 0) return compared;
       }
       return 0;

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -272,7 +272,7 @@ export const serializeCsv = (rows, columns = COMPACT_CSV_COLUMNS) =>
   ].join("\n");
 
 const ISO_OFFSET_DATE_TIME =
-  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?(Z|([+-])(\d{2}):(\d{2}))$/;
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d+))?)?(Z|([+-])(\d{2}):(\d{2}))$/;
 
 const isValidIsoOffsetDateTime = (text) => {
   const match = ISO_OFFSET_DATE_TIME.exec(text);
@@ -284,7 +284,7 @@ const isValidIsoOffsetDateTime = (text) => {
     dayText,
     hourText,
     minuteText,
-    secondText,
+    secondText = "0",
     fractionText = "0",
     offsetText,
     offsetSign,
@@ -1130,7 +1130,7 @@ export const browserApplicationExportToLifecycleRows = (bundle) => {
         application_id: event.applicationId,
         company: application.company ?? "",
         role_title: application.role ?? "",
-        event_type: event.eventType ?? event.status ?? "",
+        event_type: event.eventType ?? "",
         occurred_at: event.occurredAt ?? "",
         stage: event.stageLabel ?? event.status ?? "",
         channel: event.channel ?? "",

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -545,6 +545,10 @@ const lifecycleStatusForEvent = (eventType) => {
   if (KNOWN_STATUSES.has(eventType)) return eventType;
   return undefined;
 };
+const lifecycleStatusForStage = (stageLabel) => {
+  const status = normalizeLabelKey(stageLabel);
+  return KNOWN_STATUSES.has(status) ? status : undefined;
+};
 
 export const lifecycleRowsToBrowserApplicationExport = (
   rows,
@@ -602,6 +606,7 @@ export const lifecycleRowsToBrowserApplicationExport = (
       });
     const status =
       knownLifecycleStatus ??
+      lifecycleStatusForStage(stageLabel) ??
       mapStatus({ status: "", interview_stage: stageLabel ?? "", outcome: "" });
     const sourceArtifact = compact(row.source_artifact) || undefined;
     const details = compact(row.details) || undefined;

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -292,6 +292,14 @@ const parseDate = (
     });
     return undefined;
   }
+  // Preserve explicit ISO date/time strings exactly enough for backup round trips,
+  // including timezone offsets, while normalizing other Date-parseable inputs.
+  if (
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(
+      text,
+    )
+  )
+    return text;
   return date.toISOString();
 };
 const hasTimeComponent = (value) =>
@@ -919,6 +927,11 @@ export const csvToBrowserApplicationExport = (csvText, options) =>
 
 const dateOnly = (value) => (value ? String(value).slice(0, 10) : "");
 const dateTime = (value) => (value ? String(value) : "");
+const compareCodePoints = (left, right) => {
+  const leftText = String(left);
+  const rightText = String(right);
+  return leftText < rightText ? -1 : leftText > rightText ? 1 : 0;
+};
 const firstBy = (records, predicate) => records.find(predicate) ?? {};
 export const browserApplicationExportToRows = (bundle) => {
   const parsed = browserApplicationExportSchema.parse(bundle);
@@ -1019,12 +1032,56 @@ export const browserApplicationExportToRows = (bundle) => {
 };
 export const exportCompactCsv = (bundle) =>
   serializeCsv(browserApplicationExportToRows(bundle));
-const compareCodePoints = (left, right) => {
-  const leftText = String(left);
-  const rightText = String(right);
-  return leftText < rightText ? -1 : leftText > rightText ? 1 : 0;
+export const browserApplicationExportToLifecycleRows = (bundle) => {
+  const parsed = browserApplicationExportSchema.parse(bundle);
+  const applicationsById = new Map(
+    parsed.applications.map((application) => [application.id, application]),
+  );
+  return [...parsed.lifecycleEvents]
+    .sort((a, b) => {
+      for (const [left, right] of [
+        [a.applicationId, b.applicationId],
+        [a.occurredAt ?? "", b.occurredAt ?? ""],
+        [a.dueAt ?? "", b.dueAt ?? ""],
+        [a.eventType ?? "", b.eventType ?? ""],
+        [a.id, b.id],
+      ]) {
+        const compared = compareCodePoints(left, right);
+        if (compared !== 0) return compared;
+      }
+      return 0;
+    })
+    .map((event) => {
+      const application = applicationsById.get(event.applicationId) ?? {};
+      return {
+        ...blankLifecycleRow(),
+        application_id: event.applicationId,
+        company: application.company ?? "",
+        role_title: application.role ?? "",
+        event_type: event.eventType ?? event.status ?? "",
+        occurred_at: event.occurredAt ?? "",
+        stage: event.stageLabel ?? event.status ?? "",
+        channel: event.channel ?? "",
+        actor: event.actor ?? "",
+        source_artifact: event.sourceArtifact ?? "",
+        requires_user_action:
+          event.requiresUserAction === undefined
+            ? ""
+            : String(event.requiresUserAction),
+        action_status: event.actionStatus ?? "",
+        due_at: event.dueAt ?? "",
+        no_ai_required:
+          event.noAiRequired === undefined ? "" : String(event.noAiRequired),
+        details: event.details ?? event.note ?? "",
+      };
+    });
 };
 
+export const exportLifecycleCsv = (bundle) =>
+  serializeCsv(
+    browserApplicationExportToLifecycleRows(bundle),
+    LIFECYCLE_CSV_COLUMNS,
+  );
 const canonicalizeBackupBundle = (bundle) => {
   const parsed = browserApplicationExportSchema.parse(bundle);
   const sorted = { ...parsed };
@@ -1059,8 +1116,34 @@ export const exportNdjsonBackup = (bundle) => {
       .join("\n") + "\n"
   );
 };
+const normalizeBackupBundleInput = (input, { source = "json_import" } = {}) => {
+  const now = nowIso();
+  const bundle = {
+    schemaVersion: 1,
+    exportedAt: input?.exportedAt ?? now,
+    applications: input?.applications ?? [],
+    contacts: input?.contacts ?? [],
+    outreachMessages: input?.outreachMessages ?? [],
+    lifecycleEvents: (input?.lifecycleEvents ?? []).map((event) => ({
+      source,
+      createdAt: event.occurredAt ?? input?.exportedAt ?? now,
+      ...event,
+    })),
+    interviews: input?.interviews ?? [],
+    offers: input?.offers ?? [],
+    artifacts: input?.artifacts ?? [],
+    reminders: input?.reminders ?? [],
+    settings: input?.settings,
+  };
+  if (input?.schemaVersion !== undefined)
+    bundle.schemaVersion = input.schemaVersion;
+  return bundle;
+};
+
 export const importJsonBackup = (text) =>
-  browserApplicationExportSchema.parse(JSON.parse(text));
+  browserApplicationExportSchema.parse(
+    normalizeBackupBundleInput(JSON.parse(text), { source: "json_import" }),
+  );
 export const importNdjsonBackup = (text) => {
   const bundle = {
     schemaVersion: 1,
@@ -1096,7 +1179,9 @@ export const importNdjsonBackup = (text) => {
           `Unknown or malformed NDJSON record type: ${String(entry.type)}`,
         );
     });
-  return browserApplicationExportSchema.parse(bundle);
+  return browserApplicationExportSchema.parse(
+    normalizeBackupBundleInput(bundle, { source: "ndjson_import" }),
+  );
 };
 export const previewCompactCsvImport = async (csvText, repository) => {
   const rows = parseCsv(csvText);

--- a/src/web/tracker/index.html
+++ b/src/web/tracker/index.html
@@ -133,7 +133,7 @@
         <h2>Import/Export</h2>
         <div class="grid two-column">
           <article class="card">
-            <h3>Import CSV/JSON/NDJSON backup</h3>
+            <h3>Import compact CSV, lifecycle CSV, JSON, or NDJSON</h3>
             <label class="tracker-form"
               ><span>Backup file</span
               ><input
@@ -160,14 +160,20 @@
           <article class="card">
             <h3>Export backups</h3>
             <p>
-              Use <strong>Backup now</strong> to download a JSON backup of
-              everything currently stored in IndexedDB.
+              Use <strong>Backup JSON</strong> or
+              <strong>Export NDJSON</strong> for full-fidelity restore backups.
+              Compact CSV stays spreadsheet-compatible, and lifecycle CSV
+              exports event metadata keyed by application ID.
             </p>
             <div class="tracker-actions">
-              <button class="button" data-export="json">Backup now</button
-              ><button class="button" data-export="csv">Export CSV</button
+              <button class="button" data-export="json">Backup now JSON</button
               ><button class="button" data-export="ndjson">
                 Export NDJSON
+              </button>
+              <button class="button" data-export="csv">
+                Export compact CSV</button
+              ><button class="button" data-export="lifecycle-csv">
+                Export lifecycle CSV
               </button>
             </div>
             <p class="muted">Exports are generated entirely in the browser.</p>

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -5,6 +5,7 @@ import {
   detectSpreadsheetImportFormat,
   exportCompactCsv,
   exportJsonBackup,
+  exportLifecycleCsv,
   exportNdjsonBackup,
   importJsonBackup,
   importNdjsonBackup,
@@ -1132,6 +1133,12 @@ function exportData(fmt) {
       "jobbot3000-backup.ndjson",
       "application/x-ndjson",
       exportNdjsonBackup(bundle),
+    );
+  } else if (fmt === "lifecycle-csv") {
+    download(
+      "jobbot3000-lifecycle-events.csv",
+      "text/csv",
+      exportLifecycleCsv(bundle),
     );
   } else {
     if (!COMPACT_CSV_COLUMNS.length)

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -14,6 +14,7 @@ import {
   detectSpreadsheetImportFormat,
   exportCompactCsv,
   exportJsonBackup,
+  exportLifecycleCsv,
   exportNdjsonBackup,
   importCompactCsv,
   importSupplementalLifecycleCsv,
@@ -1035,6 +1036,123 @@ describe("spreadsheet import/export", () => {
       ]),
     );
     repo.close();
+  });
+
+  it("exports supplemental lifecycle CSV with deterministic order and escaping", () => {
+    const exportedAt = "2026-03-01T00:00:00.000Z";
+    const bundle = {
+      schemaVersion: 1,
+      exportedAt,
+      applications: [
+        {
+          id: "app_b",
+          company: "Beta, Inc.",
+          role: 'Engineer "Two"',
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+        {
+          id: "app_a",
+          company: "Alpha",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+      contacts: [],
+      outreachMessages: [],
+      lifecycleEvents: [
+        {
+          id: "event_b_later",
+          applicationId: "app_b",
+          status: "outreach_sent",
+          occurredAt: "2026-03-03T10:00:00-05:00",
+          source: "csv_import",
+          eventType: "hiring_manager_reply",
+          stageLabel: "Hiring manager follow-up",
+          channel: "email",
+          actor: "hiring_manager",
+          sourceArtifact: "https://example.test/artifact/reply?x=1&y=2",
+          requiresUserAction: false,
+          actionStatus: "received",
+          noAiRequired: true,
+          details:
+            'Reply included comma, quote "here", and newline\nSecond line.',
+          createdAt: exportedAt,
+        },
+        {
+          id: "event_a_due",
+          applicationId: "app_a",
+          status: "applied",
+          occurredAt: "2026-03-02T09:00:00.000Z",
+          source: "csv_import",
+          eventType: "next_tracking_step",
+          dueAt: "2026-03-05T17:00:00.000Z",
+          requiresUserAction: true,
+          details: "Follow up",
+          createdAt: exportedAt,
+        },
+      ],
+      interviews: [],
+      offers: [],
+      artifacts: [],
+      reminders: [],
+    };
+
+    const csv = exportLifecycleCsv(bundle);
+    expect(csv.split("\n")[0]).toBe(LIFECYCLE_CSV_COLUMNS.join(","));
+    expect(csv).toContain('"Beta, Inc."');
+    expect(csv).toContain('"Engineer ""Two"""');
+    expect(csv).toContain(
+      '"Reply included comma, quote ""here"", and newline\nSecond line."',
+    );
+    const rows = parseCsv(csv);
+    expect(rows.map((row) => row.application_id)).toEqual(["app_a", "app_b"]);
+    expect(rows[1]).toMatchObject({
+      source_artifact: "https://example.test/artifact/reply?x=1&y=2",
+      requires_user_action: "false",
+      no_ai_required: "true",
+      occurred_at: "2026-03-03T10:00:00-05:00",
+    });
+  });
+
+  it("restores older JSON and NDJSON backups that omit lifecycle metadata stores", () => {
+    const oldJson = JSON.stringify({
+      schemaVersion: 1,
+      exportedAt: "2026-03-01T00:00:00.000Z",
+      applications: [
+        {
+          id: "app_old_backup",
+          company: "Old Backup",
+          role: "Engineer",
+          status: "applied",
+          createdAt: "2026-03-01T00:00:00.000Z",
+          updatedAt: "2026-03-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(importJsonBackup(oldJson)).toMatchObject({
+      applications: [expect.objectContaining({ id: "app_old_backup" })],
+      contacts: [],
+      lifecycleEvents: [],
+      reminders: [],
+    });
+
+    const oldNdjson = [
+      JSON.stringify({
+        type: "meta",
+        schemaVersion: 1,
+        exportedAt: "2026-03-01T00:00:00.000Z",
+      }),
+      JSON.stringify({
+        type: "applications",
+        record: JSON.parse(oldJson).applications[0],
+      }),
+    ].join("\n");
+    expect(importNdjsonBackup(`${oldNdjson}\n`).applications).toHaveLength(1);
   });
 
   it("detects lifecycle CSVs with quoted headers", () => {

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -1289,50 +1289,100 @@ describe("spreadsheet import/export", () => {
     ]);
   });
 
-  it("exports blank event_type for status-only lifecycle events", () => {
+  it("round trips status-only lifecycle events without status loss", async () => {
     const exportedAt = "2026-03-01T00:00:00.000Z";
+    const statuses = [
+      "offer",
+      "outreach_sent",
+      "rejected",
+      "accepted",
+      "withdrawn",
+      "closed_archived",
+    ];
+    const compactCsv = serializeCsv(
+      statuses.map((status) => ({
+        application_id: `app_status_only_${status}`,
+        company: `Status Only ${status}`,
+        role_title: "Engineer",
+        status: "applied",
+        applied_at: "2026-03-01",
+        schema_version: "1",
+      })),
+    );
     const existing = {
-      applications: [
-        {
-          id: "app_status_only",
-          company: "Status Only",
-          role: "Engineer",
-          status: "offer",
-          createdAt: exportedAt,
-          updatedAt: exportedAt,
-        },
-      ],
+      applications: statuses.map((status) => ({
+        id: `app_status_only_${status}`,
+        company: `Status Only ${status}`,
+        role: "Engineer",
+        status: "applied",
+        createdAt: exportedAt,
+        updatedAt: exportedAt,
+      })),
     };
+    const lifecycleEvents = statuses.map((status) => ({
+      id: `event_status_only_${status}`,
+      applicationId: `app_status_only_${status}`,
+      status,
+      occurredAt: "2026-03-02T00:00:00.000Z",
+      source: "manual",
+      createdAt: exportedAt,
+    }));
     const csv = exportLifecycleCsv({
       schemaVersion: 1,
       exportedAt,
       ...existing,
       contacts: [],
       outreachMessages: [],
-      lifecycleEvents: [
-        {
-          id: "event_status_only_offer",
-          applicationId: "app_status_only",
-          status: "offer",
-          occurredAt: "2026-03-02T00:00:00.000Z",
-          source: "manual",
-          createdAt: exportedAt,
-        },
-      ],
+      lifecycleEvents,
       interviews: [],
       offers: [],
       artifacts: [],
       reminders: [],
     });
 
-    const rows = parseCsv(csv);
+    expect(parseCsv(csv)).toEqual(
+      expect.arrayContaining(
+        statuses.map((status) =>
+          expect.objectContaining({
+            application_id: `app_status_only_${status}`,
+            event_type: "",
+            stage: status,
+          }),
+        ),
+      ),
+    );
 
-    expect(rows).toEqual([
-      expect.objectContaining({
-        event_type: "",
-        stage: "offer",
-      }),
-    ]);
+    let repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await importCompactCsv(compactCsv, repo, { mode: "replace" });
+    await importSupplementalLifecycleCsv(csv, repo);
+    const exportedAgain = exportLifecycleCsv(await repo.exportAllData());
+    repo.close();
+
+    await deleteDatabase();
+    repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await importCompactCsv(compactCsv, repo, { mode: "replace" });
+    await importSupplementalLifecycleCsv(exportedAgain, repo);
+    const restored = await repo.exportAllData();
+
+    expect(restored.lifecycleEvents).toEqual(
+      expect.arrayContaining(
+        statuses.map((status) =>
+          expect.objectContaining({
+            applicationId: `app_status_only_${status}`,
+            status,
+          }),
+        ),
+      ),
+    );
+    expect(
+      restored.lifecycleEvents.filter(
+        ({ eventType, id, occurredAt }) =>
+          eventType === "lifecycle_event" &&
+          id.startsWith("event_app_status_only_") &&
+          occurredAt === "2026-03-02T00:00:00.000Z",
+      ),
+    ).toHaveLength(statuses.length);
+    repo.close();
   });
 
   it("preserves valid ISO offset datetimes without milliseconds", () => {

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -20,6 +20,7 @@ import {
   importSupplementalLifecycleCsv,
   importJsonBackup,
   importNdjsonBackup,
+  lifecycleRowsToBrowserApplicationExport,
   parseCsv,
   serializeCsv,
   previewCompactCsvImport,
@@ -1116,6 +1117,128 @@ describe("spreadsheet import/export", () => {
       no_ai_required: "true",
       occurred_at: "2026-03-03T10:00:00-05:00",
     });
+  });
+
+  it("sorts supplemental lifecycle CSV timestamps chronologically across offsets", () => {
+    const exportedAt = "2026-03-01T00:00:00.000Z";
+    const bundle = {
+      schemaVersion: 1,
+      exportedAt,
+      applications: [
+        {
+          id: "app_offsets",
+          company: "Offsets Inc.",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+      contacts: [],
+      outreachMessages: [],
+      lifecycleEvents: [
+        {
+          id: "event_later_offset",
+          applicationId: "app_offsets",
+          status: "outreach_sent",
+          occurredAt: "2026-03-03T08:00:00-05:00",
+          source: "manual",
+          createdAt: exportedAt,
+        },
+        {
+          id: "event_earlier_utc",
+          applicationId: "app_offsets",
+          status: "applied",
+          occurredAt: "2026-03-03T12:00:00+00:00",
+          source: "manual",
+          createdAt: exportedAt,
+        },
+      ],
+      interviews: [],
+      offers: [],
+      artifacts: [],
+      reminders: [],
+    };
+
+    const rows = parseCsv(exportLifecycleCsv(bundle));
+
+    expect(rows.map((row) => row.occurred_at)).toEqual([
+      "2026-03-03T12:00:00+00:00",
+      "2026-03-03T08:00:00-05:00",
+    ]);
+  });
+
+  it("round trips status-only lifecycle events through supplemental lifecycle CSV", () => {
+    const exportedAt = "2026-03-01T00:00:00.000Z";
+    const existing = {
+      applications: [
+        {
+          id: "app_status_only",
+          company: "Status Only",
+          role: "Engineer",
+          status: "offer",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+    };
+    const csv = exportLifecycleCsv({
+      schemaVersion: 1,
+      exportedAt,
+      ...existing,
+      contacts: [],
+      outreachMessages: [],
+      lifecycleEvents: [
+        {
+          id: "event_status_only_offer",
+          applicationId: "app_status_only",
+          status: "offer",
+          occurredAt: "2026-03-02T00:00:00.000Z",
+          source: "manual",
+          createdAt: exportedAt,
+        },
+      ],
+      interviews: [],
+      offers: [],
+      artifacts: [],
+      reminders: [],
+    });
+
+    const { bundle, errors, warnings } =
+      lifecycleRowsToBrowserApplicationExport(parseCsv(csv), existing, {
+        exportedAt,
+      });
+
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([]);
+    expect(bundle.lifecycleEvents).toEqual([
+      expect.objectContaining({
+        eventType: "offer",
+        status: "offer",
+      }),
+    ]);
+  });
+
+  it("reports invalid ISO offset datetimes as malformed date fields", () => {
+    const { errors } = csvToBrowserApplicationExport(
+      serializeCsv([
+        {
+          application_id: "app_bad_date",
+          company: "Bad Date",
+          role_title: "Engineer",
+          applied_at: "2026-02-30T10:00:00.000Z",
+          schema_version: "1",
+        },
+      ]),
+      { exportedAt: "2026-03-10T00:00:00.000Z" },
+    );
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        field: "applied_at",
+        code: "malformed_date",
+      }),
+    ]);
   });
 
   it("restores older JSON and NDJSON backups that omit lifecycle metadata stores", () => {

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -1241,6 +1241,47 @@ describe("spreadsheet import/export", () => {
     ]);
   });
 
+  it("reports invalid supplemental lifecycle ISO datetimes as malformed date fields", () => {
+    const existing = {
+      applications: [
+        {
+          id: "app_bad_lifecycle_date",
+          company: "Bad Lifecycle Date",
+          role: "Engineer",
+          status: "applied",
+          createdAt: "2026-03-10T00:00:00.000Z",
+          updatedAt: "2026-03-10T00:00:00.000Z",
+        },
+      ],
+    };
+    const { errors, bundle } = lifecycleRowsToBrowserApplicationExport(
+      [
+        {
+          ...Object.fromEntries(
+            LIFECYCLE_CSV_COLUMNS.map((column) => [column, ""]),
+          ),
+          application_id: "app_bad_lifecycle_date",
+          event_type: "hiring_manager_reply",
+          occurred_at: "2026-02-30T10:00:00.000Z",
+        },
+      ],
+      existing,
+      { exportedAt: "2026-03-10T00:00:00.000Z" },
+    );
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        field: "occurred_at",
+        code: "malformed_date",
+      }),
+    ]);
+    expect(bundle.lifecycleEvents).toEqual([
+      expect.objectContaining({
+        occurredAt: "1970-01-01T00:00:00.000Z",
+      }),
+    ]);
+  });
+
   it("restores older JSON and NDJSON backups that omit lifecycle metadata stores", () => {
     const oldJson = JSON.stringify({
       schemaVersion: 1,

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -1039,6 +1039,127 @@ describe("spreadsheet import/export", () => {
     repo.close();
   });
 
+  it("round trips compact and supplemental lifecycle CSV deterministically", async () => {
+    let repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const compactCsv = serializeCsv([
+      {
+        application_id: "app_roundtrip_alpha",
+        company: "Roundtrip Alpha",
+        role_title: "Engineer, Platform",
+        status: "applied",
+        applied_at: "2026-03-01",
+        schema_version: "1",
+      },
+    ]);
+    await importCompactCsv(compactCsv, repo, { mode: "replace" });
+    const lifecycleCsv = serializeCsv(
+      [
+        {
+          application_id: "app_roundtrip_alpha",
+          company: "Roundtrip Alpha",
+          role_title: "Engineer, Platform",
+          event_type: "hiring_manager_reply",
+          occurred_at: "2026-03-03T10:00:00-05:00",
+          stage: "Hiring manager follow-up",
+          channel: "email",
+          actor: "hiring_manager",
+          source_artifact: "https://example.test/artifact/reply-alpha",
+          requires_user_action: "false",
+          action_status: "received",
+          no_ai_required: "true",
+          details: 'Reply said "great fit, next steps".\nSecond line.',
+        },
+        {
+          application_id: "app_roundtrip_alpha",
+          company: "Roundtrip Alpha",
+          role_title: "Engineer, Platform",
+          event_type: "next_tracking_step",
+          occurred_at: "2026-03-04T09:30:00-05:00",
+          stage: "",
+          channel: "",
+          actor: "candidate",
+          requires_user_action: "true",
+          action_status: "pending",
+          due_at: "2026-03-05T17:00:00-05:00",
+          no_ai_required: "",
+          details: "Follow up with quoted, comma text",
+        },
+        {
+          application_id: "app_roundtrip_alpha",
+          company: "Roundtrip Alpha",
+          role_title: "Engineer, Platform",
+          event_type: "recruiter_screen_scheduled",
+          occurred_at: "2026-03-06T08:00:00-05:00",
+          stage: "Recruiter screen",
+          channel: "video",
+          actor: "recruiter",
+          source_artifact: "",
+          requires_user_action: "",
+          action_status: "scheduled",
+          due_at: "2026-03-07T10:00:00-05:00",
+          no_ai_required: "false",
+          details: "Recruiter screen scheduled",
+        },
+      ],
+      LIFECYCLE_CSV_COLUMNS,
+    );
+
+    await importSupplementalLifecycleCsv(lifecycleCsv, repo);
+    const exportedLifecycleCsv = exportLifecycleCsv(await repo.exportAllData());
+    await importSupplementalLifecycleCsv(lifecycleCsv, repo);
+    const afterRepeatedImport = await repo.exportAllData();
+    expect(afterRepeatedImport.interviews).toHaveLength(1);
+    expect(afterRepeatedImport.reminders).toHaveLength(1);
+    expect(afterRepeatedImport.artifacts).toHaveLength(0);
+
+    repo.close();
+    await deleteDatabase();
+    repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await importCompactCsv(compactCsv, repo, { mode: "replace" });
+    await importSupplementalLifecycleCsv(exportedLifecycleCsv, repo);
+    await importSupplementalLifecycleCsv(exportedLifecycleCsv, repo);
+    const restored = await repo.exportAllData();
+
+    expect(restored.lifecycleEvents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          eventType: "hiring_manager_reply",
+          occurredAt: "2026-03-03T10:00:00-05:00",
+          sourceArtifact: "https://example.test/artifact/reply-alpha",
+          requiresUserAction: false,
+          actionStatus: "received",
+          noAiRequired: true,
+          actor: "hiring_manager",
+          channel: "email",
+          details: 'Reply said "great fit, next steps".\nSecond line.',
+        }),
+        expect.objectContaining({
+          eventType: "next_tracking_step",
+          dueAt: "2026-03-05T17:00:00-05:00",
+          requiresUserAction: true,
+          actionStatus: "pending",
+          actor: "candidate",
+          details: "Follow up with quoted, comma text",
+        }),
+        expect.objectContaining({
+          eventType: "recruiter_screen_scheduled",
+          dueAt: "2026-03-07T10:00:00-05:00",
+          noAiRequired: false,
+        }),
+      ]),
+    );
+    expect(
+      restored.lifecycleEvents.filter(
+        ({ applicationId, eventType }) =>
+          applicationId === "app_roundtrip_alpha" && eventType,
+      ),
+    ).toHaveLength(4);
+    expect(restored.interviews).toHaveLength(1);
+    expect(restored.reminders).toHaveLength(1);
+    expect(restored.artifacts).toHaveLength(0);
+    repo.close();
+  });
+
   it("exports supplemental lifecycle CSV with deterministic order and escaping", () => {
     const exportedAt = "2026-03-01T00:00:00.000Z";
     const bundle = {
@@ -1168,7 +1289,7 @@ describe("spreadsheet import/export", () => {
     ]);
   });
 
-  it("round trips status-only lifecycle events through supplemental lifecycle CSV", () => {
+  it("exports blank event_type for status-only lifecycle events", () => {
     const exportedAt = "2026-03-01T00:00:00.000Z";
     const existing = {
       applications: [
@@ -1204,17 +1325,36 @@ describe("spreadsheet import/export", () => {
       reminders: [],
     });
 
-    const { bundle, errors, warnings } =
-      lifecycleRowsToBrowserApplicationExport(parseCsv(csv), existing, {
-        exportedAt,
-      });
+    const rows = parseCsv(csv);
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        event_type: "",
+        stage: "offer",
+      }),
+    ]);
+  });
+
+  it("preserves valid ISO offset datetimes without milliseconds", () => {
+    const { bundle, errors } = csvToBrowserApplicationExport(
+      serializeCsv([
+        {
+          application_id: "app_offset_seconds",
+          company: "Offset Seconds",
+          role_title: "Engineer",
+          applied_at: "2026-03-03T10:00:00-05:00",
+          follow_up_date: "2026-03-04T10:00:00-05:00",
+          schema_version: "1",
+        },
+      ]),
+      { exportedAt: "2026-03-10T00:00:00.000Z" },
+    );
 
     expect(errors).toEqual([]);
-    expect(warnings).toEqual([]);
-    expect(bundle.lifecycleEvents).toEqual([
+    expect(bundle.applications).toEqual([
       expect.objectContaining({
-        eventType: "offer",
-        status: "offer",
+        appliedAt: "2026-03-03T10:00:00-05:00",
+        followUpDate: "2026-03-04T10:00:00-05:00",
       }),
     ]);
   });


### PR DESCRIPTION
### Motivation
- Make import/export and backup workflows reliable so the browser tracker can be the source of truth without losing lifecycle/event metadata or timezone-bearing timestamps. 
- Keep compact CSV spreadsheet compatibility while adding a deterministic supplemental lifecycle CSV for event-rich exchanges keyed by `application_id` and preserve JSON/NDJSON as full-fidelity backups. 
- Ensure old backups that omit newer lifecycle fields still restore cleanly and that re-imports are idempotent and do not create orphaned child records.

### Description
- Add deterministic supplemental lifecycle CSV export and helper `browserApplicationExportToLifecycleRows` which emits the documented `LIFECYCLE_CSV_COLUMNS` header and stable ordering by `application_id`, `occurred_at`, `due_at`, `event_type`, and `id`; wired to the tracker UI as `Export lifecycle CSV`. (see `src/web/import-export/spreadsheet.js`, `src/web/tracker/tracker.js`, `src/web/tracker/index.html`).
- Harden date handling to preserve explicit ISO date/time strings with timezone offsets during parse/export while still normalizing other parseable inputs and reporting malformed dates, and allow offset-bearing datetimes in the schema validation. (see `parseDate` in `src/web/import-export/spreadsheet.js` and `isoDateTimeSchema` change in `src/domain/browserApplication.js`).
- Add JSON/NDJSON import compatibility normalization so older backups that omit lifecycle/contact/etc. stores still parse and restore without throwing, by applying sensible defaults and preserving `schemaVersion` when present. (see `normalizeBackupBundleInput` in `src/web/import-export/spreadsheet.js`).
- Extend tracker UI and export helpers so the browser export buttons and import panel clearly distinguish compact CSV, lifecycle CSV, JSON, and NDJSON responsibilities and route all browser exports through the canonical helpers. (see `src/web/tracker/index.html` and `src/web/tracker/tracker.js`).
- Add regression tests for lifecycle CSV escaping, deterministic ordering, boolean parsing, multiline details, timezone-preserving timestamps, and old-backup compatibility, and update docs to explain format responsibilities, restore guidance, and privacy cautions. (see `test/web-spreadsheet-import-export.test.js`, `docs/backup-restore-guide.md`, `docs/spreadsheet-replacement.md`, `docs/import-current-spreadsheet.md`).

### Testing
- Ran `npm ci` and dependency/install steps which completed successfully. (passed)
- Ran formatting/lint/typecheck: `npm run format:check` reported repository-wide pre-existing formatting warnings outside this patch while staged files passed the pre-commit prettier check, and `npm run lint` / `npm run typecheck` completed successfully. (format: warnings, lint: passed, typecheck: passed)
- Ran focused unit tests: `npx vitest run test/web-spreadsheet-import-export.test.js test/browser-application-schema.test.js test/docs-backup-restore.test.js` which passed after fixes. (passed)
- Ran full CI test flow: `npm run build` then `npm run test:ci` which executed unit and Playwright suites; all repository tests and Playwright E2E passed in the final run (`139` test files, Playwright 25 tests). (passed)
- Secrets/scan verification: `git diff | ./scripts/scan-secrets.py` returned no issues. (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f30c7eb1c832f8e7858bd299d46e7)