### PR TITLE
Add tracker browser smoke guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Production readiness docs:
 - [Production readiness](docs/production-readiness.md)
 - [Spreadsheet migration](docs/import-current-spreadsheet.md)
 - [Backup and restore](docs/backup-restore-guide.md)
+- [Tracker staging verification](docs/tracker-staging-verification.md)
 - [GHCR image release](docs/release-ghcr.md)
 - [Helm chart release](docs/release-helm.md)
 

--- a/docs/backup-restore-guide.md
+++ b/docs/backup-restore-guide.md
@@ -31,6 +31,8 @@ private tracker data on the server.
 
 ## Restore into dev, staging, or production browsers
 
+For staging promotion, also follow the [tracker staging verification checklist](tracker-staging-verification.md) so compact CSV import, supplemental lifecycle CSV import, JSON/NDJSON export, clean-profile restore, and browser-local privacy guardrails are verified together.
+
 Dev, staging, and production are separate browser origins/profiles unless you
 import the same backup into each. The browser UI restores compact CSV, supplemental lifecycle CSV, JSON, and NDJSON
 files. To restore, open the target deployed app in the chosen browser profile,

--- a/docs/import-current-spreadsheet.md
+++ b/docs/import-current-spreadsheet.md
@@ -46,3 +46,7 @@ Compact CSV is one row per application for spreadsheet compatibility. Supplement
 During the first two weeks of using jobbot3000 as the primary tracker, export
 JSON and NDJSON after each job-search session and export CSV at least daily while
 you still reconcile with the spreadsheet. Keep backups private and encrypted, and never commit real backups, embed them in Docker images, or paste them into public issues.
+
+## Staging verification
+
+After importing an anonymized spreadsheet fixture in staging, follow the [tracker staging verification checklist](tracker-staging-verification.md) before promotion. The checklist covers preview counts, dashboard metrics, supplemental lifecycle CSV metadata, full-fidelity JSON/NDJSON backups, clean-profile restore, and browser-local privacy guardrails.

--- a/docs/spreadsheet-replacement.md
+++ b/docs/spreadsheet-replacement.md
@@ -64,3 +64,7 @@ Store backups somewhere private and encrypted. The files may include application
 3. Run the dry-run preview and confirm record counts.
 4. Use **Replace** semantics to restore the complete backup.
 5. Verify the restored application list and export a fresh CSV to confirm the compact spreadsheet view is available.
+
+## Staging verification
+
+Use the [tracker staging verification checklist](tracker-staging-verification.md) to validate compact CSV replacement workflows against the browser UI before promotion. Keep all real backups, screenshots, application notes, private URLs, and personal artifacts out of the repository.

--- a/docs/tracker-staging-verification.md
+++ b/docs/tracker-staging-verification.md
@@ -1,0 +1,98 @@
+# Tracker staging verification checklist
+
+Use this checklist for each staging deployment of the static browser tracker. Use only anonymized fixtures or disposable fake data. Never use real job-search backups, screenshots, application notes, names, companies, private URLs, or artifact links in this repo, tickets, CI logs, Helm values, ConfigMaps, or Docker build contexts.
+
+## Deploy staging
+
+1. Deploy the staging image with an immutable `main-SHORTSHA` tag.
+2. Confirm the server is static-only and healthy:
+   - `/`
+   - `/tracker`
+   - `/healthz`
+   - `/livez`
+   - `/assets/tracker.js`
+   - `/assets/tracker.css`
+3. Open `/tracker` and confirm the footer/build metadata shows `static/browser-only`.
+
+## Compact CSV import smoke
+
+1. Use a clean browser profile, private test profile, or clear local tracker data after saving any needed backup.
+2. Open **Import/Export**.
+3. Select the anonymized compact main CSV fixture.
+4. Click **Preview/dry-run** and verify counts before applying:
+   - 15 applications.
+   - 7 outreach messages.
+   - 0 interviews.
+   - 1 assessment.
+   - No blocking errors.
+5. Click **Apply import**.
+6. Open **Dashboard** and verify sane metrics:
+   - 15 total applications.
+   - 7 outreach sent.
+   - 4 application responses.
+   - Application response rate is at or below 100%.
+   - Outreach reply rate is at or below 100%.
+   - 0 interviews after compact CSV import alone.
+   - 0 recruiter screens after compact CSV import alone.
+
+## Supplemental lifecycle CSV smoke
+
+Import the anonymized supplemental lifecycle CSV fixtures after the compact CSV import.
+
+1. Assessment/take-home fixture:
+   - Preview and apply the lifecycle CSV.
+   - Open the matching application detail page.
+   - Verify the assessment/take-home timeline entry is visible.
+   - Verify `No AI required: yes` metadata is visible.
+   - Verify written assessment events do not create interviews.
+2. Hiring-manager reply fixture:
+   - Preview and apply the lifecycle CSV.
+   - Open the matching application detail page.
+   - Verify the hiring-manager reply appears in the timeline.
+   - Verify the response signal/details are visible.
+   - Verify hiring-manager reply events do not create interviews.
+3. Recruiter-screen fixture:
+   - Preview and apply the lifecycle CSV.
+   - Open the matching application detail page.
+   - Verify exactly one recruiter screen is visible.
+   - Verify recruiter screens remain distinct from other interview stages.
+
+## Full-fidelity backup and restore smoke
+
+1. Open **Import/Export**.
+2. Export **Backup now JSON** and **Export NDJSON**.
+3. Store both files outside the repo, static web root, Docker context, Helm chart, and any public/shared folder.
+4. Restore into a clean browser profile:
+   - Prefer JSON for the browser smoke restore.
+   - Use NDJSON as the equivalent full-fidelity fallback when needed.
+5. Preview the backup before applying and confirm record counts look expected.
+6. Apply the restore.
+7. Re-check dashboard metrics and representative lifecycle detail metadata, including assessment/take-home metadata, hiring-manager replies, and recruiter screens.
+
+## Browser-local privacy guardrails
+
+During import, edit, dashboard navigation, and export:
+
+- Private tracker payloads must remain in the browser's IndexedDB.
+- The staging server should only serve static assets, navigation routes, and health probes.
+- Do not add upload endpoints or server-side persistence for tracker data.
+- Do not commit or attach real backups, screenshots, notes, company names, person names, private URLs, or artifact links.
+- If a browser profile contains real data, export and store backups privately before clearing local data.
+
+## Suggested automated checks
+
+Run the repository checks that match the deployment surface before promotion:
+
+```bash
+npm ci
+npm run format:check
+npm run lint
+npm run typecheck
+npm run test:ci
+npm run build
+npm run web:screenshots
+npm run smoke:container
+scripts/validate-helm.sh
+helm lint charts/jobbot3000
+helm template jobbot3000 charts/jobbot3000 --set image.tag=main-TESTSHA
+```

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "format:check": "prettier --check \"**/*.{js,mjs,cjs,ts,tsx,jsx,json,md,mdx,yml,yaml}\"",
     "format:fix": "prettier --write \"**/*.{js,mjs,cjs,ts,tsx,jsx,json,md,mdx,yml,yaml}\"",
     "test": "vitest",
+    "test:e2e": "playwright test",
     "test:ci": "node scripts/test-ci.js",
     "prepare:test": "node scripts/test-ci.js install",
     "summarize": "node scripts/summarize.js",

--- a/src/web/server.js
+++ b/src/web/server.js
@@ -8109,7 +8109,7 @@ export function createWebApp({
     res.send(compactHtml(rawHtml));
   });
 
-  app.get("/health", async (req, res) => {
+  app.get(["/health", "/healthz"], async (req, res) => {
     const timestamp = new Date().toISOString();
     const uptime = process.uptime();
     const results = await runHealthChecks(normalizedChecks);
@@ -8123,7 +8123,7 @@ export function createWebApp({
     res.status(statusCode).json(payload);
   });
 
-  app.get("/ready", (req, res) => {
+  app.get(["/ready", "/livez"], (req, res) => {
     const timestamp = new Date().toISOString();
     const uptime = process.uptime();
     const payload = buildReadyResponse({

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -32,6 +32,70 @@ const regressionCsvFixture = () =>
 const lifecycleFixture = (name) =>
   readFile(`test/fixtures/tracker-import/${name}`, "utf8");
 
+async function importThroughUi(page, { name, text, mimeType = "text/csv" }) {
+  await page.getByRole("button", { name: "Import/Export" }).click();
+  await page.setInputFiles("[data-import-file]", {
+    name,
+    mimeType,
+    buffer: Buffer.from(text),
+  });
+  await page.getByRole("button", { name: "Preview/dry-run" }).click();
+  await page.getByRole("button", { name: "Apply import" }).click();
+  await expect(page.locator("[data-import-result]")).toContainText(
+    "Import applied",
+  );
+}
+
+async function importRegressionBundle(page) {
+  await importThroughUi(page, {
+    name: "compact-main-regression.csv",
+    text: await regressionCsvFixture(),
+  });
+  for (const fixtureName of [
+    "assessment-lifecycle-regression.csv",
+    "employer-reply-lifecycle-regression.csv",
+    "recruiter-screen-lifecycle-regression.csv",
+  ]) {
+    await importThroughUi(page, {
+      name: fixtureName,
+      text: await lifecycleFixture(fixtureName),
+    });
+  }
+}
+
+async function assertRegressionMetrics(page) {
+  await page.getByRole("button", { name: "Dashboard" }).click();
+  const metrics = page.locator("[data-metrics]");
+  await expect(metrics).toContainText("Total applications15");
+  await expect(metrics).toContainText("Outreach sent7");
+  await expect(metrics).toContainText("Application responses5");
+  await expect(metrics).toContainText("Application response rate33%");
+  await expect(metrics).toContainText("Outreach reply rate29%");
+  await expect(metrics).toContainText("Recruiter screens1");
+  await expect(metrics).toContainText("Interviews0");
+}
+
+async function assertCompactRegressionMetrics(page) {
+  await page.getByRole("button", { name: "Dashboard" }).click();
+  const metrics = page.locator("[data-metrics]");
+  await expect(metrics).toContainText("Total applications15");
+  await expect(metrics).toContainText("Outreach sent7");
+  await expect(metrics).toContainText("Application responses4");
+  await expect(metrics).toContainText("Application response rate27%");
+  await expect(metrics).toContainText("Outreach reply rate29%");
+  await expect(metrics).toContainText("Recruiter screens0");
+  await expect(metrics).toContainText("Interviews0");
+}
+
+async function clearLocalTrackerData(page) {
+  page.once("dialog", (dialog) => dialog.accept());
+  await page.getByRole("button", { name: "Settings" }).click();
+  await page.getByRole("button", { name: "Clear local data" }).click();
+  await expect(page.locator("[data-settings-result]")).toContainText(
+    "Local IndexedDB tracker data cleared.",
+  );
+}
+
 test.describe("browser application tracker", () => {
   let server;
 
@@ -64,6 +128,30 @@ test.describe("browser application tracker", () => {
       .click();
     await expect(page.getByText("No applications yet")).toBeVisible();
   });
+
+  test("serves static tracker, health probes, assets, and build metadata", async ({
+    page,
+    request,
+  }) => {
+    for (const route of ["/", "/tracker", "/healthz", "/livez"]) {
+      const response = await request.get(`${server.url}${route}`);
+      expect(response.ok(), `${route} should be healthy`).toBe(true);
+    }
+
+    await page.goto(`${server.url}/tracker`);
+    await expect(page.locator("[data-build-metadata]")).toContainText(
+      "static/browser-only",
+    );
+
+    const script = await request.get(`${server.url}/assets/tracker.js`);
+    expect(script.ok()).toBe(true);
+    expect(script.headers()["content-type"]).toContain("javascript");
+
+    const css = await request.get(`${server.url}/assets/tracker.css`);
+    expect(css.ok()).toBe(true);
+    expect(css.headers()["content-type"]).toContain("text/css");
+  });
+
   test("previews compact CSV regression fixture without phantom interviews", async ({
     page,
   }) => {
@@ -487,6 +575,136 @@ test.describe("browser application tracker", () => {
     await expect(page.locator("[data-detail]")).toContainText(
       "Recruiter screen",
     );
+  });
+
+  test("imports all anonymized lifecycle fixtures with categorized timelines", async ({
+    page,
+  }) => {
+    await importRegressionBundle(page);
+
+    await assertRegressionMetrics(page);
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Company Alpha" }).click();
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Assessment/take-home",
+    );
+    await expect(page.locator("[data-detail]")).toContainText(
+      "No AI required: yes",
+    );
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Assessment request received from example employer.",
+    );
+    await expect(page.locator("[data-detail]")).toContainText(
+      "No non-recruiter interviews yet.",
+    );
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Company Beta" }).click();
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Hiring manager follow-up",
+    );
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Example hiring manager reply received.",
+    );
+    await expect(page.locator("[data-detail]")).toContainText(
+      "No non-recruiter interviews yet.",
+    );
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Company Gamma" }).click();
+    const recruiterSection = page.locator("[data-detail] article").filter({
+      has: page.getByRole("heading", { name: "Recruiter screens" }),
+    });
+    await expect(recruiterSection.locator("li")).toHaveCount(1);
+    await expect(recruiterSection).toContainText("Recruiter screen");
+    await expect(page.locator("[data-detail]")).toContainText(
+      "No non-recruiter interviews yet.",
+    );
+  });
+
+  test("exports JSON and NDJSON backups and restores JSON into a clean profile", async ({
+    page,
+  }) => {
+    await importRegressionBundle(page);
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    const jsonDownloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Backup now JSON" }).click();
+    const jsonDownload = await jsonDownloadPromise;
+    expect(jsonDownload.suggestedFilename()).toBe("jobbot3000-backup.json");
+    const jsonBackup = await readFile(await jsonDownload.path(), "utf8");
+    expect(jsonBackup).toContain("lifecycleEvents");
+
+    const ndjsonDownloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Export NDJSON" }).click();
+    const ndjsonDownload = await ndjsonDownloadPromise;
+    expect(ndjsonDownload.suggestedFilename()).toBe("jobbot3000-backup.ndjson");
+
+    await clearLocalTrackerData(page);
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await expect(page.getByText("No applications yet")).toBeVisible();
+
+    await importThroughUi(page, {
+      name: "jobbot3000-backup.json",
+      text: jsonBackup,
+      mimeType: "application/json",
+    });
+
+    await assertRegressionMetrics(page);
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Company Alpha" }).click();
+    await expect(page.locator("[data-detail]")).toContainText(
+      "No AI required: yes",
+    );
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Assessment request received from example employer.",
+    );
+  });
+
+  test("keeps tracker import, edit, dashboard, and export payloads browser-local", async ({
+    page,
+  }) => {
+    const privatePayloadRequests = [];
+    page.on("request", (request) => {
+      if (["POST", "PUT", "PATCH"].includes(request.method())) {
+        privatePayloadRequests.push({
+          method: request.method(),
+          url: request.url(),
+          body: request.postData() ?? "",
+        });
+      }
+    });
+
+    await importThroughUi(page, {
+      name: "compact-main-regression.csv",
+      text: await regressionCsvFixture(),
+    });
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Company Alpha" }).click();
+    await page
+      .locator('[data-core-form] [name="notes"]')
+      .fill("Browser-local smoke note");
+    await page.getByRole("button", { name: "Save application" }).click();
+    await assertCompactRegressionMetrics(page);
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Backup now JSON" }).click();
+    await downloadPromise;
+
+    expect(privatePayloadRequests).toEqual([]);
   });
 
   test("imports CSV, shows list, edits detail, and renders follow-ups", async ({


### PR DESCRIPTION
### Motivation
- Close the MVP stabilization loop by adding browser-level smoke coverage that validates compact CSV import, supplemental lifecycle CSV metadata, and full-fidelity backup/restore from the actual tracker UI. 
- Provide operator-facing staging checklists and guardrails to keep private tracker data browser-local and avoid accidental server-side persistence. 

### Description
- Added Playwright E2E helpers and smoke tests in `test/playwright/browser-tracker.spec.js` to exercise: static server probes, compact CSV preview/apply, supplemental lifecycle CSV import, JSON/NDJSON export, JSON restore into a clean profile, and a browser-network privacy guard that asserts no `POST`/`PUT`/`PATCH` tracker payloads leave the browser. 
- Added `test:e2e` script to `package.json` (`"test:e2e": "playwright test"`). 
- Added `/healthz` and `/livez` aliases to the web server health endpoints in `src/web/server.js` so browser smoke tests match container/static probe names. 
- Added `docs/tracker-staging-verification.md` with a staging verification checklist and linked it from `README.md`, `docs/backup-restore-guide.md`, `docs/import-current-spreadsheet.md`, and `docs/spreadsheet-replacement.md`. 

### Testing
- `npm run prepare:test` — succeeded (Playwright browser artifacts prepared). 
- `PLAYWRIGHT_BROWSERS_PATH=.cache/ms-playwright PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 npx playwright test test/playwright/browser-tracker.spec.js --grep "serves static|imports all anonymized|exports JSON|keeps tracker"` — succeeded (Playwright smoke tests exercising static probes, compact+lifecycle imports, JSON/NDJSON export, JSON restore, and privacy guard passed). 
- `npm run typecheck` — succeeded. 
- `npm run lint` — succeeded. 
- `npx vitest run test/web-deployment.test.js test/web-server.test.js test/web-tracker-metrics.test.js` — succeeded (selected server/metrics tests passed). 
- `npm run build` — succeeded (built static tracker into `dist/`). 
- `npm run format:check` — reported pre-existing repository-wide Prettier drift (non-blocking for these staged changes); staged files passed the pre-commit `prettier --check` gate. 

Residual risks and notes: Playwright requires downloaded browser artifacts in CI (the repo uses `scripts/test-ci.js install` to fetch them), and `format:check` will surface unrelated formatting drift across many files in the repo; this PR only touches docs, the server health aliases, the Playwright spec, and `package.json` to add `test:e2e`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f4e8fa2cc832fb30eb144992b3cd4)