### PR TITLE
Classify scheduled lifecycle interviews

### DIFF
--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1,4 +1,11 @@
 import { browserApplicationExportSchema } from "../../domain/browserApplication.js";
+import {
+  classifyLifecycleEventType,
+  interviewStageForLifecycleEvent,
+  isNonRecruiterInterviewLifecycleEvent,
+  isRecruiterScreenLifecycleEvent,
+  LIFECYCLE_EVENT_CATEGORIES,
+} from "../tracker/lifecycleClassification.js";
 
 export const LIFECYCLE_CSV_COLUMNS = [
   "application_id",
@@ -539,9 +546,15 @@ export const detectSpreadsheetImportFormat = (text) => {
 };
 
 const lifecycleStatusForEvent = (eventType) => {
-  if (eventType === "hiring_manager_reply") return "outreach_sent";
-  if (eventType === "recruiter_screen_scheduled") return "recruiter_screen";
-  if (eventType === "application_submitted") return "applied";
+  const category = classifyLifecycleEventType(eventType);
+  if (category === LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE)
+    return eventType === "hiring_manager_reply" ? "outreach_sent" : undefined;
+  if (category === LIFECYCLE_EVENT_CATEGORIES.RECRUITER_SCREEN)
+    return "recruiter_screen";
+  if (category === LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW)
+    return interviewStageForLifecycleEvent(eventType);
+  if (category === LIFECYCLE_EVENT_CATEGORIES.APPLICATION_SUBMISSION)
+    return "applied";
   if (KNOWN_STATUSES.has(eventType)) return eventType;
   return undefined;
 };
@@ -595,6 +608,8 @@ export const lifecycleRowsToBrowserApplicationExport = (
     const knownLifecycleStatus = lifecycleStatusForEvent(eventType);
     if (
       !knownLifecycleStatus &&
+      classifyLifecycleEventType(eventType) ===
+        LIFECYCLE_EVENT_CATEGORIES.UNKNOWN_METADATA &&
       !["lifecycle_event", "next_tracking_step"].includes(eventType)
     )
       warnings.push({
@@ -664,18 +679,32 @@ export const lifecycleRowsToBrowserApplicationExport = (
         createdAt: exportedAt,
         updatedAt: exportedAt,
       });
+    const interviewStage = isRecruiterScreenLifecycleEvent(eventType)
+      ? "recruiter_screen"
+      : interviewStageForLifecycleEvent(eventType);
+    const isCompletedInterviewEvent = eventType.endsWith("_completed");
+    const interviewStartsAt = isCompletedInterviewEvent ? occurredAt : dueAt;
+    const hasInterviewTiming = isCompletedInterviewEvent
+      ? Boolean(occurredAt)
+      : Boolean(dueAt && hasTimeComponent(row.due_at));
     if (
-      eventType === "recruiter_screen_scheduled" &&
-      dueAt &&
-      hasTimeComponent(row.due_at)
+      interviewStage &&
+      hasInterviewTiming &&
+      (isRecruiterScreenLifecycleEvent(eventType) ||
+        isNonRecruiterInterviewLifecycleEvent(eventType))
     )
       interviews.push({
-        id: stableId("interview", applicationId, "recruiter_screen", dueAt),
+        id: stableId(
+          "interview",
+          applicationId,
+          interviewStage,
+          interviewStartsAt,
+        ),
         applicationId,
         contactIds: [],
-        stage: "recruiter_screen",
-        startsAt: dueAt,
-        outcome: "scheduled",
+        stage: interviewStage,
+        startsAt: interviewStartsAt,
+        outcome: isCompletedInterviewEvent ? "completed" : "scheduled",
         createdAt: exportedAt,
         updatedAt: exportedAt,
       });

--- a/src/web/tracker/lifecycleClassification.js
+++ b/src/web/tracker/lifecycleClassification.js
@@ -1,0 +1,127 @@
+const normalize = (value) =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+export const LIFECYCLE_EVENT_CATEGORIES = Object.freeze({
+  RECRUITER_SCREEN: "recruiter_screen",
+  NON_RECRUITER_INTERVIEW: "non_recruiter_interview",
+  ASSESSMENT: "assessment_take_home",
+  EMPLOYER_RESPONSE: "employer_response_engagement",
+  APPLICATION_SUBMISSION: "application_submission",
+  REMINDER_ACTION: "reminder_action",
+  UNKNOWN_METADATA: "unknown_metadata_only",
+});
+
+const CATEGORY_BY_EVENT_TYPE = new Map(
+  [
+    [
+      "application_submitted",
+      LIFECYCLE_EVENT_CATEGORIES.APPLICATION_SUBMISSION,
+    ],
+    ["applied", LIFECYCLE_EVENT_CATEGORIES.APPLICATION_SUBMISSION],
+    ["hiring_manager_reply", LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE],
+    ["employer_reply", LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE],
+    ["recruiter_reply", LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE],
+    ["offer", LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE],
+    ["offer_received", LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE],
+    ["recruiter_screen_scheduled", LIFECYCLE_EVENT_CATEGORIES.RECRUITER_SCREEN],
+    ["recruiter_screen_completed", LIFECYCLE_EVENT_CATEGORIES.RECRUITER_SCREEN],
+    ["written_assessment", LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT],
+    ["written_assessment_requested", LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT],
+    ["written_assessment_submitted", LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT],
+    ["take_home", LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT],
+    ["take_home_requested", LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT],
+    ["take_home_submitted", LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT],
+    ["next_tracking_step", LIFECYCLE_EVENT_CATEGORIES.REMINDER_ACTION],
+    ["follow_up", LIFECYCLE_EVENT_CATEGORIES.REMINDER_ACTION],
+    ["follow_up_reminder", LIFECYCLE_EVENT_CATEGORIES.REMINDER_ACTION],
+    [
+      "devops_interview_scheduled",
+      LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    ],
+    [
+      "devops_interview_completed",
+      LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    ],
+    [
+      "technical_interview_scheduled",
+      LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    ],
+    [
+      "technical_interview_completed",
+      LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    ],
+    [
+      "technical_screen_scheduled",
+      LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    ],
+    [
+      "technical_screen_completed",
+      LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    ],
+    [
+      "onsite_interview_scheduled",
+      LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    ],
+    [
+      "onsite_interview_completed",
+      LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    ],
+    [
+      "final_interview_scheduled",
+      LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    ],
+    [
+      "final_interview_completed",
+      LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    ],
+  ].map(([eventType, category]) => [normalize(eventType), category]),
+);
+
+const INTERVIEW_STAGE_BY_EVENT_TYPE = new Map(
+  [
+    ["devops_interview_scheduled", "technical_screen"],
+    ["devops_interview_completed", "technical_screen"],
+    ["technical_interview_scheduled", "technical_screen"],
+    ["technical_interview_completed", "technical_screen"],
+    ["technical_screen_scheduled", "technical_screen"],
+    ["technical_screen_completed", "technical_screen"],
+    ["onsite_interview_scheduled", "onsite_loop"],
+    ["onsite_interview_completed", "onsite_loop"],
+    ["final_interview_scheduled", "other"],
+    ["final_interview_completed", "other"],
+  ].map(([eventType, stage]) => [normalize(eventType), stage]),
+);
+
+export const normalizeLifecycleEventType = normalize;
+
+export const classifyLifecycleEventType = (eventType) =>
+  CATEGORY_BY_EVENT_TYPE.get(normalize(eventType)) ??
+  LIFECYCLE_EVENT_CATEGORIES.UNKNOWN_METADATA;
+
+export const isRecruiterScreenLifecycleEvent = (eventType) =>
+  classifyLifecycleEventType(eventType) ===
+  LIFECYCLE_EVENT_CATEGORIES.RECRUITER_SCREEN;
+
+export const isNonRecruiterInterviewLifecycleEvent = (eventType) =>
+  classifyLifecycleEventType(eventType) ===
+  LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW;
+
+export const isAssessmentLifecycleEvent = (eventType) =>
+  classifyLifecycleEventType(eventType) ===
+  LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT;
+
+export const isEmployerResponseLifecycleEvent = (eventType) =>
+  classifyLifecycleEventType(eventType) ===
+  LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE;
+
+export const interviewStageForLifecycleEvent = (eventType) =>
+  INTERVIEW_STAGE_BY_EVENT_TYPE.get(normalize(eventType));
+
+export const lifecycleEventTypeRegistry = Object.freeze(
+  Object.fromEntries(CATEGORY_BY_EVENT_TYPE),
+);

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -1,40 +1,22 @@
+import {
+  isAssessmentLifecycleEvent,
+  isEmployerResponseLifecycleEvent,
+  isNonRecruiterInterviewLifecycleEvent,
+  isRecruiterScreenLifecycleEvent,
+  normalizeLifecycleEventType,
+} from "./lifecycleClassification.js";
+
 const TERMINAL_EMPLOYER_STATUSES = new Set([
   "offer",
   "accepted",
   "rejected",
   "closed_archived",
 ]);
-const RESPONSE_EVENT_TYPES = new Set([
-  "hiring_manager_reply",
-  "written_assessment_requested",
-  "recruiter_screen_scheduled",
-  "recruiter_screen_completed",
-  "offer",
-  "offer_received",
-]);
-const ASSESSMENT_EVENT_TYPES = new Set([
-  "written_assessment",
-  "written_assessment_requested",
-  "written_assessment_submitted",
-  "take_home",
-  "take_home_requested",
-  "take_home_submitted",
-]);
-const RECRUITER_SCREEN_EVENT_TYPES = new Set([
-  "recruiter_screen_scheduled",
-  "recruiter_screen_completed",
-]);
 const OFFER_EVENT_TYPES = new Set(["offer", "offer_received"]);
 const OUTREACH_REPLY_STATUSES = new Set(["replied", "reply", "responded"]);
 const OUTREACH_SENT_STATUSES = new Set(["sent", ...OUTREACH_REPLY_STATUSES]);
 const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
-const normalize = (value) =>
-  String(value ?? "")
-    .trim()
-    .toLowerCase()
-    .replace(/&/g, " and ")
-    .replace(/[^a-z0-9]+/g, "_")
-    .replace(/^_+|_+$/g, "");
+const normalize = normalizeLifecycleEventType;
 
 export const readSpreadsheetMetadata = (notes) => {
   const prefix = "Spreadsheet metadata:";
@@ -109,6 +91,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
   const compactOutreachApplicationIds = new Set();
   const outboundOutreachApplicationIds = new Set();
   const recruiterScreenKeys = new Set();
+  const interviewKeys = new Set();
   const assessmentApplicationIds = new Set();
   const offerApplicationIds = new Set();
 
@@ -164,22 +147,27 @@ export const selectDashboardMetrics = (bundle = {}) => {
     const eventType = normalize(event.eventType);
     const status = normalize(event.status);
     if (
-      RESPONSE_EVENT_TYPES.has(eventType) ||
+      isEmployerResponseLifecycleEvent(eventType) ||
+      isRecruiterScreenLifecycleEvent(eventType) ||
+      isAssessmentLifecycleEvent(eventType) ||
+      isNonRecruiterInterviewLifecycleEvent(eventType) ||
       TERMINAL_EMPLOYER_STATUSES.has(status)
     )
       addResponse(responseApplicationIds, event.applicationId);
     if (eventType === "hiring_manager_reply" && event.applicationId)
       lifecycleReplyApplicationIds.add(event.applicationId);
-    if (ASSESSMENT_EVENT_TYPES.has(eventType)) {
+    if (isAssessmentLifecycleEvent(eventType)) {
       addResponse(responseApplicationIds, event.applicationId);
       if (event.applicationId)
         assessmentApplicationIds.add(event.applicationId);
     }
     if (
-      RECRUITER_SCREEN_EVENT_TYPES.has(eventType) ||
+      isRecruiterScreenLifecycleEvent(eventType) ||
       status === "recruiter_screen"
     )
       recruiterScreenKeys.add(recruiterScreenKey(event));
+    if (isNonRecruiterInterviewLifecycleEvent(eventType))
+      interviewKeys.add(recruiterScreenKey(event));
     if (
       OFFER_EVENT_TYPES.has(eventType) ||
       ["offer", "accepted"].includes(status)
@@ -199,10 +187,8 @@ export const selectDashboardMetrics = (bundle = {}) => {
     addResponse(responseApplicationIds, interview.applicationId);
     if (interview.stage === "recruiter_screen")
       recruiterScreenKeys.add(recruiterScreenKey(interview));
+    else interviewKeys.add(recruiterScreenKey(interview));
   }
-  const nonRecruiterInterviews = interviews.filter(
-    (interview) => interview.stage !== "recruiter_screen",
-  );
 
   return {
     totalApplications: applications.length,
@@ -215,7 +201,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
     ),
     outreachReplyRate: boundedPercentage(outreachReplies, outreachSent),
     recruiterScreens: recruiterScreenKeys.size,
-    interviews: nonRecruiterInterviews.length,
+    interviews: interviewKeys.size,
     assessments: assessmentApplicationIds.size,
     offers: new Set(
       [

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -13,6 +13,11 @@ import {
   previewSupplementalLifecycleCsvImport,
 } from "../import-export/spreadsheet.js";
 import { readSpreadsheetMetadata, selectDashboardMetrics } from "./metrics.js";
+import {
+  isAssessmentLifecycleEvent,
+  isNonRecruiterInterviewLifecycleEvent,
+  isRecruiterScreenLifecycleEvent,
+} from "./lifecycleClassification.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
 const ARRAY_STORES = [
@@ -240,25 +245,16 @@ const normalize = (value) =>
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_+|_+$/g, "");
 const isAssessmentEvent = (record = {}) =>
-  [
-    record.eventType,
-    record.stageLabel,
-    record.status,
-    record.note,
-    record.details,
-  ]
+  isAssessmentLifecycleEvent(record.eventType) ||
+  [record.stageLabel, record.status, record.note, record.details]
     .map(normalize)
     .some(
       (value) => value.includes("assessment") || value.includes("take_home"),
     );
-const RECRUITER_SCREEN_EVENT_TYPES = new Set([
-  "recruiter_screen_scheduled",
-  "recruiter_screen_completed",
-]);
 const isRecruiterScreen = (record = {}) =>
   normalize(record.stage) === "recruiter_screen" ||
   normalize(record.status) === "recruiter_screen" ||
-  RECRUITER_SCREEN_EVENT_TYPES.has(normalize(record.eventType));
+  isRecruiterScreenLifecycleEvent(record.eventType);
 const recruiterScreenKey = (record = {}) =>
   [
     record.applicationId,
@@ -331,6 +327,7 @@ const hasListResponseSignal = (app, meta, metadata = {}) =>
   meta.lifecycle.some(
     (x) =>
       RESPONSE_EVENT_TYPES.has(normalize(x.eventType)) ||
+      isNonRecruiterInterviewLifecycleEvent(x.eventType) ||
       TERMINAL_EMPLOYER_STATUSES.has(normalize(x.status)),
   ) ||
   hasMetadataResponseSignal(metadata);
@@ -652,13 +649,17 @@ function timelineItem(e) {
     ? "assessment"
     : isRecruiterScreen(e)
       ? "recruiter"
-      : "event";
+      : isNonRecruiterInterviewLifecycleEvent(e.eventType)
+        ? "interview"
+        : "event";
   const label =
     kind === "assessment"
       ? "Assessment/take-home"
       : kind === "recruiter"
         ? "Recruiter screen"
-        : "Lifecycle event";
+        : kind === "interview"
+          ? "Interview"
+          : "Lifecycle event";
   return `<li class="timeline-item timeline-${kind}"><div><strong>${esc(label)}</strong> <span class="chip">${esc(e.status || e.eventType || "event")}</span></div><time>${esc(day(e.occurredAt) || day(e.dueAt) || "No date")}</time><div class="timeline-meta">${eventDetails(e)}</div></li>`;
 }
 function metadataSection(app) {
@@ -672,9 +673,19 @@ function detailForm(app) {
   const events = sortedLifecycleEvents(app.id);
   const metadata = readSpreadsheetMetadata(app.notes);
   const recruiterScreens = uniqueRecruiterScreens(m, events);
-  const otherInterviews = m.interviews.filter(
-    (item) => !isRecruiterScreen(item),
-  );
+  const lifecycleInterviews = events
+    .filter((event) => isNonRecruiterInterviewLifecycleEvent(event.eventType))
+    .map((event) => ({
+      startsAt: event.dueAt || event.occurredAt,
+      stage: event.stageLabel || event.eventType || "interview",
+      outcome: event.eventType?.endsWith("_completed")
+        ? "completed"
+        : "scheduled",
+    }));
+  const otherInterviews = [
+    ...m.interviews.filter((item) => !isRecruiterScreen(item)),
+    ...lifecycleInterviews,
+  ];
   const assessments = events.filter(isAssessmentEvent).map((event) => ({
     date: day(event.occurredAt) || day(event.dueAt),
     label: event.stageLabel || event.eventType || event.details || "assessment",

--- a/test/web-lifecycle-classification.test.js
+++ b/test/web-lifecycle-classification.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  classifyLifecycleEventType,
+  interviewStageForLifecycleEvent,
+  LIFECYCLE_EVENT_CATEGORIES,
+} from "../src/web/tracker/lifecycleClassification.js";
+
+const {
+  NON_RECRUITER_INTERVIEW,
+  RECRUITER_SCREEN,
+  ASSESSMENT,
+  EMPLOYER_RESPONSE,
+  REMINDER_ACTION,
+} = LIFECYCLE_EVENT_CATEGORIES;
+
+describe("lifecycle event classification", () => {
+  it.each([
+    ["devops_interview_scheduled", "technical_screen"],
+    ["devops_interview_completed", "technical_screen"],
+    ["technical_interview_scheduled", "technical_screen"],
+    ["technical_interview_completed", "technical_screen"],
+    ["technical_screen_scheduled", "technical_screen"],
+    ["technical_screen_completed", "technical_screen"],
+    ["onsite_interview_scheduled", "onsite_loop"],
+    ["onsite_interview_completed", "onsite_loop"],
+    ["final_interview_scheduled", "other"],
+    ["final_interview_completed", "other"],
+  ])("classifies %s as a non-recruiter interview", (eventType, stage) => {
+    expect(classifyLifecycleEventType(eventType)).toBe(NON_RECRUITER_INTERVIEW);
+    expect(interviewStageForLifecycleEvent(eventType)).toBe(stage);
+  });
+
+  it.each([
+    ["recruiter_screen_scheduled", RECRUITER_SCREEN],
+    ["recruiter_screen_completed", RECRUITER_SCREEN],
+    ["written_assessment_submitted", ASSESSMENT],
+    ["hiring_manager_reply", EMPLOYER_RESPONSE],
+    ["follow_up", REMINDER_ACTION],
+  ])("keeps %s out of non-recruiter interviews", (eventType, category) => {
+    expect(classifyLifecycleEventType(eventType)).toBe(category);
+    expect(interviewStageForLifecycleEvent(eventType)).toBeUndefined();
+  });
+});

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -1039,6 +1039,100 @@ describe("spreadsheet import/export", () => {
     repo.close();
   });
 
+  it("derives non-recruiter interview records idempotently", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const compactCsv = serializeCsv([
+      {
+        application_id: "app_devops_lifecycle",
+        company: "Lifecycle DevOps",
+        role_title: "DevOps Engineer",
+        applied_at: "2026-01-01",
+        outreach_status: "replied",
+        schema_version: "1",
+      },
+    ]);
+    await importCompactCsv(compactCsv, repo, { mode: "replace" });
+    const lifecycleCsv = serializeCsv(
+      [
+        {
+          application_id: "app_devops_lifecycle",
+          company: "Lifecycle DevOps",
+          role_title: "DevOps Engineer",
+          event_type: "recruiter_screen_scheduled",
+          occurred_at: "2026-01-02T12:00:00.000Z",
+          stage: "Recruiter screen",
+          channel: "video",
+          actor: "recruiter",
+          due_at: "2026-01-03T16:00:00.000Z",
+          details: "Recruiter screen scheduled.",
+        },
+        {
+          application_id: "app_devops_lifecycle",
+          company: "Lifecycle DevOps",
+          role_title: "DevOps Engineer",
+          event_type: "devops_interview_scheduled",
+          occurred_at: "2026-01-04T12:00:00.000Z",
+          stage: "DevOps interview",
+          channel: "video",
+          actor: "engineering",
+          due_at: "2026-01-05T18:00:00.000Z",
+          details: "DevOps interview scheduled.",
+        },
+        {
+          application_id: "app_devops_lifecycle",
+          company: "Lifecycle DevOps",
+          role_title: "DevOps Engineer",
+          event_type: "technical_interview_scheduled",
+          occurred_at: "2026-01-06T12:00:00.000Z",
+          stage: "Technical interview",
+          channel: "video",
+          actor: "engineering",
+          due_at: "2026-01-07T18:00:00.000Z",
+          details: "Technical interview scheduled.",
+        },
+        {
+          application_id: "app_devops_lifecycle",
+          company: "Lifecycle DevOps",
+          role_title: "DevOps Engineer",
+          event_type: "onsite_interview_scheduled",
+          occurred_at: "2026-01-08T12:00:00.000Z",
+          stage: "Onsite interview",
+          channel: "video",
+          actor: "engineering",
+          due_at: "2026-01-09T18:00:00.000Z",
+          details: "Onsite interview scheduled.",
+        },
+      ],
+      LIFECYCLE_CSV_COLUMNS,
+    );
+
+    const preview = await previewSupplementalLifecycleCsvImport(
+      lifecycleCsv,
+      repo,
+    );
+    expect(preview.errors).toEqual([]);
+    expect(preview.bundle.interviews).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ stage: "recruiter_screen" }),
+        expect.objectContaining({ stage: "technical_screen" }),
+        expect.objectContaining({ stage: "technical_screen" }),
+        expect.objectContaining({ stage: "onsite_loop" }),
+      ]),
+    );
+
+    await importSupplementalLifecycleCsv(lifecycleCsv, repo);
+    await importSupplementalLifecycleCsv(lifecycleCsv, repo);
+    const bundle = await repo.exportAllData();
+    expect(bundle.interviews).toHaveLength(4);
+    expect(
+      bundle.interviews.filter(({ stage }) => stage === "recruiter_screen"),
+    ).toHaveLength(1);
+    expect(
+      bundle.interviews.filter(({ stage }) => stage !== "recruiter_screen"),
+    ).toHaveLength(3);
+    repo.close();
+  });
+
   it("round trips compact and supplemental lifecycle CSV deterministically", async () => {
     let repo = await createIndexedDbRepository({ indexedDb: indexedDB });
     const compactCsv = serializeCsv([

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -84,24 +84,21 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationsWithResponse).toBe(5);
   });
 
-  it(
-    "dedupes hiring-manager lifecycle replies already represented by compact metadata",
-    async () => {
-      const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
-        exportedAt,
-      });
-      const lifecycle = importLifecycle(
-        await lifecycleFixture("employer-reply-lifecycle-regression.csv"),
-        bundle,
-      );
+  it("dedupes hiring-manager lifecycle replies in compact metadata", async () => {
+    const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
+      exportedAt,
+    });
+    const lifecycle = importLifecycle(
+      await lifecycleFixture("employer-reply-lifecycle-regression.csv"),
+      bundle,
+    );
 
-      const metrics = selectDashboardMetrics(mergeBundle(bundle, lifecycle));
+    const metrics = selectDashboardMetrics(mergeBundle(bundle, lifecycle));
 
-      expect(metrics.outreachReplies).toBe(2);
-      expect(metrics.applicationsWithResponse).toBe(4);
-      expect(metrics.interviews).toBe(0);
-    },
-  );
+    expect(metrics.outreachReplies).toBe(2);
+    expect(metrics.applicationsWithResponse).toBe(4);
+    expect(metrics.interviews).toBe(0);
+  });
 
   it("counts lifecycle-only hiring-manager replies as outreach replies", () => {
     const timestamp = "2026-01-01T00:00:00.000Z";
@@ -524,5 +521,88 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationsWithResponse).toBe(1);
     expect(metrics.applicationResponseRate).toBe(100);
     expect(metrics.outreachReplyRate).toBe(100);
+  });
+});
+
+describe("tracker dashboard lifecycle interview metrics", () => {
+  it("counts Reducto-like devops lifecycle interviews separately from recruiter screens", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const bundle = {
+      applications: [
+        {
+          id: "app_reducto_like",
+          company: "Example Systems",
+          role: "DevOps Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_recruiter",
+          applicationId: "app_reducto_like",
+          eventType: "recruiter_screen_scheduled",
+          status: "recruiter_screen",
+          occurredAt: "2026-01-02T00:00:00.000Z",
+          dueAt: "2026-01-03T17:00:00.000Z",
+        },
+        {
+          id: "event_devops",
+          applicationId: "app_reducto_like",
+          eventType: "devops_interview_scheduled",
+          status: "technical_screen",
+          occurredAt: "2026-01-04T00:00:00.000Z",
+          dueAt: "2026-01-05T18:00:00.000Z",
+        },
+      ],
+      interviews: [],
+    };
+
+    expect(selectDashboardMetrics(bundle)).toMatchObject({
+      recruiterScreens: 1,
+      interviews: 1,
+      applicationsWithResponse: 1,
+    });
+  });
+
+  it("does not count assessments, hiring-manager replies, or follow-ups as interviews", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_negative_events",
+          company: "Example",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_assessment",
+          applicationId: "app_negative_events",
+          eventType: "written_assessment_submitted",
+          occurredAt: timestamp,
+        },
+        {
+          id: "event_reply",
+          applicationId: "app_negative_events",
+          eventType: "hiring_manager_reply",
+          occurredAt: timestamp,
+        },
+        {
+          id: "event_follow_up",
+          applicationId: "app_negative_events",
+          eventType: "follow_up",
+          occurredAt: timestamp,
+        },
+      ],
+      interviews: [],
+    });
+
+    expect(metrics.interviews).toBe(0);
+    expect(metrics.assessments).toBe(1);
   });
 });


### PR DESCRIPTION
### Motivation
- Lifecycle CSV rows such as `devops_interview_scheduled` should be counted as non-recruiter interviews while keeping recruiter screens, assessments, and employer replies distinct. 
- The fix should be extensible (registry/table) to avoid fragile ad-hoc string checks and make idempotent derived interview creation deterministic.

### Description
- Added a centralized event classification module `src/web/tracker/lifecycleClassification.js` with categories (recruiter screen, non-recruiter interview, assessment, employer response, application submission, reminder/action, unknown) and helpers such as `classifyLifecycleEventType`, `isNonRecruiterInterviewLifecycleEvent`, and `interviewStageForLifecycleEvent`.
- Updated lifecycle CSV import (`src/web/import-export/spreadsheet.js`) to derive deterministic first-class `interviews` records for scheduled/completed recruiter and non-recruiter interview events when timing metadata (`due_at` or `occurred_at`) exists while preserving the original lifecycle event rows.
- Updated dashboard metric logic (`src/web/tracker/metrics.js`) to count lifecycle-only non-recruiter interviews (deduped against derived `interviews`) and keep recruiter screens, assessments, and employer replies separate from interview counts.
- Updated tracker UI/timeline (`src/web/tracker/tracker.js`) to render lifecycle-classified interview events in the non-recruiter interviews list so already-imported lifecycle rows are visible as interviews without requiring manual migration.
- Added unit and integration tests covering classification, Reducto-like DevOps lifecycle behavior, negative non-interview cases, and idempotent import/derivation (`test/web-lifecycle-classification.test.js`, extended `test/web-tracker-metrics.test.js`, and `test/web-spreadsheet-import-export.test.js`).

### Testing
- Ran `npm ci` — success.
- Ran `npm run lint` — success.
- Ran `npm run typecheck` — success.
- Ran targeted Prettier checks for changed files with `npx prettier --check <changed files>` — success; note `npm run format:check` reports pre-existing repository-wide Prettier drift unrelated to these changes.
- Ran the focused test suites with `npx vitest run test/web-lifecycle-classification.test.js test/web-tracker-metrics.test.js test/web-spreadsheet-import-export.test.js` — all targeted tests passed.
- Attempted full CI run with `npm run test:ci`; many suites ran and 242 tests passed but Vitest exited with an unhandled worker `onTaskUpdate` timeout (test runner error) — this appears to be a transient runner timing issue not caused by the change and should be retried in CI.
- Built and captured static screenshots with `npm run build` and `npm run web:screenshots` — success.

Notes / follow-ups: re-run full CI in the CI environment to confirm the transient Vitest worker timeout is not blocking merge; no new external runtime dependencies were added and the change preserves JSON/NDJSON round-trip and idempotent import behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ff54d6054832fb168ff7bb9887490)