### PR TITLE
Classify lifecycle interview events

### DIFF
--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1,4 +1,5 @@
 import { browserApplicationExportSchema } from "../../domain/browserApplication.js";
+import { classifyLifecycleEventType } from "../tracker/lifecycleClassification.js";
 
 export const LIFECYCLE_CSV_COLUMNS = [
   "application_id",
@@ -539,9 +540,8 @@ export const detectSpreadsheetImportFormat = (text) => {
 };
 
 const lifecycleStatusForEvent = (eventType) => {
-  if (eventType === "hiring_manager_reply") return "outreach_sent";
-  if (eventType === "recruiter_screen_scheduled") return "recruiter_screen";
-  if (eventType === "application_submitted") return "applied";
+  const classification = classifyLifecycleEventType(eventType);
+  if (classification.status) return classification.status;
   if (KNOWN_STATUSES.has(eventType)) return eventType;
   return undefined;
 };
@@ -592,9 +592,10 @@ export const lifecycleRowsToBrowserApplicationExport = (
     const dueAt = parseDate(row.due_at, "due_at", rowNumber, errors);
     const eventOccurredAt = occurredAt ?? dueAt ?? "1970-01-01T00:00:00.000Z";
     const stageLabel = compact(row.stage) || undefined;
+    const classification = classifyLifecycleEventType(eventType);
     const knownLifecycleStatus = lifecycleStatusForEvent(eventType);
     if (
-      !knownLifecycleStatus &&
+      classification.category === "unknown" &&
       !["lifecycle_event", "next_tracking_step"].includes(eventType)
     )
       warnings.push({
@@ -664,18 +665,31 @@ export const lifecycleRowsToBrowserApplicationExport = (
         createdAt: exportedAt,
         updatedAt: exportedAt,
       });
+    const interviewStartsAt =
+      classification.outcome === "completed" ? occurredAt : dueAt;
+    const rawInterviewStartsAt =
+      classification.outcome === "completed" ? row.occurred_at : row.due_at;
     if (
-      eventType === "recruiter_screen_scheduled" &&
-      dueAt &&
-      hasTimeComponent(row.due_at)
+      classification.interviewStage &&
+      interviewStartsAt &&
+      hasTimeComponent(rawInterviewStartsAt)
     )
       interviews.push({
-        id: stableId("interview", applicationId, "recruiter_screen", dueAt),
+        id: stableId(
+          "interview",
+          applicationId,
+          classification.interviewStage,
+          interviewStartsAt,
+        ),
         applicationId,
         contactIds: [],
-        stage: "recruiter_screen",
-        startsAt: dueAt,
-        outcome: "scheduled",
+        stage: classification.interviewStage,
+        startsAt: interviewStartsAt,
+        outcome: classification.outcome ?? "scheduled",
+        preparationNotes:
+          classification.category === "non_recruiter_interview"
+            ? [eventType, details].filter(Boolean).join(": ")
+            : undefined,
         createdAt: exportedAt,
         updatedAt: exportedAt,
       });

--- a/src/web/tracker/lifecycleClassification.js
+++ b/src/web/tracker/lifecycleClassification.js
@@ -1,0 +1,167 @@
+const normalize = (value) =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+const EVENT_TYPE_CLASSIFICATIONS = new Map([
+  [
+    "recruiter_screen_scheduled",
+    {
+      category: "recruiter_screen",
+      status: "recruiter_screen",
+      interviewStage: "recruiter_screen",
+      outcome: "scheduled",
+    },
+  ],
+  [
+    "recruiter_screen_completed",
+    {
+      category: "recruiter_screen",
+      status: "recruiter_screen",
+      interviewStage: "recruiter_screen",
+      outcome: "completed",
+    },
+  ],
+  [
+    "devops_interview_scheduled",
+    {
+      category: "non_recruiter_interview",
+      status: "technical_screen",
+      interviewStage: "technical_screen",
+      outcome: "scheduled",
+    },
+  ],
+  [
+    "devops_interview_completed",
+    {
+      category: "non_recruiter_interview",
+      status: "technical_screen",
+      interviewStage: "technical_screen",
+      outcome: "completed",
+    },
+  ],
+  [
+    "technical_interview_scheduled",
+    {
+      category: "non_recruiter_interview",
+      status: "technical_screen",
+      interviewStage: "technical_screen",
+      outcome: "scheduled",
+    },
+  ],
+  [
+    "technical_interview_completed",
+    {
+      category: "non_recruiter_interview",
+      status: "technical_screen",
+      interviewStage: "technical_screen",
+      outcome: "completed",
+    },
+  ],
+  [
+    "technical_screen_scheduled",
+    {
+      category: "non_recruiter_interview",
+      status: "technical_screen",
+      interviewStage: "technical_screen",
+      outcome: "scheduled",
+    },
+  ],
+  [
+    "technical_screen_completed",
+    {
+      category: "non_recruiter_interview",
+      status: "technical_screen",
+      interviewStage: "technical_screen",
+      outcome: "completed",
+    },
+  ],
+  [
+    "onsite_interview_scheduled",
+    {
+      category: "non_recruiter_interview",
+      status: "onsite_loop",
+      interviewStage: "onsite_loop",
+      outcome: "scheduled",
+    },
+  ],
+  [
+    "onsite_interview_completed",
+    {
+      category: "non_recruiter_interview",
+      status: "onsite_loop",
+      interviewStage: "onsite_loop",
+      outcome: "completed",
+    },
+  ],
+  [
+    "final_interview_scheduled",
+    {
+      category: "non_recruiter_interview",
+      status: "onsite_loop",
+      interviewStage: "onsite_loop",
+      outcome: "scheduled",
+    },
+  ],
+  [
+    "final_interview_completed",
+    {
+      category: "non_recruiter_interview",
+      status: "onsite_loop",
+      interviewStage: "onsite_loop",
+      outcome: "completed",
+    },
+  ],
+  ["written_assessment", { category: "assessment", status: "applied" }],
+  [
+    "written_assessment_requested",
+    { category: "assessment", status: "applied" },
+  ],
+  [
+    "written_assessment_submitted",
+    { category: "assessment", status: "applied" },
+  ],
+  ["take_home", { category: "assessment", status: "applied" }],
+  ["take_home_requested", { category: "assessment", status: "applied" }],
+  ["take_home_submitted", { category: "assessment", status: "applied" }],
+  [
+    "hiring_manager_reply",
+    { category: "employer_response", status: "outreach_sent" },
+  ],
+  ["offer", { category: "employer_response", status: "offer" }],
+  ["offer_received", { category: "employer_response", status: "offer" }],
+  [
+    "application_submitted",
+    { category: "application_submission", status: "applied" },
+  ],
+  ["next_tracking_step", { category: "reminder" }],
+  ["lifecycle_event", { category: "unknown" }],
+]);
+
+export const normalizeLifecycleEventType = normalize;
+
+export const classifyLifecycleEventType = (eventType) => {
+  const normalizedEventType = normalize(eventType);
+  return {
+    eventType: normalizedEventType,
+    category:
+      EVENT_TYPE_CLASSIFICATIONS.get(normalizedEventType)?.category ??
+      "unknown",
+    ...EVENT_TYPE_CLASSIFICATIONS.get(normalizedEventType),
+  };
+};
+
+export const isRecruiterScreenLifecycleEvent = (eventType) =>
+  classifyLifecycleEventType(eventType).category === "recruiter_screen";
+
+export const isNonRecruiterInterviewLifecycleEvent = (eventType) =>
+  classifyLifecycleEventType(eventType).category === "non_recruiter_interview";
+
+export const isAssessmentLifecycleEvent = (eventType) =>
+  classifyLifecycleEventType(eventType).category === "assessment";
+
+export const isEmployerResponseLifecycleEvent = (eventType) =>
+  classifyLifecycleEventType(eventType).category === "employer_response";

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -1,28 +1,16 @@
+import { classifyLifecycleEventType } from "./lifecycleClassification.js";
+
 const TERMINAL_EMPLOYER_STATUSES = new Set([
   "offer",
   "accepted",
   "rejected",
   "closed_archived",
 ]);
-const RESPONSE_EVENT_TYPES = new Set([
-  "hiring_manager_reply",
-  "written_assessment_requested",
-  "recruiter_screen_scheduled",
-  "recruiter_screen_completed",
-  "offer",
-  "offer_received",
-]);
-const ASSESSMENT_EVENT_TYPES = new Set([
-  "written_assessment",
-  "written_assessment_requested",
-  "written_assessment_submitted",
-  "take_home",
-  "take_home_requested",
-  "take_home_submitted",
-]);
-const RECRUITER_SCREEN_EVENT_TYPES = new Set([
-  "recruiter_screen_scheduled",
-  "recruiter_screen_completed",
+const RESPONSE_CATEGORIES = new Set([
+  "assessment",
+  "employer_response",
+  "non_recruiter_interview",
+  "recruiter_screen",
 ]);
 const OFFER_EVENT_TYPES = new Set(["offer", "offer_received"]);
 const OUTREACH_REPLY_STATUSES = new Set(["replied", "reply", "responded"]);
@@ -82,11 +70,12 @@ const isAssessmentMetadata = (metadata) => {
 const addResponse = (responses, applicationId) => {
   if (applicationId) responses.add(applicationId);
 };
+const lifecycleTimingKey = (record) =>
+  record.dueAt ?? record.startsAt ?? record.occurredAt ?? record.id;
 const recruiterScreenKey = (record) =>
-  [
-    record.applicationId,
-    record.dueAt ?? record.startsAt ?? record.occurredAt ?? record.id,
-  ]
+  [record.applicationId, lifecycleTimingKey(record)].filter(Boolean).join(":");
+const interviewKey = (record) =>
+  [record.applicationId, record.stage, lifecycleTimingKey(record)]
     .filter(Boolean)
     .join(":");
 
@@ -111,6 +100,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
   const recruiterScreenKeys = new Set();
   const assessmentApplicationIds = new Set();
   const offerApplicationIds = new Set();
+  const nonRecruiterInterviewKeys = new Set();
 
   for (const application of applications) {
     const metadata = metadataByApplicationId.get(application.id) ?? {};
@@ -163,23 +153,28 @@ export const selectDashboardMetrics = (bundle = {}) => {
   for (const event of lifecycleEvents) {
     const eventType = normalize(event.eventType);
     const status = normalize(event.status);
+    const classification = classifyLifecycleEventType(eventType);
     if (
-      RESPONSE_EVENT_TYPES.has(eventType) ||
+      RESPONSE_CATEGORIES.has(classification.category) ||
       TERMINAL_EMPLOYER_STATUSES.has(status)
     )
       addResponse(responseApplicationIds, event.applicationId);
     if (eventType === "hiring_manager_reply" && event.applicationId)
       lifecycleReplyApplicationIds.add(event.applicationId);
-    if (ASSESSMENT_EVENT_TYPES.has(eventType)) {
+    if (classification.category === "assessment") {
       addResponse(responseApplicationIds, event.applicationId);
       if (event.applicationId)
         assessmentApplicationIds.add(event.applicationId);
     }
     if (
-      RECRUITER_SCREEN_EVENT_TYPES.has(eventType) ||
+      classification.category === "recruiter_screen" ||
       status === "recruiter_screen"
     )
       recruiterScreenKeys.add(recruiterScreenKey(event));
+    if (classification.category === "non_recruiter_interview")
+      nonRecruiterInterviewKeys.add(
+        interviewKey({ ...event, stage: classification.interviewStage }),
+      );
     if (
       OFFER_EVENT_TYPES.has(eventType) ||
       ["offer", "accepted"].includes(status)
@@ -200,9 +195,10 @@ export const selectDashboardMetrics = (bundle = {}) => {
     if (interview.stage === "recruiter_screen")
       recruiterScreenKeys.add(recruiterScreenKey(interview));
   }
-  const nonRecruiterInterviews = interviews.filter(
-    (interview) => interview.stage !== "recruiter_screen",
-  );
+  for (const interview of interviews) {
+    if (interview.stage !== "recruiter_screen")
+      nonRecruiterInterviewKeys.add(interviewKey(interview));
+  }
 
   return {
     totalApplications: applications.length,
@@ -215,7 +211,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
     ),
     outreachReplyRate: boundedPercentage(outreachReplies, outreachSent),
     recruiterScreens: recruiterScreenKeys.size,
-    interviews: nonRecruiterInterviews.length,
+    interviews: nonRecruiterInterviewKeys.size,
     assessments: assessmentApplicationIds.size,
     offers: new Set(
       [

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -12,6 +12,10 @@ import {
   previewCompactCsvImport,
   previewSupplementalLifecycleCsvImport,
 } from "../import-export/spreadsheet.js";
+import {
+  classifyLifecycleEventType,
+  isAssessmentLifecycleEvent,
+} from "./lifecycleClassification.js";
 import { readSpreadsheetMetadata, selectDashboardMetrics } from "./metrics.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
@@ -240,25 +244,19 @@ const normalize = (value) =>
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_+|_+$/g, "");
 const isAssessmentEvent = (record = {}) =>
-  [
-    record.eventType,
-    record.stageLabel,
-    record.status,
-    record.note,
-    record.details,
-  ]
+  isAssessmentLifecycleEvent(record.eventType) ||
+  [record.stageLabel, record.status, record.note, record.details]
     .map(normalize)
     .some(
       (value) => value.includes("assessment") || value.includes("take_home"),
     );
-const RECRUITER_SCREEN_EVENT_TYPES = new Set([
-  "recruiter_screen_scheduled",
-  "recruiter_screen_completed",
-]);
 const isRecruiterScreen = (record = {}) =>
   normalize(record.stage) === "recruiter_screen" ||
   normalize(record.status) === "recruiter_screen" ||
-  RECRUITER_SCREEN_EVENT_TYPES.has(normalize(record.eventType));
+  classifyLifecycleEventType(record.eventType).category === "recruiter_screen";
+const isNonRecruiterInterviewEvent = (record = {}) =>
+  classifyLifecycleEventType(record.eventType).category ===
+  "non_recruiter_interview";
 const recruiterScreenKey = (record = {}) =>
   [
     record.applicationId,
@@ -309,13 +307,11 @@ const COMPACT_OUTREACH_REPLY_STATUSES = new Set([
   "reply",
   "responded",
 ]);
-const RESPONSE_EVENT_TYPES = new Set([
-  "hiring_manager_reply",
-  "written_assessment_requested",
-  "recruiter_screen_scheduled",
-  "recruiter_screen_completed",
-  "offer",
-  "offer_received",
+const RESPONSE_CATEGORIES = new Set([
+  "assessment",
+  "employer_response",
+  "non_recruiter_interview",
+  "recruiter_screen",
 ]);
 const hasMetadataResponseSignal = (metadata = {}) =>
   COMPACT_OUTREACH_REPLY_STATUSES.has(normalize(metadata.outreach_status)) ||
@@ -330,8 +326,9 @@ const hasListResponseSignal = (app, meta, metadata = {}) =>
   ) ||
   meta.lifecycle.some(
     (x) =>
-      RESPONSE_EVENT_TYPES.has(normalize(x.eventType)) ||
-      TERMINAL_EMPLOYER_STATUSES.has(normalize(x.status)),
+      RESPONSE_CATEGORIES.has(
+        classifyLifecycleEventType(x.eventType).category,
+      ) || TERMINAL_EMPLOYER_STATUSES.has(normalize(x.status)),
   ) ||
   hasMetadataResponseSignal(metadata);
 function metadataEntries(app) {
@@ -652,13 +649,17 @@ function timelineItem(e) {
     ? "assessment"
     : isRecruiterScreen(e)
       ? "recruiter"
-      : "event";
+      : isNonRecruiterInterviewEvent(e)
+        ? "interview"
+        : "event";
   const label =
     kind === "assessment"
       ? "Assessment/take-home"
       : kind === "recruiter"
         ? "Recruiter screen"
-        : "Lifecycle event";
+        : kind === "interview"
+          ? "Interview"
+          : "Lifecycle event";
   return `<li class="timeline-item timeline-${kind}"><div><strong>${esc(label)}</strong> <span class="chip">${esc(e.status || e.eventType || "event")}</span></div><time>${esc(day(e.occurredAt) || day(e.dueAt) || "No date")}</time><div class="timeline-meta">${eventDetails(e)}</div></li>`;
 }
 function metadataSection(app) {
@@ -672,9 +673,21 @@ function detailForm(app) {
   const events = sortedLifecycleEvents(app.id);
   const metadata = readSpreadsheetMetadata(app.notes);
   const recruiterScreens = uniqueRecruiterScreens(m, events);
-  const otherInterviews = m.interviews.filter(
-    (item) => !isRecruiterScreen(item),
-  );
+  const lifecycleInterviewItems = events
+    .filter(isNonRecruiterInterviewEvent)
+    .map((event) => ({
+      startsAt: event.dueAt || event.occurredAt,
+      stage:
+        event.stageLabel ||
+        classifyLifecycleEventType(event.eventType).interviewStage ||
+        event.eventType,
+      outcome:
+        classifyLifecycleEventType(event.eventType).outcome || "scheduled",
+    }));
+  const otherInterviews = [
+    ...m.interviews.filter((item) => !isRecruiterScreen(item)),
+    ...lifecycleInterviewItems,
+  ];
   const assessments = events.filter(isAssessmentEvent).map((event) => ({
     date: day(event.occurredAt) || day(event.dueAt),
     label: event.stageLabel || event.eventType || event.details || "assessment",

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -84,24 +84,24 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationsWithResponse).toBe(5);
   });
 
+  // prettier-ignore
   it(
     "dedupes hiring-manager lifecycle replies already represented by compact metadata",
     async () => {
-      const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
-        exportedAt,
-      });
-      const lifecycle = importLifecycle(
-        await lifecycleFixture("employer-reply-lifecycle-regression.csv"),
-        bundle,
-      );
+    const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
+      exportedAt,
+    });
+    const lifecycle = importLifecycle(
+      await lifecycleFixture("employer-reply-lifecycle-regression.csv"),
+      bundle,
+    );
 
-      const metrics = selectDashboardMetrics(mergeBundle(bundle, lifecycle));
+    const metrics = selectDashboardMetrics(mergeBundle(bundle, lifecycle));
 
-      expect(metrics.outreachReplies).toBe(2);
-      expect(metrics.applicationsWithResponse).toBe(4);
-      expect(metrics.interviews).toBe(0);
-    },
-  );
+    expect(metrics.outreachReplies).toBe(2);
+    expect(metrics.applicationsWithResponse).toBe(4);
+    expect(metrics.interviews).toBe(0);
+  });
 
   it("counts lifecycle-only hiring-manager replies as outreach replies", () => {
     const timestamp = "2026-01-01T00:00:00.000Z";
@@ -524,5 +524,181 @@ describe("tracker dashboard metrics", () => {
     expect(metrics.applicationsWithResponse).toBe(1);
     expect(metrics.applicationResponseRate).toBe(100);
     expect(metrics.outreachReplyRate).toBe(100);
+  });
+});
+
+describe("lifecycle event classification", () => {
+  const nonRecruiterTitle = [
+    "classifies scheduled non-recruiter interviews without folding",
+    "recruiter screens into interviews",
+  ].join(" ");
+  const idempotentImportTitle =
+    "imports scheduled and completed non-recruiter lifecycle interviews idempotently";
+
+  it(nonRecruiterTitle, () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_devops",
+          company: "Example",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_devops",
+          applicationId: "app_devops",
+          eventType: "devops_interview_scheduled",
+          status: "technical_screen",
+          occurredAt: timestamp,
+          dueAt: "2026-01-02T18:00:00.000Z",
+          createdAt: timestamp,
+        },
+        {
+          id: "event_recruiter",
+          applicationId: "app_devops",
+          eventType: "recruiter_screen_completed",
+          status: "recruiter_screen",
+          occurredAt: timestamp,
+          createdAt: timestamp,
+        },
+      ],
+      interviews: [],
+    });
+
+    expect(metrics.recruiterScreens).toBe(1);
+    expect(metrics.interviews).toBe(1);
+    expect(metrics.applicationsWithResponse).toBe(1);
+  });
+
+  it("does not count assessments, hiring-manager replies, or reminders as interviews", () => {
+    const timestamp = "2026-01-01T00:00:00.000Z";
+    const metrics = selectDashboardMetrics({
+      applications: [
+        {
+          id: "app_negative",
+          company: "Example",
+          role: "Engineer",
+          status: "applied",
+          createdAt: timestamp,
+          updatedAt: timestamp,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_assessment",
+          applicationId: "app_negative",
+          eventType: "written_assessment_submitted",
+          occurredAt: timestamp,
+          createdAt: timestamp,
+        },
+        {
+          id: "event_reply",
+          applicationId: "app_negative",
+          eventType: "hiring_manager_reply",
+          occurredAt: timestamp,
+          createdAt: timestamp,
+        },
+        {
+          id: "event_reminder",
+          applicationId: "app_negative",
+          eventType: "next_tracking_step",
+          occurredAt: timestamp,
+          dueAt: "2026-01-02T18:00:00.000Z",
+          createdAt: timestamp,
+        },
+      ],
+    });
+
+    expect(metrics.assessments).toBe(1);
+    expect(metrics.interviews).toBe(0);
+    expect(metrics.recruiterScreens).toBe(0);
+  });
+
+  it(idempotentImportTitle, async () => {
+    const { bundle } = csvToBrowserApplicationExport(await compactFixture(), {
+      exportedAt,
+    });
+    const csv = [
+      [
+        "application_id",
+        "company",
+        "role_title",
+        "event_type",
+        "occurred_at",
+        "stage",
+        "channel",
+        "actor",
+        "source_artifact",
+        "requires_user_action",
+        "action_status",
+        "due_at",
+        "no_ai_required",
+        "details",
+      ].join(","),
+      [
+        "app_reg_alpha_001",
+        "Company Alpha",
+        "Frontend Platform Engineer",
+        "devops_interview_scheduled",
+        "2026-02-06T15:00:00.000Z",
+        "DevOps interview",
+        "video",
+        "employer",
+        "",
+        "false",
+        "scheduled",
+        "2026-02-10T17:00:00.000Z",
+        "",
+        "DevOps pairing interview scheduled.",
+      ].join(","),
+      [
+        "app_reg_beta_002",
+        "Company Beta",
+        "Backend Systems Engineer",
+        "technical_interview_completed",
+        "2026-02-07T18:00:00.000Z",
+        "Technical interview",
+        "video",
+        "engineer",
+        "",
+        "false",
+        "completed",
+        "",
+        "",
+        "Technical interview completed.",
+      ].join(","),
+      [
+        "app_reg_gamma_003",
+        "Company Gamma",
+        "Data Product Engineer",
+        "onsite_interview_scheduled",
+        "2026-02-08T18:00:00.000Z",
+        "Onsite interview",
+        "video",
+        "employer",
+        "",
+        "false",
+        "scheduled",
+        "2026-02-12T19:00:00.000Z",
+        "",
+        "Onsite scheduled.",
+      ].join(","),
+    ].join("\n");
+
+    const first = importLifecycle(csv, bundle);
+    const second = importLifecycle(csv, bundle);
+    const merged = mergeBundle(mergeBundle(bundle, first), second);
+    const uniqueInterviewIds = new Set(
+      merged.interviews.map((interview) => interview.id),
+    );
+
+    expect(first.interviews).toHaveLength(3);
+    expect(uniqueInterviewIds.size).toBe(3);
+    expect(selectDashboardMetrics(merged).interviews).toBe(3);
   });
 });


### PR DESCRIPTION
### Motivation
- Incoming supplemental lifecycle CSVs can include event-rich interview rows (e.g. `devops_interview_scheduled`) that were recorded as lifecycle metadata but not counted as non-recruiter interviews on the dashboard.
- The previous approach relied on scattered string checks and special-casing, causing gaps (Reducto fixture) and fragility as new pipeline step names appear.
- Provide a small, centralized, extensible classification system so the app deterministically classifies lifecycle event types and derives interview records when appropriate.

### Description
- Added `src/web/tracker/lifecycleClassification.js`, a compact registry/classifier mapping lifecycle event types to categories (recruiter_screen, non_recruiter_interview, assessment, employer_response, application_submission, reminder, unknown) and exported helpers like `classifyLifecycleEventType` for easy extension. 
- Updated supplemental lifecycle CSV import (`lifecycleRowsToBrowserApplicationExport` in `src/web/import-export/spreadsheet.js`) to use the classifier for lifecycle status mapping, preserve lifecycle events, and create deterministic first-class `interviews` for scheduled/completed non-recruiter interview events when timing metadata (`due_at` for scheduled, `occurred_at` for completed) includes a time component. 
- Updated dashboard selection and metrics (`src/web/tracker/metrics.js`) to count lifecycle-only non-recruiter interviews, deduplicate via stable keys, and keep recruiter screens, assessments, and employer replies semantically separate so they do not inflate the `Interviews` metric. 
- Updated tracker detail/timeline rendering (`src/web/tracker/tracker.js`) to surface lifecycle-only non-recruiter interview events in the Interviews section (without requiring a manual re-import) and added regression tests (`test/web-tracker-metrics.test.js`) covering DevOps/technical/onsite types, negative non-interview types, and idempotent import behavior.

### Testing
- Ran targeted formatting check on changed files with `npx prettier --check src/web/tracker/lifecycleClassification.js src/web/import-export/spreadsheet.js src/web/tracker/metrics.js src/web/tracker/tracker.js test/web-tracker-metrics.test.js` which passed for the changed files. (passed)
- Ran lint/typecheck: `npm run lint` and `npm run typecheck`, both completed successfully against the working tree (passed).
- Ran unit/regression tests: `npm test -- test/web-tracker-metrics.test.js --run`, all tests in that file passed (19/19) (passed).
- Ran full CI test suite and build: `npm run test:ci` and `npm run build`, both completed successfully (passed).
- Generated browser screenshots (sanity smoke): `npm run web:screenshots`, completed and saved screenshots (passed).
- Note: `npm run format:check` reports wide, pre-existing formatting drift in unrelated files in the repository; the patch only ran targeted Prettier checks against the modified files which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ff559dedc832f95bf8541b3436723)