### PR TITLE
Persist browser lifecycle mutations atomically and add reconciliation planner

### DIFF
--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -186,6 +186,7 @@ export const browserApplicationOfferSchema = z
       "accepted",
       "declined",
       "expired",
+      "rescinded",
     ]),
     baseSalaryMin: z.number().nonnegative().optional(),
     baseSalaryMax: z.number().nonnegative().optional(),

--- a/src/web/storage/indexedDbRepository.js
+++ b/src/web/storage/indexedDbRepository.js
@@ -462,6 +462,130 @@ const validateImport = (data) => {
   return { parsed: result.data, warnings: upgraded.warnings };
 };
 
+const validateSupersessionGraph = (events) => {
+  const byId = new Map(events.map((event) => [event.id, event]));
+  for (const event of events) {
+    if (!event.supersedesEventId) continue;
+    const target = byId.get(event.supersedesEventId);
+    if (!target) {
+      throw new IndexedDbRepositoryError(
+        "schema_validation_failed",
+        "Superseded lifecycle event does not exist.",
+        { details: { supersedesEventId: event.supersedesEventId } },
+      );
+    }
+    if (target.applicationId !== event.applicationId) {
+      throw new IndexedDbRepositoryError(
+        "schema_validation_failed",
+        "Superseded lifecycle event belongs to another application.",
+        { details: { supersedesEventId: event.supersedesEventId } },
+      );
+    }
+    const seen = new Set([event.id]);
+    let cursor = target;
+    while (cursor?.supersedesEventId) {
+      if (seen.has(cursor.supersedesEventId)) {
+        throw new IndexedDbRepositoryError(
+          "schema_validation_failed",
+          "Lifecycle event supersession chain must be acyclic.",
+          { details: { eventId: event.id } },
+        );
+      }
+      seen.add(cursor.supersedesEventId);
+      cursor = byId.get(cursor.supersedesEventId);
+    }
+  }
+};
+
+const parseLifecycleMutation = async (db, mutation) => {
+  const operationTime = mutation.operationTime ?? new Date().toISOString();
+  const applicationInput = mutation.application ?? mutation.upsertApplication;
+  if (!applicationInput?.id) {
+    throw new IndexedDbRepositoryError(
+      "schema_validation_failed",
+      "Lifecycle mutation requires an application.",
+    );
+  }
+  const existingApplication = await getAll(db, "applications").then((rows) =>
+    rows.find((row) => row.id === applicationInput.id),
+  );
+  const application = parseRecord("applications", {
+    ...applicationInput,
+    updatedAt: applicationInput.updatedAt ?? operationTime,
+    createdAt:
+      applicationInput.createdAt ??
+      existingApplication?.createdAt ??
+      operationTime,
+  });
+  const previousStatus = existingApplication?.status;
+  const childRecords = mutation.records ?? {};
+  const parsed = {
+    application,
+    contacts: (childRecords.contacts ?? mutation.contacts ?? []).map((row) =>
+      parseRecord("contacts", row),
+    ),
+    outreachMessages: (
+      childRecords.outreachMessages ??
+      mutation.outreachMessages ??
+      []
+    ).map((row) => parseRecord("outreachMessages", row)),
+    interviews: (childRecords.interviews ?? mutation.interviews ?? []).map(
+      (row) => parseRecord("interviews", row),
+    ),
+    offers: (childRecords.offers ?? mutation.offers ?? []).map((row) =>
+      parseRecord("offers", row),
+    ),
+    artifacts: (childRecords.artifacts ?? mutation.artifacts ?? []).map((row) =>
+      parseRecord("artifacts", row),
+    ),
+    reminders: (childRecords.reminders ?? mutation.reminders ?? []).map((row) =>
+      parseRecord("reminders", row),
+    ),
+    lifecycleEvents: (
+      childRecords.lifecycleEvents ??
+      mutation.lifecycleEvents ??
+      []
+    ).map((row) =>
+      parseRecord("lifecycleEvents", {
+        ...row,
+        previousStatus: row.previousStatus ?? previousStatus,
+        createdAt: row.createdAt ?? operationTime,
+      }),
+    ),
+  };
+  for (const [storeName, rows] of Object.entries(parsed)) {
+    if (storeName === "application") continue;
+    for (const row of rows) {
+      if (row.applicationId !== application.id) {
+        throw new IndexedDbRepositoryError(
+          "schema_validation_failed",
+          "Lifecycle mutation child records must reference the mutated application.",
+          { details: { storeName, applicationId: row.applicationId } },
+        );
+      }
+    }
+  }
+  const contacts = new Set(parsed.contacts.map((row) => row.id));
+  for (const row of [...parsed.outreachMessages, ...parsed.reminders])
+    if (row.contactId && !contacts.has(row.contactId)) {
+      const existing = await getAll(db, "contacts");
+      if (
+        !existing.some(
+          (contact) =>
+            contact.id === row.contactId &&
+            contact.applicationId === application.id,
+        )
+      )
+        throw new IndexedDbRepositoryError(
+          "schema_validation_failed",
+          "Lifecycle mutation references an unknown contact.",
+        );
+    }
+  const existingEvents = await getAll(db, "lifecycleEvents");
+  validateSupersessionGraph([...existingEvents, ...parsed.lifecycleEvents]);
+  return { operationTime, previousStatus, ...parsed };
+};
+
 export const createIndexedDbRepository = async (options = {}) => {
   let db;
   try {
@@ -707,6 +831,43 @@ export const createIndexedDbRepository = async (options = {}) => {
     },
     createOffer(record) {
       return safe(() => addChildRecord(db, "offers", record));
+    },
+
+    async commitLifecycleMutation(mutation) {
+      return safe(async () => {
+        const parsed = await parseLifecycleMutation(db, mutation);
+        const stores = [
+          "applications",
+          "contacts",
+          "outreachMessages",
+          "interviews",
+          "offers",
+          "artifacts",
+          "reminders",
+          "lifecycleEvents",
+        ].filter(
+          (storeName) =>
+            storeName === "applications" || parsed[storeName]?.length > 0,
+        );
+        const tx = db.transaction(stores, "readwrite");
+        const done = transactionDone(tx);
+        tx.objectStore("applications").put(parsed.application);
+        for (const storeName of stores.filter(
+          (name) => name !== "applications" && name !== "lifecycleEvents",
+        ))
+          for (const row of parsed[storeName])
+            tx.objectStore(storeName).put(row);
+        if (stores.includes("lifecycleEvents"))
+          for (const row of parsed.lifecycleEvents)
+            tx.objectStore("lifecycleEvents").add(row);
+        await done;
+        return {
+          application: parsed.application,
+          lifecycleEvents: parsed.lifecycleEvents,
+          previousStatus: parsed.previousStatus,
+          operationTime: parsed.operationTime,
+        };
+      });
     },
     async importPartialData(recordsByStore) {
       return safe(async () => {

--- a/src/web/tracker/lifecycleReconciliation.js
+++ b/src/web/tracker/lifecycleReconciliation.js
@@ -1,0 +1,320 @@
+const ORIGINS = [
+  "application_submitted",
+  "recruiter_company_outreach",
+  "candidate_outreach",
+  "referral",
+  "other_unknown",
+];
+
+const STATUS_ENDPOINT = {
+  applied: "awaiting_response",
+  outreach_sent: "awaiting_response",
+  recruiter_screen: "interviewing",
+  technical_screen: "interviewing",
+  onsite_loop: "interviewing",
+  offer: "offer_negotiating",
+  accepted: "offer_accepted",
+  rejected: "employer_rejected",
+  withdrawn: "candidate_withdrew",
+  closed_archived: "closed_archived",
+};
+
+const STATUS_EVENT = {
+  applied: "application_submitted",
+  outreach_sent: "candidate_outreach",
+  recruiter_screen: "recruiter_screen",
+  technical_screen: "technical_interview",
+  onsite_loop: "onsite_final_loop",
+  offer: "offer_received",
+  accepted: "offer_accepted",
+  rejected: "employer_rejected",
+  withdrawn: "candidate_withdrew",
+  closed_archived: "closed_archived",
+};
+
+const INTERVIEW_EVENT = {
+  recruiter_screen: "recruiter_screen",
+  technical_screen: "technical_interview",
+  onsite_loop: "onsite_final_loop",
+};
+
+const OFFER_EVENT = {
+  received: "offer_received",
+  negotiating: "offer_negotiating",
+  accepted: "offer_accepted",
+  declined: "offer_declined",
+  expired: "offer_expired_rescinded",
+  rescinded: "offer_expired_rescinded",
+};
+
+const OFFER_APP_STATUS = { accepted: "accepted" };
+
+const safeWarning = (code, applicationId, extra = {}) => ({
+  code,
+  applicationId,
+  ...extra,
+});
+
+const effectiveEvents = (events) => {
+  const superseded = new Set(
+    events.map((event) => event.supersedesEventId).filter(Boolean),
+  );
+  return events.filter((event) => !superseded.has(event.id));
+};
+
+const eventKey = (event) =>
+  [
+    event.applicationId,
+    event.eventType,
+    event.sourceArtifact ?? "",
+    event.actionStatus ?? "",
+    event.status ?? "",
+  ].join("|");
+
+const deterministicId = (...parts) =>
+  `event_reconcile_${parts
+    .join("_")
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")}`.slice(0, 180);
+
+const precisionFor = (value) =>
+  /^\d{4}-\d{2}-\d{2}$/.test(String(value)) ? "date" : "instant";
+
+const makeEvent = ({
+  application,
+  eventType,
+  at,
+  childId,
+  status,
+  actionStatus,
+}) => ({
+  id: deterministicId(application.id, eventType, childId ?? status ?? "state"),
+  applicationId: application.id,
+  eventType,
+  status: status ?? application.status,
+  occurredAt: at,
+  occurredAtPrecision: precisionFor(at),
+  inferred: true,
+  source: "reconciliation",
+  previousStatus: application.status,
+  sourceArtifact: childId,
+  actionStatus,
+  createdAt: at,
+});
+
+const replayEndpoint = (events) => {
+  const sorted = [...events].sort((a, b) =>
+    `${a.occurredAt}|${a.id}`.localeCompare(`${b.occurredAt}|${b.id}`),
+  );
+  let terminal;
+  for (const event of sorted) {
+    if (event.eventType === "application_reopened") terminal = undefined;
+    if (
+      [
+        "employer_rejected",
+        "candidate_withdrew",
+        "offer_declined",
+        "offer_expired_rescinded",
+        "offer_accepted",
+        "closed_archived",
+      ].includes(event.eventType)
+    )
+      terminal = event.eventType;
+  }
+  if (terminal) return terminal;
+  if (
+    sorted.some((event) =>
+      ["offer_received", "offer_negotiating"].includes(event.eventType),
+    )
+  )
+    return "offer_negotiating";
+  if (
+    sorted.some(
+      (event) =>
+        event.eventType === "assessment_take_home" &&
+        ["requested", "pending", "started", "in_progress"].includes(
+          event.actionStatus,
+        ),
+    )
+  )
+    return "assessment_in_progress";
+  if (
+    sorted.some((event) =>
+      ["recruiter_screen", "technical_interview", "onsite_final_loop"].includes(
+        event.eventType,
+      ),
+    )
+  )
+    return "interviewing";
+  if (sorted.length) return "awaiting_response";
+  return "unknown";
+};
+
+export function planLifecycleReconciliation(bundle) {
+  const applications = [...(bundle.applications ?? [])].sort((a, b) =>
+    a.id.localeCompare(b.id),
+  );
+  const events = bundle.lifecycleEvents ?? [];
+  const warnings = [];
+  const plans = [];
+  for (const application of applications) {
+    const appEvents = events.filter(
+      (event) => event.applicationId === application.id,
+    );
+    const effective = effectiveEvents(appEvents);
+    const existingKeys = new Set(effective.map(eventKey));
+    const additions = [];
+    const add = (event) => {
+      const key = eventKey(event);
+      if (
+        existingKeys.has(key) ||
+        additions.some((item) => eventKey(item) === key)
+      )
+        return;
+      additions.push(event);
+    };
+
+    if (!effective.some((event) => ORIGINS.includes(event.eventType))) {
+      const at = application.appliedAt ?? application.createdAt;
+      if (!at)
+        warnings.push(safeWarning("missing_origin_timestamp", application.id));
+      add(
+        makeEvent({
+          application,
+          eventType: application.origin ?? "other_unknown",
+          at: at ?? "1970-01-01",
+          status: application.status,
+          childId: "origin",
+        }),
+      );
+      if (!at) additions.at(-1).occurredAtPrecision = "unknown";
+    }
+
+    for (const message of [...(bundle.outreachMessages ?? [])]
+      .filter((row) => row.applicationId === application.id)
+      .sort((a, b) => a.id.localeCompare(b.id))) {
+      const at =
+        message.direction === "inbound" ? message.receivedAt : message.sentAt;
+      if (!at) {
+        warnings.push(
+          safeWarning("unknown_occurrence_precision", application.id, {
+            childStore: "outreachMessages",
+          }),
+        );
+        continue;
+      }
+      add(
+        makeEvent({
+          application,
+          eventType:
+            message.direction === "inbound"
+              ? "employer_response_received"
+              : "candidate_outreach",
+          at,
+          childId: message.id,
+        }),
+      );
+    }
+
+    for (const interview of [...(bundle.interviews ?? [])]
+      .filter((row) => row.applicationId === application.id)
+      .sort((a, b) => a.id.localeCompare(b.id))) {
+      const eventType = ["cancelled", "no_show"].includes(interview.outcome)
+        ? "status_changed"
+        : (INTERVIEW_EVENT[interview.stage] ?? "status_changed");
+      if (eventType === "status_changed")
+        warnings.push(
+          safeWarning("unreconciled_child_activity", application.id, {
+            childStore: "interviews",
+          }),
+        );
+      if (interview.startsAt)
+        add(
+          makeEvent({
+            application,
+            eventType,
+            at: interview.startsAt,
+            childId: interview.id,
+          }),
+        );
+    }
+
+    for (const offer of [...(bundle.offers ?? [])]
+      .filter((row) => row.applicationId === application.id)
+      .sort((a, b) => a.id.localeCompare(b.id))) {
+      const eventType = OFFER_EVENT[offer.status];
+      if (!eventType) {
+        warnings.push(
+          safeWarning("unreconciled_child_activity", application.id, {
+            childStore: "offers",
+          }),
+        );
+        continue;
+      }
+      add(
+        makeEvent({
+          application,
+          eventType,
+          at: offer.updatedAt ?? offer.createdAt,
+          childId: offer.id,
+          status: OFFER_APP_STATUS[offer.status] ?? "offer",
+        }),
+      );
+    }
+
+    const projected = replayEndpoint([...effective, ...additions]);
+    if (
+      STATUS_ENDPOINT[application.status] &&
+      projected !== STATUS_ENDPOINT[application.status]
+    ) {
+      warnings.push(safeWarning("status_history_mismatch", application.id));
+      const snapshotExists = effective.some(
+        (event) => event.eventType === "migration_status_snapshot",
+      );
+      if (!snapshotExists) {
+        warnings.push(safeWarning("status_snapshot_inferred", application.id));
+        const snapshot = makeEvent({
+          application,
+          eventType: "migration_status_snapshot",
+          at: application.updatedAt ?? application.createdAt ?? "1970-01-01",
+          childId: `status_${application.status}`,
+          status: application.status,
+        });
+        snapshot.occurredAtPrecision = "unknown";
+        snapshot.rawEventType =
+          STATUS_EVENT[application.status] ?? "status_changed";
+        add(snapshot);
+      }
+    }
+
+    if (
+      effective.some(
+        (event) =>
+          event.previousStatus && event.previousStatus !== application.status,
+      )
+    )
+      warnings.push(safeWarning("regressive_history", application.id));
+    additions.sort((a, b) => a.id.localeCompare(b.id));
+    if (additions.length)
+      plans.push({ applicationId: application.id, additions });
+  }
+  plans.sort((a, b) => a.applicationId.localeCompare(b.applicationId));
+  return {
+    plans,
+    additions: plans.flatMap((plan) => plan.additions),
+    warnings: warnings.sort((a, b) =>
+      `${a.applicationId}|${a.code}`.localeCompare(
+        `${b.applicationId}|${b.code}`,
+      ),
+    ),
+    counts: {
+      applications: applications.length,
+      plannedApplications: plans.length,
+      plannedEvents: plans.reduce(
+        (sum, plan) => sum + plan.additions.length,
+        0,
+      ),
+      warnings: warnings.length,
+    },
+  };
+}

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -25,6 +25,7 @@ import {
   selectDashboardMetrics,
 } from "./metrics.js";
 import { createIndexedDbRepository } from "../storage/indexedDbRepository.js";
+import { planLifecycleReconciliation } from "./lifecycleReconciliation.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
 const ARRAY_STORES = [
@@ -49,6 +50,13 @@ const STATUSES = [
   "withdrawn",
   "closed_archived",
 ];
+const ORIGINS = [
+  "application_submitted",
+  "recruiter_company_outreach",
+  "candidate_outreach",
+  "referral",
+  "other_unknown",
+];
 const OUTCOMES = new Set([
   "offer",
   "accepted",
@@ -61,6 +69,20 @@ const $$ = (s, r = document) => Array.from(r.querySelectorAll(s));
 const now = () => new Date().toISOString();
 const day = (v) => (v ? String(v).slice(0, 10) : "");
 const STATUS_RANK = Object.fromEntries(STATUSES.map((s, i) => [s, i]));
+const STATUS_EVENT_TYPE = {
+  applied: "status_changed",
+  outreach_sent: "candidate_outreach",
+  recruiter_screen: "recruiter_screen",
+  technical_screen: "technical_interview",
+  onsite_loop: "onsite_final_loop",
+  offer: "offer_received",
+  accepted: "offer_accepted",
+  rejected: "employer_rejected",
+  withdrawn: "candidate_withdrew",
+  closed_archived: "closed_archived",
+};
+const statusEventType = (status) =>
+  STATUS_EVENT_TYPE[status] ?? "status_changed";
 const esc = (v) =>
   String(v ?? "").replace(
     /[&<>"]/g,
@@ -104,10 +126,36 @@ const repo = {
   },
   clear: async () => (await getRepository()).clearAllData(),
   exportAll: async () => (await getRepository()).exportAllData(),
+  commitLifecycleMutation: async (mutation) =>
+    (await getRepository()).commitLifecycleMutation(mutation),
 };
 async function batchImport(recordsByStore) {
   return (await getRepository()).importPartialData(recordsByStore);
 }
+async function currentBundle() {
+  return Object.fromEntries(
+    await Promise.all(
+      ARRAY_STORES.map(async (name) => [name, await repo.list(name)]),
+    ),
+  );
+}
+async function applyLifecycleReconciliation() {
+  const bundle = await currentBundle();
+  const plan = planLifecycleReconciliation(bundle);
+  state.reconciliationWarnings = plan.warnings;
+  const apps = new Map(bundle.applications.map((app) => [app.id, app]));
+  for (const applicationPlan of plan.plans) {
+    const application = apps.get(applicationPlan.applicationId);
+    if (!application) continue;
+    await repo.commitLifecycleMutation({
+      application,
+      lifecycleEvents: applicationPlan.additions,
+    });
+  }
+  return plan;
+}
+if (typeof window !== "undefined")
+  window.jobbotApplyLifecycleReconciliation = applyLifecycleReconciliation;
 const state = {
   apps: [],
   bundle: null,
@@ -117,6 +165,7 @@ const state = {
   dir: -1,
   current: null,
   detailSave: Promise.resolve(),
+  reconciliationWarnings: [],
 };
 function weekBucket(value) {
   const d = day(value);
@@ -658,12 +707,12 @@ function detailForm(app) {
         "Compact CSV assessment signal",
     });
   }
-  return `<div class="tracker-detail"><article class="card"><h2>${esc(app.company || "New application")} — ${esc(app.role || "Unsaved")}</h2><form class="tracker-form" data-core-form>${input("company", app.company, true)}${input("role", app.role, true)}${input("postingUrl", app.postingUrl, "url")}<label>Status<select name="status" required>${STATUSES.map((s) => `<option ${app.status === s ? "selected" : ""}>${s}</option>`).join("")}</select></label>${input("source", app.source, "text")}${input("appliedAt", day(app.appliedAt), "date", true)}${input("followUpDate", day(app.followUpDate), "date")}<label>Notes<textarea name="notes">${esc(app.notes)}</textarea></label><button class="button">Save application</button></form></article><article class="card"><h3>Compact CSV metadata</h3>${metadataSection(app)}</article><article class="card wide-card"><h3>Lifecycle timeline</h3><p class="muted">Events are sorted by occurred date, then due date, then stable ID. All data stays local in this browser.</p><ul class="timeline">${events.map(timelineItem).join("") || '<li class="muted">No lifecycle events for this application yet.</li>'}</ul></article><article class="card"><h3>Assessments/take-homes</h3>${assessments.length ? `<ul>${assessments.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No written assessments or take-homes yet.</p>'}</article><article class="card"><h3>Recruiter screens</h3>${recruiterScreens.length ? `<ul>${recruiterScreens.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No recruiter screens yet.</p>'}</article><article class="card"><h3>Interviews</h3><form class="tracker-form" data-interview-form><label>Stage<select name="stage"><option>recruiter_screen</option><option>technical_screen</option><option>onsite_loop</option><option>other</option></select></label>${input("startsAt", day(now()), "date")}<button class="button">Log interview</button></form><ul>${otherInterviews.map((i) => `<li>${day(i.startsAt)} ${esc(i.stage)} ${esc(i.outcome)}</li>`).join("") || '<li class="muted">No non-recruiter interviews yet.</li>'}</ul></article><article class="card"><h3>Links/artifacts</h3><form class="tracker-form" data-artifact-form>${input("name", "", true)}${input("url", "")}<button class="button">Add link/artifact</button></form><ul>${m.artifacts.map((a) => `<li>${linkForArtifact(a)}</li>`).join("")}</ul></article><article class="card"><h3>Outreach messages</h3><form class="tracker-form" data-outreach-form><label>Channel<select name="channel"><option>email</option><option>linkedin</option><option>phone</option><option>sms</option><option>other</option></select></label><label>Message<textarea name="body" required></textarea></label><button class="button">Add outreach</button></form><ul>${m.outreach.map((o) => `<li>${day(o.sentAt)} ${esc(o.channel)} ${esc(o.body)}</li>`).join("")}</ul></article><article class="card"><h3>Offers</h3><form class="tracker-form" data-offer-form><label>Status<select name="status"><option>received</option><option>negotiating</option><option>accepted</option><option>declined</option></select></label>${input("notes", "")}<button class="button">Log offer</button></form><ul>${m.offers.map((o) => `<li>${esc(o.status)} ${esc(o.notes || "")}</li>`).join("")}</ul></article></div>`;
+  return `<div class="tracker-detail"><article class="card"><h2>${esc(app.company || "New application")} — ${esc(app.role || "Unsaved")}</h2><form class="tracker-form" data-core-form>${input("company", app.company, true)}${input("role", app.role, true)}${input("postingUrl", app.postingUrl, "url")}<label>Status<select name="status" required>${STATUSES.map((s) => `<option ${app.status === s ? "selected" : ""}>${s}</option>`).join("")}</select></label><label>Origin<select name="origin" required>${ORIGINS.map((origin) => `<option value="${origin}" ${app.origin === origin ? "selected" : ""}>${origin}</option>`).join("")}</select></label>${input("source", app.source, "text")}${input("appliedAt", day(app.appliedAt), "date", app.status === "applied", "Application date (if applicable)")}${input("followUpDate", day(app.followUpDate), "date")}<label>Notes<textarea name="notes">${esc(app.notes)}</textarea></label><button class="button">Save application</button></form></article><article class="card"><h3>Compact CSV metadata</h3>${metadataSection(app)}</article><article class="card wide-card"><h3>Lifecycle timeline</h3><p class="muted">Events are sorted by occurred date, then due date, then stable ID. All data stays local in this browser.</p><ul class="timeline">${events.map(timelineItem).join("") || '<li class="muted">No lifecycle events for this application yet.</li>'}</ul></article><article class="card"><h3>Assessments/take-homes</h3><form class="tracker-form" data-assessment-form><label>Action status<select name="actionStatus"><option>requested</option><option>pending</option><option>started</option><option>in_progress</option><option>submitted</option><option>completed</option></select></label>${input("dueAt", "", "date")}${input("details", "")}<button class="button">Log assessment</button></form>${assessments.length ? `<ul>${assessments.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No written assessments or take-homes yet.</p>'}</article><article class="card"><h3>Recruiter screens</h3>${recruiterScreens.length ? `<ul>${recruiterScreens.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No recruiter screens yet.</p>'}</article><article class="card"><h3>Interviews</h3><form class="tracker-form" data-interview-form><label>Stage<select name="stage"><option>recruiter_screen</option><option>technical_screen</option><option>onsite_loop</option><option>other</option></select></label><label>Outcome<select name="outcome"><option>scheduled</option><option>completed</option><option>cancelled</option><option>no_show</option></select></label>${input("startsAt", day(now()), "date")}<button class="button">Log interview</button></form><ul>${otherInterviews.map((i) => `<li>${day(i.startsAt)} ${esc(i.stage)} ${esc(i.outcome)}</li>`).join("") || '<li class="muted">No non-recruiter interviews yet.</li>'}</ul></article><article class="card"><h3>Links/artifacts</h3><form class="tracker-form" data-artifact-form>${input("name", "", true)}${input("url", "")}<button class="button">Add link/artifact</button></form><ul>${m.artifacts.map((a) => `<li>${linkForArtifact(a)}</li>`).join("")}</ul></article><article class="card"><h3>Outreach messages</h3><form class="tracker-form" data-outreach-form><label>Direction<select name="direction"><option value="outbound">Outbound</option><option value="inbound">Inbound</option></select></label><label>Channel<select name="channel"><option>email</option><option>linkedin</option><option>phone</option><option>sms</option><option>other</option></select></label><label>Message<textarea name="body" required></textarea></label><button class="button">Add outreach</button></form><ul>${m.outreach.map((o) => `<li>${day(o.sentAt || o.receivedAt)} ${esc(o.direction)} ${esc(o.channel)} ${esc(o.body)}</li>`).join("")}</ul></article><article class="card"><h3>Offers</h3><form class="tracker-form" data-offer-form><label>Status<select name="status"><option>received</option><option>negotiating</option><option>accepted</option><option>declined</option><option>expired</option><option>rescinded</option></select></label>${input("notes", "")}<button class="button">Log offer</button></form><ul>${m.offers.map((o) => `<li>${esc(o.status)} ${esc(o.notes || "")}</li>`).join("")}</ul></article></div>`;
 }
-function input(n, v = "", type = "text", required = false) {
+function input(n, v = "", type = "text", required = false, label = n) {
   const req = type === true || required ? "required" : "";
   type = type === true ? "text" : type;
-  return `<label>${n}<input name="${n}" type="${type}" value="${esc(v)}" ${req}></label>`;
+  return `<label>${label}<input name="${n}" type="${type}" value="${esc(v)}" ${req}></label>`;
 }
 function values(form) {
   return Object.fromEntries(new FormData(form).entries());
@@ -710,26 +759,53 @@ function bindDetail(app) {
           source: optionalBlankToUndefined(v.source),
           postingUrl: optionalBlankToUndefined(v.postingUrl),
           notes: optionalBlankToUndefined(v.notes),
-          origin: current.origin ?? "other_unknown",
+          origin: v.origin ?? current.origin ?? "other_unknown",
           appliedAt: isoDate(v.appliedAt),
           followUpDate: isoDate(v.followUpDate),
           updatedAt: now(),
         };
         delete saved.unsaved;
-        await repo.put("applications", saved);
+        const operationTime = now();
+        const lifecycleEvents = [];
         if (!persisted || v.status !== current.status)
-          await repo.add("lifecycleEvents", {
+          lifecycleEvents.push({
             id: id("event"),
             applicationId: app.id,
-            eventType:
-              v.status === "applied" ? "application_submitted" : "status_changed",
+            eventType: !persisted
+              ? saved.origin
+              : OUTCOMES.has(current.status) && !OUTCOMES.has(v.status)
+                ? "application_reopened"
+                : statusEventType(v.status),
             status: v.status,
-            occurredAt: now(),
-            occurredAtPrecision: "instant",
+            occurredAt:
+              !persisted && saved.appliedAt ? saved.appliedAt : operationTime,
+            occurredAtPrecision:
+              !persisted && saved.appliedAt ? "instant" : "instant",
             inferred: false,
             source: "manual",
-            createdAt: now(),
+            createdAt: operationTime,
           });
+        const previousOriginEvent = sortedLifecycleEvents(app.id).find(
+          (event) => ORIGINS.includes(event.eventType),
+        );
+        if (persisted && v.origin !== current.origin)
+          lifecycleEvents.push({
+            id: id("event"),
+            applicationId: app.id,
+            eventType: v.origin,
+            status: saved.status,
+            occurredAt: operationTime,
+            occurredAtPrecision: "instant",
+            inferred: false,
+            supersedesEventId: previousOriginEvent?.id,
+            source: "manual",
+            createdAt: operationTime,
+          });
+        await repo.commitLifecycleMutation({
+          operationTime,
+          application: saved,
+          lifecycleEvents,
+        });
         await refresh();
         openDetail(app.id);
       });
@@ -760,24 +836,70 @@ function bindDetail(app) {
     e.preventDefault();
     const v = values(e.target);
     const current = latestApp();
-    await repo.add("outreachMessages", {
+    const operationTime = now();
+    const message = {
       id: id("msg"),
       applicationId: app.id,
-      direction: "outbound",
+      direction: v.direction || "outbound",
       channel: v.channel,
       body: v.body,
-      sentAt: now(),
-      createdAt: now(),
-      updatedAt: now(),
-    });
+      [v.direction === "inbound" ? "receivedAt" : "sentAt"]: operationTime,
+      createdAt: operationTime,
+      updatedAt: operationTime,
+    };
     const nextStatus =
       STATUS_RANK[current.status] >= STATUS_RANK.outreach_sent
         ? current.status
         : "outreach_sent";
-    await repo.put("applications", {
-      ...current,
-      status: nextStatus,
-      updatedAt: now(),
+    await repo.commitLifecycleMutation({
+      operationTime,
+      application: { ...current, status: nextStatus, updatedAt: operationTime },
+      outreachMessages: [message],
+      lifecycleEvents: [
+        {
+          id: id("event"),
+          applicationId: app.id,
+          eventType:
+            message.direction === "inbound"
+              ? "employer_response_received"
+              : "candidate_outreach",
+          status: nextStatus,
+          occurredAt: operationTime,
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          createdAt: operationTime,
+        },
+      ],
+    });
+    await refresh();
+    openDetail(app.id);
+  };
+
+  $("[data-assessment-form]").onsubmit = async (e) => {
+    e.preventDefault();
+    const v = values(e.target);
+    const current = latestApp();
+    const operationTime = now();
+    await repo.commitLifecycleMutation({
+      operationTime,
+      application: { ...current, updatedAt: operationTime },
+      lifecycleEvents: [
+        {
+          id: id("event"),
+          applicationId: app.id,
+          eventType: "assessment_take_home",
+          status: current.status,
+          actionStatus: v.actionStatus,
+          dueAt: isoDate(v.dueAt),
+          details: optionalBlankToUndefined(v.details),
+          occurredAt: operationTime,
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          createdAt: operationTime,
+        },
+      ],
     });
     await refresh();
     openDetail(app.id);
@@ -786,24 +908,48 @@ function bindDetail(app) {
     e.preventDefault();
     const v = values(e.target);
     const current = latestApp();
-    await repo.add("interviews", {
+    const operationTime = now();
+    const interview = {
       id: id("interview"),
       applicationId: app.id,
       contactIds: [],
       stage: v.stage,
       startsAt: isoDate(v.startsAt),
-      outcome: "scheduled",
-      createdAt: now(),
-      updatedAt: now(),
-    });
+      outcome: v.outcome,
+      createdAt: operationTime,
+      updatedAt: operationTime,
+    };
+    const achievedStage = !["cancelled", "no_show"].includes(v.outcome);
     const nextStatus =
-      v.stage !== "other" && STATUS_RANK[v.stage] > STATUS_RANK[current.status]
+      achievedStage &&
+      v.stage !== "other" &&
+      STATUS_RANK[v.stage] > STATUS_RANK[current.status]
         ? v.stage
         : current.status;
-    await repo.put("applications", {
-      ...current,
-      status: nextStatus,
-      updatedAt: now(),
+    await repo.commitLifecycleMutation({
+      operationTime,
+      application: { ...current, status: nextStatus, updatedAt: operationTime },
+      interviews: [interview],
+      lifecycleEvents: [
+        {
+          id: id("event"),
+          applicationId: app.id,
+          eventType:
+            v.stage === "recruiter_screen"
+              ? "recruiter_screen"
+              : v.stage === "technical_screen"
+                ? "technical_interview"
+                : v.stage === "onsite_loop"
+                  ? "onsite_final_loop"
+                  : "status_changed",
+          status: nextStatus,
+          occurredAt: operationTime,
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          createdAt: operationTime,
+        },
+      ],
     });
     await refresh();
     openDetail(app.id);
@@ -812,18 +958,42 @@ function bindDetail(app) {
     e.preventDefault();
     const v = values(e.target);
     const current = latestApp();
-    await repo.add("offers", {
+    const operationTime = now();
+    const offer = {
       id: id("offer"),
       applicationId: app.id,
       status: v.status,
       notes: v.notes || undefined,
-      createdAt: now(),
-      updatedAt: now(),
-    });
-    await repo.put("applications", {
-      ...current,
-      status: v.status === "accepted" ? "accepted" : "offer",
-      updatedAt: now(),
+      createdAt: operationTime,
+      updatedAt: operationTime,
+    };
+    const nextStatus = v.status === "accepted" ? "accepted" : "offer";
+    const offerEventType =
+      {
+        received: "offer_received",
+        negotiating: "offer_negotiating",
+        accepted: "offer_accepted",
+        declined: "offer_declined",
+        expired: "offer_expired_rescinded",
+        rescinded: "offer_expired_rescinded",
+      }[v.status] || "offer_received";
+    await repo.commitLifecycleMutation({
+      operationTime,
+      application: { ...current, status: nextStatus, updatedAt: operationTime },
+      offers: [offer],
+      lifecycleEvents: [
+        {
+          id: id("event"),
+          applicationId: app.id,
+          eventType: offerEventType,
+          status: nextStatus,
+          occurredAt: operationTime,
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          createdAt: operationTime,
+        },
+      ],
     });
     await refresh();
     openDetail(app.id);

--- a/test/web-tracker-lifecycle-persistence.test.js
+++ b/test/web-tracker-lifecycle-persistence.test.js
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { indexedDB } from "fake-indexeddb";
+
+import {
+  DATABASE_NAME,
+  createIndexedDbRepository,
+} from "../src/web/storage/indexedDbRepository.js";
+
+const now = "2026-01-02T03:04:05.000Z";
+const later = "2026-01-03T03:04:05.000Z";
+const application = {
+  id: "app_fake_001",
+  company: "Example Robotics",
+  role: "Engineer",
+  status: "applied",
+  origin: "application_submitted",
+  appliedAt: now,
+  createdAt: now,
+  updatedAt: now,
+};
+const event = {
+  id: "event_fake_001",
+  applicationId: application.id,
+  status: "applied",
+  eventType: "application_submitted",
+  occurredAt: now,
+  occurredAtPrecision: "instant",
+  inferred: false,
+  source: "manual",
+  createdAt: now,
+};
+
+const deleteDatabase = () =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(DATABASE_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => resolve();
+  });
+
+afterEach(async () => {
+  await deleteDatabase();
+});
+
+describe("lifecycle persistence", () => {
+  it("atomically persists an application and append-only lifecycle event", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await repo.commitLifecycleMutation({
+      application,
+      lifecycleEvents: [event],
+    });
+    const exported = await repo.exportAllData();
+    expect(exported.applications).toHaveLength(1);
+    expect(exported.lifecycleEvents).toMatchObject([{ id: event.id }]);
+    repo.close();
+  });
+
+  it("rolls back every store when an event add fails", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await expect(
+      repo.commitLifecycleMutation({
+        application,
+        lifecycleEvents: [event, { ...event, occurredAt: later }],
+      }),
+    ).rejects.toThrow();
+    const exported = await repo.exportAllData();
+    expect(exported.applications).toEqual([]);
+    expect(exported.lifecycleEvents).toEqual([]);
+    repo.close();
+  });
+
+  it("derives previous status from persisted state", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await repo.commitLifecycleMutation({
+      application,
+      lifecycleEvents: [event],
+    });
+    await repo.commitLifecycleMutation({
+      application: { ...application, status: "offer", updatedAt: later },
+      lifecycleEvents: [
+        {
+          ...event,
+          id: "event_fake_002",
+          eventType: "offer_received",
+          status: "offer",
+          occurredAt: later,
+          createdAt: later,
+        },
+      ],
+    });
+    const exported = await repo.exportAllData();
+    expect(
+      exported.lifecycleEvents.find((item) => item.id === "event_fake_002")
+        .previousStatus,
+    ).toBe("applied");
+    repo.close();
+  });
+
+  it("rejects cross-application supersession references", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await repo.commitLifecycleMutation({
+      application,
+      lifecycleEvents: [event],
+    });
+    const other = { ...application, id: "app_fake_002" };
+    await expect(
+      repo.commitLifecycleMutation({
+        application: other,
+        lifecycleEvents: [
+          {
+            ...event,
+            id: "event_fake_002",
+            applicationId: other.id,
+            supersedesEventId: event.id,
+          },
+        ],
+      }),
+    ).rejects.toThrow(/another application/i);
+    repo.close();
+  });
+});

--- a/test/web-tracker-lifecycle-reconciliation.test.js
+++ b/test/web-tracker-lifecycle-reconciliation.test.js
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+
+import { planLifecycleReconciliation } from "../src/web/tracker/lifecycleReconciliation.js";
+
+const now = "2026-01-02T03:04:05.000Z";
+const app = (overrides = {}) => ({
+  id: "app_fake_001",
+  company: "Example Robotics",
+  role: "Engineer",
+  status: "offer",
+  origin: "application_submitted",
+  appliedAt: now,
+  createdAt: now,
+  updatedAt: now,
+  ...overrides,
+});
+const bundle = (overrides = {}) => ({
+  applications: [app()],
+  lifecycleEvents: [],
+  outreachMessages: [],
+  interviews: [],
+  offers: [],
+  ...overrides,
+});
+
+describe("lifecycle reconciliation planner", () => {
+  it("plans deterministic structured child events and a single status snapshot", () => {
+    const input = bundle({
+      outreachMessages: [
+        {
+          id: "msg_fake_001",
+          applicationId: "app_fake_001",
+          direction: "inbound",
+          channel: "email",
+          body: "private body must not be copied",
+          receivedAt: "2026-01-03T00:00:00.000Z",
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+      interviews: [
+        {
+          id: "interview_fake_001",
+          applicationId: "app_fake_001",
+          contactIds: [],
+          stage: "technical_screen",
+          startsAt: "2026-02-01T00:00:00.000Z",
+          outcome: "scheduled",
+          createdAt: now,
+          updatedAt: now,
+        },
+      ],
+      offers: [
+        {
+          id: "offer_fake_001",
+          applicationId: "app_fake_001",
+          status: "declined",
+          createdAt: "2026-01-04T00:00:00.000Z",
+          updatedAt: "2026-01-05T00:00:00.000Z",
+        },
+      ],
+    });
+    const first = planLifecycleReconciliation(input);
+    expect(first.additions.map((event) => event.eventType)).toEqual([
+      "application_submitted",
+      "employer_response_received",
+      "migration_status_snapshot",
+      "offer_declined",
+      "technical_interview",
+    ]);
+    expect(JSON.stringify(first.warnings)).not.toContain("private body");
+    expect(
+      first.additions.filter(
+        (e) => e.eventType === "migration_status_snapshot",
+      ),
+    ).toHaveLength(1);
+
+    const second = planLifecycleReconciliation({
+      ...input,
+      lifecycleEvents: first.additions,
+    });
+    expect(second.additions).toEqual([]);
+  });
+
+  it("warns safely for unrecognized child activity and unknown origin timing", () => {
+    const result = planLifecycleReconciliation(
+      bundle({
+        applications: [
+          app({
+            appliedAt: undefined,
+            createdAt: undefined,
+            updatedAt: undefined,
+          }),
+        ],
+        interviews: [
+          {
+            id: "interview_private",
+            applicationId: "app_fake_001",
+            contactIds: [],
+            stage: "other",
+            outcome: "cancelled",
+            startsAt: "2026-03-01T00:00:00.000Z",
+            preparationNotes: "do not leak this",
+            createdAt: now,
+            updatedAt: now,
+          },
+        ],
+      }),
+    );
+    expect(result.warnings.map((warning) => warning.code)).toContain(
+      "missing_origin_timestamp",
+    );
+    expect(result.warnings.map((warning) => warning.code)).toContain(
+      "unreconciled_child_activity",
+    );
+    expect(JSON.stringify(result.warnings)).not.toContain("do not leak this");
+    expect(
+      result.additions.find((event) => event.sourceArtifact === "origin")
+        .occurredAtPrecision,
+    ).toBe("unknown");
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure every lifecycle-changing browser action writes append-only lifecycle events as the historical source of truth while keeping applications as the current projection, and make those writes atomic and validated.  
- Provide a conservative, deterministic, idempotent reconciliation planner that infers missing structured lifecycle events from child records without leaking private text.

### Description
- Added `commitLifecycleMutation` to the IndexedDB repository to parse, validate, derive `previousStatus` from persisted state, assert cross-record references, validate supersession graphs, and persist the application plus any child records and appended lifecycle events in a single required readwrite transaction.  
- Implemented a pure, deterministic planner `src/web/tracker/lifecycleReconciliation.js` that infers missing origin/outreach/interview/offer events, deduplicates by (application,eventType,childId,state), emits safe warnings, generates deterministic IDs, and produces idempotent no-op second runs.  
- Updated tracker UI save flows (`src/web/tracker/tracker.js`) to add origin selection, outreach direction, assessment form, interview outcome handling, expanded offer outcomes, and route all lifecycle-changing actions through `commitLifecycleMutation` so application + child + event writes are atomic and append-only.  
- Extended offer schema to include `rescinded` and added unit tests (`test/web-tracker-lifecycle-persistence.test.js`, `test/web-tracker-lifecycle-reconciliation.test.js`) covering atomic success/rollback, previous-status derivation, supersession rejection, deterministic planner behavior, safe warnings, and second-run no-op.

### Testing
- Ran formatting/lint/typecheck and focused formatting checks: `npx prettier --check <changed files>` passed for the modified files while `npm run format:check` reported unrelated repository-wide Prettier warnings; `npm run lint -- --quiet` and `npm run typecheck` both passed.  
- Ran unit tests with Vitest: `npx vitest run test/web-storage-indexeddb-repository.test.js test/web-tracker-lifecycle-persistence.test.js test/web-tracker-lifecycle-reconciliation.test.js test/web-spreadsheet-import-export.test.js` — all targeted tests passed (total tests run for these suites passed).  
- Built static assets and ran browser E2E: `npm run build` succeeded and `npx playwright test test/playwright/browser-tracker.spec.js` initially required `npx playwright install` which was executed to download browsers, after which the Playwright suite completed successfully (all browser-tracker tests passed).  
- Notes and limits: `npm run format:check` flagged pre-existing formatting issues across many unrelated files (not introduced by this change), and a longer `npm run test:ci` invocation was started during verification and was manually terminated due to an environment CLI hang, so the full CI script was not completed end-to-end in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51c79a1080832f80964d26f88c8eb1)