### PR TITLE
Classify lifecycle interview events and derive non‑recruiter interviews

### DIFF
--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -665,13 +665,19 @@ export const lifecycleRowsToBrowserApplicationExport = (
         updatedAt: exportedAt,
       });
     const classification = classifyLifecycleEventType(eventType);
+    const occurredAtHasTime = hasTimeComponent(row.occurred_at);
+    const dueAtHasTime = hasTimeComponent(row.due_at);
     const interviewStartsAt =
-      classification.interviewOutcome === "completed" ? occurredAt : dueAt;
-    const hasScheduledTime =
       classification.interviewOutcome === "completed"
-        ? Boolean(occurredAt)
-        : hasTimeComponent(row.due_at);
-    if (classification.interviewStage && interviewStartsAt && hasScheduledTime)
+        ? occurredAtHasTime
+          ? occurredAt
+          : dueAtHasTime
+            ? dueAt
+            : undefined
+        : dueAtHasTime
+          ? dueAt
+          : undefined;
+    if (classification.interviewStage && interviewStartsAt)
       interviews.push({
         id: stableId(
           "interview",

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1478,6 +1478,9 @@ export const importCompactCsv = async (
   };
 };
 
+// Precision flags are intentionally ignored only for conflict comparison.
+// Supplemental imports still replace the existing same-id lifecycle record with
+// the incoming record, so re-importing upgrades legacy flagless records.
 const lifecycleComparableRecord = (record) =>
   Object.fromEntries(
     Object.entries(record).filter(

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1,8 +1,5 @@
 import { browserApplicationExportSchema } from "../../domain/browserApplication.js";
-import {
-  classifyLifecycleEventType,
-  isLifecycleNonRecruiterInterview,
-} from "../tracker/lifecycleClassification.js";
+import { classifyLifecycleEventType } from "../tracker/lifecycleClassification.js";
 
 export const LIFECYCLE_CSV_COLUMNS = [
   "application_id",
@@ -668,14 +665,12 @@ export const lifecycleRowsToBrowserApplicationExport = (
         updatedAt: exportedAt,
       });
     const classification = classifyLifecycleEventType(eventType);
-    const interviewStartsAt = isLifecycleNonRecruiterInterview(eventType)
-      ? classification.interviewOutcome === "completed"
-        ? occurredAt
-        : dueAt
-      : dueAt;
+    const interviewStartsAt =
+      classification.interviewOutcome === "completed" ? occurredAt : dueAt;
     const hasScheduledTime =
-      classification.interviewOutcome === "completed" ||
-      hasTimeComponent(row.due_at);
+      classification.interviewOutcome === "completed"
+        ? Boolean(occurredAt)
+        : hasTimeComponent(row.due_at);
     if (classification.interviewStage && interviewStartsAt && hasScheduledTime)
       interviews.push({
         id: stableId(

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1481,7 +1481,13 @@ export const importCompactCsv = async (
 const lifecycleComparableRecord = (record) =>
   Object.fromEntries(
     Object.entries(record).filter(
-      ([key]) => !["createdAt", "updatedAt"].includes(key),
+      ([key]) =>
+        ![
+          "createdAt",
+          "updatedAt",
+          "occurredAtHasTime",
+          "dueAtHasTime",
+        ].includes(key),
     ),
   );
 

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -684,7 +684,6 @@ export const lifecycleRowsToBrowserApplicationExport = (
           applicationId,
           classification.interviewStage,
           interviewStartsAt,
-          eventType,
         ),
         applicationId,
         contactIds: [],

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -591,6 +591,8 @@ export const lifecycleRowsToBrowserApplicationExport = (
     );
     const dueAt = parseDate(row.due_at, "due_at", rowNumber, errors);
     const eventOccurredAt = occurredAt ?? dueAt ?? "1970-01-01T00:00:00.000Z";
+    const occurredAtHasTime = hasTimeComponent(row.occurred_at);
+    const dueAtHasTime = hasTimeComponent(row.due_at);
     const stageLabel = compact(row.stage) || undefined;
     const knownLifecycleStatus = lifecycleStatusForEvent(eventType);
     if (
@@ -639,6 +641,8 @@ export const lifecycleRowsToBrowserApplicationExport = (
       ),
       actionStatus: compact(row.action_status) || undefined,
       dueAt,
+      occurredAtHasTime,
+      dueAtHasTime,
       noAiRequired: parseBoolean(
         row.no_ai_required,
         "no_ai_required",
@@ -665,8 +669,6 @@ export const lifecycleRowsToBrowserApplicationExport = (
         updatedAt: exportedAt,
       });
     const classification = classifyLifecycleEventType(eventType);
-    const occurredAtHasTime = hasTimeComponent(row.occurred_at);
-    const dueAtHasTime = hasTimeComponent(row.due_at);
     const interviewStartsAt =
       classification.interviewOutcome === "completed"
         ? occurredAtHasTime

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1,4 +1,8 @@
 import { browserApplicationExportSchema } from "../../domain/browserApplication.js";
+import {
+  classifyLifecycleEventType,
+  isLifecycleNonRecruiterInterview,
+} from "../tracker/lifecycleClassification.js";
 
 export const LIFECYCLE_CSV_COLUMNS = [
   "application_id",
@@ -539,9 +543,8 @@ export const detectSpreadsheetImportFormat = (text) => {
 };
 
 const lifecycleStatusForEvent = (eventType) => {
-  if (eventType === "hiring_manager_reply") return "outreach_sent";
-  if (eventType === "recruiter_screen_scheduled") return "recruiter_screen";
-  if (eventType === "application_submitted") return "applied";
+  const classification = classifyLifecycleEventType(eventType);
+  if (classification.status) return classification.status;
   if (KNOWN_STATUSES.has(eventType)) return eventType;
   return undefined;
 };
@@ -664,18 +667,29 @@ export const lifecycleRowsToBrowserApplicationExport = (
         createdAt: exportedAt,
         updatedAt: exportedAt,
       });
-    if (
-      eventType === "recruiter_screen_scheduled" &&
-      dueAt &&
-      hasTimeComponent(row.due_at)
-    )
+    const classification = classifyLifecycleEventType(eventType);
+    const interviewStartsAt = isLifecycleNonRecruiterInterview(eventType)
+      ? classification.interviewOutcome === "completed"
+        ? occurredAt
+        : dueAt
+      : dueAt;
+    const hasScheduledTime =
+      classification.interviewOutcome === "completed" ||
+      hasTimeComponent(row.due_at);
+    if (classification.interviewStage && interviewStartsAt && hasScheduledTime)
       interviews.push({
-        id: stableId("interview", applicationId, "recruiter_screen", dueAt),
+        id: stableId(
+          "interview",
+          applicationId,
+          classification.interviewStage,
+          interviewStartsAt,
+          eventType,
+        ),
         applicationId,
         contactIds: [],
-        stage: "recruiter_screen",
-        startsAt: dueAt,
-        outcome: "scheduled",
+        stage: classification.interviewStage,
+        startsAt: interviewStartsAt,
+        outcome: classification.interviewOutcome ?? "scheduled",
         createdAt: exportedAt,
         updatedAt: exportedAt,
       });

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1175,8 +1175,42 @@ export const exportLifecycleCsv = (bundle) =>
     browserApplicationExportToLifecycleRows(bundle),
     LIFECYCLE_CSV_COLUMNS,
   );
+const lifecyclePrecisionFlagsById = (events = []) =>
+  new Map(
+    events.map((event) => [
+      event.id,
+      {
+        occurredAtHasTime: event.occurredAtHasTime,
+        dueAtHasTime: event.dueAtHasTime,
+      },
+    ]),
+  );
+const restoreLifecyclePrecisionFlags = (bundle, sourceEvents) => {
+  const flagsById = lifecyclePrecisionFlagsById(sourceEvents);
+  return {
+    ...bundle,
+    lifecycleEvents: bundle.lifecycleEvents.map((event) => {
+      const flags = flagsById.get(event.id);
+      if (!flags) return event;
+      return {
+        ...event,
+        ...(typeof flags.occurredAtHasTime === "boolean"
+          ? { occurredAtHasTime: flags.occurredAtHasTime }
+          : {}),
+        ...(typeof flags.dueAtHasTime === "boolean"
+          ? { dueAtHasTime: flags.dueAtHasTime }
+          : {}),
+      };
+    }),
+  };
+};
+const parseBackupBundlePreservingLifecyclePrecision = (bundle) =>
+  restoreLifecyclePrecisionFlags(
+    browserApplicationExportSchema.parse(bundle),
+    bundle?.lifecycleEvents ?? [],
+  );
 const canonicalizeBackupBundle = (bundle) => {
-  const parsed = browserApplicationExportSchema.parse(bundle);
+  const parsed = parseBackupBundlePreservingLifecyclePrecision(bundle);
   const sorted = { ...parsed };
   for (const store of ARRAY_STORES) {
     sorted[store] = [...parsed[store]].sort((a, b) =>
@@ -1234,7 +1268,7 @@ const normalizeBackupBundleInput = (input, { source = "json_import" } = {}) => {
 };
 
 export const importJsonBackup = (text) =>
-  browserApplicationExportSchema.parse(
+  parseBackupBundlePreservingLifecyclePrecision(
     normalizeBackupBundleInput(JSON.parse(text), { source: "json_import" }),
   );
 export const importNdjsonBackup = (text) => {
@@ -1272,7 +1306,7 @@ export const importNdjsonBackup = (text) => {
           `Unknown or malformed NDJSON record type: ${String(entry.type)}`,
         );
     });
-  return browserApplicationExportSchema.parse(
+  return parseBackupBundlePreservingLifecyclePrecision(
     normalizeBackupBundleInput(bundle, { source: "ndjson_import" }),
   );
 };

--- a/src/web/tracker/lifecycleClassification.js
+++ b/src/web/tracker/lifecycleClassification.js
@@ -1,0 +1,158 @@
+const normalize = (value) =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+export const LIFECYCLE_EVENT_CATEGORIES = Object.freeze({
+  RECRUITER_SCREEN: "recruiter_screen",
+  NON_RECRUITER_INTERVIEW: "non_recruiter_interview",
+  ASSESSMENT: "assessment",
+  EMPLOYER_RESPONSE: "employer_response",
+  APPLICATION_SUBMISSION: "application_submission",
+  REMINDER_ACTION: "reminder_action",
+  UNKNOWN_METADATA: "unknown_metadata",
+});
+
+const EVENT_REGISTRY = Object.freeze({
+  application_submitted: {
+    category: LIFECYCLE_EVENT_CATEGORIES.APPLICATION_SUBMISSION,
+    status: "applied",
+  },
+  hiring_manager_reply: {
+    category: LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE,
+    status: "outreach_sent",
+    countsAsResponse: true,
+  },
+  recruiter_screen_scheduled: {
+    category: LIFECYCLE_EVENT_CATEGORIES.RECRUITER_SCREEN,
+    status: "recruiter_screen",
+    interviewStage: "recruiter_screen",
+    interviewOutcome: "scheduled",
+    countsAsResponse: true,
+  },
+  recruiter_screen_completed: {
+    category: LIFECYCLE_EVENT_CATEGORIES.RECRUITER_SCREEN,
+    status: "recruiter_screen",
+    interviewStage: "recruiter_screen",
+    interviewOutcome: "completed",
+    countsAsResponse: true,
+  },
+  devops_interview_scheduled: {
+    category: LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    status: "technical_screen",
+    interviewStage: "technical_screen",
+    interviewOutcome: "scheduled",
+    countsAsResponse: true,
+  },
+  devops_interview_completed: {
+    category: LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    status: "technical_screen",
+    interviewStage: "technical_screen",
+    interviewOutcome: "completed",
+    countsAsResponse: true,
+  },
+  technical_interview_scheduled: {
+    category: LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    status: "technical_screen",
+    interviewStage: "technical_screen",
+    interviewOutcome: "scheduled",
+    countsAsResponse: true,
+  },
+  technical_interview_completed: {
+    category: LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    status: "technical_screen",
+    interviewStage: "technical_screen",
+    interviewOutcome: "completed",
+    countsAsResponse: true,
+  },
+  technical_screen_scheduled: {
+    category: LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    status: "technical_screen",
+    interviewStage: "technical_screen",
+    interviewOutcome: "scheduled",
+    countsAsResponse: true,
+  },
+  technical_screen_completed: {
+    category: LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    status: "technical_screen",
+    interviewStage: "technical_screen",
+    interviewOutcome: "completed",
+    countsAsResponse: true,
+  },
+  onsite_interview_scheduled: {
+    category: LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    status: "onsite_loop",
+    interviewStage: "onsite_loop",
+    interviewOutcome: "scheduled",
+    countsAsResponse: true,
+  },
+  onsite_interview_completed: {
+    category: LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    status: "onsite_loop",
+    interviewStage: "onsite_loop",
+    interviewOutcome: "completed",
+    countsAsResponse: true,
+  },
+  final_interview_scheduled: {
+    category: LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    status: "onsite_loop",
+    interviewStage: "onsite_loop",
+    interviewOutcome: "scheduled",
+    countsAsResponse: true,
+  },
+  final_interview_completed: {
+    category: LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+    status: "onsite_loop",
+    interviewStage: "onsite_loop",
+    interviewOutcome: "completed",
+    countsAsResponse: true,
+  },
+  written_assessment: {
+    category: LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT,
+    countsAsResponse: true,
+  },
+  written_assessment_requested: {
+    category: LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT,
+    countsAsResponse: true,
+  },
+  written_assessment_submitted: {
+    category: LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT,
+    countsAsResponse: true,
+  },
+  take_home: {
+    category: LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT,
+    countsAsResponse: true,
+  },
+  take_home_requested: {
+    category: LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT,
+    countsAsResponse: true,
+  },
+  take_home_submitted: {
+    category: LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT,
+    countsAsResponse: true,
+  },
+  next_tracking_step: {
+    category: LIFECYCLE_EVENT_CATEGORIES.REMINDER_ACTION,
+  },
+});
+
+export const classifyLifecycleEventType = (eventType) => ({
+  category: LIFECYCLE_EVENT_CATEGORIES.UNKNOWN_METADATA,
+  ...EVENT_REGISTRY[normalize(eventType)],
+  eventType: normalize(eventType),
+});
+
+export const isLifecycleRecruiterScreen = (eventType) =>
+  classifyLifecycleEventType(eventType).category ===
+  LIFECYCLE_EVENT_CATEGORIES.RECRUITER_SCREEN;
+
+export const isLifecycleNonRecruiterInterview = (eventType) =>
+  classifyLifecycleEventType(eventType).category ===
+  LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW;
+
+export const isLifecycleAssessment = (eventType) =>
+  classifyLifecycleEventType(eventType).category ===
+  LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT;

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -124,11 +124,29 @@ const recruiterScreenKey = (record) =>
     .join(":");
 const isPlaceholderTimestamp = (value) =>
   value === "1970-01-01T00:00:00.000Z" || value === "1970-01-01";
+const lifecycleInterviewTimestampCandidates = (event, classification) => {
+  const candidates = [lifecycleInterviewTimestamp(event, classification)];
+  if (classification.interviewOutcome === "completed") {
+    candidates.push(
+      timedValue(event, ["dueAt", event.dueAt]),
+      timedValue(event, ["startsAt", event.startsAt]),
+      timedValue(event, ["occurredAt", event.occurredAt]),
+    );
+  }
+  return [...new Set(candidates.filter(Boolean))];
+};
 const lifecycleInterviewKey = (event, classification) => {
-  const timestamp = lifecycleInterviewTimestamp(event, classification);
+  const [timestamp] = lifecycleInterviewTimestampCandidates(
+    event,
+    classification,
+  );
   if (!timestamp) return undefined;
   return interviewKey(event, timestamp);
 };
+const lifecycleInterviewDuplicateKeys = (event, classification) =>
+  lifecycleInterviewTimestampCandidates(event, classification).map(
+    (timestamp) => interviewKey(event, timestamp),
+  );
 
 /**
  * Dashboard selector for imported tracker bundles.
@@ -152,6 +170,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
   const assessmentApplicationIds = new Set();
   const offerApplicationIds = new Set();
   const lifecycleNonRecruiterInterviewKeys = new Set();
+  const lifecycleNonRecruiterInterviewDuplicateKeys = new Set();
   const explicitNonRecruiterInterviewKeys = new Set();
 
   for (const application of applications) {
@@ -223,7 +242,14 @@ export const selectDashboardMetrics = (bundle = {}) => {
       recruiterScreenKeys.add(recruiterScreenKey(event));
     if (isLifecycleNonRecruiterInterview(eventType)) {
       const key = lifecycleInterviewKey(event, classification);
-      if (key) lifecycleNonRecruiterInterviewKeys.add(key);
+      if (key) {
+        lifecycleNonRecruiterInterviewKeys.add(key);
+        for (const duplicateKey of lifecycleInterviewDuplicateKeys(
+          event,
+          classification,
+        ))
+          lifecycleNonRecruiterInterviewDuplicateKeys.add(duplicateKey);
+      }
     }
     if (
       OFFER_EVENT_TYPES.has(eventType) ||
@@ -248,7 +274,9 @@ export const selectDashboardMetrics = (bundle = {}) => {
   for (const interview of interviews) {
     if (interview.stage !== "recruiter_screen") {
       const lifecycleDuplicateKey = interviewKey(interview, interview.startsAt);
-      if (!lifecycleNonRecruiterInterviewKeys.has(lifecycleDuplicateKey))
+      if (
+        !lifecycleNonRecruiterInterviewDuplicateKeys.has(lifecycleDuplicateKey)
+      )
         explicitNonRecruiterInterviewKeys.add(
           interview.id ? `explicit:${interview.id}` : lifecycleDuplicateKey,
         );

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -68,13 +68,12 @@ const isAssessmentMetadata = (metadata) => {
 const addResponse = (responses, applicationId) => {
   if (applicationId) responses.add(applicationId);
 };
+const timedValue = (...values) =>
+  values.find((value) => value && !isPlaceholderTimestamp(value));
 const lifecycleInterviewTimestamp = (event, classification) => {
-  if (classification.interviewOutcome === "completed") {
-    if (event.occurredAt && !isPlaceholderTimestamp(event.occurredAt))
-      return event.occurredAt;
-    return event.dueAt ?? event.startsAt;
-  }
-  return event.dueAt ?? event.startsAt;
+  if (classification.interviewOutcome === "completed")
+    return timedValue(event.occurredAt, event.dueAt, event.startsAt);
+  return timedValue(event.dueAt, event.startsAt);
 };
 const interviewKey = (record, timestamp) => {
   const classification = classifyLifecycleEventType(record.eventType);

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -1,28 +1,14 @@
+import {
+  classifyLifecycleEventType,
+  isLifecycleAssessment,
+  isLifecycleNonRecruiterInterview,
+  isLifecycleRecruiterScreen,
+} from "./lifecycleClassification.js";
 const TERMINAL_EMPLOYER_STATUSES = new Set([
   "offer",
   "accepted",
   "rejected",
   "closed_archived",
-]);
-const RESPONSE_EVENT_TYPES = new Set([
-  "hiring_manager_reply",
-  "written_assessment_requested",
-  "recruiter_screen_scheduled",
-  "recruiter_screen_completed",
-  "offer",
-  "offer_received",
-]);
-const ASSESSMENT_EVENT_TYPES = new Set([
-  "written_assessment",
-  "written_assessment_requested",
-  "written_assessment_submitted",
-  "take_home",
-  "take_home_requested",
-  "take_home_submitted",
-]);
-const RECRUITER_SCREEN_EVENT_TYPES = new Set([
-  "recruiter_screen_scheduled",
-  "recruiter_screen_completed",
 ]);
 const OFFER_EVENT_TYPES = new Set(["offer", "offer_received"]);
 const OUTREACH_REPLY_STATUSES = new Set(["replied", "reply", "responded"]);
@@ -82,6 +68,19 @@ const isAssessmentMetadata = (metadata) => {
 const addResponse = (responses, applicationId) => {
   if (applicationId) responses.add(applicationId);
 };
+const interviewKey = (record) => {
+  const classification = classifyLifecycleEventType(record.eventType);
+  return [
+    record.applicationId,
+    record.startsAt ?? record.dueAt ?? record.occurredAt ?? record.id,
+    record.stage ??
+      classification.interviewStage ??
+      record.eventType ??
+      "interview",
+  ]
+    .filter(Boolean)
+    .join(":");
+};
 const recruiterScreenKey = (record) =>
   [
     record.applicationId,
@@ -111,6 +110,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
   const recruiterScreenKeys = new Set();
   const assessmentApplicationIds = new Set();
   const offerApplicationIds = new Set();
+  const nonRecruiterInterviewKeys = new Set();
 
   for (const application of applications) {
     const metadata = metadataByApplicationId.get(application.id) ?? {};
@@ -163,23 +163,24 @@ export const selectDashboardMetrics = (bundle = {}) => {
   for (const event of lifecycleEvents) {
     const eventType = normalize(event.eventType);
     const status = normalize(event.status);
+    const classification = classifyLifecycleEventType(eventType);
     if (
-      RESPONSE_EVENT_TYPES.has(eventType) ||
+      classification.countsAsResponse ||
+      OFFER_EVENT_TYPES.has(eventType) ||
       TERMINAL_EMPLOYER_STATUSES.has(status)
     )
       addResponse(responseApplicationIds, event.applicationId);
     if (eventType === "hiring_manager_reply" && event.applicationId)
       lifecycleReplyApplicationIds.add(event.applicationId);
-    if (ASSESSMENT_EVENT_TYPES.has(eventType)) {
+    if (isLifecycleAssessment(eventType)) {
       addResponse(responseApplicationIds, event.applicationId);
       if (event.applicationId)
         assessmentApplicationIds.add(event.applicationId);
     }
-    if (
-      RECRUITER_SCREEN_EVENT_TYPES.has(eventType) ||
-      status === "recruiter_screen"
-    )
+    if (isLifecycleRecruiterScreen(eventType) || status === "recruiter_screen")
       recruiterScreenKeys.add(recruiterScreenKey(event));
+    if (isLifecycleNonRecruiterInterview(eventType))
+      nonRecruiterInterviewKeys.add(interviewKey(event));
     if (
       OFFER_EVENT_TYPES.has(eventType) ||
       ["offer", "accepted"].includes(status)
@@ -200,9 +201,10 @@ export const selectDashboardMetrics = (bundle = {}) => {
     if (interview.stage === "recruiter_screen")
       recruiterScreenKeys.add(recruiterScreenKey(interview));
   }
-  const nonRecruiterInterviews = interviews.filter(
-    (interview) => interview.stage !== "recruiter_screen",
-  );
+  for (const interview of interviews) {
+    if (interview.stage !== "recruiter_screen")
+      nonRecruiterInterviewKeys.add(interviewKey(interview));
+  }
 
   return {
     totalApplications: applications.length,
@@ -215,7 +217,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
     ),
     outreachReplyRate: boundedPercentage(outreachReplies, outreachSent),
     recruiterScreens: recruiterScreenKeys.size,
-    interviews: nonRecruiterInterviews.length,
+    interviews: nonRecruiterInterviewKeys.size,
     assessments: assessmentApplicationIds.size,
     offers: new Set(
       [

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -68,8 +68,12 @@ const isAssessmentMetadata = (metadata) => {
 const addResponse = (responses, applicationId) => {
   if (applicationId) responses.add(applicationId);
 };
+const isTimedLifecycleInterviewTimestamp = (value) =>
+  Boolean(value) &&
+  !isPlaceholderTimestamp(value) &&
+  !/T00:00:00(?:\.000)?Z$/.test(value);
 const timedValue = (...values) =>
-  values.find((value) => value && !isPlaceholderTimestamp(value));
+  values.find((value) => isTimedLifecycleInterviewTimestamp(value));
 const lifecycleInterviewTimestamp = (event, classification) => {
   if (classification.interviewOutcome === "completed")
     return timedValue(event.occurredAt, event.dueAt, event.startsAt);

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -140,10 +140,25 @@ const interviewKey = (record, timestamp) => {
     .filter(Boolean)
     .join(":");
 };
-const recruiterScreenKey = (record) =>
+export const recruiterScreenTimestamp = (record = {}) => {
+  if (record.startsAt) return record.startsAt;
+  const classification = classifyLifecycleEventType(record.eventType);
+  if (classification.interviewOutcome === "completed")
+    return (
+      timedValue(record, ["occurredAt", record.occurredAt]) ??
+      timedValue(record, ["dueAt", record.dueAt])
+    );
+  if (classification.interviewOutcome === "scheduled")
+    return timedValue(record, ["dueAt", record.dueAt]);
+  return (
+    timedValue(record, ["dueAt", record.dueAt]) ??
+    timedValue(record, ["occurredAt", record.occurredAt])
+  );
+};
+export const recruiterScreenKey = (record = {}) =>
   [
     record.applicationId,
-    record.dueAt ?? record.startsAt ?? record.occurredAt ?? record.id,
+    canonicalTimestamp(recruiterScreenTimestamp(record)) ?? record.id,
   ]
     .filter(Boolean)
     .join(":");

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -157,13 +157,7 @@ const lifecycleInterviewDuplicateTimestampCandidates = (
   event,
   classification,
 ) => {
-  const candidates = lifecycleInterviewTimestampCandidates(
-    event,
-    classification,
-  );
-  if (classification.interviewOutcome === "completed")
-    candidates.push(event.dueAt, event.startsAt, event.occurredAt);
-  return uniqueUsableTimestamps(candidates);
+  return lifecycleInterviewTimestampCandidates(event, classification);
 };
 const lifecycleInterviewKey = (event, classification) => {
   const [timestamp] = lifecycleInterviewTimestampCandidates(

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -68,11 +68,19 @@ const isAssessmentMetadata = (metadata) => {
 const addResponse = (responses, applicationId) => {
   if (applicationId) responses.add(applicationId);
 };
-const interviewKey = (record) => {
+const lifecycleInterviewTimestamp = (event, classification) => {
+  if (classification.interviewOutcome === "completed") {
+    if (event.occurredAt && !isPlaceholderTimestamp(event.occurredAt))
+      return event.occurredAt;
+    return event.dueAt ?? event.startsAt;
+  }
+  return event.dueAt ?? event.startsAt;
+};
+const interviewKey = (record, timestamp) => {
   const classification = classifyLifecycleEventType(record.eventType);
   return [
     record.applicationId,
-    record.startsAt ?? record.dueAt ?? record.occurredAt ?? record.id,
+    timestamp ?? record.startsAt ?? record.dueAt ?? record.occurredAt,
     record.stage ??
       classification.interviewStage ??
       record.eventType ??
@@ -90,11 +98,10 @@ const recruiterScreenKey = (record) =>
     .join(":");
 const isPlaceholderTimestamp = (value) =>
   value === "1970-01-01T00:00:00.000Z" || value === "1970-01-01";
-const hasLifecycleInterviewTime = (event, classification) => {
-  if (event.startsAt || event.dueAt) return true;
-  if (!event.occurredAt || isPlaceholderTimestamp(event.occurredAt))
-    return false;
-  return classification.interviewOutcome === "completed";
+const lifecycleInterviewKey = (event, classification) => {
+  const timestamp = lifecycleInterviewTimestamp(event, classification);
+  if (!timestamp) return undefined;
+  return interviewKey(event, timestamp);
 };
 
 /**
@@ -188,11 +195,10 @@ export const selectDashboardMetrics = (bundle = {}) => {
     }
     if (isLifecycleRecruiterScreen(eventType) || status === "recruiter_screen")
       recruiterScreenKeys.add(recruiterScreenKey(event));
-    if (
-      isLifecycleNonRecruiterInterview(eventType) &&
-      hasLifecycleInterviewTime(event, classification)
-    )
-      lifecycleNonRecruiterInterviewKeys.add(interviewKey(event));
+    if (isLifecycleNonRecruiterInterview(eventType)) {
+      const key = lifecycleInterviewKey(event, classification);
+      if (key) lifecycleNonRecruiterInterviewKeys.add(key);
+    }
     if (
       OFFER_EVENT_TYPES.has(eventType) ||
       ["offer", "accepted"].includes(status)
@@ -215,7 +221,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
   }
   for (const interview of interviews) {
     if (interview.stage !== "recruiter_screen") {
-      const lifecycleDuplicateKey = interviewKey(interview);
+      const lifecycleDuplicateKey = interviewKey(interview, interview.startsAt);
       if (!lifecycleNonRecruiterInterviewKeys.has(lifecycleDuplicateKey))
         explicitNonRecruiterInterviewKeys.add(
           interview.id ? `explicit:${interview.id}` : lifecycleDuplicateKey,

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -73,10 +73,15 @@ const canonicalTimestamp = (value) => {
   const timestamp = Date.parse(value);
   return Number.isNaN(timestamp) ? value : new Date(timestamp).toISOString();
 };
+const isAmbiguousLegacyDateOnlyTimestamp = (value) => {
+  if (!value) return false;
+  const canonical = canonicalTimestamp(value);
+  return Boolean(canonical?.match(/^\d{4}-\d{2}-\d{2}T00:00:00\.000Z$/));
+};
 const lifecycleTimestampHasTime = (event, field, value) => {
   const flag = event[`${field}HasTime`];
   if (typeof flag === "boolean") return flag;
-  return Boolean(value);
+  return Boolean(value) && !isAmbiguousLegacyDateOnlyTimestamp(value);
 };
 const isTimedLifecycleInterviewTimestamp = (event, field, value) =>
   Boolean(value) &&
@@ -124,6 +129,13 @@ const recruiterScreenKey = (record) =>
     .join(":");
 const isPlaceholderTimestamp = (value) =>
   value === "1970-01-01T00:00:00.000Z" || value === "1970-01-01";
+const uniqueUsableTimestamps = (candidates) => [
+  ...new Set(
+    candidates.filter(
+      (candidate) => candidate && !isPlaceholderTimestamp(candidate),
+    ),
+  ),
+];
 const lifecycleInterviewTimestampCandidates = (event, classification) => {
   const candidates = [lifecycleInterviewTimestamp(event, classification)];
   if (classification.interviewOutcome === "completed") {
@@ -133,7 +145,19 @@ const lifecycleInterviewTimestampCandidates = (event, classification) => {
       timedValue(event, ["occurredAt", event.occurredAt]),
     );
   }
-  return [...new Set(candidates.filter(Boolean))];
+  return uniqueUsableTimestamps(candidates);
+};
+const lifecycleInterviewDuplicateTimestampCandidates = (
+  event,
+  classification,
+) => {
+  const candidates = lifecycleInterviewTimestampCandidates(
+    event,
+    classification,
+  );
+  if (classification.interviewOutcome === "completed")
+    candidates.push(event.dueAt, event.startsAt, event.occurredAt);
+  return uniqueUsableTimestamps(candidates);
 };
 const lifecycleInterviewKey = (event, classification) => {
   const [timestamp] = lifecycleInterviewTimestampCandidates(
@@ -144,7 +168,7 @@ const lifecycleInterviewKey = (event, classification) => {
   return interviewKey(event, timestamp);
 };
 const lifecycleInterviewDuplicateKeys = (event, classification) =>
-  lifecycleInterviewTimestampCandidates(event, classification).map(
+  lifecycleInterviewDuplicateTimestampCandidates(event, classification).map(
     (timestamp) => interviewKey(event, timestamp),
   );
 

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -88,6 +88,14 @@ const recruiterScreenKey = (record) =>
   ]
     .filter(Boolean)
     .join(":");
+const isPlaceholderTimestamp = (value) =>
+  value === "1970-01-01T00:00:00.000Z" || value === "1970-01-01";
+const hasLifecycleInterviewTime = (event, classification) => {
+  if (event.startsAt || event.dueAt) return true;
+  if (!event.occurredAt || isPlaceholderTimestamp(event.occurredAt))
+    return false;
+  return classification.interviewOutcome === "completed";
+};
 
 /**
  * Dashboard selector for imported tracker bundles.
@@ -110,7 +118,8 @@ export const selectDashboardMetrics = (bundle = {}) => {
   const recruiterScreenKeys = new Set();
   const assessmentApplicationIds = new Set();
   const offerApplicationIds = new Set();
-  const nonRecruiterInterviewKeys = new Set();
+  const lifecycleNonRecruiterInterviewKeys = new Set();
+  const explicitNonRecruiterInterviewKeys = new Set();
 
   for (const application of applications) {
     const metadata = metadataByApplicationId.get(application.id) ?? {};
@@ -179,8 +188,11 @@ export const selectDashboardMetrics = (bundle = {}) => {
     }
     if (isLifecycleRecruiterScreen(eventType) || status === "recruiter_screen")
       recruiterScreenKeys.add(recruiterScreenKey(event));
-    if (isLifecycleNonRecruiterInterview(eventType))
-      nonRecruiterInterviewKeys.add(interviewKey(event));
+    if (
+      isLifecycleNonRecruiterInterview(eventType) &&
+      hasLifecycleInterviewTime(event, classification)
+    )
+      lifecycleNonRecruiterInterviewKeys.add(interviewKey(event));
     if (
       OFFER_EVENT_TYPES.has(eventType) ||
       ["offer", "accepted"].includes(status)
@@ -202,8 +214,13 @@ export const selectDashboardMetrics = (bundle = {}) => {
       recruiterScreenKeys.add(recruiterScreenKey(interview));
   }
   for (const interview of interviews) {
-    if (interview.stage !== "recruiter_screen")
-      nonRecruiterInterviewKeys.add(interviewKey(interview));
+    if (interview.stage !== "recruiter_screen") {
+      const lifecycleDuplicateKey = interviewKey(interview);
+      if (!lifecycleNonRecruiterInterviewKeys.has(lifecycleDuplicateKey))
+        explicitNonRecruiterInterviewKeys.add(
+          interview.id ? `explicit:${interview.id}` : lifecycleDuplicateKey,
+        );
+    }
   }
 
   return {
@@ -217,7 +234,9 @@ export const selectDashboardMetrics = (bundle = {}) => {
     ),
     outreachReplyRate: boundedPercentage(outreachReplies, outreachSent),
     recruiterScreens: recruiterScreenKeys.size,
-    interviews: nonRecruiterInterviewKeys.size,
+    interviews:
+      lifecycleNonRecruiterInterviewKeys.size +
+      explicitNonRecruiterInterviewKeys.size,
     assessments: assessmentApplicationIds.size,
     offers: new Set(
       [

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -140,11 +140,35 @@ const interviewKey = (record, timestamp) => {
     .filter(Boolean)
     .join(":");
 };
-export const recruiterScreenTimestamp = (record = {}) => {
+const recruiterScreenIdentityKey = (record = {}, timestamp) =>
+  [record.applicationId, canonicalTimestamp(timestamp) ?? record.id]
+    .filter(Boolean)
+    .join(":");
+const matchingExplicitCompletedRecruiterScreenTimestamp = (
+  record,
+  explicitRecruiterScreenKeys = new Set(),
+) => {
+  if (
+    typeof record.occurredAtHasTime === "boolean" ||
+    !record.occurredAt ||
+    !explicitRecruiterScreenKeys.size
+  )
+    return undefined;
+  const key = recruiterScreenIdentityKey(record, record.occurredAt);
+  return explicitRecruiterScreenKeys.has(key) ? record.occurredAt : undefined;
+};
+export const recruiterScreenTimestamp = (
+  record = {},
+  explicitRecruiterScreenKeys = new Set(),
+) => {
   if (record.startsAt) return record.startsAt;
   const classification = classifyLifecycleEventType(record.eventType);
   if (classification.interviewOutcome === "completed")
     return (
+      matchingExplicitCompletedRecruiterScreenTimestamp(
+        record,
+        explicitRecruiterScreenKeys,
+      ) ??
       timedValue(record, ["occurredAt", record.occurredAt]) ??
       timedValue(record, ["dueAt", record.dueAt])
     );
@@ -155,13 +179,14 @@ export const recruiterScreenTimestamp = (record = {}) => {
     timedValue(record, ["occurredAt", record.occurredAt])
   );
 };
-export const recruiterScreenKey = (record = {}) =>
-  [
-    record.applicationId,
-    canonicalTimestamp(recruiterScreenTimestamp(record)) ?? record.id,
-  ]
-    .filter(Boolean)
-    .join(":");
+export const recruiterScreenKey = (
+  record = {},
+  explicitRecruiterScreenKeys = new Set(),
+) =>
+  recruiterScreenIdentityKey(
+    record,
+    recruiterScreenTimestamp(record, explicitRecruiterScreenKeys),
+  );
 const isPlaceholderTimestamp = (value) =>
   value === "1970-01-01T00:00:00.000Z" || value === "1970-01-01";
 const uniqueUsableTimestamps = (candidates) => [
@@ -258,6 +283,11 @@ export const selectDashboardMetrics = (bundle = {}) => {
       .filter(({ stage }) => stage !== "recruiter_screen")
       .map((interview) => interviewKey(interview, interview.startsAt)),
   );
+  const explicitRecruiterScreenKeys = new Set(
+    interviews
+      .filter(({ stage }) => stage === "recruiter_screen")
+      .map((interview) => recruiterScreenKey(interview)),
+  );
 
   for (const application of applications) {
     const metadata = metadataByApplicationId.get(application.id) ?? {};
@@ -325,7 +355,9 @@ export const selectDashboardMetrics = (bundle = {}) => {
         assessmentApplicationIds.add(event.applicationId);
     }
     if (isLifecycleRecruiterScreen(eventType) || status === "recruiter_screen")
-      recruiterScreenKeys.add(recruiterScreenKey(event));
+      recruiterScreenKeys.add(
+        recruiterScreenKey(event, explicitRecruiterScreenKeys),
+      );
     if (isLifecycleNonRecruiterInterview(eventType)) {
       const key = lifecycleInterviewKey(
         event,

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -81,7 +81,13 @@ const isAmbiguousLegacyDateOnlyTimestamp = (value) => {
 const lifecycleTimestampHasTime = (event, field, value) => {
   const flag = event[`${field}HasTime`];
   if (typeof flag === "boolean") return flag;
-  return Boolean(value) && !isAmbiguousLegacyDateOnlyTimestamp(value);
+  if (!value) return false;
+  if (
+    event.source === "csv_import" &&
+    isAmbiguousLegacyDateOnlyTimestamp(value)
+  )
+    return false;
+  return true;
 };
 const isTimedLifecycleInterviewTimestamp = (event, field, value) =>
   Boolean(value) &&

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -68,8 +68,6 @@ const isAssessmentMetadata = (metadata) => {
 const addResponse = (responses, applicationId) => {
   if (applicationId) responses.add(applicationId);
 };
-const hasParsedDateOnlyTimestamp = (value) =>
-  /T00:00:00(?:\.000)?(?:Z|[+-]\d{2}:?\d{2})$/.test(value);
 const canonicalTimestamp = (value) => {
   if (!value) return undefined;
   const timestamp = Date.parse(value);
@@ -78,7 +76,7 @@ const canonicalTimestamp = (value) => {
 const lifecycleTimestampHasTime = (event, field, value) => {
   const flag = event[`${field}HasTime`];
   if (typeof flag === "boolean") return flag;
-  return !hasParsedDateOnlyTimestamp(value);
+  return Boolean(value);
 };
 const isTimedLifecycleInterviewTimestamp = (event, field, value) =>
   Boolean(value) &&

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -111,6 +111,20 @@ const lifecycleInterviewTimestamp = (event, classification) => {
     ["startsAt", event.startsAt],
   );
 };
+const matchingExplicitCompletedTimestamp = (
+  event,
+  classification,
+  explicitInterviewKeys,
+) => {
+  if (
+    classification.interviewOutcome !== "completed" ||
+    typeof event.occurredAtHasTime === "boolean" ||
+    !event.occurredAt
+  )
+    return undefined;
+  const key = interviewKey(event, event.occurredAt);
+  return explicitInterviewKeys.has(key) ? event.occurredAt : undefined;
+};
 const interviewKey = (record, timestamp) => {
   const classification = classifyLifecycleEventType(record.eventType);
   return [
@@ -142,8 +156,18 @@ const uniqueUsableTimestamps = (candidates) => [
     ),
   ),
 ];
-const lifecycleInterviewTimestampCandidates = (event, classification) => {
-  const candidates = [lifecycleInterviewTimestamp(event, classification)];
+const lifecycleInterviewTimestampCandidates = (
+  event,
+  classification,
+  explicitInterviewKeys = new Set(),
+) => {
+  const candidates = [
+    matchingExplicitCompletedTimestamp(
+      event,
+      classification,
+      explicitInterviewKeys,
+    ) ?? lifecycleInterviewTimestamp(event, classification),
+  ];
   if (classification.interviewOutcome === "completed") {
     candidates.push(
       timedValue(event, ["dueAt", event.dueAt]),
@@ -156,22 +180,39 @@ const lifecycleInterviewTimestampCandidates = (event, classification) => {
 const lifecycleInterviewDuplicateTimestampCandidates = (
   event,
   classification,
+  explicitInterviewKeys = new Set(),
 ) => {
-  const timestamp = lifecycleInterviewTimestamp(event, classification);
+  const timestamp =
+    matchingExplicitCompletedTimestamp(
+      event,
+      classification,
+      explicitInterviewKeys,
+    ) ?? lifecycleInterviewTimestamp(event, classification);
   return uniqueUsableTimestamps([timestamp]);
 };
-const lifecycleInterviewKey = (event, classification) => {
+const lifecycleInterviewKey = (
+  event,
+  classification,
+  explicitInterviewKeys,
+) => {
   const [timestamp] = lifecycleInterviewTimestampCandidates(
     event,
     classification,
+    explicitInterviewKeys,
   );
   if (!timestamp) return undefined;
   return interviewKey(event, timestamp);
 };
-const lifecycleInterviewDuplicateKeys = (event, classification) =>
-  lifecycleInterviewDuplicateTimestampCandidates(event, classification).map(
-    (timestamp) => interviewKey(event, timestamp),
-  );
+const lifecycleInterviewDuplicateKeys = (
+  event,
+  classification,
+  explicitInterviewKeys,
+) =>
+  lifecycleInterviewDuplicateTimestampCandidates(
+    event,
+    classification,
+    explicitInterviewKeys,
+  ).map((timestamp) => interviewKey(event, timestamp));
 
 /**
  * Dashboard selector for imported tracker bundles.
@@ -197,6 +238,11 @@ export const selectDashboardMetrics = (bundle = {}) => {
   const lifecycleNonRecruiterInterviewKeys = new Set();
   const lifecycleNonRecruiterInterviewDuplicateKeys = new Set();
   const explicitNonRecruiterInterviewKeys = new Set();
+  const explicitNonRecruiterInterviewCanonicalKeys = new Set(
+    interviews
+      .filter(({ stage }) => stage !== "recruiter_screen")
+      .map((interview) => interviewKey(interview, interview.startsAt)),
+  );
 
   for (const application of applications) {
     const metadata = metadataByApplicationId.get(application.id) ?? {};
@@ -266,12 +312,17 @@ export const selectDashboardMetrics = (bundle = {}) => {
     if (isLifecycleRecruiterScreen(eventType) || status === "recruiter_screen")
       recruiterScreenKeys.add(recruiterScreenKey(event));
     if (isLifecycleNonRecruiterInterview(eventType)) {
-      const key = lifecycleInterviewKey(event, classification);
+      const key = lifecycleInterviewKey(
+        event,
+        classification,
+        explicitNonRecruiterInterviewCanonicalKeys,
+      );
       if (key) {
         lifecycleNonRecruiterInterviewKeys.add(key);
         for (const duplicateKey of lifecycleInterviewDuplicateKeys(
           event,
           classification,
+          explicitNonRecruiterInterviewCanonicalKeys,
         ))
           lifecycleNonRecruiterInterviewDuplicateKeys.add(duplicateKey);
       }

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -68,10 +68,12 @@ const isAssessmentMetadata = (metadata) => {
 const addResponse = (responses, applicationId) => {
   if (applicationId) responses.add(applicationId);
 };
+const isParsedDateOnlyTimestamp = (value) =>
+  /T00:00:00(?:\.000)?(?:Z|[+-]\d{2}:?\d{2})$/.test(value);
 const isTimedLifecycleInterviewTimestamp = (value) =>
   Boolean(value) &&
   !isPlaceholderTimestamp(value) &&
-  !/T00:00:00(?:\.000)?Z$/.test(value);
+  !isParsedDateOnlyTimestamp(value);
 const timedValue = (...values) =>
   values.find((value) => isTimedLifecycleInterviewTimestamp(value));
 const lifecycleInterviewTimestamp = (event, classification) => {

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -157,7 +157,8 @@ const lifecycleInterviewDuplicateTimestampCandidates = (
   event,
   classification,
 ) => {
-  return lifecycleInterviewTimestampCandidates(event, classification);
+  const timestamp = lifecycleInterviewTimestamp(event, classification);
+  return uniqueUsableTimestamps([timestamp]);
 };
 const lifecycleInterviewKey = (event, classification) => {
   const [timestamp] = lifecycleInterviewTimestampCandidates(

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -68,24 +68,47 @@ const isAssessmentMetadata = (metadata) => {
 const addResponse = (responses, applicationId) => {
   if (applicationId) responses.add(applicationId);
 };
-const isParsedDateOnlyTimestamp = (value) =>
+const hasParsedDateOnlyTimestamp = (value) =>
   /T00:00:00(?:\.000)?(?:Z|[+-]\d{2}:?\d{2})$/.test(value);
-const isTimedLifecycleInterviewTimestamp = (value) =>
+const canonicalTimestamp = (value) => {
+  if (!value) return undefined;
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? value : new Date(timestamp).toISOString();
+};
+const lifecycleTimestampHasTime = (event, field, value) => {
+  const flag = event[`${field}HasTime`];
+  if (typeof flag === "boolean") return flag;
+  return !hasParsedDateOnlyTimestamp(value);
+};
+const isTimedLifecycleInterviewTimestamp = (event, field, value) =>
   Boolean(value) &&
   !isPlaceholderTimestamp(value) &&
-  !isParsedDateOnlyTimestamp(value);
-const timedValue = (...values) =>
-  values.find((value) => isTimedLifecycleInterviewTimestamp(value));
+  lifecycleTimestampHasTime(event, field, value);
+const timedValue = (event, ...fieldValuePairs) =>
+  fieldValuePairs.find(([field, value]) =>
+    isTimedLifecycleInterviewTimestamp(event, field, value),
+  )?.[1];
 const lifecycleInterviewTimestamp = (event, classification) => {
   if (classification.interviewOutcome === "completed")
-    return timedValue(event.occurredAt, event.dueAt, event.startsAt);
-  return timedValue(event.dueAt, event.startsAt);
+    return timedValue(
+      event,
+      ["occurredAt", event.occurredAt],
+      ["dueAt", event.dueAt],
+      ["startsAt", event.startsAt],
+    );
+  return timedValue(
+    event,
+    ["dueAt", event.dueAt],
+    ["startsAt", event.startsAt],
+  );
 };
 const interviewKey = (record, timestamp) => {
   const classification = classifyLifecycleEventType(record.eventType);
   return [
     record.applicationId,
-    timestamp ?? record.startsAt ?? record.dueAt ?? record.occurredAt,
+    canonicalTimestamp(
+      timestamp ?? record.startsAt ?? record.dueAt ?? record.occurredAt,
+    ),
     record.stage ??
       classification.interviewStage ??
       record.eventType ??

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -267,10 +267,15 @@ const isNonRecruiterInterview = (record = {}) =>
 export const uniqueRecruiterScreens = (meta, events = meta.lifecycle) => {
   const screens = [];
   const seen = new Set();
+  const explicitRecruiterScreenKeys = new Set(
+    meta.interviews
+      .filter(isRecruiterScreen)
+      .map((interview) => recruiterScreenKey(interview)),
+  );
   for (const item of [
     ...events.filter(isRecruiterScreen).map((event) => ({
-      key: recruiterScreenKey(event),
-      date: day(recruiterScreenTimestamp(event)),
+      key: recruiterScreenKey(event, explicitRecruiterScreenKeys),
+      date: day(recruiterScreenTimestamp(event, explicitRecruiterScreenKeys)),
       label:
         event.stageLabel ||
         event.eventType ||

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -18,7 +18,12 @@ import {
   isLifecycleNonRecruiterInterview,
   isLifecycleRecruiterScreen,
 } from "./lifecycleClassification.js";
-import { readSpreadsheetMetadata, selectDashboardMetrics } from "./metrics.js";
+import {
+  readSpreadsheetMetadata,
+  recruiterScreenKey,
+  recruiterScreenTimestamp,
+  selectDashboardMetrics,
+} from "./metrics.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
 const ARRAY_STORES = [
@@ -259,20 +264,13 @@ const isRecruiterScreen = (record = {}) =>
 const isNonRecruiterInterview = (record = {}) =>
   (record.stage && normalize(record.stage) !== "recruiter_screen") ||
   isLifecycleNonRecruiterInterview(record.eventType);
-const recruiterScreenKey = (record = {}) =>
-  [
-    record.applicationId,
-    record.dueAt ?? record.startsAt ?? record.occurredAt ?? record.id,
-  ]
-    .filter(Boolean)
-    .join(":");
-const uniqueRecruiterScreens = (meta, events = meta.lifecycle) => {
+export const uniqueRecruiterScreens = (meta, events = meta.lifecycle) => {
   const screens = [];
   const seen = new Set();
   for (const item of [
     ...events.filter(isRecruiterScreen).map((event) => ({
       key: recruiterScreenKey(event),
-      date: day(event.occurredAt) || day(event.dueAt),
+      date: day(recruiterScreenTimestamp(event)),
       label:
         event.stageLabel ||
         event.eventType ||
@@ -1205,4 +1203,4 @@ function init() {
   };
   refresh();
 }
-init();
+if (typeof document !== "undefined") init();

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -12,6 +12,12 @@ import {
   previewCompactCsvImport,
   previewSupplementalLifecycleCsvImport,
 } from "../import-export/spreadsheet.js";
+import {
+  classifyLifecycleEventType,
+  isLifecycleAssessment,
+  isLifecycleNonRecruiterInterview,
+  isLifecycleRecruiterScreen,
+} from "./lifecycleClassification.js";
 import { readSpreadsheetMetadata, selectDashboardMetrics } from "./metrics.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
@@ -240,25 +246,19 @@ const normalize = (value) =>
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_+|_+$/g, "");
 const isAssessmentEvent = (record = {}) =>
-  [
-    record.eventType,
-    record.stageLabel,
-    record.status,
-    record.note,
-    record.details,
-  ]
+  isLifecycleAssessment(record.eventType) ||
+  [record.stageLabel, record.status, record.note, record.details]
     .map(normalize)
     .some(
       (value) => value.includes("assessment") || value.includes("take_home"),
     );
-const RECRUITER_SCREEN_EVENT_TYPES = new Set([
-  "recruiter_screen_scheduled",
-  "recruiter_screen_completed",
-]);
 const isRecruiterScreen = (record = {}) =>
   normalize(record.stage) === "recruiter_screen" ||
   normalize(record.status) === "recruiter_screen" ||
-  RECRUITER_SCREEN_EVENT_TYPES.has(normalize(record.eventType));
+  isLifecycleRecruiterScreen(record.eventType);
+const isNonRecruiterInterview = (record = {}) =>
+  (record.stage && normalize(record.stage) !== "recruiter_screen") ||
+  isLifecycleNonRecruiterInterview(record.eventType);
 const recruiterScreenKey = (record = {}) =>
   [
     record.applicationId,
@@ -309,14 +309,7 @@ const COMPACT_OUTREACH_REPLY_STATUSES = new Set([
   "reply",
   "responded",
 ]);
-const RESPONSE_EVENT_TYPES = new Set([
-  "hiring_manager_reply",
-  "written_assessment_requested",
-  "recruiter_screen_scheduled",
-  "recruiter_screen_completed",
-  "offer",
-  "offer_received",
-]);
+const RESPONSE_EVENT_TYPES = new Set(["offer", "offer_received"]);
 const hasMetadataResponseSignal = (metadata = {}) =>
   COMPACT_OUTREACH_REPLY_STATUSES.has(normalize(metadata.outreach_status)) ||
   hasMetadataAssessmentSignal(metadata);
@@ -330,6 +323,7 @@ const hasListResponseSignal = (app, meta, metadata = {}) =>
   ) ||
   meta.lifecycle.some(
     (x) =>
+      classifyLifecycleEventType(x.eventType).countsAsResponse ||
       RESPONSE_EVENT_TYPES.has(normalize(x.eventType)) ||
       TERMINAL_EMPLOYER_STATUSES.has(normalize(x.status)),
   ) ||
@@ -546,7 +540,7 @@ function renderList() {
       const m = appMeta(a);
       const metadata = metadataText(a);
       const latestInterview = m.interviews
-        .filter((item) => !isRecruiterScreen(item))
+        .filter(isNonRecruiterInterview)
         .at(-1);
       const recruiterCount = uniqueRecruiterScreens(m).length;
       const rowMetadata = readSpreadsheetMetadata(a.notes);
@@ -652,13 +646,17 @@ function timelineItem(e) {
     ? "assessment"
     : isRecruiterScreen(e)
       ? "recruiter"
-      : "event";
+      : isLifecycleNonRecruiterInterview(e.eventType)
+        ? "interview"
+        : "event";
   const label =
     kind === "assessment"
       ? "Assessment/take-home"
       : kind === "recruiter"
         ? "Recruiter screen"
-        : "Lifecycle event";
+        : kind === "interview"
+          ? "Interview"
+          : "Lifecycle event";
   return `<li class="timeline-item timeline-${kind}"><div><strong>${esc(label)}</strong> <span class="chip">${esc(e.status || e.eventType || "event")}</span></div><time>${esc(day(e.occurredAt) || day(e.dueAt) || "No date")}</time><div class="timeline-meta">${eventDetails(e)}</div></li>`;
 }
 function metadataSection(app) {
@@ -959,7 +957,7 @@ function renderImportPreview({
     "reminders",
     "settings",
   ].reduce((sum, store) => sum + (recordsByStore[store]?.length ?? 0), 0);
-  const compactSummary = `Dry-run OK: ${recordsByStore.applications?.length ?? 0} applications, ${recordsByStore.outreachMessages?.length ?? 0} outreach messages, ${(recordsByStore.interviews ?? []).filter((item) => !isRecruiterScreen(item)).length} interviews`;
+  const compactSummary = `Dry-run OK: ${recordsByStore.applications?.length ?? 0} applications, ${recordsByStore.outreachMessages?.length ?? 0} outreach messages, ${(recordsByStore.interviews ?? []).filter(isNonRecruiterInterview).length} interviews`;
   $("[data-import-result]").innerHTML =
     `<h4>${blocking ? "Import preview needs attention" : "Dry-run succeeded"}</h4>${blocking ? "" : `<p>${esc(compactSummary)}</p>`}<p><strong>Detected format:</strong> ${esc(label)}.</p><p>${blocking ? "Apply import is disabled until blocking errors are fixed." : "Data remains local in this browser until you choose Apply import; no tracker details are sent to a server."}</p><h5>Record counts</h5><ul>${counts.map(([store, count]) => `<li>${esc(store)}: ${count}</li>`).join("") || "<li>No records detected.</li>"}</ul><p><strong>Total records:</strong> ${totalRecords}</p><h5>Conflicts</h5><ul>${conflicts.map((conflict) => `<li>${esc(formatIssue(conflict))}</li>`).join("") || "<li>No existing record conflicts in local browser data.</li>"}</ul>${warnings.length ? `<h5>Warnings</h5><ul>${warnings.map((warning) => `<li>${esc(formatIssue(warning))}</li>`).join("")}</ul>` : ""}${errors.length ? `<h5>Blocking errors</h5><ul>${errors.map((error) => `<li>${esc(formatIssue(error))}</li>`).join("")}</ul>` : ""}`;
 }

--- a/test/fixtures/tracker-import/devops-interview-lifecycle-regression.csv
+++ b/test/fixtures/tracker-import/devops-interview-lifecycle-regression.csv
@@ -1,0 +1,3 @@
+application_id,company,role_title,event_type,occurred_at,stage,channel,actor,source_artifact,requires_user_action,action_status,due_at,no_ai_required,details
+app_reg_epsilon_005,Company Epsilon,Developer Tools Engineer,recruiter_screen_scheduled,2026-02-12T16:00:00.000Z,Recruiter screen,video,recruiter,https://example.test/artifact/epsilon/recruiter-screen.ics,false,scheduled,2026-02-15T18:00:00.000Z,,Example recruiter screen scheduled.
+app_reg_epsilon_005,Company Epsilon,Developer Tools Engineer,devops_interview_scheduled,2026-02-16T16:00:00.000Z,DevOps interview,video,engineering,https://example.test/artifact/epsilon/devops-interview.ics,false,scheduled,2026-02-18T20:00:00.000Z,,Example DevOps interview scheduled.

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -26,6 +26,7 @@ import {
   previewCompactCsvImport,
   previewSupplementalLifecycleCsvImport,
 } from "../src/web/import-export/spreadsheet.js";
+import { selectDashboardMetrics } from "../src/web/tracker/metrics.js";
 
 const deleteDatabase = () =>
   new Promise((resolve, reject) => {
@@ -1651,6 +1652,121 @@ describe("spreadsheet import/export", () => {
     expect(exported.interviews).toHaveLength(0);
     expect(exported.reminders).toHaveLength(0);
     repo.close();
+  });
+
+  it("upgrades legacy flagless lifecycle precision on supplemental re-import", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await importCompactCsv(
+      serializeCsv([
+        {
+          application_id: "app_lifecycle_precision_upgrade",
+          company: "Lifecycle Precision Upgrade",
+          role_title: "Engineer",
+          applied_at: "2026-01-01",
+          schema_version: "1",
+        },
+      ]),
+      repo,
+      { mode: "replace" },
+    );
+
+    const lifecycleCsv = serializeCsv(
+      [
+        {
+          application_id: "app_lifecycle_precision_upgrade",
+          event_type: "technical_interview_completed",
+          occurred_at: "2026-05-10T00:00:00.000Z",
+          due_at: "2026-05-01T12:00:00.000Z",
+          details: "Completed at explicit midnight.",
+        },
+      ],
+      LIFECYCLE_CSV_COLUMNS,
+    );
+
+    expect(
+      (await importSupplementalLifecycleCsv(lifecycleCsv, repo)).imported,
+    ).toBe(true);
+
+    const legacyBundle = await repo.exportAllData();
+    legacyBundle.lifecycleEvents = legacyBundle.lifecycleEvents.map((event) => {
+      const legacyEvent = { ...event };
+      delete legacyEvent.occurredAtHasTime;
+      delete legacyEvent.dueAtHasTime;
+      return legacyEvent;
+    });
+    await repo.importAllData(legacyBundle, { allowOverwrite: true });
+
+    expect(
+      (await importSupplementalLifecycleCsv(lifecycleCsv, repo)).imported,
+    ).toBe(true);
+
+    const exported = await repo.exportAllData();
+    expect(
+      exported.lifecycleEvents.filter(
+        ({ applicationId, eventType }) =>
+          applicationId === "app_lifecycle_precision_upgrade" &&
+          eventType === "technical_interview_completed",
+      ),
+    ).toHaveLength(1);
+    expect(
+      exported.interviews.filter(
+        ({ applicationId, startsAt }) =>
+          applicationId === "app_lifecycle_precision_upgrade" &&
+          startsAt === "2026-05-10T00:00:00.000Z",
+      ),
+    ).toHaveLength(1);
+    expect(selectDashboardMetrics(exported).interviews).toBe(1);
+    repo.close();
+  });
+
+  it("dedupes legacy flagless explicit-midnight completions after restore", () => {
+    const exportedAt = "2026-03-10T00:00:00.000Z";
+    const bundle = {
+      schemaVersion: 1,
+      exportedAt,
+      applications: [
+        {
+          id: "app_legacy_precision_restore",
+          company: "Lifecycle Precision Restore",
+          role: "Engineer",
+          status: "technical_screen",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_legacy_precision_restore",
+          applicationId: "app_legacy_precision_restore",
+          status: "technical_screen",
+          occurredAt: "2026-05-10T00:00:00.000Z",
+          dueAt: "2026-05-01T12:00:00.000Z",
+          source: "csv_import",
+          eventType: "technical_interview_completed",
+          createdAt: exportedAt,
+        },
+      ],
+      interviews: [
+        {
+          id: "interview_legacy_precision_restore",
+          applicationId: "app_legacy_precision_restore",
+          contactIds: [],
+          stage: "technical_screen",
+          startsAt: "2026-05-10T00:00:00.000Z",
+          outcome: "completed",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+    };
+
+    const [event] = bundle.lifecycleEvents.filter(
+      ({ applicationId, eventType }) =>
+        applicationId === "app_legacy_precision_restore" &&
+        eventType === "technical_interview_completed",
+    );
+    expect(event.occurredAtHasTime).toBeUndefined();
+    expect(selectDashboardMetrics(bundle).interviews).toBe(1);
   });
 
   it("reports missing lifecycle application ids without creating orphans", async () => {

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -26,7 +26,11 @@ import {
   previewCompactCsvImport,
   previewSupplementalLifecycleCsvImport,
 } from "../src/web/import-export/spreadsheet.js";
-import { selectDashboardMetrics } from "../src/web/tracker/metrics.js";
+import {
+  recruiterScreenKey,
+  selectDashboardMetrics,
+} from "../src/web/tracker/metrics.js";
+import { uniqueRecruiterScreens } from "../src/web/tracker/tracker.js";
 
 const deleteDatabase = () =>
   new Promise((resolve, reject) => {
@@ -1767,6 +1771,83 @@ describe("spreadsheet import/export", () => {
     );
     expect(event.occurredAtHasTime).toBeUndefined();
     expect(selectDashboardMetrics(bundle).interviews).toBe(1);
+  });
+
+  it("reconciles flagless completed recruiter screens at explicit midnight", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await importCompactCsv(
+      serializeCsv([
+        {
+          application_id: "app_recruiter_midnight",
+          company: "Recruiter Midnight",
+          role_title: "Engineer",
+          applied_at: "2026-05-01",
+          schema_version: "1",
+        },
+      ]),
+      repo,
+      { mode: "replace" },
+    );
+    const lifecycleCsv = serializeCsv(
+      [
+        {
+          application_id: "app_recruiter_midnight",
+          company: "Recruiter Midnight",
+          role_title: "Engineer",
+          event_type: "recruiter_screen_completed",
+          occurred_at: "2026-05-10T00:00:00.000Z",
+          due_at: "2026-05-09T15:30:00.000Z",
+          details: "Completed recruiter screen at explicit midnight.",
+        },
+      ],
+      LIFECYCLE_CSV_COLUMNS,
+    );
+
+    const result = await importSupplementalLifecycleCsv(lifecycleCsv, repo);
+    expect(result.imported).toBe(true);
+    const exported = await repo.exportAllData();
+    expect(
+      exported.lifecycleEvents.filter(
+        ({ eventType }) => eventType === "recruiter_screen_completed",
+      ),
+    ).toEqual([
+      expect.not.objectContaining({
+        occurredAtHasTime: expect.anything(),
+        dueAtHasTime: expect.anything(),
+      }),
+    ]);
+    expect(selectDashboardMetrics(exported)).toMatchObject({
+      recruiterScreens: 1,
+      interviews: 0,
+    });
+    expect(
+      uniqueRecruiterScreens({
+        lifecycle: exported.lifecycleEvents,
+        interviews: exported.interviews,
+      }),
+    ).toHaveLength(1);
+
+    await repo.upsertInterview({
+      id: "interview_separate_due_at_screen",
+      applicationId: "app_recruiter_midnight",
+      stage: "recruiter_screen",
+      startsAt: "2026-05-09T15:30:00.000Z",
+      outcome: "scheduled",
+      createdAt: "2026-05-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+    });
+    const withSeparateDueAtScreen = await repo.exportAllData();
+    expect(
+      selectDashboardMetrics(withSeparateDueAtScreen).recruiterScreens,
+    ).toBe(2);
+    expect(
+      new Set(
+        withSeparateDueAtScreen.interviews.map((interview) =>
+          recruiterScreenKey(interview),
+        ),
+      ).size,
+    ).toBe(2);
+    repo.close();
   });
 
   it("reports missing lifecycle application ids without creating orphans", async () => {

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -859,6 +859,84 @@ describe("tracker dashboard metrics", () => {
     ).toBe(1);
   });
 
+  it("uses explicit midnight completed occurred_at instead of falling back to due_at", () => {
+    const applicationId = "app_completed_midnight";
+    const existing = {
+      applications: [
+        {
+          id: applicationId,
+          company: "Completed Midnight",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+    };
+    const lifecycle = importLifecycle(
+      [
+        "application_id,event_type,occurred_at,due_at,details",
+        [
+          applicationId,
+          "technical_interview_completed",
+          "2026-05-10T00:00:00.000Z",
+          "2026-05-01T12:00:00.000Z",
+          "Completed technical interview at midnight",
+        ].join(","),
+      ].join("\n"),
+      existing,
+    );
+
+    expect(lifecycle.interviews).toEqual([
+      expect.objectContaining({
+        startsAt: "2026-05-10T00:00:00.000Z",
+        stage: "technical_screen",
+        outcome: "completed",
+      }),
+    ]);
+    expect(
+      selectDashboardMetrics({ ...existing, ...lifecycle }).interviews,
+    ).toBe(1);
+  });
+
+  it("canonicalizes equivalent lifecycle and explicit interview timestamps", () => {
+    const applicationId = "app_equivalent_timestamps";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: applicationId,
+          company: "Equivalent Timestamps",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_equivalent_timestamps",
+          applicationId,
+          eventType: "technical_interview_completed",
+          occurredAt: "2026-02-10T17:30:00Z",
+          occurredAtHasTime: true,
+          createdAt: exportedAt,
+        },
+      ],
+      interviews: [
+        {
+          id: "interview_equivalent_timestamps",
+          applicationId,
+          stage: "technical_screen",
+          startsAt: "2026-02-10T17:30:00.000Z",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+    });
+
+    expect(metrics.interviews).toBe(1);
+  });
+
   it("preserves untimed classified lifecycle metadata without deriving interviews", () => {
     const applicationId = "app_import_untimed";
     const existing = {

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -827,6 +827,19 @@ describe("tracker dashboard metrics", () => {
       await lifecycleFixture("devops-interview-lifecycle-regression.csv"),
       bundle,
     );
+    expect(lifecycle.interviews).toEqual([
+      expect.objectContaining({
+        id: "interview_app_reg_epsilon_005_recruiter_screen_2026_02_15t18_00_00_000z",
+        stage: "recruiter_screen",
+        startsAt: "2026-02-15T18:00:00.000Z",
+      }),
+      expect.objectContaining({
+        id: "interview_app_reg_epsilon_005_technical_screen_2026_02_18t20_00_00_000z",
+        stage: "technical_screen",
+        startsAt: "2026-02-18T20:00:00.000Z",
+      }),
+    ]);
+
     const mergedOnce = mergeBundle(bundle, lifecycle);
     const mergedTwice = mergeBundle(mergedOnce, lifecycle);
 

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -824,6 +824,46 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.interviews).toBe(1);
   });
 
+  it("dedupes completed lifecycle records against restored fallback timestamp interviews", () => {
+    const applicationId = "app_completed_fallback_alias";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: applicationId,
+          company: "Completed Fallback Alias",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_completed_fallback_alias",
+          applicationId,
+          eventType: "technical_interview_completed",
+          occurredAt: "2026-05-10T17:30:00.000Z",
+          dueAt: "2026-05-01T12:00:00.000Z",
+          occurredAtHasTime: true,
+          dueAtHasTime: true,
+          createdAt: exportedAt,
+        },
+      ],
+      interviews: [
+        {
+          id: "interview_completed_fallback_alias",
+          applicationId,
+          stage: "technical_screen",
+          startsAt: "2026-05-01T12:00:00.000Z",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+    });
+
+    expect(metrics.interviews).toBe(1);
+  });
+
   it("uses completed occurred_at to dedupe lifecycle and derived interview records", () => {
     const applicationId = "app_completed_both";
     const existing = {

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -707,6 +707,43 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationsWithResponse).toBe(1);
   });
 
+  it("ignores date-only lifecycle-only interview timestamps in dashboard metrics", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_date_only",
+          company: "Date Only",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_date_only_scheduled",
+          applicationId: "app_date_only",
+          eventType: "devops_interview_scheduled",
+          occurredAt: timestamp,
+          dueAt: "2026-01-02T00:00:00.000Z",
+          createdAt: timestamp,
+        },
+        {
+          id: "event_date_only_completed",
+          applicationId: "app_date_only",
+          eventType: "technical_interview_completed",
+          occurredAt: "2026-01-03T00:00:00.000Z",
+          createdAt: timestamp,
+        },
+      ],
+      interviews: [],
+    });
+
+    expect(metrics.interviews).toBe(0);
+    expect(metrics.applicationsWithResponse).toBe(1);
+  });
+
   it("preserves distinct explicit same-time non-recruiter interviews", () => {
     const timestamp = "2026-01-01T00:00:00.000Z";
     const startsAt = "2026-01-15T00:00:00.000Z";

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -957,8 +957,8 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.interviews).toBe(2);
   });
 
-  it("dedupes completed lifecycle records against restored fallback timestamp interviews", () => {
-    const applicationId = "app_completed_fallback_alias";
+  it("does not use completed due dates as duplicate aliases", () => {
+    const applicationId = "app_completed_due_alias_distinct";
     const metrics = selectDashboardMetrics({
       applications: [
         {
@@ -972,7 +972,7 @@ describe("tracker dashboard metrics", () => {
       ],
       lifecycleEvents: [
         {
-          id: "event_completed_fallback_alias",
+          id: "event_completed_due_alias_distinct",
           applicationId,
           eventType: "technical_interview_completed",
           occurredAt: "2026-05-10T17:30:00.000Z",
@@ -984,7 +984,7 @@ describe("tracker dashboard metrics", () => {
       ],
       interviews: [
         {
-          id: "interview_completed_fallback_alias",
+          id: "interview_completed_due_alias_distinct",
           applicationId,
           stage: "technical_screen",
           startsAt: "2026-05-01T12:00:00.000Z",
@@ -994,7 +994,7 @@ describe("tracker dashboard metrics", () => {
       ],
     });
 
-    expect(metrics.interviews).toBe(1);
+    expect(metrics.interviews).toBe(2);
   });
 
   it("uses completed occurred_at to dedupe lifecycle and derived interview records", () => {

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -4,9 +4,15 @@ import { describe, expect, it } from "vitest";
 
 import {
   csvToBrowserApplicationExport,
+  exportJsonBackup,
+  importJsonBackup,
   lifecycleRowsToBrowserApplicationExport,
   parseCsv,
 } from "../src/web/import-export/spreadsheet.js";
+import {
+  LIFECYCLE_EVENT_CATEGORIES,
+  classifyLifecycleEventType,
+} from "../src/web/tracker/lifecycleClassification.js";
 import {
   boundedPercentage,
   selectDashboardMetrics,
@@ -32,6 +38,36 @@ const importLifecycle = (csv, existing) =>
   }).bundle;
 
 describe("tracker dashboard metrics", () => {
+  it("classifies scheduled lifecycle interview events centrally", () => {
+    expect(
+      classifyLifecycleEventType("devops_interview_scheduled"),
+    ).toMatchObject({
+      category: LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+      interviewStage: "technical_screen",
+      interviewOutcome: "scheduled",
+    });
+    expect(
+      classifyLifecycleEventType("technical_interview_scheduled").category,
+    ).toBe(LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW);
+    expect(
+      classifyLifecycleEventType("onsite_interview_scheduled"),
+    ).toMatchObject({
+      category: LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
+      interviewStage: "onsite_loop",
+    });
+    expect(
+      classifyLifecycleEventType("recruiter_screen_completed").category,
+    ).toBe(LIFECYCLE_EVENT_CATEGORIES.RECRUITER_SCREEN);
+    expect(
+      classifyLifecycleEventType("written_assessment_submitted").category,
+    ).toBe(LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT);
+    expect(classifyLifecycleEventType("hiring_manager_reply").category).toBe(
+      LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE,
+    );
+    expect(classifyLifecycleEventType("generic_follow_up").category).toBe(
+      LIFECYCLE_EVENT_CATEGORIES.UNKNOWN_METADATA,
+    );
+  });
   it("returns safe zero metrics for empty bundles", () => {
     expect(selectDashboardMetrics({})).toMatchObject({
       totalApplications: 0,
@@ -84,24 +120,21 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationsWithResponse).toBe(5);
   });
 
-  it(
-    "dedupes hiring-manager lifecycle replies already represented by compact metadata",
-    async () => {
-      const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
-        exportedAt,
-      });
-      const lifecycle = importLifecycle(
-        await lifecycleFixture("employer-reply-lifecycle-regression.csv"),
-        bundle,
-      );
+  it("dedupes hiring-manager lifecycle replies represented by compact metadata", async () => {
+    const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
+      exportedAt,
+    });
+    const lifecycle = importLifecycle(
+      await lifecycleFixture("employer-reply-lifecycle-regression.csv"),
+      bundle,
+    );
 
-      const metrics = selectDashboardMetrics(mergeBundle(bundle, lifecycle));
+    const metrics = selectDashboardMetrics(mergeBundle(bundle, lifecycle));
 
-      expect(metrics.outreachReplies).toBe(2);
-      expect(metrics.applicationsWithResponse).toBe(4);
-      expect(metrics.interviews).toBe(0);
-    },
-  );
+    expect(metrics.outreachReplies).toBe(2);
+    expect(metrics.applicationsWithResponse).toBe(4);
+    expect(metrics.interviews).toBe(0);
+  });
 
   it("counts lifecycle-only hiring-manager replies as outreach replies", () => {
     const timestamp = "2026-01-01T00:00:00.000Z";
@@ -483,6 +516,82 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.recruiterScreens).toBe(0);
     expect(metrics.interviews).toBe(1);
     expect(metrics.applicationsWithResponse).toBe(1);
+  });
+
+  it("counts one non-recruiter interview for Reducto-like devops events", async () => {
+    const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
+      exportedAt,
+    });
+    const lifecycle = importLifecycle(
+      await lifecycleFixture("devops-interview-lifecycle-regression.csv"),
+      bundle,
+    );
+
+    expect(lifecycle.lifecycleEvents).toHaveLength(2);
+    expect(lifecycle.interviews).toHaveLength(2);
+    expect(lifecycle.interviews).toContainEqual(
+      expect.objectContaining({
+        applicationId: "app_reg_epsilon_005",
+        stage: "technical_screen",
+        startsAt: "2026-02-18T20:00:00.000Z",
+        outcome: "scheduled",
+      }),
+    );
+
+    const metrics = selectDashboardMetrics(mergeBundle(bundle, lifecycle));
+
+    expect(metrics.recruiterScreens).toBe(1);
+    expect(metrics.interviews).toBe(1);
+    expect(metrics.assessments).toBe(1);
+    expect(metrics.applicationsWithResponse).toBe(5);
+  });
+
+  it("counts already-imported devops lifecycle events without requiring re-import", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_devops",
+          company: "Example",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_devops",
+          applicationId: "app_devops",
+          eventType: "devops_interview_scheduled",
+          occurredAt: timestamp,
+          dueAt: "2026-01-02T18:00:00.000Z",
+          createdAt: timestamp,
+        },
+      ],
+      interviews: [],
+    });
+
+    expect(metrics.interviews).toBe(1);
+    expect(metrics.applicationsWithResponse).toBe(1);
+  });
+
+  it("dedupes lifecycle-derived interviews across import and JSON backup round trip", async () => {
+    const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
+      exportedAt,
+    });
+    const lifecycle = importLifecycle(
+      await lifecycleFixture("devops-interview-lifecycle-regression.csv"),
+      bundle,
+    );
+    const mergedOnce = mergeBundle(bundle, lifecycle);
+    const mergedTwice = mergeBundle(mergedOnce, lifecycle);
+
+    expect(selectDashboardMetrics(mergedTwice).interviews).toBe(1);
+
+    const restored = importJsonBackup(exportJsonBackup(mergedOnce));
+
+    expect(selectDashboardMetrics(restored).interviews).toBe(1);
   });
 
   it("guards response percentages when child records exceed applications", () => {

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -781,6 +781,44 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.interviews).toBe(2);
   });
 
+  it("falls back to timed due_at when completed occurred_at is date-only", () => {
+    const applicationId = "app_completed_date_only";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: applicationId,
+          company: "Completed Date Only",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_completed_date_only",
+          applicationId,
+          eventType: "technical_interview_completed",
+          occurredAt: "2026-05-10T00:00:00.000Z",
+          dueAt: "2026-05-01T12:00:00.000Z",
+          createdAt: exportedAt,
+        },
+      ],
+      interviews: [
+        {
+          id: "interview_completed_date_only",
+          applicationId,
+          stage: "technical_screen",
+          startsAt: "2026-05-01T12:00:00.000Z",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+    });
+
+    expect(metrics.interviews).toBe(1);
+  });
+
   it("uses completed occurred_at to dedupe lifecycle and derived interview records", () => {
     const applicationId = "app_completed_both";
     const existing = {

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -727,6 +727,8 @@ describe("tracker dashboard metrics", () => {
           eventType: "devops_interview_scheduled",
           occurredAt: timestamp,
           dueAt: "2026-01-02T00:00:00.000Z",
+          occurredAtHasTime: false,
+          dueAtHasTime: false,
           createdAt: timestamp,
         },
         {
@@ -734,6 +736,7 @@ describe("tracker dashboard metrics", () => {
           applicationId: "app_date_only",
           eventType: "technical_interview_completed",
           occurredAt: "2026-01-03T00:00:00.000Z",
+          occurredAtHasTime: false,
           createdAt: timestamp,
         },
       ],
@@ -801,6 +804,8 @@ describe("tracker dashboard metrics", () => {
           eventType: "technical_interview_completed",
           occurredAt: "2026-05-10T00:00:00.000Z",
           dueAt: "2026-05-01T12:00:00.000Z",
+          occurredAtHasTime: false,
+          dueAtHasTime: true,
           createdAt: exportedAt,
         },
       ],
@@ -857,6 +862,44 @@ describe("tracker dashboard metrics", () => {
     expect(
       selectDashboardMetrics({ ...existing, ...lifecycle }).interviews,
     ).toBe(1);
+  });
+
+  it("treats legacy explicit midnight completed timestamps as timed", () => {
+    const applicationId = "app_legacy_midnight";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: applicationId,
+          company: "Legacy Midnight",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_legacy_midnight",
+          applicationId,
+          eventType: "technical_interview_completed",
+          occurredAt: "2026-05-10T00:00:00.000Z",
+          dueAt: "2026-05-01T12:00:00.000Z",
+          createdAt: exportedAt,
+        },
+      ],
+      interviews: [
+        {
+          id: "interview_legacy_midnight",
+          applicationId,
+          stage: "technical_screen",
+          startsAt: "2026-05-10T00:00:00.000Z",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+    });
+
+    expect(metrics.interviews).toBe(1);
   });
 
   it("uses explicit midnight completed occurred_at instead of falling back to due_at", () => {

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -909,6 +909,54 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.interviews).toBe(1);
   });
 
+  it("does not use date-only completed lifecycle timestamps as duplicate aliases", () => {
+    const applicationId = "app_completed_date_only_distinct_midnight";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: applicationId,
+          company: "Completed Date Only Distinct Midnight",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_completed_date_only_distinct_midnight",
+          applicationId,
+          eventType: "technical_interview_completed",
+          occurredAt: "2026-05-10T00:00:00.000Z",
+          dueAt: "2026-05-01T12:00:00.000Z",
+          occurredAtHasTime: false,
+          dueAtHasTime: true,
+          createdAt: exportedAt,
+        },
+      ],
+      interviews: [
+        {
+          id: "interview_completed_date_only_fallback",
+          applicationId,
+          stage: "technical_screen",
+          startsAt: "2026-05-01T12:00:00.000Z",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+        {
+          id: "interview_distinct_midnight",
+          applicationId,
+          stage: "technical_screen",
+          startsAt: "2026-05-10T00:00:00.000Z",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+    });
+
+    expect(metrics.interviews).toBe(2);
+  });
+
   it("dedupes completed lifecycle records against restored fallback timestamp interviews", () => {
     const applicationId = "app_completed_fallback_alias";
     const metrics = selectDashboardMetrics({

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -747,6 +747,42 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationsWithResponse).toBe(1);
   });
 
+  it("ignores ambiguous legacy date-only lifecycle timestamps without precision flags", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_legacy_date_only",
+          company: "Legacy Date Only",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_legacy_date_only_scheduled",
+          applicationId: "app_legacy_date_only",
+          eventType: "devops_interview_scheduled",
+          dueAt: "2026-01-02T00:00:00.000Z",
+          createdAt: timestamp,
+        },
+        {
+          id: "event_legacy_date_only_completed",
+          applicationId: "app_legacy_date_only",
+          eventType: "technical_interview_completed",
+          occurredAt: "2026-01-03T00:00:00.000Z",
+          createdAt: timestamp,
+        },
+      ],
+      interviews: [],
+    });
+
+    expect(metrics.interviews).toBe(0);
+    expect(metrics.applicationsWithResponse).toBe(1);
+  });
+
   it("preserves distinct explicit same-time non-recruiter interviews", () => {
     const timestamp = "2026-01-01T00:00:00.000Z";
     const startsAt = "2026-01-15T00:00:00.000Z";

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -747,6 +747,53 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationsWithResponse).toBe(1);
   });
 
+  it("preserves lifecycle timestamp precision flags through JSON and NDJSON backups", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const bundle = {
+      schemaVersion: 1,
+      exportedAt: timestamp,
+      applications: [
+        {
+          id: "app_precision_backup",
+          company: "Precision Backup",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_precision_backup",
+          applicationId: "app_precision_backup",
+          status: "technical_screen",
+          occurredAt: timestamp,
+          source: "csv_import",
+          eventType: "devops_interview_scheduled",
+          dueAt: "2026-01-02T00:00:00.000Z",
+          occurredAtHasTime: false,
+          dueAtHasTime: false,
+          createdAt: timestamp,
+        },
+      ],
+      interviews: [],
+    };
+
+    const jsonRestored = importJsonBackup(exportJsonBackup(bundle));
+    const ndjsonRestored = importNdjsonBackup(exportNdjsonBackup(bundle));
+
+    expect(jsonRestored.lifecycleEvents[0]).toMatchObject({
+      occurredAtHasTime: false,
+      dueAtHasTime: false,
+    });
+    expect(ndjsonRestored.lifecycleEvents[0]).toMatchObject({
+      occurredAtHasTime: false,
+      dueAtHasTime: false,
+    });
+    expect(selectDashboardMetrics(jsonRestored).interviews).toBe(0);
+    expect(selectDashboardMetrics(ndjsonRestored).interviews).toBe(0);
+  });
+
   it("ignores ambiguous legacy date-only lifecycle timestamps without precision flags", () => {
     const timestamp = "2026-01-01T00:00:00.000Z";
     const metrics = selectDashboardMetrics({

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -5,7 +5,9 @@ import { describe, expect, it } from "vitest";
 import {
   csvToBrowserApplicationExport,
   exportJsonBackup,
+  exportNdjsonBackup,
   importJsonBackup,
+  importNdjsonBackup,
   lifecycleRowsToBrowserApplicationExport,
   parseCsv,
 } from "../src/web/import-export/spreadsheet.js";
@@ -555,6 +557,69 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationsWithResponse).toBe(1);
   });
 
+  it("derives all required non-recruiter lifecycle interview event types", () => {
+    const applicationId = "app_all_lifecycle_interviews";
+    const existing = {
+      applications: [
+        {
+          id: applicationId,
+          company: "Lifecycle Interviews",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+    };
+    const eventTypes = [
+      "devops_interview_scheduled",
+      "devops_interview_completed",
+      "technical_interview_scheduled",
+      "technical_interview_completed",
+      "technical_screen_scheduled",
+      "technical_screen_completed",
+      "onsite_interview_scheduled",
+      "onsite_interview_completed",
+      "final_interview_scheduled",
+      "final_interview_completed",
+    ];
+    const rows = [
+      "application_id,event_type,occurred_at,due_at,details",
+      ...eventTypes.map((eventType, index) => {
+        const hour = String(10 + index).padStart(2, "0");
+        const occurredAt = eventType.endsWith("_completed")
+          ? `2026-04-01T${hour}:30:00.000Z`
+          : `2026-04-01T${hour}:00:00.000Z`;
+        const dueAt = `2026-04-02T${hour}:00:00.000Z`;
+        return [
+          applicationId,
+          eventType,
+          occurredAt,
+          dueAt,
+          `${eventType} regression`,
+        ].join(",");
+      }),
+    ].join("\n");
+
+    const lifecycle = importLifecycle(rows, existing);
+
+    expect(lifecycle.lifecycleEvents).toHaveLength(eventTypes.length);
+    expect(lifecycle.interviews).toHaveLength(eventTypes.length);
+    expect(
+      lifecycle.interviews
+        .map(({ outcome }) => outcome)
+        .filter((outcome) => outcome === "scheduled"),
+    ).toHaveLength(5);
+    expect(
+      lifecycle.interviews
+        .map(({ outcome }) => outcome)
+        .filter((outcome) => outcome === "completed"),
+    ).toHaveLength(5);
+    expect(
+      selectDashboardMetrics({ ...existing, ...lifecycle }).interviews,
+    ).toBe(eventTypes.length);
+  });
+
   it("counts one non-recruiter interview for Reducto-like devops events", async () => {
     const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
       exportedAt,
@@ -679,6 +744,81 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.interviews).toBe(2);
   });
 
+  it("uses completed occurred_at to dedupe lifecycle and derived interview records", () => {
+    const applicationId = "app_completed_both";
+    const existing = {
+      applications: [
+        {
+          id: applicationId,
+          company: "Completed Both",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+    };
+    const lifecycle = importLifecycle(
+      [
+        "application_id,event_type,occurred_at,due_at,details",
+        [
+          applicationId,
+          "technical_interview_completed",
+          "2026-05-10T17:30:00.000Z",
+          "2026-05-01T12:00:00.000Z",
+          "Completed technical interview",
+        ].join(","),
+      ].join("\n"),
+      existing,
+    );
+
+    expect(lifecycle.interviews).toEqual([
+      expect.objectContaining({
+        startsAt: "2026-05-10T17:30:00.000Z",
+        stage: "technical_screen",
+        outcome: "completed",
+      }),
+    ]);
+    expect(
+      selectDashboardMetrics({ ...existing, ...lifecycle }).interviews,
+    ).toBe(1);
+  });
+
+  it("preserves untimed classified lifecycle metadata without deriving interviews", () => {
+    const applicationId = "app_import_untimed";
+    const existing = {
+      applications: [
+        {
+          id: applicationId,
+          company: "Import Untimed",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+    };
+    const lifecycle = importLifecycle(
+      [
+        "application_id,event_type,occurred_at,due_at,details",
+        [
+          applicationId,
+          "devops_interview_scheduled",
+          "",
+          "",
+          "Metadata only",
+        ].join(","),
+      ].join("\n"),
+      existing,
+    );
+
+    expect(lifecycle.lifecycleEvents).toHaveLength(1);
+    expect(lifecycle.interviews).toHaveLength(0);
+    expect(
+      selectDashboardMetrics({ ...existing, ...lifecycle }).interviews,
+    ).toBe(0);
+  });
+
   it("dedupes lifecycle-derived interviews across import and JSON backup round trip", async () => {
     const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
       exportedAt,
@@ -690,11 +830,22 @@ describe("tracker dashboard metrics", () => {
     const mergedOnce = mergeBundle(bundle, lifecycle);
     const mergedTwice = mergeBundle(mergedOnce, lifecycle);
 
-    expect(selectDashboardMetrics(mergedTwice).interviews).toBe(1);
+    expect(selectDashboardMetrics(mergedTwice)).toMatchObject({
+      recruiterScreens: 1,
+      interviews: 1,
+    });
 
-    const restored = importJsonBackup(exportJsonBackup(mergedOnce));
+    const restoredJson = importJsonBackup(exportJsonBackup(mergedOnce));
+    const restoredNdjson = importNdjsonBackup(exportNdjsonBackup(mergedOnce));
 
-    expect(selectDashboardMetrics(restored).interviews).toBe(1);
+    for (const restored of [restoredJson, restoredNdjson]) {
+      expect(selectDashboardMetrics(restored)).toMatchObject({
+        recruiterScreens: 1,
+        interviews: 1,
+        assessments: 1,
+        applicationsWithResponse: 5,
+      });
+    }
   });
 
   it("guards response percentages when child records exceed applications", () => {

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -449,6 +449,43 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationResponseRate).toBe(100);
   });
 
+  it("derives completed recruiter screens from occurred_at instead of due_at", () => {
+    const existing = {
+      applications: [
+        {
+          id: "app_screen_import",
+          company: "Screen Import",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+    };
+    const lifecycle = importLifecycle(
+      [
+        "application_id,event_type,occurred_at,due_at,details",
+        [
+          "app_screen_import",
+          "recruiter_screen_completed",
+          "2026-02-10T17:30:00Z",
+          "2026-02-01",
+          "Completed screen",
+        ].join(","),
+      ].join("\n"),
+      existing,
+    );
+
+    expect(lifecycle.interviews).toContainEqual(
+      expect.objectContaining({
+        applicationId: "app_screen_import",
+        stage: "recruiter_screen",
+        startsAt: "2026-02-10T17:30:00Z",
+        outcome: "completed",
+      }),
+    );
+  });
+
   it("counts replied outreach records as outreach replies and application responses", () => {
     const timestamp = "2026-01-01T00:00:00.000Z";
     const metrics = selectDashboardMetrics({
@@ -574,6 +611,72 @@ describe("tracker dashboard metrics", () => {
 
     expect(metrics.interviews).toBe(1);
     expect(metrics.applicationsWithResponse).toBe(1);
+  });
+
+  it("ignores untimed lifecycle-only interview metadata in dashboard metrics", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_untimed",
+          company: "Untimed",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_untimed",
+          applicationId: "app_untimed",
+          eventType: "devops_interview_scheduled",
+          occurredAt: "1970-01-01T00:00:00.000Z",
+          createdAt: timestamp,
+        },
+      ],
+      interviews: [],
+    });
+
+    expect(metrics.interviews).toBe(0);
+    expect(metrics.applicationsWithResponse).toBe(1);
+  });
+
+  it("preserves distinct explicit same-time non-recruiter interviews", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const startsAt = "2026-01-15T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_same_day",
+          company: "Same Day",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      interviews: [
+        {
+          id: "interview_one",
+          applicationId: "app_same_day",
+          stage: "technical_screen",
+          startsAt,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+        {
+          id: "interview_two",
+          applicationId: "app_same_day",
+          stage: "technical_screen",
+          startsAt,
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+    });
+
+    expect(metrics.interviews).toBe(2);
   });
 
   it("dedupes lifecycle-derived interviews across import and JSON backup round trip", async () => {

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -17,8 +17,10 @@ import {
 } from "../src/web/tracker/lifecycleClassification.js";
 import {
   boundedPercentage,
+  recruiterScreenKey,
   selectDashboardMetrics,
 } from "../src/web/tracker/metrics.js";
+import { uniqueRecruiterScreens } from "../src/web/tracker/tracker.js";
 
 const exportedAt = "2026-03-10T00:00:00.000Z";
 const compactFixture = async () =>
@@ -486,6 +488,51 @@ describe("tracker dashboard metrics", () => {
         outcome: "completed",
       }),
     );
+  });
+
+  it("dedupes completed recruiter screens with distinct due_at and occurred_at", () => {
+    const existing = {
+      applications: [
+        {
+          id: "app_screen_dedupe",
+          company: "Screen Dedupe",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+    };
+    const lifecycle = importLifecycle(
+      [
+        "application_id,event_type,occurred_at,due_at,details",
+        [
+          "app_screen_dedupe",
+          "recruiter_screen_completed",
+          "2026-02-10T17:30:00Z",
+          "2026-02-01T15:00:00Z",
+          "Completed screen",
+        ].join(","),
+      ].join("\n"),
+      existing,
+    );
+    const bundle = mergeBundle(existing, lifecycle);
+    const metrics = selectDashboardMetrics(bundle);
+    const meta = {
+      lifecycle: bundle.lifecycleEvents,
+      interviews: bundle.interviews,
+    };
+    const recruiterScreens = uniqueRecruiterScreens(meta);
+
+    expect(metrics.recruiterScreens).toBe(1);
+    expect(metrics.interviews).toBe(0);
+    expect(recruiterScreens).toHaveLength(1);
+    expect(
+      new Set([
+        recruiterScreenKey(bundle.lifecycleEvents[0]),
+        recruiterScreenKey(bundle.interviews[0]),
+      ]).size,
+    ).toBe(1);
   });
 
   it("counts replied outreach records as outreach replies and application responses", () => {

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -813,6 +813,7 @@ describe("tracker dashboard metrics", () => {
           applicationId: "app_legacy_date_only",
           eventType: "devops_interview_scheduled",
           dueAt: "2026-01-02T00:00:00.000Z",
+          source: "csv_import",
           createdAt: timestamp,
         },
         {
@@ -820,6 +821,7 @@ describe("tracker dashboard metrics", () => {
           applicationId: "app_legacy_date_only",
           eventType: "technical_interview_completed",
           occurredAt: "2026-01-03T00:00:00.000Z",
+          source: "csv_import",
           createdAt: timestamp,
         },
       ],
@@ -985,6 +987,34 @@ describe("tracker dashboard metrics", () => {
     expect(
       selectDashboardMetrics({ ...existing, ...lifecycle }).interviews,
     ).toBe(1);
+  });
+
+  it("counts legacy lifecycle-only explicit midnight completed interviews", () => {
+    const applicationId = "app_legacy_midnight_lifecycle_only";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: applicationId,
+          company: "Legacy Midnight Lifecycle Only",
+          role: "Engineer",
+          status: "applied",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_legacy_midnight_lifecycle_only",
+          applicationId,
+          eventType: "technical_interview_completed",
+          occurredAt: "2026-05-10T00:00:00.000Z",
+          createdAt: exportedAt,
+        },
+      ],
+      interviews: [],
+    });
+
+    expect(metrics.interviews).toBe(1);
   });
 
   it("treats legacy explicit midnight completed timestamps as timed", () => {


### PR DESCRIPTION
### Motivation
- Lifecycle CSV imports can contain event-rich interview rows (e.g. `devops_interview_scheduled`) that were being preserved as lifecycle metadata but not counted as non-recruiter interviews on the dashboard.
- Implement a small, centralized, extensible classification system to avoid scattered string checks and to make deriving first-class interview records from lifecycle events deterministic and idempotent.

### Description
- Added a centralized classifier `src/web/tracker/lifecycleClassification.js` that maps lifecycle event types into categories (recruiter screen, non-recruiter interview, assessment, employer response, application submission, reminder/action, unknown) and exposes helpers like `classifyLifecycleEventType`, `isLifecycleNonRecruiterInterview`, and `isLifecycleRecruiterScreen`.
- Updated lifecycle CSV import (`src/web/import-export/spreadsheet.js`) to use the classifier for status mapping and to create derived `interviews` for scheduled/completed non-recruiter interview events when timing metadata (`due_at` or `occurred_at`) is present while preserving the original lifecycle event.
- Updated dashboard selection/metrics (`src/web/tracker/metrics.js`) to count lifecycle-derived non-recruiter interviews (deduped against explicit `interviews` records), keep recruiter screens separate, and ensure assessments and hiring-manager replies do not inflate interview counts.
- Updated tracker UI helpers (`src/web/tracker/tracker.js`) and timeline rendering to surface classified non-recruiter interview lifecycle events as interview timeline items and to use the classifier instead of ad-hoc event name checks.
- Added test fixture and tests (`test/fixtures/tracker-import/devops-interview-lifecycle-regression.csv` and updates to `test/web-tracker-metrics.test.js`) covering classification, import-derived interview creation, idempotency (re-import and JSON round-trip), and negative cases (assessments/hiring-manager replies remain non-interview signals).

### Testing
- Ran focused unit tests: `npm test -- --run test/web-tracker-metrics.test.js` and the new/updated tests passed (20/20 in that file).
- Ran repository checks: `npm run lint` passed and `npm run typecheck` passed.
- Ran CI test suite: `npm run test:ci` completed successfully (all tests passed in CI run shown: 1031 tests passed locally in the run recorded).
- Built the static site and screenshots: `npm run build` and `npm run web:screenshots` completed successfully (screenshot artifact was created during verification and then reverted before commit).
- Formatting: `npm run format:check` reported repo-wide formatting drift (fails due to 257 unrelated pre-existing files); source files modified by this PR were formatted with `prettier --write` before committing.
- Other notes: `npm ci` completed and reported existing audit warnings in upstream dependencies (no new runtime dependency was added); secrets scan (`./scripts/scan-secrets.py`) was run and returned clean.

Residual risks and follow-ups: the classifier is intentionally a small centralized registry for easy extension; follow-up work could expand classification coverage if other provider-specific step names appear and to address repo-wide formatting drift separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ff553b4f0832fbdd060b5ef356ab3)