### PR TITLE
Browser storage v2: schema, deterministic v1→v2 migration, import/export, and canonical IndexedDB repo

### DIFF
--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -13,7 +13,44 @@ export const browserApplicationLifecycleStatusSchema = z.enum([
   "closed_archived",
 ]);
 
+export const browserApplicationOriginSchema = z.enum([
+  "application_submitted",
+  "recruiter_company_outreach",
+  "candidate_outreach",
+  "referral",
+  "other_unknown",
+]);
+
+export const browserApplicationCanonicalEventTypeSchema = z.enum([
+  "application_submitted",
+  "recruiter_company_outreach",
+  "candidate_outreach",
+  "referral",
+  "other_unknown",
+  "employer_response_received",
+  "recruiter_screen",
+  "assessment_take_home",
+  "technical_interview",
+  "onsite_final_loop",
+  "offer_received",
+  "offer_negotiating",
+  "employer_rejected",
+  "candidate_withdrew",
+  "offer_declined",
+  "offer_expired_rescinded",
+  "offer_accepted",
+  "closed_archived",
+  "application_reopened",
+  "status_changed",
+  "migration_status_snapshot",
+]);
+
 const isoDateTimeSchema = z.string().datetime({ offset: true });
+const plainDateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
+const stableDateOrDateTimeSchema = z.union([
+  plainDateSchema,
+  isoDateTimeSchema,
+]);
 const requiredStringSchema = z.string().trim().min(1);
 const optionalTrimmedStringSchema = requiredStringSchema.optional();
 const idSchema = requiredStringSchema;
@@ -46,7 +83,7 @@ export const browserApplicationOutreachMessageSchema = z.object({
   updatedAt: isoDateTimeSchema,
 });
 
-export const browserApplicationLifecycleEventSchema = z.object({
+export const browserApplicationLifecycleEventV1Schema = z.object({
   id: idSchema,
   applicationId: idSchema,
   status: browserApplicationLifecycleStatusSchema,
@@ -70,7 +107,67 @@ export const browserApplicationLifecycleEventSchema = z.object({
   noAiRequired: z.boolean().optional(),
   details: optionalTrimmedStringSchema,
   createdAt: isoDateTimeSchema,
+  occurredAtHasTime: z.boolean().optional(),
+  dueAtHasTime: z.boolean().optional(),
 });
+
+export const browserApplicationLifecycleEventSchema = z
+  .object({
+    id: idSchema,
+    applicationId: idSchema,
+    status: browserApplicationLifecycleStatusSchema.optional(),
+    previousStatus: browserApplicationLifecycleStatusSchema.optional(),
+    occurredAt: stableDateOrDateTimeSchema,
+    occurredAtPrecision: z.enum(["instant", "date", "unknown"]),
+    inferred: z.boolean(),
+    supersedesEventId: idSchema.optional(),
+    source: z.enum([
+      "manual",
+      "csv_import",
+      "json_import",
+      "ndjson_import",
+      "sqlite_migration",
+      "browser_migration",
+      "reconciliation",
+    ]),
+    note: optionalTrimmedStringSchema,
+    eventType: browserApplicationCanonicalEventTypeSchema,
+    rawEventType: optionalTrimmedStringSchema,
+    stageLabel: optionalTrimmedStringSchema,
+    channel: optionalTrimmedStringSchema,
+    actor: optionalTrimmedStringSchema,
+    sourceArtifact: optionalTrimmedStringSchema,
+    requiresUserAction: z.boolean().optional(),
+    actionStatus: optionalTrimmedStringSchema,
+    actionStatusInferred: z.boolean().optional(),
+    dueAt: isoDateTimeSchema.optional(),
+    noAiRequired: z.boolean().optional(),
+    details: optionalTrimmedStringSchema,
+    createdAt: isoDateTimeSchema,
+  })
+  .superRefine((event, ctx) => {
+    if (
+      event.occurredAtPrecision === "instant" &&
+      !isoDateTimeSchema.safeParse(event.occurredAt).success
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          "instant occurredAt requires ISO datetime with explicit offset",
+        path: ["occurredAt"],
+      });
+    }
+    if (
+      event.occurredAtPrecision === "date" &&
+      !plainDateSchema.safeParse(event.occurredAt).success
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "date occurredAt requires YYYY-MM-DD",
+        path: ["occurredAt"],
+      });
+    }
+  });
 
 export const browserApplicationInterviewSchema = z.object({
   id: idSchema,
@@ -160,12 +257,42 @@ export const browserApplicationReminderSchema = z.object({
   updatedAt: isoDateTimeSchema,
 });
 
-export const browserApplicationSettingsSchema = z.object({
+export const LOCAL_SETTINGS_SCHEMA_VERSION = 2;
+
+export const browserApplicationSettingsV1Schema = z.object({
   id: z.literal("local"),
   schemaVersion: z.literal(1),
   locale: optionalTrimmedStringSchema,
   timezone: optionalTrimmedStringSchema,
   defaultExportFormat: z.enum(["json", "ndjson", "csv"]).default("json"),
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserApplicationSettingsSchema = z.object({
+  id: z.literal("local"),
+  schemaVersion: z.literal(LOCAL_SETTINGS_SCHEMA_VERSION),
+  locale: optionalTrimmedStringSchema,
+  timezone: optionalTrimmedStringSchema,
+  defaultExportFormat: z.enum(["json", "ndjson", "csv"]).default("json"),
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
+});
+
+export const browserApplicationV1Schema = z.object({
+  id: idSchema,
+  company: requiredStringSchema,
+  role: requiredStringSchema,
+  status: browserApplicationLifecycleStatusSchema,
+  source: optionalTrimmedStringSchema,
+  postingUrl: z.string().url().optional(),
+  location: optionalTrimmedStringSchema,
+  remote: z.boolean().optional(),
+  compensationText: optionalTrimmedStringSchema,
+  appliedAt: isoDateTimeSchema.optional(),
+  followUpDate: isoDateTimeSchema.optional(),
+  closedAt: isoDateTimeSchema.optional(),
+  notes: optionalTrimmedStringSchema,
   createdAt: isoDateTimeSchema,
   updatedAt: isoDateTimeSchema,
 });
@@ -176,6 +303,7 @@ export const browserApplicationSchema = z.object({
   role: requiredStringSchema,
   status: browserApplicationLifecycleStatusSchema,
   source: optionalTrimmedStringSchema,
+  origin: browserApplicationOriginSchema,
   postingUrl: z.string().url().optional(),
   location: optionalTrimmedStringSchema,
   remote: z.boolean().optional(),
@@ -234,23 +362,25 @@ const addContactReferenceIssues = (ctx, storeName, records, contactIds) => {
   });
 };
 
-export const browserApplicationExportSchema = z
+export const BROWSER_EXPORT_SCHEMA_VERSION = 2;
+
+export const browserApplicationExportV1Schema = z
   .object({
     schemaVersion: z.literal(1),
     exportedAt: isoDateTimeSchema,
-    applications: z.array(browserApplicationSchema),
+    applications: z.array(browserApplicationV1Schema),
     contacts: z.array(browserApplicationContactSchema).default([]),
     outreachMessages: z
       .array(browserApplicationOutreachMessageSchema)
       .default([]),
     lifecycleEvents: z
-      .array(browserApplicationLifecycleEventSchema)
+      .array(browserApplicationLifecycleEventV1Schema)
       .default([]),
     interviews: z.array(browserApplicationInterviewSchema).default([]),
     offers: z.array(browserApplicationOfferSchema).default([]),
     artifacts: z.array(browserApplicationArtifactSchema).default([]),
     reminders: z.array(browserApplicationReminderSchema).default([]),
-    settings: browserApplicationSettingsSchema.optional(),
+    settings: browserApplicationSettingsV1Schema.optional(),
   })
   .superRefine((exportData, ctx) => {
     const keyedStores = [
@@ -315,3 +445,111 @@ export const browserApplicationExportSchema = z
       },
     );
   });
+
+export const browserApplicationExportV2Schema = z
+  .object({
+    schemaVersion: z.literal(BROWSER_EXPORT_SCHEMA_VERSION),
+    exportedAt: isoDateTimeSchema,
+    applications: z.array(browserApplicationSchema),
+    contacts: z.array(browserApplicationContactSchema).default([]),
+    outreachMessages: z
+      .array(browserApplicationOutreachMessageSchema)
+      .default([]),
+    lifecycleEvents: z
+      .array(browserApplicationLifecycleEventSchema)
+      .default([]),
+    interviews: z.array(browserApplicationInterviewSchema).default([]),
+    offers: z.array(browserApplicationOfferSchema).default([]),
+    artifacts: z.array(browserApplicationArtifactSchema).default([]),
+    reminders: z.array(browserApplicationReminderSchema).default([]),
+    settings: browserApplicationSettingsSchema.optional(),
+  })
+  .superRefine((exportData, ctx) => {
+    const keyedStores = [
+      ["applications", exportData.applications],
+      ["contacts", exportData.contacts],
+      ["outreachMessages", exportData.outreachMessages],
+      ["lifecycleEvents", exportData.lifecycleEvents],
+      ["interviews", exportData.interviews],
+      ["offers", exportData.offers],
+      ["artifacts", exportData.artifacts],
+      ["reminders", exportData.reminders],
+    ];
+    keyedStores.forEach(([storeName, records]) =>
+      addDuplicateIdIssues(ctx, storeName, records),
+    );
+    const applicationIds = new Set(
+      exportData.applications.map((application) => application.id),
+    );
+    const contactIds = new Set(
+      exportData.contacts.map((contact) => contact.id),
+    );
+    for (const [storeName, records] of keyedStores.filter(
+      ([name]) => name !== "applications",
+    )) {
+      addApplicationReferenceIssues(ctx, storeName, records, applicationIds);
+    }
+    addContactReferenceIssues(
+      ctx,
+      "outreachMessages",
+      exportData.outreachMessages,
+      contactIds,
+    );
+    addContactReferenceIssues(
+      ctx,
+      "reminders",
+      exportData.reminders,
+      contactIds,
+    );
+    exportData.interviews.forEach(
+      ({ contactIds: interviewContactIds }, index) => {
+        interviewContactIds.forEach((contactId, contactIndex) => {
+          if (!contactIds.has(contactId))
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `Unknown contactId: ${contactId}`,
+              path: ["interviews", index, "contactIds", contactIndex],
+            });
+        });
+      },
+    );
+    const eventsById = new Map(
+      exportData.lifecycleEvents.map((event) => [event.id, event]),
+    );
+    exportData.lifecycleEvents.forEach((event, index) => {
+      if (!event.supersedesEventId) return;
+      const referenced = eventsById.get(event.supersedesEventId);
+      if (!referenced) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Unknown supersedesEventId: ${event.supersedesEventId}`,
+          path: ["lifecycleEvents", index, "supersedesEventId"],
+        });
+        return;
+      }
+      if (referenced.applicationId !== event.applicationId) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            "supersedesEventId must reference an event for the same application",
+          path: ["lifecycleEvents", index, "supersedesEventId"],
+        });
+      }
+      const seen = new Set([event.id]);
+      let cursor = referenced;
+      while (cursor?.supersedesEventId) {
+        if (seen.has(cursor.supersedesEventId)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: "supersession chains must be acyclic",
+            path: ["lifecycleEvents", index, "supersedesEventId"],
+          });
+          break;
+        }
+        seen.add(cursor.supersedesEventId);
+        cursor = eventsById.get(cursor.supersedesEventId);
+      }
+    });
+  });
+
+export const browserApplicationExportSchema = browserApplicationExportV2Schema;

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1,4 +1,5 @@
 import { browserApplicationExportSchema } from "../../domain/browserApplication.js";
+import { upgradeBrowserExportToV2 } from "../storage/browserDataMigration.js";
 import { classifyLifecycleEventType } from "../tracker/lifecycleClassification.js";
 
 export const LIFECYCLE_CSV_COLUMNS = [
@@ -6,7 +7,12 @@ export const LIFECYCLE_CSV_COLUMNS = [
   "company",
   "role_title",
   "event_type",
+  "raw_event_type",
+  "previous_status",
   "occurred_at",
+  "occurred_at_precision",
+  "inferred",
+  "supersedes_event_id",
   "stage",
   "channel",
   "actor",
@@ -28,6 +34,7 @@ export const COMPACT_CSV_COLUMNS = [
   "application_url",
   "posting_id",
   "application_channel",
+  "origin",
   "work_model",
   "location_display",
   "compensation_min_usd",
@@ -708,7 +715,14 @@ export const lifecycleRowsToBrowserApplicationExport = (
     artifacts: [],
     reminders,
   };
-  return { bundle, errors, warnings };
+  const upgraded = upgradeBrowserExportToV2(bundle, {
+    migrationCreatedAt: exportedAt,
+  });
+  return {
+    bundle: upgraded.data,
+    errors,
+    warnings: [...warnings, ...upgraded.warnings],
+  };
 };
 
 export const csvToSupplementalLifecycleExport = (csvText, existing, options) =>
@@ -993,7 +1007,24 @@ export const rowsToBrowserApplicationExport = (
     artifacts,
     reminders: [],
   };
-  const parsed = browserApplicationExportSchema.safeParse(bundle);
+  const upgraded = upgradeBrowserExportToV2(bundle, {
+    migrationCreatedAt: exportedAt,
+  });
+  for (const application of upgraded.data.applications) {
+    const row = rows.find((candidate, index) => {
+      const candidateId =
+        compact(candidate.application_id) ||
+        stableId(
+          candidate.company,
+          candidate.role_title,
+          candidate.posting_url,
+          index + 2,
+        );
+      return candidateId === application.id;
+    });
+    if (row && compact(row.origin)) application.origin = compact(row.origin);
+  }
+  const parsed = browserApplicationExportSchema.safeParse(upgraded.data);
   if (!parsed.success)
     errors.push({
       rowNumber: null,
@@ -1001,7 +1032,11 @@ export const rowsToBrowserApplicationExport = (
       code: "schema_validation_failed",
       message: parsed.error.message,
     });
-  return { bundle, errors, warnings };
+  return {
+    bundle: parsed.success ? parsed.data : upgraded.data,
+    errors,
+    warnings: [...warnings, ...upgraded.warnings],
+  };
 };
 
 export const csvToBrowserApplicationExport = (csvText, options) =>
@@ -1028,7 +1063,7 @@ const compareIsoDateTimes = (left, right) => {
 };
 const firstBy = (records, predicate) => records.find(predicate) ?? {};
 export const browserApplicationExportToRows = (bundle) => {
-  const parsed = browserApplicationExportSchema.parse(bundle);
+  const parsed = upgradeBrowserExportToV2(bundle).data;
   return [...parsed.applications]
     .sort((a, b) => a.id.localeCompare(b.id))
     .map((application) => {
@@ -1075,11 +1110,12 @@ export const browserApplicationExportToRows = (bundle) => {
         applied_at: dateOnly(application.appliedAt),
         posting_url: application.postingUrl ?? "",
         application_channel: application.source ?? "",
+        origin: application.origin ?? "",
         work_model: application.remote ? "remote" : (metadata.work_model ?? ""),
         location_display: application.location ?? "",
         follow_up_date: dateOnly(application.followUpDate),
         notes,
-        schema_version: metadata.schema_version ?? "1",
+        schema_version: "2",
       });
       const resume = firstBy(artifacts, ({ kind }) => kind === "resume");
       const cover = firstBy(artifacts, ({ kind }) => kind === "cover_letter");
@@ -1127,7 +1163,7 @@ export const browserApplicationExportToRows = (bundle) => {
 export const exportCompactCsv = (bundle) =>
   serializeCsv(browserApplicationExportToRows(bundle));
 export const browserApplicationExportToLifecycleRows = (bundle) => {
-  const parsed = browserApplicationExportSchema.parse(bundle);
+  const parsed = upgradeBrowserExportToV2(bundle).data;
   const applicationsById = new Map(
     parsed.applications.map((application) => [application.id, application]),
   );
@@ -1152,7 +1188,12 @@ export const browserApplicationExportToLifecycleRows = (bundle) => {
         company: application.company ?? "",
         role_title: application.role ?? "",
         event_type: event.eventType ?? "",
+        raw_event_type: event.rawEventType ?? "",
+        previous_status: event.previousStatus ?? "",
         occurred_at: event.occurredAt ?? "",
+        occurred_at_precision: event.occurredAtPrecision ?? "",
+        inferred: event.inferred === undefined ? "" : String(event.inferred),
+        supersedes_event_id: event.supersedesEventId ?? "",
         stage: event.stageLabel ?? event.status ?? "",
         channel: event.channel ?? "",
         actor: event.actor ?? "",
@@ -1206,7 +1247,7 @@ const restoreLifecyclePrecisionFlags = (bundle, sourceEvents) => {
 };
 const parseBackupBundlePreservingLifecyclePrecision = (bundle) =>
   restoreLifecyclePrecisionFlags(
-    browserApplicationExportSchema.parse(bundle),
+    upgradeBrowserExportToV2(bundle).data,
     bundle?.lifecycleEvents ?? [],
   );
 const canonicalizeBackupBundle = (bundle) => {
@@ -1246,7 +1287,7 @@ export const exportNdjsonBackup = (bundle) => {
 const normalizeBackupBundleInput = (input, { source = "json_import" } = {}) => {
   const now = nowIso();
   const bundle = {
-    schemaVersion: 1,
+    schemaVersion: input?.schemaVersion ?? 1,
     exportedAt: input?.exportedAt ?? now,
     applications: input?.applications ?? [],
     contacts: input?.contacts ?? [],

--- a/src/web/storage/browserDataMigration.js
+++ b/src/web/storage/browserDataMigration.js
@@ -1,0 +1,378 @@
+import {
+  BROWSER_EXPORT_SCHEMA_VERSION,
+  LOCAL_SETTINGS_SCHEMA_VERSION,
+  browserApplicationCanonicalEventTypeSchema,
+  browserApplicationExportV1Schema,
+  browserApplicationExportV2Schema,
+} from "../../domain/browserApplication.js";
+
+const ORIGIN_ORDER = [
+  "application_submitted",
+  "recruiter_company_outreach",
+  "candidate_outreach",
+  "referral",
+  "other_unknown",
+];
+const ORIGIN_EVENTS = new Set(ORIGIN_ORDER);
+const CANONICAL_EVENTS = new Set(
+  browserApplicationCanonicalEventTypeSchema.options,
+);
+
+const LEGACY_EVENT_TYPES = new Map([
+  ["application_submitted", "application_submitted"],
+  ["hiring_manager_reply", "employer_response_received"],
+  ["recruiter_screen_scheduled", "recruiter_screen"],
+  ["recruiter_screen_completed", "recruiter_screen"],
+  ["devops_interview_scheduled", "technical_interview"],
+  ["devops_interview_completed", "technical_interview"],
+  ["technical_interview_scheduled", "technical_interview"],
+  ["technical_interview_completed", "technical_interview"],
+  ["technical_screen_scheduled", "technical_interview"],
+  ["technical_screen_completed", "technical_interview"],
+  ["onsite_interview_scheduled", "onsite_final_loop"],
+  ["onsite_interview_completed", "onsite_final_loop"],
+  ["final_interview_scheduled", "onsite_final_loop"],
+  ["final_interview_completed", "onsite_final_loop"],
+  ["written_assessment", "assessment_take_home"],
+  ["written_assessment_requested", "assessment_take_home"],
+  ["written_assessment_submitted", "assessment_take_home"],
+  ["take_home", "assessment_take_home"],
+  ["take_home_requested", "assessment_take_home"],
+  ["take_home_submitted", "assessment_take_home"],
+  ["next_tracking_step", "status_changed"],
+]);
+const STRUCTURED_MILESTONE_ALIASES = new Map([
+  ["recruiter_screen", "recruiter_screen"],
+  ["technical_screen", "technical_interview"],
+  ["onsite_loop", "onsite_final_loop"],
+  ["offer", "offer_received"],
+]);
+const STATUS_TO_EVENT = new Map([
+  ["applied", "application_submitted"],
+  ["outreach_sent", "candidate_outreach"],
+  ["offer", "offer_negotiating"],
+  ["accepted", "offer_accepted"],
+  ["rejected", "employer_rejected"],
+  ["withdrawn", "candidate_withdrew"],
+  ["closed_archived", "closed_archived"],
+]);
+const STATUS_ENDPOINT_EVENT = new Map([
+  ...STATUS_TO_EVENT,
+  ...STRUCTURED_MILESTONE_ALIASES,
+]);
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+const normalizeExact = (value) =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase();
+const isDateOnly = (value) => /^\d{4}-\d{2}-\d{2}$/.test(String(value ?? ""));
+const isEpoch = (value) =>
+  value === "1970-01-01" ||
+  value === "1970-01-01T00:00:00.000Z" ||
+  value === "1970-01-01T00:00:00Z";
+const dateKey = (value) => (isDateOnly(value) ? value : String(value ?? ""));
+const cmp = (a, b) => String(a).localeCompare(String(b));
+const stableId = (...parts) =>
+  parts
+    .map(
+      (p) =>
+        String(p ?? "")
+          .trim()
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "_")
+          .replace(/^_+|_+$/g, "") || "record",
+    )
+    .join("_");
+const warning = (code, extra = {}) => ({ code, count: 1, ...extra });
+
+export const normalizeLifecycleEventType = (event, warnings = []) => {
+  const raw = normalizeExact(event.eventType);
+  let eventType;
+  let rawEventType;
+  if (CANONICAL_EVENTS.has(raw)) eventType = raw;
+  else if (LEGACY_EVENT_TYPES.has(raw)) {
+    eventType = LEGACY_EVENT_TYPES.get(raw);
+    rawEventType = raw;
+  } else if (STRUCTURED_MILESTONE_ALIASES.has(event.status)) {
+    eventType = STRUCTURED_MILESTONE_ALIASES.get(event.status);
+  } else if (STRUCTURED_MILESTONE_ALIASES.has(event.stage)) {
+    eventType = STRUCTURED_MILESTONE_ALIASES.get(event.stage);
+  } else if (raw) {
+    eventType = "status_changed";
+    rawEventType = raw;
+    warnings.push(warning("unknown_legacy_event_type"));
+  } else if (STATUS_TO_EVENT.has(event.status))
+    eventType = STATUS_TO_EVENT.get(event.status);
+  else eventType = "status_changed";
+  const patch = { eventType };
+  if (rawEventType && rawEventType !== eventType)
+    patch.rawEventType = rawEventType;
+  if (eventType === "assessment_take_home" && !event.actionStatus) {
+    if (raw.endsWith("_requested"))
+      Object.assign(patch, {
+        actionStatus: "requested",
+        actionStatusInferred: true,
+      });
+    if (raw.endsWith("_submitted"))
+      Object.assign(patch, {
+        actionStatus: "submitted",
+        actionStatusInferred: true,
+      });
+  }
+  return patch;
+};
+
+const normalizeOccurred = (event) => {
+  const original = event.occurredAt;
+  if (event.occurredAtPrecision)
+    return {
+      occurredAt: original,
+      occurredAtPrecision: event.occurredAtPrecision,
+    };
+  if (isEpoch(original))
+    return {
+      occurredAt: isDateOnly(original) ? original : "1970-01-01",
+      occurredAtPrecision: "unknown",
+    };
+  if (event.occurredAtHasTime === false)
+    return {
+      occurredAt: String(original).slice(0, 10),
+      occurredAtPrecision: "date",
+    };
+  if (event.occurredAtHasTime === true)
+    return { occurredAt: original, occurredAtPrecision: "instant" };
+  if (isDateOnly(original))
+    return { occurredAt: original, occurredAtPrecision: "date" };
+  return { occurredAt: original, occurredAtPrecision: "instant" };
+};
+
+const effectiveEvents = (events) => {
+  const superseded = new Set(
+    events.map((e) => e.supersedesEventId).filter(Boolean),
+  );
+  return events.filter((e) => !superseded.has(e.id));
+};
+
+export const inferApplicationOrigin = (
+  application,
+  bundle,
+  events,
+  warnings = [],
+) => {
+  const effective = effectiveEvents(
+    events.filter((e) => e.applicationId === application.id),
+  );
+  const originEvent = effective
+    .filter((e) => ORIGIN_EVENTS.has(e.eventType))
+    .sort(
+      (a, b) =>
+        cmp(dateKey(a.occurredAt), dateKey(b.occurredAt)) ||
+        ORIGIN_ORDER.indexOf(a.eventType) - ORIGIN_ORDER.indexOf(b.eventType) ||
+        cmp(a.id, b.id),
+    )[0];
+  if (originEvent)
+    return {
+      origin: originEvent.eventType,
+      evidence: originEvent,
+      createEvent: false,
+    };
+  if (normalizeExact(application.source) === "referral")
+    return { origin: "referral", createEvent: false };
+  const evidence = [];
+  if (application.appliedAt)
+    evidence.push({
+      origin: "application_submitted",
+      at: application.appliedAt,
+      id: application.id,
+      precision: isDateOnly(application.appliedAt) ? "date" : "instant",
+    });
+  for (const m of bundle.outreachMessages ?? []) {
+    if (m.applicationId !== application.id) continue;
+    if (m.direction === "inbound" && m.receivedAt)
+      evidence.push({
+        origin: "recruiter_company_outreach",
+        at: m.receivedAt,
+        id: m.id,
+        precision: "instant",
+      });
+    if (m.direction === "outbound" && m.sentAt)
+      evidence.push({
+        origin: "candidate_outreach",
+        at: m.sentAt,
+        id: m.id,
+        precision: "instant",
+      });
+  }
+  if (evidence.length === 0)
+    return { origin: "other_unknown", createEvent: false };
+  const distinct = new Set(evidence.map((e) => e.origin));
+  if (distinct.size > 1)
+    warnings.push(
+      warning("origin_structured_evidence_conflict", {
+        applicationId: application.id,
+      }),
+    );
+  evidence.sort(
+    (a, b) =>
+      cmp(dateKey(a.at), dateKey(b.at)) ||
+      ORIGIN_ORDER.indexOf(a.origin) - ORIGIN_ORDER.indexOf(b.origin) ||
+      cmp(a.id, b.id),
+  );
+  return {
+    origin: evidence[0].origin,
+    evidence: evidence[0],
+    createEvent: true,
+  };
+};
+
+const normalizeEvent = (event, warnings) => {
+  const { occurredAt, occurredAtPrecision } = normalizeOccurred(event);
+  const typePatch = normalizeLifecycleEventType(event, warnings);
+  const normalized = {
+    ...event,
+    ...typePatch,
+    occurredAt,
+    occurredAtPrecision,
+    inferred: Boolean(event.inferred),
+    createdAt: event.createdAt,
+  };
+  delete normalized.occurredAtHasTime;
+  delete normalized.dueAtHasTime;
+  return normalized;
+};
+
+const hasRepresentingEvent = (application, events) => {
+  const expected = STATUS_ENDPOINT_EVENT.get(application.status);
+  if (!expected) return false;
+  return effectiveEvents(
+    events.filter((e) => e.applicationId === application.id),
+  ).some((e) => e.eventType === expected || e.status === application.status);
+};
+
+const normalizeSettings = (settings) =>
+  settings
+    ? { ...settings, schemaVersion: LOCAL_SETTINGS_SCHEMA_VERSION }
+    : undefined;
+
+export const upgradeBrowserExportToV2 = (input, options = {}) => {
+  const migrationCreatedAt =
+    options.migrationCreatedAt ?? new Date().toISOString();
+  const source = clone(input ?? {});
+  const warnings = [];
+  const inputVersion = source.schemaVersion ?? 1;
+  let base;
+  if (inputVersion === BROWSER_EXPORT_SCHEMA_VERSION) {
+    base = clone(source);
+  } else {
+    const parsed = browserApplicationExportV1Schema.parse({
+      schemaVersion: 1,
+      exportedAt: source.exportedAt ?? migrationCreatedAt,
+      applications: source.applications ?? [],
+      contacts: source.contacts ?? [],
+      outreachMessages: source.outreachMessages ?? [],
+      lifecycleEvents: source.lifecycleEvents ?? [],
+      interviews: source.interviews ?? [],
+      offers: source.offers ?? [],
+      artifacts: source.artifacts ?? [],
+      reminders: source.reminders ?? [],
+      settings: source.settings,
+    });
+    base = parsed;
+  }
+  let events = (base.lifecycleEvents ?? []).map((event) =>
+    normalizeEvent(event, warnings),
+  );
+  const applications = (base.applications ?? []).map((application) => {
+    if (application.origin && inputVersion === BROWSER_EXPORT_SCHEMA_VERSION)
+      return application;
+    const inferred = inferApplicationOrigin(
+      application,
+      base,
+      events,
+      warnings,
+    );
+    return { ...application, origin: inferred.origin };
+  });
+  for (const app of applications) {
+    const inferred = inferApplicationOrigin(app, base, events, warnings);
+    if (
+      inferred.createEvent &&
+      !events.some(
+        (e) => e.applicationId === app.id && e.eventType === inferred.origin,
+      )
+    ) {
+      events.push({
+        id: stableId(
+          "event",
+          app.id,
+          "origin",
+          inferred.origin,
+          inferred.evidence.at,
+        ),
+        applicationId: app.id,
+        status: app.status,
+        eventType: inferred.origin,
+        occurredAt:
+          inferred.evidence.precision === "date"
+            ? String(inferred.evidence.at).slice(0, 10)
+            : inferred.evidence.at,
+        occurredAtPrecision: inferred.evidence.precision,
+        inferred: true,
+        source: "browser_migration",
+        createdAt: migrationCreatedAt,
+      });
+    }
+    if (
+      !hasRepresentingEvent(app, events) &&
+      !events.some(
+        (e) =>
+          e.applicationId === app.id &&
+          e.eventType === "migration_status_snapshot" &&
+          e.status === app.status,
+      )
+    ) {
+      const anchor = app.updatedAt ?? app.createdAt ?? migrationCreatedAt;
+      events.push({
+        id: stableId(
+          "event",
+          app.id,
+          "migration_status_snapshot",
+          app.status,
+          anchor,
+        ),
+        applicationId: app.id,
+        status: app.status,
+        eventType: "migration_status_snapshot",
+        occurredAt: isDateOnly(anchor) ? anchor : anchor,
+        occurredAtPrecision: "unknown",
+        inferred: true,
+        source: "browser_migration",
+        createdAt: migrationCreatedAt,
+      });
+    }
+  }
+  const output = {
+    schemaVersion: BROWSER_EXPORT_SCHEMA_VERSION,
+    exportedAt: base.exportedAt ?? migrationCreatedAt,
+    applications,
+    contacts: base.contacts ?? [],
+    outreachMessages: base.outreachMessages ?? [],
+    lifecycleEvents: events,
+    interviews: base.interviews ?? [],
+    offers: base.offers ?? [],
+    artifacts: base.artifacts ?? [],
+    reminders: base.reminders ?? [],
+    settings: normalizeSettings(base.settings),
+  };
+  if (!output.settings) delete output.settings;
+  const parsed = browserApplicationExportV2Schema.parse(output);
+  const sortedWarnings = warnings.sort(
+    (a, b) =>
+      cmp(a.code, b.code) || cmp(a.applicationId ?? "", b.applicationId ?? ""),
+  );
+  return { data: parsed, warnings: sortedWarnings };
+};
+
+export const normalizeBrowserExportToV2 = (input, options) =>
+  upgradeBrowserExportToV2(input, options).data;

--- a/src/web/storage/indexedDbRepository.js
+++ b/src/web/storage/indexedDbRepository.js
@@ -1,6 +1,7 @@
 import {
   browserApplicationArtifactSchema,
   browserApplicationContactSchema,
+  BROWSER_EXPORT_SCHEMA_VERSION,
   browserApplicationExportSchema,
   browserApplicationInterviewSchema,
   browserApplicationLifecycleEventSchema,
@@ -10,9 +11,11 @@ import {
   browserApplicationSchema,
   browserApplicationSettingsSchema,
 } from "../../domain/browserApplication.js";
+import { upgradeBrowserExportToV2 } from "./browserDataMigration.js";
 
 export const DATABASE_NAME = "jobbot3000";
-export const DATABASE_VERSION = 1;
+export const INDEXEDDB_DATABASE_VERSION = 2;
+export const DATABASE_VERSION = INDEXEDDB_DATABASE_VERSION;
 
 export const STORE_NAMES = [
   "applications",
@@ -112,6 +115,7 @@ export const migrations = {
       ensureIndex(applications, "by_status", "status");
       ensureIndex(applications, "by_appliedAt", "appliedAt");
       ensureIndex(applications, "by_followUpDate", "followUpDate");
+      ensureIndex(applications, "by_origin", "origin");
     }
 
     const contacts = createStore(db, "contacts");
@@ -131,6 +135,7 @@ export const migrations = {
         "applicationId",
         "occurredAt",
       ]);
+      ensureIndex(lifecycleEvents, "by_occurredAt", "occurredAt");
     }
 
     const interviews = createStore(db, "interviews");
@@ -153,6 +158,14 @@ export const migrations = {
       ensureIndex(reminders, "by_applicationId", "applicationId");
     }
     createStore(db, "settings");
+  },
+  2(db, transaction) {
+    const applications = transaction.objectStore("applications");
+    ensureIndex(applications, "by_origin", "origin");
+    const lifecycleEvents = transaction.objectStore("lifecycleEvents");
+    ensureIndex(lifecycleEvents, "by_occurredAt", "occurredAt");
+    // Existing records are upgraded by repository export/import validation paths;
+    // the versionchange transaction owns v2 index creation atomically.
   },
 };
 
@@ -308,8 +321,55 @@ const deleteMatchingFromStore = async (store, indexName, value) => {
   });
 };
 
+const migrateExistingDataToV2 = async (db) => {
+  const tx = db.transaction(STORE_NAMES, "readwrite");
+  const done = transactionDone(tx);
+  const storeResults = await Promise.all(
+    STORE_NAMES.map((storeName) =>
+      requestToPromise(tx.objectStore(storeName).getAll()),
+    ),
+  );
+  const [
+    applications,
+    contacts,
+    outreachMessages,
+    lifecycleEvents,
+    interviews,
+    offers,
+    artifacts,
+    reminders,
+    settingsAll,
+  ] = storeResults;
+  const needsMigration =
+    applications.some((record) => !record.origin) ||
+    lifecycleEvents.some((record) => !record.occurredAtPrecision);
+  if (needsMigration) {
+    const upgraded = upgradeBrowserExportToV2({
+      schemaVersion: 1,
+      exportedAt: new Date().toISOString(),
+      applications,
+      contacts,
+      outreachMessages,
+      lifecycleEvents,
+      interviews,
+      offers,
+      artifacts,
+      reminders,
+      settings: settingsAll[0],
+    }).data;
+    for (const storeName of STORE_NAMES) tx.objectStore(storeName).clear();
+    for (const storeName of STORE_NAMES.filter((name) => name !== "settings")) {
+      for (const record of upgraded[storeName])
+        tx.objectStore(storeName).put(record);
+    }
+    if (upgraded.settings) tx.objectStore("settings").put(upgraded.settings);
+  }
+  await done;
+};
+
 const validateImport = (data) => {
-  const result = browserApplicationExportSchema.safeParse(data);
+  const upgraded = upgradeBrowserExportToV2(data);
+  const result = browserApplicationExportSchema.safeParse(upgraded.data);
   if (!result.success) {
     throw new IndexedDbRepositoryError(
       "schema_validation_failed",
@@ -317,7 +377,7 @@ const validateImport = (data) => {
       { details: result.error.flatten() },
     );
   }
-  return { parsed: result.data };
+  return { parsed: result.data, warnings: upgraded.warnings };
 };
 
 export const createIndexedDbRepository = async (options = {}) => {
@@ -331,6 +391,8 @@ export const createIndexedDbRepository = async (options = {}) => {
       "Unable to open jobbot3000 IndexedDB database.",
     );
   }
+
+  await migrateExistingDataToV2(db);
 
   const safe = async (operation) => {
     try {
@@ -435,8 +497,8 @@ export const createIndexedDbRepository = async (options = {}) => {
           reminders,
           settingsAll,
         ] = storeResults;
-        const result = browserApplicationExportSchema.safeParse({
-          schemaVersion: DATABASE_VERSION,
+        const upgraded = upgradeBrowserExportToV2({
+          schemaVersion: BROWSER_EXPORT_SCHEMA_VERSION,
           exportedAt: new Date().toISOString(),
           applications,
           contacts,
@@ -448,6 +510,7 @@ export const createIndexedDbRepository = async (options = {}) => {
           reminders,
           settings: settingsAll[0],
         });
+        const result = browserApplicationExportSchema.safeParse(upgraded.data);
         if (!result.success) {
           throw new IndexedDbRepositoryError(
             "schema_validation_failed",

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -1,4 +1,4 @@
-/* global document, indexedDB, confirm */
+/* global document, confirm */
 /* eslint-disable max-len */
 import {
   COMPACT_CSV_COLUMNS,
@@ -12,6 +12,7 @@ import {
   previewCompactCsvImport,
   previewSupplementalLifecycleCsvImport,
 } from "../import-export/spreadsheet.js";
+import { createIndexedDbRepository } from "../storage/indexedDbRepository.js";
 import {
   classifyLifecycleEventType,
   isLifecycleAssessment,
@@ -48,17 +49,6 @@ const STATUSES = [
   "withdrawn",
   "closed_archived",
 ];
-const STORES = [
-  "applications",
-  "contacts",
-  "outreachMessages",
-  "lifecycleEvents",
-  "interviews",
-  "offers",
-  "artifacts",
-  "reminders",
-  "settings",
-];
 const OUTCOMES = new Set([
   "offer",
   "accepted",
@@ -78,117 +68,64 @@ const esc = (v) =>
   );
 const id = (p = "id") =>
   `${p}_${Date.now().toString(36)}_${crypto.getRandomValues(new Uint32Array(1))[0].toString(36)}`;
-function ensureIndex(store, name, keyPath) {
-  if (!store.indexNames.contains(name)) store.createIndex(name, keyPath);
-}
-function runMigrationV1(db) {
-  const getStore = (name) =>
-    db.objectStoreNames.contains(name)
-      ? null
-      : db.createObjectStore(name, { keyPath: "id" });
-  const applications = getStore("applications");
-  if (applications) {
-    ensureIndex(applications, "by_company", "company");
-    ensureIndex(applications, "by_status", "status");
-    ensureIndex(applications, "by_appliedAt", "appliedAt");
-    ensureIndex(applications, "by_followUpDate", "followUpDate");
-  }
-  for (const n of STORES.filter(
-    (name) => !["applications", "settings"].includes(name),
-  )) {
-    const store = getStore(n);
-    if (!store) continue;
-    ensureIndex(store, "by_applicationId", "applicationId");
-    if (n === "lifecycleEvents")
-      ensureIndex(store, "by_applicationId_occurredAt", [
-        "applicationId",
-        "occurredAt",
-      ]);
-  }
-  getStore("settings");
-}
-function openDb() {
-  return new Promise((res, rej) => {
-    const r = indexedDB.open("jobbot3000", 1);
-    r.onupgradeneeded = () => runMigrationV1(r.result);
-    r.onsuccess = () => res(r.result);
-    r.onerror = () => rej(r.error);
-  });
-}
-async function tx(store, mode, fn) {
-  const db = await openDb();
-  try {
-    return await new Promise((res, rej) => {
-      const t = db.transaction(store, mode);
-      const out = fn(t.objectStore(store), t);
-      t.oncomplete = () => res(out);
-      t.onerror = () => rej(t.error);
-      t.onabort = () => rej(t.error);
-    });
-  } finally {
-    db.close();
-  }
-}
-async function batchPut(recordsByStore) {
-  const db = await openDb();
-  const storeNames = Object.entries(recordsByStore)
-    .filter(([, rows]) => rows.length)
-    .map(([storeName]) => storeName);
-  if (!storeNames.length) {
-    db.close();
-    return;
-  }
-  try {
-    await new Promise((res, rej) => {
-      const t = db.transaction(storeNames, "readwrite");
-      for (const [storeName, rows] of Object.entries(recordsByStore)) {
-        if (!rows.length) continue;
-        const store = t.objectStore(storeName);
-        for (const row of rows) store.put(row);
-      }
-      t.oncomplete = res;
-      t.onerror = () => rej(t.error);
-      t.onabort = () => rej(t.error);
-    });
-  } finally {
-    db.close();
-  }
-}
-const req = (r) =>
-  new Promise((res, rej) => {
-    r.onsuccess = () => res(r.result);
-    r.onerror = () => rej(r.error);
-  });
-const repo = {
-  list: (s) => tx(s, "readonly", (st) => req(st.getAll())),
-  put: (s, o) => tx(s, "readwrite", (st) => st.put(o)),
-  add: (s, o) => tx(s, "readwrite", (st) => st.add(o)),
-  clear: async () => {
-    const db = await openDb();
-    try {
-      await new Promise((res, rej) => {
-        const t = db.transaction(STORES, "readwrite");
-        for (const s of STORES) t.objectStore(s).clear();
-        t.oncomplete = res;
-        t.onerror = () => rej(t.error);
-      });
-    } finally {
-      db.close();
-    }
-  },
-  exportAll: async () =>
-    Object.assign(
-      { schemaVersion: 1, exportedAt: now() },
-      Object.fromEntries(
-        await Promise.all(
-          STORES.map(async (s) => [
-            s,
-            s === "settings" ? (await repo.list(s))[0] : await repo.list(s),
-          ]),
-        ),
-      ),
-    ),
+
+let repositoryPromise;
+const getRepository = () => {
+  repositoryPromise ??= createIndexedDbRepository();
+  return repositoryPromise;
 };
+const replaceAllData = async (bundle) => {
+  const repository = await getRepository();
+  await repository.importAllData(bundle, { allowOverwrite: true });
+};
+const repo = {
+  async list(storeName) {
+    const data = await (await getRepository()).exportAllData();
+    return storeName === "settings"
+      ? data.settings
+        ? [data.settings]
+        : []
+      : (data[storeName] ?? []);
+  },
+  async put(storeName, record) {
+    const data = await (await getRepository()).exportAllData();
+    if (storeName === "settings") data.settings = record;
+    else {
+      const records = data[storeName] ?? [];
+      const index = records.findIndex(({ id }) => id === record.id);
+      if (index === -1) records.push(record);
+      else records[index] = record;
+      data[storeName] = records;
+    }
+    await replaceAllData(data);
+    return record;
+  },
+  async add(storeName, record) {
+    const data = await (await getRepository()).exportAllData();
+    const records = data[storeName] ?? [];
+    if (records.some(({ id }) => id === record.id))
+      throw new Error(`Duplicate ${storeName} id: ${record.id}`);
+    records.push(record);
+    data[storeName] = records;
+    await replaceAllData(data);
+    return record;
+  },
+  async clear() {
+    await (await getRepository()).clearAllData();
+  },
+  exportAll: async () => (await getRepository()).exportAllData(),
+};
+async function batchPut(recordsByStore) {
+  const data = await (await getRepository()).exportAllData();
+  for (const [storeName, records] of Object.entries(recordsByStore)) {
+    const existing = data[storeName] ?? [];
+    const byId = new Map(existing.map((record) => [record.id, record]));
+    for (const record of records) byId.set(record.id, record);
+    data[storeName] = [...byId.values()];
+  }
+  await replaceAllData(data);
+}
+
 const state = {
   apps: [],
   bundle: null,
@@ -858,7 +795,8 @@ async function newApplication() {
     status: "applied",
     source: "",
     postingUrl: "",
-    appliedAt: day(ts),
+    appliedAt: ts,
+    origin: "application_submitted",
     createdAt: ts,
     updatedAt: ts,
     unsaved: true,

--- a/test/web-storage-browser-data-migration.test.js
+++ b/test/web-storage-browser-data-migration.test.js
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  browserApplicationCanonicalEventTypeSchema,
+  browserApplicationExportSchema,
+  browserApplicationOriginSchema,
+} from "../src/domain/browserApplication.js";
+import { upgradeBrowserExportToV2 } from "../src/web/storage/browserDataMigration.js";
+
+const now = "2026-01-02T03:04:05.000Z";
+const app = {
+  id: "app_fake_001",
+  company: "Example Robotics",
+  role: "Staff Engineer",
+  status: "applied",
+  source: "direct",
+  appliedAt: now,
+  createdAt: now,
+  updatedAt: now,
+};
+const base = {
+  schemaVersion: 1,
+  exportedAt: now,
+  applications: [app],
+  contacts: [],
+  outreachMessages: [],
+  lifecycleEvents: [
+    {
+      id: "event_fake_001",
+      applicationId: app.id,
+      status: "applied",
+      occurredAt: now,
+      source: "manual",
+      createdAt: now,
+    },
+  ],
+  interviews: [],
+  offers: [],
+  artifacts: [],
+  reminders: [],
+};
+
+describe("browser data v2 migration", () => {
+  it("pins the exact origin and canonical event vocabularies", () => {
+    expect(browserApplicationOriginSchema.options).toEqual([
+      "application_submitted",
+      "recruiter_company_outreach",
+      "candidate_outreach",
+      "referral",
+      "other_unknown",
+    ]);
+    expect(browserApplicationCanonicalEventTypeSchema.options).toContain(
+      "migration_status_snapshot",
+    );
+    expect(browserApplicationCanonicalEventTypeSchema.options).not.toContain(
+      "offer_declined_by_candidate",
+    );
+  });
+
+  it("upgrades v1 data to canonical validated v2 deterministically", () => {
+    const first = upgradeBrowserExportToV2(base, { migrationCreatedAt: now });
+    const second = upgradeBrowserExportToV2(base, { migrationCreatedAt: now });
+
+    expect(first.data).toEqual(second.data);
+    expect(first.data.schemaVersion).toBe(2);
+    expect(first.data.applications[0]).toMatchObject({
+      id: app.id,
+      source: "direct",
+      origin: "application_submitted",
+    });
+    expect(first.data.lifecycleEvents[0]).toMatchObject({
+      eventType: "application_submitted",
+      occurredAtPrecision: "instant",
+      inferred: false,
+      createdAt: now,
+    });
+    expect(() =>
+      browserApplicationExportSchema.parse(first.data),
+    ).not.toThrow();
+  });
+
+  it("does not treat direct, email, linkedin, or sourcing as origin aliases", () => {
+    for (const source of ["direct", "email", "linkedin", "sourcing"]) {
+      const { data } = upgradeBrowserExportToV2(
+        {
+          ...base,
+          applications: [{ ...app, source, appliedAt: undefined }],
+          lifecycleEvents: [],
+        },
+        { migrationCreatedAt: now },
+      );
+      expect(data.applications[0].origin).toBe("other_unknown");
+    }
+  });
+
+  it("maps exact legacy event aliases and preserves rawEventType", () => {
+    const { data } = upgradeBrowserExportToV2(
+      {
+        ...base,
+        lifecycleEvents: [
+          {
+            ...base.lifecycleEvents[0],
+            eventType: "technical_screen_completed",
+          },
+        ],
+      },
+      { migrationCreatedAt: now },
+    );
+    expect(data.lifecycleEvents[0]).toMatchObject({
+      eventType: "technical_interview",
+      rawEventType: "technical_screen_completed",
+    });
+  });
+
+  it("is idempotent for its own v2 output", () => {
+    const { data } = upgradeBrowserExportToV2(base, {
+      migrationCreatedAt: now,
+    });
+    expect(
+      upgradeBrowserExportToV2(data, { migrationCreatedAt: now }).data,
+    ).toEqual(data);
+  });
+});


### PR DESCRIPTION
### Motivation

- Implement the Phase‑2 contract from the Application Lifecycle Diagram design to introduce a canonical v2 browser/export schema and make migration deterministic and conservative. 
- Consolidate IndexedDB access so a single production repository implementation owns opening, migrations, schema validation, CRUD, import/export, and clear-data behavior.

### Description

- Add v2 vocabulary and validation: exported `browserApplicationOriginSchema`, `browserApplicationCanonicalEventTypeSchema`, v2 lifecycle event schema with `occurredAtPrecision`, `inferred`, `rawEventType`, `previousStatus`, `supersedesEventId`, and new settings/export version constants; preserve explicit v1 schemas for legacy import. (see `src/domain/browserApplication.js`).
- Implement pure, deterministic, idempotent upgrader `upgradeBrowserExportToV2(input, options?)` with exact legacy-event allowlist, timestamp/precision normalization, exact origin inference precedence, safe warnings, deterministic IDs, and single migration snapshot semantics. (see `src/web/storage/browserDataMigration.js`).
- Bump IndexedDB version to v2, add `applications.by_origin` and `lifecycleEvents.by_occurredAt` indexes, and wire repository to run safe transactional migration paths using the canonical upgrader; centralize import/export validation and add lazy existing-data migration during repository creation. (see `src/web/storage/indexedDbRepository.js`).
- Update spreadsheet/CSV/NDJSON/JSON import-export paths to normalize inputs through the v2 upgrader, emit v2 compact CSV columns including `origin` and lifecycle CSV v2 columns, and preserve lifecycle precision flags for round trips. (see `src/web/import-export/spreadsheet.js`).
- Refactor tracker to use the new repository API (`createIndexedDbRepository()`), removing ad-hoc `indexedDB.open()`/migration code, and adapt the local tracker adapter to the repository's narrow methods while preserving UI behavior. (see `src/web/tracker/tracker.js`).
- Add focused tests covering vocabularies, deterministic/idempotent v1→v2 upgrades, origin inference rules, exact legacy event mappings and `rawEventType` preservation. (see `test/web-storage-browser-data-migration.test.js`).

### Testing

- Ran lint and typecheck: `npm run lint -- --max-warnings=0` (passed) and `npm run typecheck` (passed). 
- Ran the new focused migration test: `npx vitest run test/web-storage-browser-data-migration.test.js` (all tests in that file passed). 
- Exercised repository behavior locally against `fake-indexeddb` (opened v2 DB and verified new indexes are created). 
- Noted remaining verification state: `npm run format:check` reported pre-existing repository-wide formatting warnings unrelated to this change, and full test runs that include legacy v1‑expecting suites (for example `test/browser-application-schema.test.js` and `test/web-storage-indexeddb-repository.test.js`) showed failing assertions until the suite expectations are aligned with v2 semantics—this PR intentionally changes canonical schema/exports so follow-up targeted test updates or dependent fixes may be required. 

If you want, I can split any remaining test-suite adjustments into a follow-up PR or continue adapter work so all legacy tests run green in this branch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a514614164c832fb434026a6c445b80)