### PR TITLE
Classify lifecycle interview events and derive non-recruiter interviews

### DIFF
--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1,4 +1,10 @@
 import { browserApplicationExportSchema } from "../../domain/browserApplication.js";
+import {
+  interviewStageForLifecycleEventType,
+  isKnownLifecycleEventType,
+  isRecruiterScreenLifecycleEvent,
+  lifecycleInterviewOutcomeForEventType,
+} from "../tracker/lifecycle-classification.js";
 
 export const LIFECYCLE_CSV_COLUMNS = [
   "application_id",
@@ -540,7 +546,7 @@ export const detectSpreadsheetImportFormat = (text) => {
 
 const lifecycleStatusForEvent = (eventType) => {
   if (eventType === "hiring_manager_reply") return "outreach_sent";
-  if (eventType === "recruiter_screen_scheduled") return "recruiter_screen";
+  if (isRecruiterScreenLifecycleEvent(eventType)) return "recruiter_screen";
   if (eventType === "application_submitted") return "applied";
   if (KNOWN_STATUSES.has(eventType)) return eventType;
   return undefined;
@@ -595,7 +601,8 @@ export const lifecycleRowsToBrowserApplicationExport = (
     const knownLifecycleStatus = lifecycleStatusForEvent(eventType);
     if (
       !knownLifecycleStatus &&
-      !["lifecycle_event", "next_tracking_step"].includes(eventType)
+      !isKnownLifecycleEventType(eventType) &&
+      !["lifecycle_event"].includes(eventType)
     )
       warnings.push({
         rowNumber,
@@ -664,18 +671,29 @@ export const lifecycleRowsToBrowserApplicationExport = (
         createdAt: exportedAt,
         updatedAt: exportedAt,
       });
-    if (
-      eventType === "recruiter_screen_scheduled" &&
-      dueAt &&
-      hasTimeComponent(row.due_at)
-    )
+    const interviewStage = interviewStageForLifecycleEventType(eventType);
+    const interviewOutcome = lifecycleInterviewOutcomeForEventType(eventType);
+    const interviewTiming =
+      interviewOutcome === "completed"
+        ? occurredAt && hasTimeComponent(row.occurred_at)
+          ? occurredAt
+          : undefined
+        : dueAt && hasTimeComponent(row.due_at)
+          ? dueAt
+          : undefined;
+    if (interviewStage && interviewOutcome && interviewTiming)
       interviews.push({
-        id: stableId("interview", applicationId, "recruiter_screen", dueAt),
+        id: stableId(
+          "interview",
+          applicationId,
+          interviewStage,
+          interviewTiming,
+        ),
         applicationId,
         contactIds: [],
-        stage: "recruiter_screen",
-        startsAt: dueAt,
-        outcome: "scheduled",
+        stage: interviewStage,
+        startsAt: interviewTiming,
+        outcome: interviewOutcome,
         createdAt: exportedAt,
         updatedAt: exportedAt,
       });

--- a/src/web/tracker/lifecycle-classification.js
+++ b/src/web/tracker/lifecycle-classification.js
@@ -1,0 +1,110 @@
+const normalize = (value) =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+export const LIFECYCLE_EVENT_CATEGORIES = Object.freeze({
+  RECRUITER_SCREEN: "recruiter_screen",
+  NON_RECRUITER_INTERVIEW: "non_recruiter_interview",
+  ASSESSMENT: "assessment",
+  EMPLOYER_RESPONSE: "employer_response",
+  APPLICATION_SUBMISSION: "application_submission",
+  REMINDER: "reminder",
+  UNKNOWN_METADATA: "unknown_metadata",
+});
+
+const EVENT_CATEGORY_ENTRIES = [
+  [
+    LIFECYCLE_EVENT_CATEGORIES.RECRUITER_SCREEN,
+    ["recruiter_screen_scheduled", "recruiter_screen_completed"],
+  ],
+  [
+    LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    [
+      "devops_interview_scheduled",
+      "devops_interview_completed",
+      "technical_interview_scheduled",
+      "technical_interview_completed",
+      "technical_screen_scheduled",
+      "technical_screen_completed",
+      "onsite_interview_scheduled",
+      "onsite_interview_completed",
+      "final_interview_scheduled",
+      "final_interview_completed",
+    ],
+  ],
+  [
+    LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT,
+    [
+      "written_assessment",
+      "written_assessment_requested",
+      "written_assessment_submitted",
+      "take_home",
+      "take_home_requested",
+      "take_home_submitted",
+    ],
+  ],
+  [
+    LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE,
+    ["hiring_manager_reply", "offer", "offer_received"],
+  ],
+  [
+    LIFECYCLE_EVENT_CATEGORIES.APPLICATION_SUBMISSION,
+    ["application_submitted"],
+  ],
+  [LIFECYCLE_EVENT_CATEGORIES.REMINDER, ["next_tracking_step"]],
+];
+
+const EVENT_CATEGORY_REGISTRY = new Map(
+  EVENT_CATEGORY_ENTRIES.flatMap(([category, eventTypes]) =>
+    eventTypes.map((eventType) => [eventType, category]),
+  ),
+);
+
+const INTERVIEW_STAGE_BY_EVENT_TYPE = new Map([
+  ["devops_interview_scheduled", "technical_screen"],
+  ["devops_interview_completed", "technical_screen"],
+  ["technical_interview_scheduled", "technical_screen"],
+  ["technical_interview_completed", "technical_screen"],
+  ["technical_screen_scheduled", "technical_screen"],
+  ["technical_screen_completed", "technical_screen"],
+  ["onsite_interview_scheduled", "onsite_loop"],
+  ["onsite_interview_completed", "onsite_loop"],
+  ["final_interview_scheduled", "onsite_loop"],
+  ["final_interview_completed", "onsite_loop"],
+  ["recruiter_screen_scheduled", "recruiter_screen"],
+  ["recruiter_screen_completed", "recruiter_screen"],
+]);
+
+export const classifyLifecycleEventType = (eventType) =>
+  EVENT_CATEGORY_REGISTRY.get(normalize(eventType)) ??
+  LIFECYCLE_EVENT_CATEGORIES.UNKNOWN_METADATA;
+
+export const isRecruiterScreenLifecycleEvent = (eventType) =>
+  classifyLifecycleEventType(eventType) ===
+  LIFECYCLE_EVENT_CATEGORIES.RECRUITER_SCREEN;
+
+export const isNonRecruiterInterviewLifecycleEvent = (eventType) =>
+  classifyLifecycleEventType(eventType) ===
+  LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW;
+
+export const isAssessmentLifecycleEvent = (eventType) =>
+  classifyLifecycleEventType(eventType) ===
+  LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT;
+
+export const isKnownLifecycleEventType = (eventType) =>
+  classifyLifecycleEventType(eventType) !==
+  LIFECYCLE_EVENT_CATEGORIES.UNKNOWN_METADATA;
+
+export const interviewStageForLifecycleEventType = (eventType) =>
+  INTERVIEW_STAGE_BY_EVENT_TYPE.get(normalize(eventType));
+
+export const lifecycleInterviewOutcomeForEventType = (eventType) => {
+  const normalized = normalize(eventType);
+  if (normalized.endsWith("_completed")) return "completed";
+  if (normalized.endsWith("_scheduled")) return "scheduled";
+  return undefined;
+};

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -1,3 +1,9 @@
+import {
+  isAssessmentLifecycleEvent,
+  isNonRecruiterInterviewLifecycleEvent,
+  isRecruiterScreenLifecycleEvent,
+} from "./lifecycle-classification.js";
+
 const TERMINAL_EMPLOYER_STATUSES = new Set([
   "offer",
   "accepted",
@@ -11,18 +17,6 @@ const RESPONSE_EVENT_TYPES = new Set([
   "recruiter_screen_completed",
   "offer",
   "offer_received",
-]);
-const ASSESSMENT_EVENT_TYPES = new Set([
-  "written_assessment",
-  "written_assessment_requested",
-  "written_assessment_submitted",
-  "take_home",
-  "take_home_requested",
-  "take_home_submitted",
-]);
-const RECRUITER_SCREEN_EVENT_TYPES = new Set([
-  "recruiter_screen_scheduled",
-  "recruiter_screen_completed",
 ]);
 const OFFER_EVENT_TYPES = new Set(["offer", "offer_received"]);
 const OUTREACH_REPLY_STATUSES = new Set(["replied", "reply", "responded"]);
@@ -109,6 +103,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
   const compactOutreachApplicationIds = new Set();
   const outboundOutreachApplicationIds = new Set();
   const recruiterScreenKeys = new Set();
+  const nonRecruiterInterviewKeys = new Set();
   const assessmentApplicationIds = new Set();
   const offerApplicationIds = new Set();
 
@@ -170,16 +165,20 @@ export const selectDashboardMetrics = (bundle = {}) => {
       addResponse(responseApplicationIds, event.applicationId);
     if (eventType === "hiring_manager_reply" && event.applicationId)
       lifecycleReplyApplicationIds.add(event.applicationId);
-    if (ASSESSMENT_EVENT_TYPES.has(eventType)) {
+    if (isAssessmentLifecycleEvent(eventType)) {
       addResponse(responseApplicationIds, event.applicationId);
       if (event.applicationId)
         assessmentApplicationIds.add(event.applicationId);
     }
     if (
-      RECRUITER_SCREEN_EVENT_TYPES.has(eventType) ||
+      isRecruiterScreenLifecycleEvent(eventType) ||
       status === "recruiter_screen"
     )
       recruiterScreenKeys.add(recruiterScreenKey(event));
+    if (isNonRecruiterInterviewLifecycleEvent(eventType)) {
+      addResponse(responseApplicationIds, event.applicationId);
+      nonRecruiterInterviewKeys.add(recruiterScreenKey(event));
+    }
     if (
       OFFER_EVENT_TYPES.has(eventType) ||
       ["offer", "accepted"].includes(status)
@@ -200,9 +199,10 @@ export const selectDashboardMetrics = (bundle = {}) => {
     if (interview.stage === "recruiter_screen")
       recruiterScreenKeys.add(recruiterScreenKey(interview));
   }
-  const nonRecruiterInterviews = interviews.filter(
-    (interview) => interview.stage !== "recruiter_screen",
-  );
+  for (const interview of interviews) {
+    if (interview.stage !== "recruiter_screen")
+      nonRecruiterInterviewKeys.add(recruiterScreenKey(interview));
+  }
 
   return {
     totalApplications: applications.length,
@@ -215,7 +215,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
     ),
     outreachReplyRate: boundedPercentage(outreachReplies, outreachSent),
     recruiterScreens: recruiterScreenKeys.size,
-    interviews: nonRecruiterInterviews.length,
+    interviews: nonRecruiterInterviewKeys.size,
     assessments: assessmentApplicationIds.size,
     offers: new Set(
       [

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -1039,6 +1039,111 @@ describe("spreadsheet import/export", () => {
     repo.close();
   });
 
+  it("derives non-recruiter interviews from lifecycle rows idempotently", async () => {
+    const exportedAt = "2026-03-10T00:00:00.000Z";
+    const existing = {
+      applications: [
+        {
+          id: "app_devops",
+          company: "Redacted DevOps",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+        {
+          id: "app_onsite",
+          company: "Redacted Onsite",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+    };
+    const lifecycleCsv = serializeCsv(
+      [
+        {
+          application_id: "app_devops",
+          company: "Redacted DevOps",
+          role_title: "Engineer",
+          event_type: "devops_interview_scheduled",
+          occurred_at: "2026-01-06T12:00:00.000Z",
+          stage: "DevOps interview",
+          channel: "video",
+          actor: "interviewer",
+          due_at: "2026-01-10T15:30:00.000Z",
+          details: "DevOps interview scheduled.",
+        },
+        {
+          application_id: "app_onsite",
+          company: "Redacted Onsite",
+          role_title: "Engineer",
+          event_type: "onsite_interview_completed",
+          occurred_at: "2026-01-11T18:00:00.000Z",
+          stage: "Onsite interview",
+          channel: "video",
+          actor: "panel",
+          details: "Onsite interview completed.",
+        },
+        {
+          application_id: "app_devops",
+          company: "Redacted DevOps",
+          role_title: "Engineer",
+          event_type: "technical_interview_scheduled",
+          occurred_at: "2026-01-07T12:00:00.000Z",
+          stage: "Technical interview",
+          channel: "video",
+          actor: "interviewer",
+          due_at: "2026-01-12T15:30:00.000Z",
+          details: "Technical interview scheduled.",
+        },
+      ],
+      LIFECYCLE_CSV_COLUMNS,
+    );
+
+    const firstImport = lifecycleRowsToBrowserApplicationExport(
+      parseCsv(lifecycleCsv),
+      existing,
+      { exportedAt },
+    );
+    expect(firstImport.errors).toEqual([]);
+    expect(firstImport.warnings).toEqual([]);
+    expect(firstImport.bundle.interviews).toEqual([
+      expect.objectContaining({
+        applicationId: "app_devops",
+        stage: "technical_screen",
+        startsAt: "2026-01-10T15:30:00.000Z",
+        outcome: "scheduled",
+      }),
+      expect.objectContaining({
+        applicationId: "app_onsite",
+        stage: "onsite_loop",
+        startsAt: "2026-01-11T18:00:00.000Z",
+        outcome: "completed",
+      }),
+      expect.objectContaining({
+        applicationId: "app_devops",
+        stage: "technical_screen",
+        startsAt: "2026-01-12T15:30:00.000Z",
+        outcome: "scheduled",
+      }),
+    ]);
+
+    const secondImport = lifecycleRowsToBrowserApplicationExport(
+      parseCsv(lifecycleCsv),
+      { ...existing, interviews: firstImport.bundle.interviews },
+      { exportedAt },
+    );
+    expect(secondImport.bundle.interviews.map(({ id }) => id)).toEqual(
+      firstImport.bundle.interviews.map(({ id }) => id),
+    );
+
+    const restored = importJsonBackup(exportJsonBackup(firstImport.bundle));
+    expect(restored.lifecycleEvents).toHaveLength(3);
+    expect(restored.interviews).toHaveLength(3);
+  });
+
   it("round trips compact and supplemental lifecycle CSV deterministically", async () => {
     let repo = await createIndexedDbRepository({ indexedDb: indexedDB });
     const compactCsv = serializeCsv([

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -11,6 +11,10 @@ import {
   boundedPercentage,
   selectDashboardMetrics,
 } from "../src/web/tracker/metrics.js";
+import {
+  LIFECYCLE_EVENT_CATEGORIES,
+  classifyLifecycleEventType,
+} from "../src/web/tracker/lifecycle-classification.js";
 
 const exportedAt = "2026-03-10T00:00:00.000Z";
 const compactFixture = async () =>
@@ -68,6 +72,27 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationResponseRate).toBeLessThanOrEqual(100);
   });
 
+  it("classifies scheduled non-recruiter lifecycle interviews distinctly", () => {
+    expect(classifyLifecycleEventType("devops_interview_scheduled")).toBe(
+      LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    );
+    expect(classifyLifecycleEventType("technical_interview_scheduled")).toBe(
+      LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    );
+    expect(classifyLifecycleEventType("onsite_interview_scheduled")).toBe(
+      LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    );
+    expect(classifyLifecycleEventType("recruiter_screen_scheduled")).toBe(
+      LIFECYCLE_EVENT_CATEGORIES.RECRUITER_SCREEN,
+    );
+    expect(classifyLifecycleEventType("written_assessment_submitted")).toBe(
+      LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT,
+    );
+    expect(classifyLifecycleEventType("hiring_manager_reply")).toBe(
+      LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE,
+    );
+  });
+
   it("counts assessment lifecycle events as assessments, not interviews", async () => {
     const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
       exportedAt,
@@ -84,24 +109,21 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationsWithResponse).toBe(5);
   });
 
-  it(
-    "dedupes hiring-manager lifecycle replies already represented by compact metadata",
-    async () => {
-      const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
-        exportedAt,
-      });
-      const lifecycle = importLifecycle(
-        await lifecycleFixture("employer-reply-lifecycle-regression.csv"),
-        bundle,
-      );
+  it("dedupes hiring-manager lifecycle replies represented by compact metadata", async () => {
+    const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
+      exportedAt,
+    });
+    const lifecycle = importLifecycle(
+      await lifecycleFixture("employer-reply-lifecycle-regression.csv"),
+      bundle,
+    );
 
-      const metrics = selectDashboardMetrics(mergeBundle(bundle, lifecycle));
+    const metrics = selectDashboardMetrics(mergeBundle(bundle, lifecycle));
 
-      expect(metrics.outreachReplies).toBe(2);
-      expect(metrics.applicationsWithResponse).toBe(4);
-      expect(metrics.interviews).toBe(0);
-    },
-  );
+    expect(metrics.outreachReplies).toBe(2);
+    expect(metrics.applicationsWithResponse).toBe(4);
+    expect(metrics.interviews).toBe(0);
+  });
 
   it("counts lifecycle-only hiring-manager replies as outreach replies", () => {
     const timestamp = "2026-01-01T00:00:00.000Z";
@@ -475,6 +497,46 @@ describe("tracker dashboard metrics", () => {
           applicationId: "app_interview",
           stage: "technical_screen",
           startsAt: timestamp,
+          createdAt: timestamp,
+        },
+      ],
+    });
+
+    expect(metrics.recruiterScreens).toBe(0);
+    expect(metrics.interviews).toBe(1);
+    expect(metrics.applicationsWithResponse).toBe(1);
+  });
+
+  it("counts lifecycle-only interview events without double-counting records", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_devops",
+          company: "Redacted",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_devops",
+          applicationId: "app_devops",
+          eventType: "devops_interview_scheduled",
+          dueAt: "2026-01-02T18:00:00.000Z",
+          occurredAt: timestamp,
+          createdAt: timestamp,
+        },
+      ],
+      interviews: [
+        {
+          id: "interview_devops",
+          applicationId: "app_devops",
+          stage: "technical_screen",
+          startsAt: "2026-01-02T18:00:00.000Z",
+          outcome: "scheduled",
           createdAt: timestamp,
         },
       ],


### PR DESCRIPTION
### Motivation
- Supplemental lifecycle CSV rows such as `devops_interview_scheduled` were not being classified as non-recruiter interviews, causing dashboard counts to miss imported interview steps. 
- Implement an extensible, centralized classification registry so new pipeline interview steps can be recognized and handled deterministically rather than with scattered string checks.

### Description
- Add a centralized classification helper `src/web/tracker/lifecycle-classification.js` that registers lifecycle event categories and maps explicit interview event types (including `devops_*`, `technical_*`, `onsite_*`, and `final_*`) to canonical interview stages and outcomes. 
- Update supplemental lifecycle CSV import in `src/web/import-export/spreadsheet.js` to consult the classification helper, suppress unsupported-event warnings for registered types, and derive first-class interview records for scheduled/completed lifecycle events when timing metadata contains a time component while preserving the original lifecycle event row. 
- Update dashboard selector in `src/web/tracker/metrics.js` to count lifecycle-derived non-recruiter interviews separately from recruiter screens, to dedupe lifecycle-only and derived interview records consistently, and to avoid counting assessments or employer replies as interviews. 
- Add/adjust regression tests in `test/web-spreadsheet-import-export.test.js` and `test/web-tracker-metrics.test.js` covering classification behavior, idempotent interview derivation, JSON round-trip preservation, and negative cases (assessments and hiring-manager replies remain non-interview signals).

### Testing
- Installed dependencies with `npm ci` and typechecked with `npm run typecheck`, both succeeding. 
- Linted with `npm run lint` which succeeded, while `npm run format:check` flagged pre-existing formatting issues in unrelated files. 
- Ran focused test runs with `npm test -- --run test/web-tracker-metrics.test.js test/web-spreadsheet-import-export.test.js` and all tests in those files passed. 
- Performed a local build with `npm run build` and generated browser screenshots with `npm run web:screenshots`, both of which completed successfully. 
- Ran `npm run test:ci` which progressed through a large portion of the suite (242 tests passing) before the test runner hit a Vitest worker RPC timeout (`Timeout calling "onTaskUpdate"`), which appears to be an environment-level flake rather than a functional regression. 
- Residual risk: `npm run format:check` failure is from unrelated repository files and not introduced by this change, and a full CI run may need a re-run to confirm no intermittent test runner timeouts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ff5478898832f823a9648f453fdba)