### PR TITLE
Add browser E2E smoke tests, static smoke spec, and staging verification checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Production readiness docs:
 - [Production readiness](docs/production-readiness.md)
 - [Spreadsheet migration](docs/import-current-spreadsheet.md)
 - [Backup and restore](docs/backup-restore-guide.md)
+- [Static tracker staging verification](docs/staging-tracker-verification.md)
 - [GHCR image release](docs/release-ghcr.md)
 - [Helm chart release](docs/release-helm.md)
 

--- a/docs/staging-tracker-verification.md
+++ b/docs/staging-tracker-verification.md
@@ -1,0 +1,50 @@
+# Static Tracker Staging Verification Checklist
+
+Use this checklist after deploying a staging image or chart update for the browser-only tracker. Use only anonymized fixtures or private local backups; never commit real backups, screenshots, application notes, company names, candidate names, private URLs, or artifact links.
+
+## Deploy and smoke-check staging
+
+1. Deploy staging with the intended immutable image tag.
+2. Open `/` and confirm the static browser-only landing page loads.
+3. Open `/tracker` and confirm the tracker loads without a login or server-backed data prompt.
+4. Check `/healthz` and `/livez`; both should return healthy static responses.
+5. Confirm build metadata is visible in the tracker footer/header area and identifies `static/browser-only` mode.
+
+## Compact CSV import and dashboard sanity
+
+1. In a clean or disposable browser profile, open `/tracker`.
+2. Go to **Settings** and clear local data if the profile is not already empty.
+3. Go to **Import/Export** and select the anonymized compact application CSV.
+4. Run **Preview/dry-run** before applying.
+5. Confirm preview counts match expectations, especially application count, outreach count, zero compact-import interviews, warnings, and conflicts.
+6. Apply the import only if the preview is expected.
+7. Open **Dashboard** and confirm sane metrics:
+   - total applications matches the compact CSV;
+   - outreach sent matches the compact CSV;
+   - application response rate is at or below 100%;
+   - outreach reply rate is at or below 100%;
+   - compact CSV import alone does not create phantom interviews.
+
+## Supplemental lifecycle CSV checks
+
+1. Import the canonical-like lifecycle CSV and inspect an application detail timeline.
+   - Confirm assessment/take-home events appear.
+   - Confirm `no_ai_required` metadata is visible.
+   - Confirm written assessment events do not create interviews.
+2. Import the Loft-like lifecycle CSV and inspect an application detail timeline.
+   - Confirm hiring-manager replies appear.
+   - Confirm response/action signals are visible.
+   - Confirm hiring-manager replies do not create interviews.
+3. Import the Reducto-like lifecycle CSV and inspect an application detail timeline.
+   - Confirm exactly one recruiter screen is visible.
+   - Confirm recruiter screens are separate from non-recruiter-screen interviews.
+
+## Backup, restore, and privacy guardrails
+
+1. Export a JSON backup and an NDJSON backup from **Import/Export**.
+2. Store backups outside the repo, Docker context, Helm values, public folders, and chat/support transcripts.
+3. Restore JSON into a clean browser profile or a different disposable profile.
+4. Confirm dashboard metrics and representative lifecycle timeline metadata survive restore.
+5. Restore NDJSON into a clean browser profile when you need a line-oriented backup validation path; the UI supports NDJSON preview and apply from the same import panel.
+6. During import, edit, dashboard navigation, and export, confirm browser devtools/network logs show no private tracker payloads posted or put to the server. Expected traffic should be static navigation/assets, health checks, and local `blob:` download URLs only.
+7. Before promoting production, delete any disposable browser data and keep private backups in encrypted storage.

--- a/scripts/build-static.js
+++ b/scripts/build-static.js
@@ -6,7 +6,9 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
-const distDir = path.join(repoRoot, "dist");
+const distDir = path.resolve(
+  process.env.JOBBOT_STATIC_DIR ?? path.join(repoRoot, "dist"),
+);
 const assetsDir = path.join(distDir, "assets");
 const packageJson = JSON.parse(
   await fs.readFile(path.join(repoRoot, "package.json"), "utf8"),

--- a/scripts/static-server.js
+++ b/scripts/static-server.js
@@ -11,10 +11,14 @@ const distDir = path.resolve(
 const host = process.env.HOST ?? process.env.JOBBOT_WEB_HOST ?? "0.0.0.0";
 const rawPort = process.env.PORT ?? process.env.JOBBOT_WEB_PORT ?? "3000";
 const port = Number.parseInt(rawPort, 10);
-if (!/^[1-9]\d*$/.test(rawPort) || !Number.isInteger(port) || port > 65535) {
+if (
+  !/^(0|[1-9]\d*)$/.test(rawPort) ||
+  !Number.isInteger(port) ||
+  port > 65535
+) {
   console.error(
     `Invalid static server port "${rawPort}". ` +
-      "Set PORT or JOBBOT_WEB_PORT to an integer from 1 to 65535.",
+      "Set PORT or JOBBOT_WEB_PORT to an integer from 0 to 65535.",
   );
   process.exit(1);
 }

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -1,5 +1,7 @@
 /* global IDBDatabase, indexedDB */
-import { readFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 import { expect, test } from "@playwright/test";
 
@@ -32,6 +34,68 @@ const regressionCsvFixture = () =>
 const lifecycleFixture = (name) =>
   readFile(`test/fixtures/tracker-import/${name}`, "utf8");
 
+async function importFixture(page, name, text) {
+  await page.setInputFiles("[data-import-file]", {
+    name,
+    mimeType: name.endsWith(".json")
+      ? "application/json"
+      : name.endsWith(".ndjson")
+        ? "application/x-ndjson"
+        : "text/csv",
+    buffer: Buffer.from(text),
+  });
+  await page.getByRole("button", { name: "Preview/dry-run" }).click();
+  await page.getByRole("button", { name: "Apply import" }).click();
+  await expect(page.locator("[data-import-result]")).toContainText(
+    "Import applied",
+  );
+}
+
+async function importRegressionBundle(page, { includeRecruiter = true } = {}) {
+  const compact = await regressionCsvFixture();
+  const assessmentLifecycle = await lifecycleFixture(
+    "assessment-lifecycle-regression.csv",
+  );
+  const employerLifecycle = await lifecycleFixture(
+    "employer-reply-lifecycle-regression.csv",
+  );
+  const recruiterLifecycle = await lifecycleFixture(
+    "recruiter-screen-lifecycle-regression.csv",
+  );
+
+  await page.getByRole("button", { name: "Import/Export" }).click();
+  await importFixture(page, "compact-main-regression.csv", compact);
+  await importFixture(
+    page,
+    "assessment-lifecycle-regression.csv",
+    assessmentLifecycle,
+  );
+  await importFixture(
+    page,
+    "employer-reply-lifecycle-regression.csv",
+    employerLifecycle,
+  );
+  if (includeRecruiter) {
+    await importFixture(
+      page,
+      "recruiter-screen-lifecycle-regression.csv",
+      recruiterLifecycle,
+    );
+  }
+}
+
+async function clearTrackerData(page) {
+  await page.evaluate(
+    () =>
+      new Promise((resolve, reject) => {
+        const request = indexedDB.deleteDatabase("jobbot3000");
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+        request.onblocked = () => reject(new Error("IndexedDB delete blocked"));
+      }),
+  );
+}
+
 test.describe("browser application tracker", () => {
   let server;
 
@@ -45,16 +109,7 @@ test.describe("browser application tracker", () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto(server.url);
-    await page.evaluate(
-      () =>
-        new Promise((resolve, reject) => {
-          const request = indexedDB.deleteDatabase("jobbot3000");
-          request.onsuccess = () => resolve();
-          request.onerror = () => reject(request.error);
-          request.onblocked = () =>
-            reject(new Error("IndexedDB delete blocked"));
-        }),
-    );
+    await clearTrackerData(page);
     await page.goto(`${server.url}/tracker`);
   });
 
@@ -889,5 +944,173 @@ test.describe("browser application tracker", () => {
       .getByRole("button", { name: "Applications", exact: true })
       .click();
     await expect(page.getByText("No applications yet")).toBeVisible();
+  });
+
+  test("imports lifecycle fixtures and restores JSON/NDJSON backups", async ({
+    page,
+  }) => {
+    await importRegressionBundle(page);
+
+    await page.getByRole("button", { name: "Dashboard" }).click();
+    const metrics = page.locator("[data-metrics]");
+    await expect(metrics).toContainText("Total applications15");
+    await expect(metrics).toContainText("Outreach sent7");
+    await expect(metrics).toContainText("Application responses5");
+    await expect(metrics).toContainText("Recruiter screens1");
+    await expect(metrics).toContainText("Interviews0");
+    await expect(metrics).toContainText("Application response rate33%");
+    await expect(metrics).toContainText("Outreach reply rate29%");
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Company Alpha" }).click();
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Assessment/take-home",
+    );
+    await expect(page.locator("[data-detail]")).toContainText(
+      "No AI required: yes",
+    );
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Assessment request received from example employer.",
+    );
+    await expect(page.locator("[data-detail]")).toContainText(
+      "No non-recruiter interviews yet.",
+    );
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Company Beta" }).click();
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Hiring manager follow-up",
+    );
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Example hiring manager reply received.",
+    );
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Action status: received",
+    );
+    await expect(page.locator("[data-detail]")).toContainText(
+      "No non-recruiter interviews yet.",
+    );
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Company Gamma" }).click();
+    const recruiterSection = page.locator("[data-detail] article").filter({
+      has: page.getByRole("heading", { name: "Recruiter screens" }),
+    });
+    await expect(recruiterSection.locator("li")).toHaveCount(1);
+    await expect(recruiterSection).toContainText("Recruiter screen");
+    await expect(page.locator("[data-detail]")).toContainText(
+      "No non-recruiter interviews yet.",
+    );
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "jobbot-backup-"));
+    try {
+      const jsonDownloadPromise = page.waitForEvent("download");
+      await page.getByRole("button", { name: "Backup now JSON" }).click();
+      const jsonDownload = await jsonDownloadPromise;
+      const jsonBackupPath = path.join(
+        tempDir,
+        jsonDownload.suggestedFilename(),
+      );
+      await jsonDownload.saveAs(jsonBackupPath);
+      const backupJson = await readFile(jsonBackupPath, "utf8");
+
+      const ndjsonDownloadPromise = page.waitForEvent("download");
+      await page.getByRole("button", { name: "Export NDJSON" }).click();
+      const ndjsonDownload = await ndjsonDownloadPromise;
+      const ndjsonBackupPath = path.join(
+        tempDir,
+        ndjsonDownload.suggestedFilename(),
+      );
+      await ndjsonDownload.saveAs(ndjsonBackupPath);
+      const backupNdjson = await readFile(ndjsonBackupPath, "utf8");
+
+      await clearTrackerData(page);
+      await page.reload();
+      await page.getByRole("button", { name: "Import/Export" }).click();
+      await importFixture(page, "jobbot3000-backup.json", backupJson);
+
+      await page.getByRole("button", { name: "Dashboard" }).click();
+      await expect(page.locator("[data-metrics]")).toContainText(
+        "Total applications15",
+      );
+      await expect(page.locator("[data-metrics]")).toContainText(
+        "Recruiter screens1",
+      );
+      await page
+        .getByRole("button", { name: "Applications", exact: true })
+        .click();
+      await page.getByRole("button", { name: "Company Alpha" }).click();
+      await expect(page.locator("[data-detail]")).toContainText(
+        "No AI required: yes",
+      );
+      await expect(page.locator("[data-detail]")).toContainText(
+        "Assessment submission completed in example portal.",
+      );
+
+      await clearTrackerData(page);
+      await page.reload();
+      await page.getByRole("button", { name: "Import/Export" }).click();
+      await importFixture(page, "jobbot3000-backup.ndjson", backupNdjson);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+
+    await page.getByRole("button", { name: "Dashboard" }).click();
+    await expect(page.locator("[data-metrics]")).toContainText(
+      "Total applications15",
+    );
+    await expect(page.locator("[data-metrics]")).toContainText(
+      "Recruiter screens1",
+    );
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Company Alpha" }).click();
+    await expect(page.locator("[data-detail]")).toContainText(
+      "No AI required: yes",
+    );
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Assessment submission completed in example portal.",
+    );
+  });
+
+  test("keeps import, edit, dashboard, and export data browser-local", async ({
+    page,
+  }) => {
+    const mutatingRequests = [];
+    page.on("request", (request) => {
+      if (["POST", "PUT", "PATCH"].includes(request.method())) {
+        mutatingRequests.push({
+          method: request.method(),
+          url: request.url(),
+          body: request.postData() ?? "",
+        });
+      }
+    });
+
+    await importRegressionBundle(page, { includeRecruiter: false });
+    await page.getByRole("button", { name: "Dashboard" }).click();
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Company Alpha" }).click();
+    await page.locator('[name="followUpDate"]').fill("2026-03-15");
+    await page.getByRole("button", { name: "Save application" }).click();
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    const jsonDownload = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Backup now JSON" }).click();
+    await jsonDownload;
+    const ndjsonDownload = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Export NDJSON" }).click();
+    await ndjsonDownload;
+
+    expect(mutatingRequests).toEqual([]);
   });
 });

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -96,6 +96,17 @@ async function clearTrackerData(page) {
   );
 }
 
+async function assertRegressionMetrics(page) {
+  const metrics = page.locator("[data-metrics]");
+  await expect(metrics).toContainText("Total applications15");
+  await expect(metrics).toContainText("Outreach sent7");
+  await expect(metrics).toContainText("Application responses5");
+  await expect(metrics).toContainText("Application response rate33%");
+  await expect(metrics).toContainText("Outreach reply rate29%");
+  await expect(metrics).toContainText("Recruiter screens1");
+  await expect(metrics).toContainText("Interviews0");
+}
+
 test.describe("browser application tracker", () => {
   let server;
 
@@ -952,14 +963,7 @@ test.describe("browser application tracker", () => {
     await importRegressionBundle(page);
 
     await page.getByRole("button", { name: "Dashboard" }).click();
-    const metrics = page.locator("[data-metrics]");
-    await expect(metrics).toContainText("Total applications15");
-    await expect(metrics).toContainText("Outreach sent7");
-    await expect(metrics).toContainText("Application responses5");
-    await expect(metrics).toContainText("Recruiter screens1");
-    await expect(metrics).toContainText("Interviews0");
-    await expect(metrics).toContainText("Application response rate33%");
-    await expect(metrics).toContainText("Outreach reply rate29%");
+    await assertRegressionMetrics(page);
 
     await page
       .getByRole("button", { name: "Applications", exact: true })
@@ -1037,12 +1041,7 @@ test.describe("browser application tracker", () => {
       await importFixture(page, "jobbot3000-backup.json", backupJson);
 
       await page.getByRole("button", { name: "Dashboard" }).click();
-      await expect(page.locator("[data-metrics]")).toContainText(
-        "Total applications15",
-      );
-      await expect(page.locator("[data-metrics]")).toContainText(
-        "Recruiter screens1",
-      );
+      await assertRegressionMetrics(page);
       await page
         .getByRole("button", { name: "Applications", exact: true })
         .click();
@@ -1052,6 +1051,13 @@ test.describe("browser application tracker", () => {
       );
       await expect(page.locator("[data-detail]")).toContainText(
         "Assessment submission completed in example portal.",
+      );
+      await page
+        .getByRole("button", { name: "Applications", exact: true })
+        .click();
+      await page.getByRole("button", { name: "Company Beta" }).click();
+      await expect(page.locator("[data-detail]")).toContainText(
+        "Example hiring manager reply received.",
       );
 
       await clearTrackerData(page);
@@ -1063,12 +1069,7 @@ test.describe("browser application tracker", () => {
     }
 
     await page.getByRole("button", { name: "Dashboard" }).click();
-    await expect(page.locator("[data-metrics]")).toContainText(
-      "Total applications15",
-    );
-    await expect(page.locator("[data-metrics]")).toContainText(
-      "Recruiter screens1",
-    );
+    await assertRegressionMetrics(page);
     await page
       .getByRole("button", { name: "Applications", exact: true })
       .click();
@@ -1078,6 +1079,13 @@ test.describe("browser application tracker", () => {
     );
     await expect(page.locator("[data-detail]")).toContainText(
       "Assessment submission completed in example portal.",
+    );
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Company Gamma" }).click();
+    await expect(page.locator("[data-detail]")).toContainText(
+      "Recruiter screen",
     );
   });
 

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -1086,7 +1086,7 @@ test.describe("browser application tracker", () => {
   }) => {
     const mutatingRequests = [];
     page.on("request", (request) => {
-      if (["POST", "PUT", "PATCH"].includes(request.method())) {
+      if (["POST", "PUT", "PATCH", "DELETE"].includes(request.method())) {
         mutatingRequests.push({
           method: request.method(),
           url: request.url(),

--- a/test/playwright/static-smoke.spec.js
+++ b/test/playwright/static-smoke.spec.js
@@ -117,10 +117,11 @@ test.describe("static tracker smoke", () => {
   });
 
   test.afterAll(async () => {
-    if (serverProcess && serverProcess.exitCode === null) {
-      const exited = new Promise((resolve) =>
-        serverProcess.once("exit", resolve),
-      );
+    if (serverProcess?.exitCode === null && serverProcess.signalCode === null) {
+      const exited = new Promise((resolve) => {
+        serverProcess.once("exit", resolve);
+        serverProcess.once("close", resolve);
+      });
       serverProcess.kill("SIGTERM");
       await exited;
     }

--- a/test/playwright/static-smoke.spec.js
+++ b/test/playwright/static-smoke.spec.js
@@ -1,0 +1,106 @@
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+
+import { expect, test } from "@playwright/test";
+
+const getFreePort = () =>
+  new Promise((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      server.close(() => resolve(port));
+    });
+  });
+
+async function waitForStaticServer(baseUrl) {
+  const deadline = Date.now() + 15_000;
+  let lastError;
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${baseUrl}/healthz`);
+      if (response.ok) return;
+      lastError = new Error(`Unexpected health status ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw lastError ?? new Error("Timed out waiting for static server");
+}
+
+test.describe("static tracker smoke", () => {
+  let serverProcess;
+  let baseUrl;
+
+  test.beforeAll(async () => {
+    const port = await getFreePort();
+    baseUrl = `http://127.0.0.1:${port}`;
+
+    const build = spawn("node", ["scripts/build-static.js"], {
+      cwd: process.cwd(),
+      stdio: "inherit",
+    });
+    await new Promise((resolve, reject) => {
+      build.on("exit", (code) =>
+        code === 0 ? resolve() : reject(new Error(`build exited ${code}`)),
+      );
+      build.on("error", reject);
+    });
+
+    serverProcess = spawn("node", ["scripts/static-server.js"], {
+      cwd: process.cwd(),
+      env: { ...process.env, HOST: "127.0.0.1", PORT: String(port) },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    await waitForStaticServer(baseUrl);
+  });
+
+  test.afterAll(async () => {
+    if (serverProcess) {
+      serverProcess.kill("SIGTERM");
+      await new Promise((resolve) => serverProcess.once("exit", resolve));
+    }
+  });
+
+  test("serves health, tracker, assets, and build metadata", async ({
+    page,
+  }) => {
+    const health = await page.request.get(`${baseUrl}/healthz`);
+    expect(health.ok()).toBe(true);
+    await expect(health.json()).resolves.toEqual({
+      status: "ok",
+      mode: "static",
+      persistence: "browser-indexeddb",
+    });
+
+    const live = await page.request.get(`${baseUrl}/livez`);
+    expect(live.ok()).toBe(true);
+
+    await page.goto(baseUrl);
+    await expect(
+      page.getByRole("heading", { name: "Browser-only application tracker" }),
+    ).toBeVisible();
+    await expect(page.getByText("static/browser-only")).toBeVisible();
+
+    await page.goto(`${baseUrl}/tracker`);
+    await expect(
+      page.getByRole("heading", { name: "Application tracker" }),
+    ).toBeVisible();
+    await expect(page.locator("[data-build-metadata]")).toContainText(
+      "static/browser-only",
+    );
+
+    for (const asset of [
+      "/assets/tracker.js",
+      "/assets/tracker.css",
+      "/assets/status-hub.css",
+      "/manifest.webmanifest",
+    ]) {
+      const response = await page.request.get(`${baseUrl}${asset}`);
+      expect(response.ok(), asset).toBe(true);
+    }
+  });
+});

--- a/test/playwright/static-smoke.spec.js
+++ b/test/playwright/static-smoke.spec.js
@@ -1,68 +1,130 @@
 import { spawn } from "node:child_process";
-import { createServer } from "node:net";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 import { expect, test } from "@playwright/test";
 
-const getFreePort = () =>
-  new Promise((resolve, reject) => {
-    const server = createServer();
-    server.unref();
-    server.on("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      const address = server.address();
-      const port = typeof address === "object" && address ? address.port : 0;
-      server.close(() => resolve(port));
+const BUILD_TIMEOUT_MS = 120_000;
+const SERVER_READY_TIMEOUT_MS = 15_000;
+
+function waitForProcess(process, label, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      process.kill("SIGTERM");
+      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    process.once("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(error);
+    });
+    process.once("exit", (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      code === 0
+        ? resolve()
+        : reject(new Error(`${label} exited ${code ?? signal}`));
     });
   });
+}
 
-async function waitForStaticServer(baseUrl) {
-  const deadline = Date.now() + 15_000;
+async function waitForStaticServer(process) {
+  const deadline = Date.now() + SERVER_READY_TIMEOUT_MS;
+  let output = "";
   let lastError;
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetch(`${baseUrl}/healthz`);
-      if (response.ok) return;
-      lastError = new Error(`Unexpected health status ${response.status}`);
-    } catch (error) {
-      lastError = error;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 250));
-  }
-  throw lastError ?? new Error("Timed out waiting for static server");
+
+  return await new Promise((resolve, reject) => {
+    const cleanup = () => {
+      clearInterval(interval);
+      clearTimeout(timeout);
+      process.stdout?.off("data", onData);
+      process.off("exit", onExit);
+      process.off("error", onError);
+    };
+    const fail = (error) => {
+      cleanup();
+      reject(error);
+    };
+    const checkReady = async (candidateUrl) => {
+      try {
+        const response = await fetch(`${candidateUrl}/healthz`);
+        if (response.ok) {
+          cleanup();
+          resolve(candidateUrl);
+          return;
+        }
+        lastError = new Error(`Unexpected health status ${response.status}`);
+      } catch (error) {
+        lastError = error;
+      }
+    };
+    const onData = (chunk) => {
+      output += chunk.toString();
+      const match = output.match(/listening on (http:\/\/[^\s]+)/);
+      if (match) void checkReady(match[1]);
+    };
+    const onExit = (code, signal) =>
+      fail(new Error(`static server exited before ready: ${code ?? signal}`));
+    const onError = (error) => fail(error);
+    const interval = setInterval(() => {
+      if (Date.now() >= deadline) return;
+      const match = output.match(/listening on (http:\/\/[^\s]+)/);
+      if (match) void checkReady(match[1]);
+    }, 250);
+    const timeout = setTimeout(() => {
+      fail(lastError ?? new Error("Timed out waiting for static server"));
+    }, SERVER_READY_TIMEOUT_MS);
+
+    process.stdout?.on("data", onData);
+    process.stderr?.resume();
+    process.once("exit", onExit);
+    process.once("error", onError);
+  });
 }
 
 test.describe("static tracker smoke", () => {
   let serverProcess;
   let baseUrl;
+  let staticDir;
 
   test.beforeAll(async () => {
-    const port = await getFreePort();
-    baseUrl = `http://127.0.0.1:${port}`;
-
+    staticDir = await fs.mkdtemp(path.join(os.tmpdir(), "jobbot-static-"));
     const build = spawn("node", ["scripts/build-static.js"], {
       cwd: process.cwd(),
+      env: { ...process.env, JOBBOT_STATIC_DIR: staticDir },
       stdio: "inherit",
     });
-    await new Promise((resolve, reject) => {
-      build.on("exit", (code) =>
-        code === 0 ? resolve() : reject(new Error(`build exited ${code}`)),
-      );
-      build.on("error", reject);
-    });
+    await waitForProcess(build, "static build", BUILD_TIMEOUT_MS);
 
     serverProcess = spawn("node", ["scripts/static-server.js"], {
       cwd: process.cwd(),
-      env: { ...process.env, HOST: "127.0.0.1", PORT: String(port) },
+      env: {
+        ...process.env,
+        HOST: "127.0.0.1",
+        PORT: "0",
+        JOBBOT_STATIC_DIR: staticDir,
+      },
       stdio: ["ignore", "pipe", "pipe"],
     });
-    await waitForStaticServer(baseUrl);
+    baseUrl = await waitForStaticServer(serverProcess);
   });
 
   test.afterAll(async () => {
-    if (serverProcess) {
+    if (serverProcess && serverProcess.exitCode === null) {
+      const exited = new Promise((resolve) =>
+        serverProcess.once("exit", resolve),
+      );
       serverProcess.kill("SIGTERM");
-      await new Promise((resolve) => serverProcess.once("exit", resolve));
+      await exited;
     }
+    if (staticDir) await fs.rm(staticDir, { recursive: true, force: true });
   });
 
   test("serves health, tracker, assets, and build metadata", async ({


### PR DESCRIPTION
### Motivation
- Close the tracker MVP stabilization loop by adding browser-level smoke coverage that validates compact CSV import, supplemental lifecycle CSVs, full-fidelity backups, restore behavior, and the browser-only privacy model.
- Provide operator-facing staging verification guardrails so staging deploys can be validated without adding server-side persistence or leaking private data.

### Description
- Add Playwright helpers and extend `test/playwright/browser-tracker.spec.js` with E2E flows that import the anonymized compact CSV fixture, import supplemental lifecycle CSVs, assert dashboard metrics and lifecycle categorizations, export JSON/NDJSON backups, clear IndexedDB, and restore backups to verify fidelity. 
- Add a privacy/network guard that intercepts requests during import/edit/export flows and asserts no `POST`, `PUT`, or `PATCH` tracker payloads are sent to the server. 
- Add a static smoke Playwright spec `test/playwright/static-smoke.spec.js` that builds the static tracker, starts the static server, and verifies `/`, `/tracker`, `/healthz`, `/livez`, static assets, manifest, and build metadata. 
- Add `docs/staging-tracker-verification.md` with a clear staging checklist and link it from `README.md` under production readiness docs; no server-side persistence or real private data are introduced.

### Testing
- Lint and format checks: ran `npx eslint test/playwright/browser-tracker.spec.js test/playwright/static-smoke.spec.js` and `npx prettier --check test/playwright/browser-tracker.spec.js test/playwright/static-smoke.spec.js docs/staging-tracker-verification.md README.md`, both succeeded. 
- Browser E2E: prepared Playwright browsers and ran `PLAYWRIGHT_BROWSERS_PATH=.cache/ms-playwright npx playwright test test/playwright/browser-tracker.spec.js test/playwright/static-smoke.spec.js`, which passed (24 passed) after the Playwright browser install step; an isolated run of the restore/backup-focused test also passed. 
- Build/typecheck/tests: ran `npm run build` (succeeded), `npm run typecheck` (succeeded), and `npx vitest run test/docs-backup-restore.test.js` (succeeded). 
- Secret scan: ran `git diff --cached | ./scripts/scan-secrets.py` (no secrets found). 
- Note: `npm run test:ci` was attempted but was manually terminated during a long-running `test-ci` session that was doing environment/browser provisioning; focused lint/Playwright/build/typecheck/Vitest and secret-scan checks above completed successfully. 

Residual risks / follow-ups: CI consumers must ensure Playwright browsers are provisioned in CI (the repo already includes `scripts/test-ci.js` to mirror/download browsers), and environment-heavy Playwright setup may require the same cache or `npx playwright install` in CI; no new runtime dependencies were added and no server-side persistence or private data was committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f4e9bd6ec832fa612e4d20de31847)