### PR TITLE
Complete tracker lifecycle persistence

### DIFF
--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -186,6 +186,7 @@ export const browserApplicationOfferSchema = z
       "accepted",
       "declined",
       "expired",
+      "rescinded",
     ]),
     baseSalaryMin: z.number().nonnegative().optional(),
     baseSalaryMax: z.number().nonnegative().optional(),

--- a/src/web/storage/indexedDbRepository.js
+++ b/src/web/storage/indexedDbRepository.js
@@ -420,9 +420,11 @@ const putChildRecord = async (db, storeName, record) => {
   return putRecord(db, storeName, parsed);
 };
 
-const assertSupersessionIsValid = (events) => {
-  const byId = new Map(events.map((event) => [event.id, event]));
-  for (const event of events) {
+const assertSupersessionIsValid = (existingEvents, newEvents) => {
+  const byId = new Map(
+    [...existingEvents, ...newEvents].map((event) => [event.id, event]),
+  );
+  for (const event of newEvents) {
     if (!event.supersedesEventId) continue;
     const superseded = byId.get(event.supersedesEventId);
     if (!superseded || superseded.applicationId !== event.applicationId) {
@@ -448,7 +450,7 @@ const assertSupersessionIsValid = (events) => {
   }
 };
 
-const normalizeMutation = async (db, mutation) => {
+const normalizeMutationInput = (mutation) => {
   const application = mutation.application
     ? parseRecord("applications", mutation.application)
     : null;
@@ -473,16 +475,11 @@ const normalizeMutation = async (db, mutation) => {
     );
   }
   const applicationId = [...appIds][0];
-  const stores = [
-    ...new Set([
-      "applications",
-      "contacts",
-      "lifecycleEvents",
-      ...childRecords.map(({ storeName }) => storeName),
-    ]),
-  ];
-  const tx = db.transaction(stores, "readonly");
-  const done = transactionDone(tx);
+  return { application, childRecords, applicationId };
+};
+
+const normalizeMutation = async (tx, mutationInput) => {
+  const { application, childRecords, applicationId } = mutationInput;
   const existingApplication = await requestToPromise(
     tx.objectStore("applications").get(applicationId),
   );
@@ -500,7 +497,6 @@ const normalizeMutation = async (db, mutation) => {
       requestToPromise(tx.objectStore("contacts").get(contactId)),
     ),
   );
-  await done;
   if (!application && !existingApplication) {
     throw new IndexedDbRepositoryError(
       "schema_validation_failed",
@@ -519,8 +515,8 @@ const normalizeMutation = async (db, mutation) => {
   const previousStatus = existingApplication?.status;
   const lifecycleEvents = childRecords
     .filter(({ storeName }) => storeName === "lifecycleEvents")
-    .map(({ record }) => ({ previousStatus, ...record }));
-  assertSupersessionIsValid([...existingEvents, ...lifecycleEvents]);
+    .map(({ record }) => ({ ...record, previousStatus }));
+  assertSupersessionIsValid(existingEvents, lifecycleEvents);
   return {
     application,
     childRecords: childRecords.map((item) =>
@@ -663,17 +659,18 @@ export const createIndexedDbRepository = async (options = {}) => {
 
     async commitLifecycleMutation(mutation) {
       return safe(async () => {
-        const normalized = await normalizeMutation(db, mutation);
+        const mutationInput = normalizeMutationInput(mutation);
         const storeNames = [
-          ...new Set(
-            [
-              normalized.application ? "applications" : null,
-              ...normalized.childRecords.map(({ storeName }) => storeName),
-            ].filter(Boolean),
-          ),
+          ...new Set([
+            "applications",
+            "contacts",
+            "lifecycleEvents",
+            ...mutationInput.childRecords.map(({ storeName }) => storeName),
+          ]),
         ];
         const tx = db.transaction(storeNames, "readwrite");
         const done = transactionDone(tx);
+        const normalized = await normalizeMutation(tx, mutationInput);
         if (normalized.application)
           tx.objectStore("applications").put(normalized.application);
         for (const { storeName, record } of normalized.childRecords) {

--- a/src/web/storage/indexedDbRepository.js
+++ b/src/web/storage/indexedDbRepository.js
@@ -420,6 +420,118 @@ const putChildRecord = async (db, storeName, record) => {
   return putRecord(db, storeName, parsed);
 };
 
+const assertSupersessionIsValid = (events) => {
+  const byId = new Map(events.map((event) => [event.id, event]));
+  for (const event of events) {
+    if (!event.supersedesEventId) continue;
+    const superseded = byId.get(event.supersedesEventId);
+    if (!superseded || superseded.applicationId !== event.applicationId) {
+      throw new IndexedDbRepositoryError(
+        "schema_validation_failed",
+        "Lifecycle supersession must reference an event for the same application.",
+        { details: { supersedesEventId: event.supersedesEventId } },
+      );
+    }
+    const seen = new Set([event.id]);
+    let cursor = superseded;
+    while (cursor?.supersedesEventId) {
+      if (seen.has(cursor.supersedesEventId)) {
+        throw new IndexedDbRepositoryError(
+          "schema_validation_failed",
+          "Lifecycle supersession cycle rejected.",
+          { details: { supersedesEventId: event.supersedesEventId } },
+        );
+      }
+      seen.add(cursor.supersedesEventId);
+      cursor = byId.get(cursor.supersedesEventId);
+    }
+  }
+};
+
+const normalizeMutation = async (db, mutation) => {
+  const application = mutation.application
+    ? parseRecord("applications", mutation.application)
+    : null;
+  const childRecords = Object.entries(mutation.records ?? {}).flatMap(
+    ([storeName, records]) =>
+      records.map((record) => ({
+        storeName,
+        record: parseRecord(storeName, record),
+      })),
+  );
+  const appIds = new Set(
+    [
+      application?.id,
+      ...childRecords.map(({ record }) => record.applicationId),
+    ].filter(Boolean),
+  );
+  if (appIds.size !== 1) {
+    throw new IndexedDbRepositoryError(
+      "schema_validation_failed",
+      "Lifecycle mutation must reference exactly one application.",
+      { details: { applicationIds: [...appIds].sort() } },
+    );
+  }
+  const applicationId = [...appIds][0];
+  const stores = [
+    ...new Set([
+      "applications",
+      "contacts",
+      "lifecycleEvents",
+      ...childRecords.map(({ storeName }) => storeName),
+    ]),
+  ];
+  const tx = db.transaction(stores, "readonly");
+  const done = transactionDone(tx);
+  const existingApplication = await requestToPromise(
+    tx.objectStore("applications").get(applicationId),
+  );
+  const existingEvents = await requestToPromise(
+    tx
+      .objectStore("lifecycleEvents")
+      .index("by_applicationId")
+      .getAll(applicationId),
+  );
+  const contactIds = childRecords
+    .flatMap(({ record }) => [record.contactId, ...(record.contactIds ?? [])])
+    .filter(Boolean);
+  const contacts = await Promise.all(
+    contactIds.map((contactId) =>
+      requestToPromise(tx.objectStore("contacts").get(contactId)),
+    ),
+  );
+  await done;
+  if (!application && !existingApplication) {
+    throw new IndexedDbRepositoryError(
+      "schema_validation_failed",
+      "Referenced application does not exist.",
+      { details: { applicationId } },
+    );
+  }
+  const missingContactIds = contactIds.filter((_, index) => !contacts[index]);
+  if (missingContactIds.length) {
+    throw new IndexedDbRepositoryError(
+      "schema_validation_failed",
+      "Referenced contact does not exist.",
+      { details: { contactIds: missingContactIds } },
+    );
+  }
+  const previousStatus = existingApplication?.status;
+  const lifecycleEvents = childRecords
+    .filter(({ storeName }) => storeName === "lifecycleEvents")
+    .map(({ record }) => ({ previousStatus, ...record }));
+  assertSupersessionIsValid([...existingEvents, ...lifecycleEvents]);
+  return {
+    application,
+    childRecords: childRecords.map((item) =>
+      item.storeName === "lifecycleEvents"
+        ? { ...item, record: lifecycleEvents.shift() }
+        : item,
+    ),
+    previousStatus,
+  };
+};
+
 const deleteFromIndex = async (db, storeName, indexName, value) => {
   const tx = db.transaction(storeName, "readwrite");
   const done = transactionDone(tx);
@@ -547,6 +659,35 @@ export const createIndexedDbRepository = async (options = {}) => {
     },
     upsertArtifact(record) {
       return safe(() => putChildRecord(db, "artifacts", record));
+    },
+
+    async commitLifecycleMutation(mutation) {
+      return safe(async () => {
+        const normalized = await normalizeMutation(db, mutation);
+        const storeNames = [
+          ...new Set(
+            [
+              normalized.application ? "applications" : null,
+              ...normalized.childRecords.map(({ storeName }) => storeName),
+            ].filter(Boolean),
+          ),
+        ];
+        const tx = db.transaction(storeNames, "readwrite");
+        const done = transactionDone(tx);
+        if (normalized.application)
+          tx.objectStore("applications").put(normalized.application);
+        for (const { storeName, record } of normalized.childRecords) {
+          const store = tx.objectStore(storeName);
+          if (
+            storeName === "lifecycleEvents" ||
+            storeName === "outreachMessages"
+          )
+            store.add(record);
+          else store.put(record);
+        }
+        await done;
+        return { previousStatus: normalized.previousStatus };
+      });
     },
     async listDueFollowUps(now = new Date().toISOString()) {
       return safe(async () =>

--- a/src/web/storage/indexedDbRepository.js
+++ b/src/web/storage/indexedDbRepository.js
@@ -450,6 +450,12 @@ const assertSupersessionIsValid = (existingEvents, newEvents) => {
   }
 };
 
+const assertLifecycleSupersessionGraphIsValid = (events) =>
+  assertSupersessionIsValid([], events);
+
+const contactBelongsToApplication = (contact, applicationId) =>
+  contact?.applicationId === applicationId;
+
 const normalizeMutationInput = (mutation) => {
   const application = mutation.application
     ? parseRecord("applications", mutation.application)
@@ -492,9 +498,16 @@ const normalizeMutation = async (tx, mutationInput) => {
   const contactIds = childRecords
     .flatMap(({ record }) => [record.contactId, ...(record.contactIds ?? [])])
     .filter(Boolean);
+  const incomingContacts = new Map(
+    childRecords
+      .filter(({ storeName }) => storeName === "contacts")
+      .map(({ record }) => [record.id, record]),
+  );
   const contacts = await Promise.all(
-    contactIds.map((contactId) =>
-      requestToPromise(tx.objectStore("contacts").get(contactId)),
+    contactIds.map(
+      async (contactId) =>
+        incomingContacts.get(contactId) ??
+        requestToPromise(tx.objectStore("contacts").get(contactId)),
     ),
   );
   if (!application && !existingApplication) {
@@ -504,12 +517,14 @@ const normalizeMutation = async (tx, mutationInput) => {
       { details: { applicationId } },
     );
   }
-  const missingContactIds = contactIds.filter((_, index) => !contacts[index]);
-  if (missingContactIds.length) {
+  const invalidContactIds = contactIds.filter(
+    (_, index) => !contactBelongsToApplication(contacts[index], applicationId),
+  );
+  if (invalidContactIds.length) {
     throw new IndexedDbRepositoryError(
       "schema_validation_failed",
-      "Referenced contact does not exist.",
-      { details: { contactIds: missingContactIds } },
+      "Referenced contact does not exist for this application.",
+      { details: { contactIds: invalidContactIds } },
     );
   }
   const previousStatus = existingApplication?.status;
@@ -873,6 +888,7 @@ export const createIndexedDbRepository = async (options = {}) => {
             return [name, [...byId.values()]];
           }),
         );
+        assertLifecycleSupersessionGraphIsValid(merged.lifecycleEvents);
         const validation = browserApplicationExportSchema.safeParse({
           schemaVersion: BROWSER_BACKUP_SCHEMA_VERSION,
           exportedAt: new Date(0).toISOString(),

--- a/src/web/tracker/lifecycleClassification.js
+++ b/src/web/tracker/lifecycleClassification.js
@@ -160,6 +160,60 @@ const EVENT_REGISTRY = Object.freeze({
     category: LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT,
     countsAsResponse: true,
   },
+  recruiter_company_outreach: {
+    category: LIFECYCLE_EVENT_CATEGORIES.APPLICATION_SUBMISSION,
+    status: "outreach_sent",
+  },
+  candidate_outreach: {
+    category: LIFECYCLE_EVENT_CATEGORIES.APPLICATION_SUBMISSION,
+    status: "outreach_sent",
+  },
+  referral: {
+    category: LIFECYCLE_EVENT_CATEGORIES.APPLICATION_SUBMISSION,
+    status: "applied",
+  },
+  other_unknown: {
+    category: LIFECYCLE_EVENT_CATEGORIES.APPLICATION_SUBMISSION,
+  },
+  offer_received: {
+    category: LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE,
+    status: "offer",
+  },
+  offer_negotiating: {
+    category: LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE,
+    status: "offer",
+  },
+  employer_rejected: {
+    category: LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE,
+    status: "rejected",
+  },
+  candidate_withdrew: {
+    category: LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE,
+    status: "withdrawn",
+  },
+  offer_declined: {
+    category: LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE,
+    status: "offer",
+  },
+  offer_expired_rescinded: {
+    category: LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE,
+    status: "offer",
+  },
+  offer_accepted: {
+    category: LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE,
+    status: "accepted",
+  },
+  closed_archived: {
+    category: LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE,
+    status: "closed_archived",
+  },
+  application_reopened: {
+    category: LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE,
+  },
+  status_changed: { category: LIFECYCLE_EVENT_CATEGORIES.EMPLOYER_RESPONSE },
+  migration_status_snapshot: {
+    category: LIFECYCLE_EVENT_CATEGORIES.UNKNOWN_METADATA,
+  },
   next_tracking_step: {
     category: LIFECYCLE_EVENT_CATEGORIES.REMINDER_ACTION,
   },

--- a/src/web/tracker/lifecycleReconciliation.js
+++ b/src/web/tracker/lifecycleReconciliation.js
@@ -167,7 +167,10 @@ export function planLifecycleReconciliation(bundle = {}) {
         i.createdAt || i.updatedAt,
         i.id,
         i.outcome,
-        INTERVIEW_EVENT[i.stage] ? i.stage : app.status,
+        INTERVIEW_EVENT[i.stage] &&
+          !["cancelled", "no_show"].includes(i.outcome)
+          ? i.stage
+          : app.status,
         {
           stageLabel: i.stage,
           dueAt: i.startsAt,

--- a/src/web/tracker/lifecycleReconciliation.js
+++ b/src/web/tracker/lifecycleReconciliation.js
@@ -25,9 +25,23 @@ const terminal = new Set([
   "closed_archived",
 ]);
 const idPart = (part) =>
-  String(part ?? "none").replace(/[^a-zA-Z0-9_-]+/g, "_");
+  String(part ?? "none")
+    .replace(/[^a-zA-Z0-9_-]+/g, "_")
+    .slice(0, 40);
+const hashPart = (part) => {
+  const input = String(part ?? "none");
+  let hash = 2166136261;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 16777619) >>> 0;
+  }
+  return hash.toString(36);
+};
 const stableId = (...parts) =>
-  `recon_${parts.map(idPart).join("_")}`.slice(0, 180);
+  `recon_${parts.map(idPart).join("_")}_${parts.map(hashPart).join("_")}`.slice(
+    0,
+    220,
+  );
 const sortById = (a, b) => String(a.id).localeCompare(String(b.id));
 const effectiveEvents = (events = []) => {
   const superseded = new Set(
@@ -164,7 +178,7 @@ export function planLifecycleReconciliation(bundle = {}) {
         existing,
         app,
         type,
-        i.createdAt || i.updatedAt,
+        i.updatedAt || i.createdAt,
         i.id,
         i.outcome,
         INTERVIEW_EVENT[i.stage] &&

--- a/src/web/tracker/lifecycleReconciliation.js
+++ b/src/web/tracker/lifecycleReconciliation.js
@@ -1,0 +1,253 @@
+const ORIGINS = new Set([
+  "application_submitted",
+  "recruiter_company_outreach",
+  "candidate_outreach",
+  "referral",
+  "other_unknown",
+]);
+const INTERVIEW_EVENT = {
+  recruiter_screen: "recruiter_screen",
+  technical_screen: "technical_interview",
+  onsite_loop: "onsite_final_loop",
+};
+const OFFER_EVENT = {
+  received: "offer_received",
+  negotiating: "offer_negotiating",
+  accepted: "offer_accepted",
+  declined: "offer_declined",
+  expired: "offer_expired_rescinded",
+  rescinded: "offer_expired_rescinded",
+};
+const terminal = new Set([
+  "accepted",
+  "rejected",
+  "withdrawn",
+  "closed_archived",
+]);
+const idPart = (part) =>
+  String(part ?? "none").replace(/[^a-zA-Z0-9_-]+/g, "_");
+const stableId = (...parts) =>
+  `recon_${parts.map(idPart).join("_")}`.slice(0, 180);
+const sortById = (a, b) => String(a.id).localeCompare(String(b.id));
+const effectiveEvents = (events = []) => {
+  const superseded = new Set(
+    events.map((event) => event.supersedesEventId).filter(Boolean),
+  );
+  return events.filter((event) => !superseded.has(event.id)).sort(sortById);
+};
+const warn = (warnings, code, applicationId, extra = {}) =>
+  warnings.push({ code, applicationId, ...extra });
+const event = (
+  app,
+  eventType,
+  occurredAt,
+  childId,
+  state,
+  status = app.status,
+  extra = {},
+) => ({
+  id: stableId("event", app.id, eventType, childId, state),
+  applicationId: app.id,
+  eventType,
+  status,
+  previousStatus: app.status,
+  occurredAt,
+  occurredAtPrecision:
+    extra.occurredAtPrecision ??
+    (String(occurredAt).includes("T") ? "instant" : "unknown"),
+  inferred: true,
+  source: "reconciliation",
+  createdAt: "1970-01-01T00:00:00.000Z",
+  ...extra,
+});
+const hasEvent = (events, appId, type, childId, state) =>
+  events.some(
+    (e) =>
+      e.applicationId === appId &&
+      e.eventType === type &&
+      String(e.sourceArtifact ?? "") === String(childId ?? "") &&
+      String(e.actionStatus ?? "") === String(state ?? ""),
+  );
+const add = (plan, existing, app, type, at, childId, state, status, extra) => {
+  if (!at) return false;
+  if (!hasEvent([...existing, ...plan.additions], app.id, type, childId, state))
+    plan.additions.push(
+      event(app, type, at, childId, state, status, {
+        sourceArtifact: childId,
+        actionStatus: state,
+        ...extra,
+      }),
+    );
+  return true;
+};
+const replayStatus = (events) =>
+  events
+    .sort(
+      (a, b) =>
+        String(a.occurredAt).localeCompare(String(b.occurredAt)) ||
+        String(a.id).localeCompare(String(b.id)),
+    )
+    .at(-1)?.status;
+export function planLifecycleReconciliation(bundle = {}) {
+  const applications = [...(bundle.applications ?? [])].sort(sortById);
+  const existing = effectiveEvents(bundle.lifecycleEvents ?? []);
+  const warnings = [];
+  const plans = applications.map((app) => {
+    const plan = { applicationId: app.id, additions: [], warnings: [] };
+    const appEvents = existing.filter((e) => e.applicationId === app.id);
+    if (!appEvents.some((e) => ORIGINS.has(e.eventType))) {
+      if (!app.appliedAt) warn(warnings, "missing_origin_timestamp", app.id);
+      add(
+        plan,
+        existing,
+        app,
+        app.origin || "other_unknown",
+        app.appliedAt || "1970-01-01",
+        "origin",
+        app.origin || "other_unknown",
+        app.status,
+        {
+          occurredAtPrecision: app.appliedAt
+            ? String(app.appliedAt).includes("T")
+              ? "instant"
+              : "date"
+            : "unknown",
+        },
+      );
+    }
+    for (const m of [...(bundle.outreachMessages ?? [])]
+      .filter((x) => x.applicationId === app.id)
+      .sort(sortById)) {
+      if (m.direction === "outbound")
+        add(
+          plan,
+          existing,
+          app,
+          "candidate_outreach",
+          m.sentAt,
+          m.id,
+          "outbound",
+          app.status,
+          { channel: m.channel, occurredAtPrecision: "instant" },
+        );
+      else if (m.direction === "inbound")
+        add(
+          plan,
+          existing,
+          app,
+          "employer_response_received",
+          m.receivedAt,
+          m.id,
+          "inbound",
+          app.status,
+          { channel: m.channel, occurredAtPrecision: "instant" },
+        );
+      else
+        warn(warnings, "unreconciled_child_activity", app.id, {
+          childStore: "outreachMessages",
+          childId: m.id,
+        });
+    }
+    for (const i of [...(bundle.interviews ?? [])]
+      .filter((x) => x.applicationId === app.id)
+      .sort(sortById)) {
+      const type = ["cancelled", "no_show"].includes(i.outcome)
+        ? "status_changed"
+        : (INTERVIEW_EVENT[i.stage] ?? "status_changed");
+      if (!INTERVIEW_EVENT[i.stage])
+        warn(warnings, "unreconciled_child_activity", app.id, {
+          childStore: "interviews",
+          childId: i.id,
+        });
+      add(
+        plan,
+        existing,
+        app,
+        type,
+        i.createdAt || i.updatedAt,
+        i.id,
+        i.outcome,
+        INTERVIEW_EVENT[i.stage] ? i.stage : app.status,
+        {
+          stageLabel: i.stage,
+          dueAt: i.startsAt,
+          occurredAtPrecision: "instant",
+        },
+      );
+    }
+    for (const o of [...(bundle.offers ?? [])]
+      .filter((x) => x.applicationId === app.id)
+      .sort(sortById)) {
+      const type = OFFER_EVENT[o.status];
+      if (!type) {
+        warn(warnings, "unreconciled_child_activity", app.id, {
+          childStore: "offers",
+          childId: o.id,
+        });
+        continue;
+      }
+      add(
+        plan,
+        existing,
+        app,
+        type,
+        o.updatedAt || o.createdAt,
+        o.id,
+        o.status,
+        o.status === "accepted" ? "accepted" : "offer",
+        { occurredAtPrecision: "instant" },
+      );
+    }
+    const represented = existing
+      .concat(plan.additions)
+      .some((e) => e.applicationId === app.id && e.status === app.status);
+    if (
+      !represented &&
+      !existing.some(
+        (e) =>
+          e.applicationId === app.id &&
+          e.eventType === "migration_status_snapshot",
+      )
+    ) {
+      warn(warnings, "status_snapshot_inferred", app.id);
+      warn(warnings, "unknown_occurrence_precision", app.id);
+      plan.additions.push(
+        event(
+          app,
+          "migration_status_snapshot",
+          "1970-01-01",
+          "status",
+          app.status,
+          app.status,
+          { occurredAtPrecision: "unknown" },
+        ),
+      );
+    }
+    const replayed = replayStatus(
+      existing.concat(plan.additions).filter((e) => e.applicationId === app.id),
+    );
+    if (replayed && replayed !== app.status)
+      warn(warnings, "status_history_mismatch", app.id);
+    if (terminal.has(replayed) && !terminal.has(app.status))
+      warn(warnings, "regressive_history", app.id);
+    plan.additions.sort(sortById);
+    plan.warnings = warnings
+      .filter((w) => w.applicationId === app.id)
+      .sort((a, b) => a.code.localeCompare(b.code));
+    return plan;
+  });
+  return {
+    plans,
+    additions: plans.flatMap((p) => p.additions),
+    warnings: warnings.sort(
+      (a, b) =>
+        a.applicationId.localeCompare(b.applicationId) ||
+        a.code.localeCompare(b.code),
+    ),
+    counts: {
+      applications: applications.length,
+      additions: plans.reduce((n, p) => n + p.additions.length, 0),
+      warnings: warnings.length,
+    },
+  };
+}

--- a/src/web/tracker/lifecycleReconciliation.js
+++ b/src/web/tracker/lifecycleReconciliation.js
@@ -43,12 +43,24 @@ const stableId = (...parts) =>
     220,
   );
 const sortById = (a, b) => String(a.id).localeCompare(String(b.id));
+const sortChronologically = (a, b) =>
+  String(a.occurredAt).localeCompare(String(b.occurredAt)) ||
+  String(a.id).localeCompare(String(b.id));
 const effectiveEvents = (events = []) => {
   const superseded = new Set(
     events.map((event) => event.supersedesEventId).filter(Boolean),
   );
   return events.filter((event) => !superseded.has(event.id)).sort(sortById);
 };
+const persistedTimestamp = (...records) => {
+  for (const record of records) {
+    const timestamp = record?.updatedAt || record?.createdAt;
+    if (timestamp) return timestamp;
+  }
+  return undefined;
+};
+const persistedApplicationTimestamp = (app) =>
+  app.updatedAt || app.createdAt || "1970-01-01";
 const warn = (warnings, code, applicationId, extra = {}) =>
   warnings.push({ code, applicationId, ...extra });
 const event = (
@@ -95,13 +107,20 @@ const add = (plan, existing, app, type, at, childId, state, status, extra) => {
   return true;
 };
 const replayStatus = (events) =>
-  events
-    .sort(
-      (a, b) =>
-        String(a.occurredAt).localeCompare(String(b.occurredAt)) ||
-        String(a.id).localeCompare(String(b.id)),
-    )
-    .at(-1)?.status;
+  [...events].sort(sortChronologically).at(-1)?.status;
+const detectsRegressiveHistory = (events) => {
+  let terminalReached = false;
+  for (const event of [...events].sort(sortChronologically)) {
+    if (event.eventType === "application_reopened") {
+      terminalReached = false;
+      continue;
+    }
+    if (terminalReached && event.status && !terminal.has(event.status))
+      return true;
+    if (terminal.has(event.status)) terminalReached = true;
+  }
+  return false;
+};
 export function planLifecycleReconciliation(bundle = {}) {
   const applications = [...(bundle.applications ?? [])].sort(sortById);
   const existing = effectiveEvents(bundle.lifecycleEvents ?? []);
@@ -132,31 +151,54 @@ export function planLifecycleReconciliation(bundle = {}) {
     for (const m of [...(bundle.outreachMessages ?? [])]
       .filter((x) => x.applicationId === app.id)
       .sort(sortById)) {
-      if (m.direction === "outbound")
-        add(
-          plan,
-          existing,
-          app,
-          "candidate_outreach",
-          m.sentAt,
-          m.id,
-          "outbound",
-          app.status,
-          { channel: m.channel, occurredAtPrecision: "instant" },
-        );
-      else if (m.direction === "inbound")
-        add(
-          plan,
-          existing,
-          app,
-          "employer_response_received",
-          m.receivedAt,
-          m.id,
-          "inbound",
-          app.status,
-          { channel: m.channel, occurredAtPrecision: "instant" },
-        );
-      else
+      if (m.direction === "outbound") {
+        const occurredAt = m.sentAt || persistedTimestamp(m);
+        if (!m.sentAt) warn(warnings, "unknown_occurrence_precision", app.id);
+        if (occurredAt)
+          add(
+            plan,
+            existing,
+            app,
+            "candidate_outreach",
+            occurredAt,
+            m.id,
+            "outbound",
+            app.status,
+            {
+              channel: m.channel,
+              occurredAtPrecision: m.sentAt ? "instant" : "unknown",
+            },
+          );
+        else
+          warn(warnings, "unreconciled_child_activity", app.id, {
+            childStore: "outreachMessages",
+            childId: m.id,
+          });
+      } else if (m.direction === "inbound") {
+        const occurredAt = m.receivedAt || persistedTimestamp(m);
+        if (!m.receivedAt)
+          warn(warnings, "unknown_occurrence_precision", app.id);
+        if (occurredAt)
+          add(
+            plan,
+            existing,
+            app,
+            "employer_response_received",
+            occurredAt,
+            m.id,
+            "inbound",
+            app.status,
+            {
+              channel: m.channel,
+              occurredAtPrecision: m.receivedAt ? "instant" : "unknown",
+            },
+          );
+        else
+          warn(warnings, "unreconciled_child_activity", app.id, {
+            childStore: "outreachMessages",
+            childId: m.id,
+          });
+      } else
         warn(warnings, "unreconciled_child_activity", app.id, {
           childStore: "outreachMessages",
           childId: m.id,
@@ -173,12 +215,20 @@ export function planLifecycleReconciliation(bundle = {}) {
           childStore: "interviews",
           childId: i.id,
         });
+      const occurredAt = i.updatedAt || i.createdAt;
+      if (!occurredAt) {
+        warn(warnings, "unknown_occurrence_precision", app.id);
+        warn(warnings, "unreconciled_child_activity", app.id, {
+          childStore: "interviews",
+          childId: i.id,
+        });
+      }
       add(
         plan,
         existing,
         app,
         type,
-        i.updatedAt || i.createdAt,
+        occurredAt,
         i.id,
         i.outcome,
         INTERVIEW_EVENT[i.stage] &&
@@ -188,7 +238,7 @@ export function planLifecycleReconciliation(bundle = {}) {
         {
           stageLabel: i.stage,
           dueAt: i.startsAt,
-          occurredAtPrecision: "instant",
+          occurredAtPrecision: occurredAt ? "instant" : "unknown",
         },
       );
     }
@@ -203,23 +253,32 @@ export function planLifecycleReconciliation(bundle = {}) {
         });
         continue;
       }
+      const occurredAt = o.updatedAt || o.createdAt;
+      if (!occurredAt) {
+        warn(warnings, "unknown_occurrence_precision", app.id);
+        warn(warnings, "unreconciled_child_activity", app.id, {
+          childStore: "offers",
+          childId: o.id,
+        });
+      }
       add(
         plan,
         existing,
         app,
         type,
-        o.updatedAt || o.createdAt,
+        occurredAt,
         o.id,
         o.status,
         o.status === "accepted" ? "accepted" : "offer",
         { occurredAtPrecision: "instant" },
       );
     }
-    const represented = existing
+    const effectiveAppEvents = existing
       .concat(plan.additions)
-      .some((e) => e.applicationId === app.id && e.status === app.status);
+      .filter((e) => e.applicationId === app.id);
+    const replayedBeforeSnapshot = replayStatus(effectiveAppEvents);
     if (
-      !represented &&
+      replayedBeforeSnapshot !== app.status &&
       !existing.some(
         (e) =>
           e.applicationId === app.id &&
@@ -232,7 +291,7 @@ export function planLifecycleReconciliation(bundle = {}) {
         event(
           app,
           "migration_status_snapshot",
-          "1970-01-01",
+          persistedApplicationTimestamp(app),
           "status",
           app.status,
           app.status,
@@ -240,12 +299,13 @@ export function planLifecycleReconciliation(bundle = {}) {
         ),
       );
     }
-    const replayed = replayStatus(
-      existing.concat(plan.additions).filter((e) => e.applicationId === app.id),
-    );
+    const replayEvents = existing
+      .concat(plan.additions)
+      .filter((e) => e.applicationId === app.id);
+    const replayed = replayStatus(replayEvents);
     if (replayed && replayed !== app.status)
       warn(warnings, "status_history_mismatch", app.id);
-    if (terminal.has(replayed) && !terminal.has(app.status))
+    if (detectsRegressiveHistory(replayEvents))
       warn(warnings, "regressive_history", app.id);
     plan.additions.sort(sortById);
     plan.warnings = warnings

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -25,6 +25,7 @@ import {
   selectDashboardMetrics,
 } from "./metrics.js";
 import { createIndexedDbRepository } from "../storage/indexedDbRepository.js";
+import { planLifecycleReconciliation } from "./lifecycleReconciliation.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
 const ARRAY_STORES = [
@@ -36,6 +37,13 @@ const ARRAY_STORES = [
   "offers",
   "artifacts",
   "reminders",
+];
+const ORIGINS = [
+  "application_submitted",
+  "recruiter_company_outreach",
+  "candidate_outreach",
+  "referral",
+  "other_unknown",
 ];
 const STATUSES = [
   "applied",
@@ -104,6 +112,8 @@ const repo = {
   },
   clear: async () => (await getRepository()).clearAllData(),
   exportAll: async () => (await getRepository()).exportAllData(),
+  commitLifecycleMutation: async (mutation) =>
+    (await getRepository()).commitLifecycleMutation(mutation),
 };
 async function batchImport(recordsByStore) {
   return (await getRepository()).importPartialData(recordsByStore);
@@ -117,6 +127,7 @@ const state = {
   dir: -1,
   current: null,
   detailSave: Promise.resolve(),
+  reconciliationWarnings: [],
 };
 function weekBucket(value) {
   const d = day(value);
@@ -273,7 +284,25 @@ const metadataText = (app) =>
   metadataEntries(app)
     .map(([label, value]) => `${label}: ${value}`)
     .join(" · ");
+let reconciliationRunning = false;
+async function reconcileLifecycle() {
+  if (reconciliationRunning) return;
+  reconciliationRunning = true;
+  try {
+    const bundle = await repo.exportAll();
+    const result = planLifecycleReconciliation(bundle);
+    state.reconciliationWarnings = result.warnings;
+    for (const plan of result.plans.filter((item) => item.additions.length)) {
+      await repo.commitLifecycleMutation({
+        records: { lifecycleEvents: plan.additions },
+      });
+    }
+  } finally {
+    reconciliationRunning = false;
+  }
+}
 async function refresh() {
+  await reconcileLifecycle();
   state.bundle = await repo.exportAll();
   state.apps = state.bundle.applications.sort((a, b) =>
     String(b.appliedAt || "").localeCompare(a.appliedAt || ""),
@@ -353,7 +382,11 @@ function renderNav() {
     )
     .join("");
   $$(".tracker-nav button").forEach(
-    (b) => (b.onclick = () => route(b.dataset.route)),
+    (b) =>
+      (b.onclick = async () => {
+        await state.detailSave.catch(() => {});
+        route(b.dataset.route);
+      }),
   );
   route("dashboard");
 }
@@ -578,7 +611,11 @@ function renderAll() {
 }
 function sortedLifecycleEvents(appId) {
   return [...state.bundle.lifecycleEvents]
-    .filter((e) => e.applicationId === appId)
+    .filter(
+      (e) =>
+        e.applicationId === appId &&
+        !(e.source === "reconciliation" && e.inferred),
+    )
     .sort((a, b) => {
       const occurred = (a.occurredAt || "").localeCompare(b.occurredAt || "");
       const due = (a.dueAt || "").localeCompare(b.dueAt || "");
@@ -637,6 +674,30 @@ function metadataSection(app) {
     return '<p class="muted">No compact CSV metadata for this application yet.</p>';
   return `<dl class="metadata-list">${entries.map(([label, value]) => `<div><dt>${esc(label)}</dt><dd>${label.includes("URL") ? safeArtifactLink(value) : esc(value)}</dd></div>`).join("")}</dl>`;
 }
+function statusEventType(previousStatus, nextStatus) {
+  const terminal = new Set([
+    "accepted",
+    "rejected",
+    "withdrawn",
+    "closed_archived",
+  ]);
+  if (terminal.has(previousStatus) && !terminal.has(nextStatus))
+    return "application_reopened";
+  return (
+    {
+      outreach_sent: "candidate_outreach",
+      recruiter_screen: "recruiter_screen",
+      technical_screen: "technical_interview",
+      onsite_loop: "onsite_final_loop",
+      offer: "offer_received",
+      accepted: "offer_accepted",
+      rejected: "employer_rejected",
+      withdrawn: "candidate_withdrew",
+      closed_archived: "closed_archived",
+      applied: "status_changed",
+    }[nextStatus] ?? "status_changed"
+  );
+}
 function detailForm(app) {
   const m = appMeta(app);
   const events = sortedLifecycleEvents(app.id);
@@ -658,7 +719,7 @@ function detailForm(app) {
         "Compact CSV assessment signal",
     });
   }
-  return `<div class="tracker-detail"><article class="card"><h2>${esc(app.company || "New application")} — ${esc(app.role || "Unsaved")}</h2><form class="tracker-form" data-core-form>${input("company", app.company, true)}${input("role", app.role, true)}${input("postingUrl", app.postingUrl, "url")}<label>Status<select name="status" required>${STATUSES.map((s) => `<option ${app.status === s ? "selected" : ""}>${s}</option>`).join("")}</select></label>${input("source", app.source, "text")}${input("appliedAt", day(app.appliedAt), "date", true)}${input("followUpDate", day(app.followUpDate), "date")}<label>Notes<textarea name="notes">${esc(app.notes)}</textarea></label><button class="button">Save application</button></form></article><article class="card"><h3>Compact CSV metadata</h3>${metadataSection(app)}</article><article class="card wide-card"><h3>Lifecycle timeline</h3><p class="muted">Events are sorted by occurred date, then due date, then stable ID. All data stays local in this browser.</p><ul class="timeline">${events.map(timelineItem).join("") || '<li class="muted">No lifecycle events for this application yet.</li>'}</ul></article><article class="card"><h3>Assessments/take-homes</h3>${assessments.length ? `<ul>${assessments.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No written assessments or take-homes yet.</p>'}</article><article class="card"><h3>Recruiter screens</h3>${recruiterScreens.length ? `<ul>${recruiterScreens.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No recruiter screens yet.</p>'}</article><article class="card"><h3>Interviews</h3><form class="tracker-form" data-interview-form><label>Stage<select name="stage"><option>recruiter_screen</option><option>technical_screen</option><option>onsite_loop</option><option>other</option></select></label>${input("startsAt", day(now()), "date")}<button class="button">Log interview</button></form><ul>${otherInterviews.map((i) => `<li>${day(i.startsAt)} ${esc(i.stage)} ${esc(i.outcome)}</li>`).join("") || '<li class="muted">No non-recruiter interviews yet.</li>'}</ul></article><article class="card"><h3>Links/artifacts</h3><form class="tracker-form" data-artifact-form>${input("name", "", true)}${input("url", "")}<button class="button">Add link/artifact</button></form><ul>${m.artifacts.map((a) => `<li>${linkForArtifact(a)}</li>`).join("")}</ul></article><article class="card"><h3>Outreach messages</h3><form class="tracker-form" data-outreach-form><label>Channel<select name="channel"><option>email</option><option>linkedin</option><option>phone</option><option>sms</option><option>other</option></select></label><label>Message<textarea name="body" required></textarea></label><button class="button">Add outreach</button></form><ul>${m.outreach.map((o) => `<li>${day(o.sentAt)} ${esc(o.channel)} ${esc(o.body)}</li>`).join("")}</ul></article><article class="card"><h3>Offers</h3><form class="tracker-form" data-offer-form><label>Status<select name="status"><option>received</option><option>negotiating</option><option>accepted</option><option>declined</option></select></label>${input("notes", "")}<button class="button">Log offer</button></form><ul>${m.offers.map((o) => `<li>${esc(o.status)} ${esc(o.notes || "")}</li>`).join("")}</ul></article></div>`;
+  return `<div class="tracker-detail"><article class="card"><h2>${esc(app.company || "New application")} — ${esc(app.role || "Unsaved")}</h2><form class="tracker-form" data-core-form>${input("company", app.company, true)}${input("role", app.role, true)}${input("postingUrl", app.postingUrl, "url")}<label>Origin<select name="origin" required>${ORIGINS.map((origin) => `<option value="${origin}" ${app.origin === origin ? "selected" : ""}>${origin}</option>`).join("")}</select></label><label>Status<select name="status" required>${STATUSES.map((s) => `<option ${app.status === s ? "selected" : ""}>${s}</option>`).join("")}</select></label>${input("source", app.source, "text")}${input("appliedAt", day(app.appliedAt), "date", app.status === "applied")}${input("followUpDate", day(app.followUpDate), "date")}<label>Notes<textarea name="notes">${esc(app.notes)}</textarea></label><button class="button">Save application</button></form></article><article class="card"><h3>Compact CSV metadata</h3>${metadataSection(app)}</article><article class="card wide-card"><h3>Lifecycle timeline</h3><p class="muted">Events are sorted by occurred date, then due date, then stable ID. All data stays local in this browser.</p><ul class="timeline">${events.map(timelineItem).join("") || '<li class="muted">No lifecycle events for this application yet.</li>'}</ul></article><article class="card"><h3>Assessments/take-homes</h3><form class="tracker-form" data-assessment-form><label>Action status<select name="actionStatus"><option>requested</option><option>pending</option><option>started</option><option>in_progress</option><option>submitted</option><option>completed</option></select></label>${input("dueAt", "", "date")}<label>Details<textarea name="details"></textarea></label><button class="button">Log assessment</button></form>${assessments.length ? `<ul>${assessments.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No written assessments or take-homes yet.</p>'}</article><article class="card"><h3>Recruiter screens</h3>${recruiterScreens.length ? `<ul>${recruiterScreens.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No recruiter screens yet.</p>'}</article><article class="card"><h3>Interviews</h3><form class="tracker-form" data-interview-form><label>Stage<select name="stage"><option>recruiter_screen</option><option>technical_screen</option><option>onsite_loop</option><option>other</option></select></label>${input("startsAt", day(now()), "date")}<label>Outcome<select name="outcome"><option>scheduled</option><option>completed</option><option>cancelled</option><option>no_show</option></select></label><button class="button">Log interview</button></form><ul>${otherInterviews.map((i) => `<li>${day(i.startsAt)} ${esc(i.stage)} ${esc(i.outcome)}</li>`).join("") || '<li class="muted">No non-recruiter interviews yet.</li>'}</ul></article><article class="card"><h3>Links/artifacts</h3><form class="tracker-form" data-artifact-form>${input("name", "", true)}${input("url", "")}<button class="button">Add link/artifact</button></form><ul>${m.artifacts.map((a) => `<li>${linkForArtifact(a)}</li>`).join("")}</ul></article><article class="card"><h3>Outreach messages</h3><form class="tracker-form" data-outreach-form><label>Direction<select name="direction"><option value="outbound">Outbound</option><option value="inbound">Inbound</option></select></label><label>Channel<select name="channel"><option>email</option><option>linkedin</option><option>phone</option><option>sms</option><option>other</option></select></label><label>Message<textarea name="body" required></textarea></label><button class="button">Add outreach</button></form><ul>${m.outreach.map((o) => `<li>${esc(o.direction)} ${day(o.sentAt || o.receivedAt)} ${esc(o.channel)} ${esc(o.body)}</li>`).join("")}</ul></article><article class="card"><h3>Offers</h3><form class="tracker-form" data-offer-form><label>Status<select name="status"><option>received</option><option>negotiating</option><option>accepted</option><option>declined</option><option>expired</option><option>rescinded</option></select></label>${input("notes", "")}<button class="button">Log offer</button></form><ul>${m.offers.map((o) => `<li>${esc(o.status)} ${esc(o.notes || "")}</li>`).join("")}</ul></article></div>`;
 }
 function input(n, v = "", type = "text", required = false) {
   const req = type === true || required ? "required" : "";
@@ -695,50 +756,102 @@ function isoDate(v) {
 function bindDetail(app) {
   const persisted = !app.unsaved;
   const latestApp = () => state.apps.find((a) => a.id === app.id) || app;
+  const submitWithRecovery = async (form, operation) => {
+    const original = new FormData(form);
+    let errorBox = form.querySelector("[data-form-error]");
+    if (!errorBox) {
+      errorBox = document.createElement("p");
+      errorBox.dataset.formError = "";
+      errorBox.className = "muted error";
+      errorBox.setAttribute("role", "alert");
+      form.prepend(errorBox);
+    }
+    errorBox.textContent = "";
+    setFormDisabled(form, true);
+    try {
+      state.detailSave = Promise.resolve().then(() =>
+        operation(Object.fromEntries(original.entries())),
+      );
+      await state.detailSave;
+    } catch (error) {
+      for (const [name, value] of original.entries()) {
+        const control = form.elements.namedItem(name);
+        if (control) control.value = value;
+      }
+      errorBox.textContent = `Save failed. No changes were written. ${error?.message ?? error}`;
+      setFormDisabled(form, false);
+      return false;
+    }
+    return true;
+  };
   $("[data-core-form]").onsubmit = async (e) => {
     e.preventDefault();
     const form = e.target;
-    const v = values(form);
-    setFormDisabled(form, true);
-    state.detailSave = state.detailSave
-      .catch(() => {})
-      .then(async () => {
-        const current = latestApp();
-        const saved = {
-          ...current,
-          ...v,
-          source: optionalBlankToUndefined(v.source),
-          postingUrl: optionalBlankToUndefined(v.postingUrl),
-          notes: optionalBlankToUndefined(v.notes),
-          origin: current.origin ?? "other_unknown",
-          appliedAt: isoDate(v.appliedAt),
-          followUpDate: isoDate(v.followUpDate),
-          updatedAt: now(),
-        };
-        delete saved.unsaved;
-        await repo.put("applications", saved);
-        if (!persisted || v.status !== current.status)
-          await repo.add("lifecycleEvents", {
-            id: id("event"),
-            applicationId: app.id,
-            eventType:
-              v.status === "applied" ? "application_submitted" : "status_changed",
-            status: v.status,
-            occurredAt: now(),
-            occurredAtPrecision: "instant",
-            inferred: false,
-            source: "manual",
-            createdAt: now(),
-          });
-        await refresh();
-        openDetail(app.id);
+    await submitWithRecovery(form, async (v) => {
+      const current = latestApp();
+      const operationTime = now();
+      const saved = {
+        ...current,
+        ...v,
+        source: optionalBlankToUndefined(v.source),
+        postingUrl: optionalBlankToUndefined(v.postingUrl),
+        notes: optionalBlankToUndefined(v.notes),
+        origin: v.origin,
+        appliedAt: isoDate(v.appliedAt),
+        followUpDate: isoDate(v.followUpDate),
+        updatedAt: operationTime,
+      };
+      delete saved.unsaved;
+      const events = [];
+      if (!persisted) {
+        events.push({
+          id: id("event"),
+          applicationId: app.id,
+          eventType: v.origin,
+          status: v.status,
+          occurredAt: saved.appliedAt || operationTime,
+          occurredAtPrecision: saved.appliedAt ? "instant" : "unknown",
+          inferred: false,
+          source: "manual",
+          createdAt: operationTime,
+        });
+      } else if (v.origin !== current.origin) {
+        const priorOrigin = sortedLifecycleEvents(app.id)
+          .filter((event) => ORIGINS.includes(event.eventType))
+          .at(-1);
+        events.push({
+          id: id("event"),
+          applicationId: app.id,
+          eventType: v.origin,
+          status: current.status,
+          occurredAt: operationTime,
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          supersedesEventId: priorOrigin?.id,
+          createdAt: operationTime,
+        });
+      }
+      if (persisted && v.status !== current.status) {
+        events.push({
+          id: id("event"),
+          applicationId: app.id,
+          eventType: statusEventType(current.status, v.status),
+          status: v.status,
+          occurredAt: operationTime,
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          createdAt: operationTime,
+        });
+      }
+      await repo.commitLifecycleMutation({
+        application: saved,
+        records: { lifecycleEvents: events },
       });
-    try {
-      await state.detailSave;
-    } catch (error) {
-      setFormDisabled(form, false);
-      throw error;
-    }
+      await refresh();
+      openDetail(app.id);
+    });
   };
   $("[data-artifact-form]").onsubmit = async (e) => {
     e.preventDefault();
@@ -758,75 +871,198 @@ function bindDetail(app) {
   };
   $("[data-outreach-form]").onsubmit = async (e) => {
     e.preventDefault();
-    const v = values(e.target);
-    const current = latestApp();
-    await repo.add("outreachMessages", {
-      id: id("msg"),
-      applicationId: app.id,
-      direction: "outbound",
-      channel: v.channel,
-      body: v.body,
-      sentAt: now(),
-      createdAt: now(),
-      updatedAt: now(),
+    const form = e.target;
+    await submitWithRecovery(form, async (v) => {
+      const current = latestApp();
+      const operationTime = now();
+      const nextStatus =
+        v.direction === "outbound" &&
+        STATUS_RANK[current.status] < STATUS_RANK.outreach_sent
+          ? "outreach_sent"
+          : current.status;
+      const message = {
+        id: id("msg"),
+        applicationId: app.id,
+        direction: v.direction,
+        channel: v.channel,
+        body: v.body,
+        sentAt: v.direction === "outbound" ? operationTime : undefined,
+        receivedAt: v.direction === "inbound" ? operationTime : undefined,
+        createdAt: operationTime,
+        updatedAt: operationTime,
+      };
+      await repo.commitLifecycleMutation({
+        application: {
+          ...current,
+          status: nextStatus,
+          updatedAt: operationTime,
+        },
+        records: {
+          outreachMessages: [message],
+          lifecycleEvents: [
+            {
+              id: id("event"),
+              applicationId: app.id,
+              eventType:
+                v.direction === "inbound"
+                  ? "employer_response_received"
+                  : "candidate_outreach",
+              status: nextStatus,
+              occurredAt: operationTime,
+              occurredAtPrecision: "instant",
+              inferred: false,
+              source: "manual",
+              channel: v.channel,
+              sourceArtifact: message.id,
+              createdAt: operationTime,
+            },
+          ],
+        },
+      });
+      await refresh();
+      openDetail(app.id);
     });
-    const nextStatus =
-      STATUS_RANK[current.status] >= STATUS_RANK.outreach_sent
-        ? current.status
-        : "outreach_sent";
-    await repo.put("applications", {
-      ...current,
-      status: nextStatus,
-      updatedAt: now(),
+  };
+  $("[data-assessment-form]").onsubmit = async (e) => {
+    e.preventDefault();
+    const form = e.target;
+    await submitWithRecovery(form, async (v) => {
+      const operationTime = now();
+      await repo.commitLifecycleMutation({
+        records: {
+          lifecycleEvents: [
+            {
+              id: id("event"),
+              applicationId: app.id,
+              eventType: "assessment_take_home",
+              status: latestApp().status,
+              occurredAt: operationTime,
+              occurredAtPrecision: "instant",
+              inferred: false,
+              source: "manual",
+              actionStatus: v.actionStatus,
+              dueAt: isoDate(v.dueAt),
+              details: optionalBlankToUndefined(v.details),
+              createdAt: operationTime,
+            },
+          ],
+        },
+      });
+      await refresh();
+      openDetail(app.id);
     });
-    await refresh();
-    openDetail(app.id);
   };
   $("[data-interview-form]").onsubmit = async (e) => {
     e.preventDefault();
-    const v = values(e.target);
-    const current = latestApp();
-    await repo.add("interviews", {
-      id: id("interview"),
-      applicationId: app.id,
-      contactIds: [],
-      stage: v.stage,
-      startsAt: isoDate(v.startsAt),
-      outcome: "scheduled",
-      createdAt: now(),
-      updatedAt: now(),
+    const form = e.target;
+    await submitWithRecovery(form, async (v) => {
+      const current = latestApp();
+      const operationTime = now();
+      const interview = {
+        id: id("interview"),
+        applicationId: app.id,
+        contactIds: [],
+        stage: v.stage,
+        startsAt: isoDate(v.startsAt),
+        outcome: v.outcome,
+        createdAt: operationTime,
+        updatedAt: operationTime,
+      };
+      const recognized = {
+        recruiter_screen: "recruiter_screen",
+        technical_screen: "technical_interview",
+        onsite_loop: "onsite_final_loop",
+      }[v.stage];
+      const nextStatus =
+        recognized &&
+        !["cancelled", "no_show"].includes(v.outcome) &&
+        STATUS_RANK[v.stage] > STATUS_RANK[current.status]
+          ? v.stage
+          : current.status;
+      await repo.commitLifecycleMutation({
+        application: {
+          ...current,
+          status: nextStatus,
+          updatedAt: operationTime,
+        },
+        records: {
+          interviews: [interview],
+          lifecycleEvents: [
+            {
+              id: id("event"),
+              applicationId: app.id,
+              eventType:
+                recognized && !["cancelled", "no_show"].includes(v.outcome)
+                  ? recognized
+                  : "status_changed",
+              status: nextStatus,
+              occurredAt: operationTime,
+              occurredAtPrecision: "instant",
+              inferred: false,
+              source: "manual",
+              stageLabel: v.stage,
+              actionStatus: v.outcome,
+              dueAt: interview.startsAt,
+              sourceArtifact: interview.id,
+              createdAt: operationTime,
+            },
+          ],
+        },
+      });
+      await refresh();
+      openDetail(app.id);
     });
-    const nextStatus =
-      v.stage !== "other" && STATUS_RANK[v.stage] > STATUS_RANK[current.status]
-        ? v.stage
-        : current.status;
-    await repo.put("applications", {
-      ...current,
-      status: nextStatus,
-      updatedAt: now(),
-    });
-    await refresh();
-    openDetail(app.id);
   };
   $("[data-offer-form]").onsubmit = async (e) => {
     e.preventDefault();
-    const v = values(e.target);
-    const current = latestApp();
-    await repo.add("offers", {
-      id: id("offer"),
-      applicationId: app.id,
-      status: v.status,
-      notes: v.notes || undefined,
-      createdAt: now(),
-      updatedAt: now(),
+    const form = e.target;
+    await submitWithRecovery(form, async (v) => {
+      const current = latestApp();
+      const operationTime = now();
+      const offer = {
+        id: id("offer"),
+        applicationId: app.id,
+        status: v.status,
+        notes: v.notes || undefined,
+        createdAt: operationTime,
+        updatedAt: operationTime,
+      };
+      const eventType = {
+        received: "offer_received",
+        negotiating: "offer_negotiating",
+        accepted: "offer_accepted",
+        declined: "offer_declined",
+        expired: "offer_expired_rescinded",
+        rescinded: "offer_expired_rescinded",
+      }[v.status];
+      await repo.commitLifecycleMutation({
+        application: {
+          ...current,
+          status: v.status === "accepted" ? "accepted" : "offer",
+          updatedAt: operationTime,
+        },
+        records: {
+          offers: [offer],
+          lifecycleEvents: [
+            {
+              id: id("event"),
+              applicationId: app.id,
+              eventType,
+              status: v.status === "accepted" ? "accepted" : "offer",
+              occurredAt: operationTime,
+              occurredAtPrecision: "instant",
+              inferred: false,
+              source: "manual",
+              sourceArtifact: offer.id,
+              actionStatus: v.status,
+              createdAt: operationTime,
+            },
+          ],
+        },
+      });
+      await refresh();
+      openDetail(app.id);
     });
-    await repo.put("applications", {
-      ...current,
-      status: v.status === "accepted" ? "accepted" : "offer",
-      updatedAt: now(),
-    });
-    await refresh();
-    openDetail(app.id);
   };
 }
 async function newApplication() {
@@ -841,6 +1077,7 @@ async function newApplication() {
     appliedAt: day(ts),
     createdAt: ts,
     updatedAt: ts,
+    origin: "application_submitted",
     unsaved: true,
   };
   openUnsavedDetail(app);

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -630,6 +630,18 @@ function effectiveLifecycleEvents(events = []) {
   );
   return events.filter((event) => !superseded.has(event.id));
 }
+function latestEffectiveOriginEvent(appId) {
+  return effectiveLifecycleEvents(
+    sortedLifecycleEvents(appId, { includeInferred: true }),
+  )
+    .filter((event) => ORIGINS.includes(event.eventType))
+    .sort(
+      (a, b) =>
+        String(a.createdAt || "").localeCompare(String(b.createdAt || "")) ||
+        String(a.id).localeCompare(String(b.id)),
+    )
+    .at(-1);
+}
 function eventDetails(e) {
   return Object.entries({
     Type: e.eventType,
@@ -843,11 +855,7 @@ function bindDetail(app) {
           createdAt: operationTime,
         });
       } else if (v.origin !== current.origin) {
-        const priorOrigin = effectiveLifecycleEvents(
-          sortedLifecycleEvents(app.id, { includeInferred: true }),
-        )
-          .filter((event) => ORIGINS.includes(event.eventType))
-          .at(-1);
+        const priorOrigin = latestEffectiveOriginEvent(app.id);
         events.push({
           id: id("event"),
           applicationId: app.id,

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -623,6 +623,13 @@ function sortedLifecycleEvents(appId, options = {}) {
       return occurred || due || String(a.id).localeCompare(String(b.id));
     });
 }
+
+function effectiveLifecycleEvents(events = []) {
+  const superseded = new Set(
+    events.map((event) => event.supersedesEventId).filter(Boolean),
+  );
+  return events.filter((event) => !superseded.has(event.id));
+}
 function eventDetails(e) {
   return Object.entries({
     Type: e.eventType,
@@ -836,9 +843,9 @@ function bindDetail(app) {
           createdAt: operationTime,
         });
       } else if (v.origin !== current.origin) {
-        const priorOrigin = sortedLifecycleEvents(app.id, {
-          includeInferred: true,
-        })
+        const priorOrigin = effectiveLifecycleEvents(
+          sortedLifecycleEvents(app.id, { includeInferred: true }),
+        )
           .filter((event) => ORIGINS.includes(event.eventType))
           .at(-1);
         events.push({

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -609,12 +609,13 @@ function renderAll() {
   renderFollowups();
   renderOutreach();
 }
-function sortedLifecycleEvents(appId) {
+function sortedLifecycleEvents(appId, options = {}) {
   return [...state.bundle.lifecycleEvents]
     .filter(
       (e) =>
         e.applicationId === appId &&
-        !(e.source === "reconciliation" && e.inferred),
+        (options.includeInferred ||
+          !(e.source === "reconciliation" && e.inferred)),
     )
     .sort((a, b) => {
       const occurred = (a.occurredAt || "").localeCompare(b.occurredAt || "");
@@ -816,7 +817,9 @@ function bindDetail(app) {
           createdAt: operationTime,
         });
       } else if (v.origin !== current.origin) {
-        const priorOrigin = sortedLifecycleEvents(app.id)
+        const priorOrigin = sortedLifecycleEvents(app.id, {
+          includeInferred: true,
+        })
           .filter((event) => ORIGINS.includes(event.eventType))
           .at(-1);
         events.push({
@@ -914,6 +917,7 @@ function bindDetail(app) {
               source: "manual",
               channel: v.channel,
               sourceArtifact: message.id,
+              actionStatus: v.direction,
               createdAt: operationTime,
             },
           ],

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -720,12 +720,12 @@ function detailForm(app) {
         "Compact CSV assessment signal",
     });
   }
-  return `<div class="tracker-detail"><article class="card"><h2>${esc(app.company || "New application")} — ${esc(app.role || "Unsaved")}</h2><form class="tracker-form" data-core-form>${input("company", app.company, true)}${input("role", app.role, true)}${input("postingUrl", app.postingUrl, "url")}<label>Origin<select name="origin" required>${ORIGINS.map((origin) => `<option value="${origin}" ${app.origin === origin ? "selected" : ""}>${origin}</option>`).join("")}</select></label><label>Status<select name="status" required>${STATUSES.map((s) => `<option ${app.status === s ? "selected" : ""}>${s}</option>`).join("")}</select></label>${input("source", app.source, "text")}${input("appliedAt", day(app.appliedAt), "date", app.status === "applied")}${input("followUpDate", day(app.followUpDate), "date")}<label>Notes<textarea name="notes">${esc(app.notes)}</textarea></label><button class="button">Save application</button></form></article><article class="card"><h3>Compact CSV metadata</h3>${metadataSection(app)}</article><article class="card wide-card"><h3>Lifecycle timeline</h3><p class="muted">Events are sorted by occurred date, then due date, then stable ID. All data stays local in this browser.</p><ul class="timeline">${events.map(timelineItem).join("") || '<li class="muted">No lifecycle events for this application yet.</li>'}</ul></article><article class="card"><h3>Assessments/take-homes</h3><form class="tracker-form" data-assessment-form><label>Action status<select name="actionStatus"><option>requested</option><option>pending</option><option>started</option><option>in_progress</option><option>submitted</option><option>completed</option></select></label>${input("dueAt", "", "date")}<label>Details<textarea name="details"></textarea></label><button class="button">Log assessment</button></form>${assessments.length ? `<ul>${assessments.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No written assessments or take-homes yet.</p>'}</article><article class="card"><h3>Recruiter screens</h3>${recruiterScreens.length ? `<ul>${recruiterScreens.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No recruiter screens yet.</p>'}</article><article class="card"><h3>Interviews</h3><form class="tracker-form" data-interview-form><label>Stage<select name="stage"><option>recruiter_screen</option><option>technical_screen</option><option>onsite_loop</option><option>other</option></select></label>${input("startsAt", day(now()), "date")}<label>Outcome<select name="outcome"><option>scheduled</option><option>completed</option><option>cancelled</option><option>no_show</option></select></label><button class="button">Log interview</button></form><ul>${otherInterviews.map((i) => `<li>${day(i.startsAt)} ${esc(i.stage)} ${esc(i.outcome)}</li>`).join("") || '<li class="muted">No non-recruiter interviews yet.</li>'}</ul></article><article class="card"><h3>Links/artifacts</h3><form class="tracker-form" data-artifact-form>${input("name", "", true)}${input("url", "")}<button class="button">Add link/artifact</button></form><ul>${m.artifacts.map((a) => `<li>${linkForArtifact(a)}</li>`).join("")}</ul></article><article class="card"><h3>Outreach messages</h3><form class="tracker-form" data-outreach-form><label>Direction<select name="direction"><option value="outbound">Outbound</option><option value="inbound">Inbound</option></select></label><label>Channel<select name="channel"><option>email</option><option>linkedin</option><option>phone</option><option>sms</option><option>other</option></select></label><label>Message<textarea name="body" required></textarea></label><button class="button">Add outreach</button></form><ul>${m.outreach.map((o) => `<li>${esc(o.direction)} ${day(o.sentAt || o.receivedAt)} ${esc(o.channel)} ${esc(o.body)}</li>`).join("")}</ul></article><article class="card"><h3>Offers</h3><form class="tracker-form" data-offer-form><label>Status<select name="status"><option>received</option><option>negotiating</option><option>accepted</option><option>declined</option><option>expired</option><option>rescinded</option></select></label>${input("notes", "")}<button class="button">Log offer</button></form><ul>${m.offers.map((o) => `<li>${esc(o.status)} ${esc(o.notes || "")}</li>`).join("")}</ul></article></div>`;
+  return `<div class="tracker-detail"><article class="card"><h2>${esc(app.company || "New application")} — ${esc(app.role || "Unsaved")}</h2><form class="tracker-form" data-core-form>${input("company", app.company, true)}${input("role", app.role, true)}${input("postingUrl", app.postingUrl, "url")}<label>Origin<select name="origin" required>${ORIGINS.map((origin) => `<option value="${origin}" ${app.origin === origin ? "selected" : ""}>${origin}</option>`).join("")}</select></label><label>Status<select name="status" required>${STATUSES.map((s) => `<option ${app.status === s ? "selected" : ""}>${s}</option>`).join("")}</select></label>${input("source", app.source, "text")}${input("appliedAt", day(app.appliedAt), "date", app.origin === "application_submitted", "Application date (if applicable).")}${input("followUpDate", day(app.followUpDate), "date")}<label>Notes<textarea name="notes">${esc(app.notes)}</textarea></label><button class="button">Save application</button></form></article><article class="card"><h3>Compact CSV metadata</h3>${metadataSection(app)}</article><article class="card wide-card"><h3>Lifecycle timeline</h3><p class="muted">Events are sorted by occurred date, then due date, then stable ID. All data stays local in this browser.</p><ul class="timeline">${events.map(timelineItem).join("") || '<li class="muted">No lifecycle events for this application yet.</li>'}</ul></article><article class="card"><h3>Assessments/take-homes</h3><form class="tracker-form" data-assessment-form><label>Action status<select name="actionStatus"><option>requested</option><option>pending</option><option>started</option><option>in_progress</option><option>submitted</option><option>completed</option></select></label>${input("dueAt", "", "date")}<label>Details<textarea name="details"></textarea></label><button class="button">Log assessment</button></form>${assessments.length ? `<ul>${assessments.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No written assessments or take-homes yet.</p>'}</article><article class="card"><h3>Recruiter screens</h3>${recruiterScreens.length ? `<ul>${recruiterScreens.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No recruiter screens yet.</p>'}</article><article class="card"><h3>Interviews</h3><form class="tracker-form" data-interview-form><label>Stage<select name="stage"><option>recruiter_screen</option><option>technical_screen</option><option>onsite_loop</option><option>other</option></select></label>${input("startsAt", day(now()), "date")}<label>Outcome<select name="outcome"><option>scheduled</option><option>completed</option><option>cancelled</option><option>no_show</option></select></label><button class="button">Log interview</button></form><ul>${otherInterviews.map((i) => `<li>${day(i.startsAt)} ${esc(i.stage)} ${esc(i.outcome)}</li>`).join("") || '<li class="muted">No non-recruiter interviews yet.</li>'}</ul></article><article class="card"><h3>Links/artifacts</h3><form class="tracker-form" data-artifact-form>${input("name", "", true)}${input("url", "")}<button class="button">Add link/artifact</button></form><ul>${m.artifacts.map((a) => `<li>${linkForArtifact(a)}</li>`).join("")}</ul></article><article class="card"><h3>Outreach messages</h3><form class="tracker-form" data-outreach-form><label>Direction<select name="direction"><option value="outbound">Outbound</option><option value="inbound">Inbound</option></select></label><label>Channel<select name="channel"><option>email</option><option>linkedin</option><option>phone</option><option>sms</option><option>other</option></select></label><label>Message<textarea name="body" required></textarea></label><button class="button">Add outreach</button></form><ul>${m.outreach.map((o) => `<li>${esc(o.direction)} ${day(o.sentAt || o.receivedAt)} ${esc(o.channel)} ${esc(o.body)}</li>`).join("")}</ul></article><article class="card"><h3>Offers</h3><form class="tracker-form" data-offer-form><label>Status<select name="status"><option>received</option><option>negotiating</option><option>accepted</option><option>declined</option><option>expired</option><option>rescinded</option></select></label>${input("notes", "")}<button class="button">Log offer</button></form><ul>${m.offers.map((o) => `<li>${esc(o.status)} ${esc(o.notes || "")}</li>`).join("")}</ul></article></div>`;
 }
-function input(n, v = "", type = "text", required = false) {
+function input(n, v = "", type = "text", required = false, label = n) {
   const req = type === true || required ? "required" : "";
   type = type === true ? "text" : type;
-  return `<label>${n}<input name="${n}" type="${type}" value="${esc(v)}" ${req}></label>`;
+  return `<label>${esc(label)}<input name="${n}" type="${type}" value="${esc(v)}" ${req}></label>`;
 }
 function values(form) {
   return Object.fromEntries(new FormData(form).entries());
@@ -785,12 +785,29 @@ function bindDetail(app) {
     }
     return true;
   };
+  const coreForm = $("[data-core-form]");
+  const syncApplicationDateRequirement = () => {
+    const date = coreForm.elements.namedItem("appliedAt");
+    if (date)
+      date.required =
+        coreForm.elements.namedItem("origin")?.value ===
+        "application_submitted";
+  };
+  coreForm.elements
+    .namedItem("origin")
+    ?.addEventListener("change", syncApplicationDateRequirement);
+  syncApplicationDateRequirement();
   $("[data-core-form]").onsubmit = async (e) => {
     e.preventDefault();
     const form = e.target;
     await submitWithRecovery(form, async (v) => {
       const current = latestApp();
       const operationTime = now();
+      if (v.origin === "application_submitted" && !v.appliedAt) {
+        throw new Error(
+          "Application date is required for submitted applications.",
+        );
+      }
       const saved = {
         ...current,
         ...v,
@@ -810,8 +827,10 @@ function bindDetail(app) {
           applicationId: app.id,
           eventType: v.origin,
           status: v.status,
-          occurredAt: saved.appliedAt || operationTime,
-          occurredAtPrecision: saved.appliedAt ? "instant" : "unknown",
+          occurredAt:
+            v.origin === "application_submitted" ? v.appliedAt : operationTime,
+          occurredAtPrecision:
+            v.origin === "application_submitted" ? "date" : "instant",
           inferred: false,
           source: "manual",
           createdAt: operationTime,
@@ -827,8 +846,10 @@ function bindDetail(app) {
           applicationId: app.id,
           eventType: v.origin,
           status: current.status,
-          occurredAt: operationTime,
-          occurredAtPrecision: "instant",
+          occurredAt:
+            v.origin === "application_submitted" ? v.appliedAt : operationTime,
+          occurredAtPrecision:
+            v.origin === "application_submitted" ? "date" : "instant",
           inferred: false,
           source: "manual",
           supersedesEventId: priorOrigin?.id,

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -1277,7 +1277,7 @@ test.describe("browser application tracker", () => {
       await page.locator('[name="appliedAt"]').fill("2026-01-10");
       await page.getByRole("button", { name: "Save application" }).click();
 
-      const recordCounts = async () =>
+      const recordSnapshots = async () =>
         page.evaluate(
           () =>
             new Promise((resolve, reject) => {
@@ -1289,28 +1289,30 @@ test.describe("browser application tracker", () => {
                   ["applications", "outreachMessages", "lifecycleEvents"],
                   "readonly",
                 );
-                const counts = {};
+                const snapshots = {};
                 for (const storeName of [
                   "applications",
                   "outreachMessages",
                   "lifecycleEvents",
                 ]) {
-                  const count = tx.objectStore(storeName).count();
-                  count.onerror = () => reject(count.error);
-                  count.onsuccess = () => {
-                    counts[storeName] = count.result;
+                  const getAll = tx.objectStore(storeName).getAll();
+                  getAll.onerror = () => reject(getAll.error);
+                  getAll.onsuccess = () => {
+                    snapshots[storeName] = getAll.result.toSorted((a, b) =>
+                      String(a.id).localeCompare(String(b.id)),
+                    );
                   };
                 }
                 tx.oncomplete = () => {
                   db.close();
-                  resolve(counts);
+                  resolve(snapshots);
                 };
                 tx.onabort = () => reject(tx.error);
               };
             }),
         );
 
-      const before = await recordCounts();
+      const before = await recordSnapshots();
 
       await page.evaluate(() => {
         const originalAdd = IDBObjectStore.prototype.add;
@@ -1324,67 +1326,105 @@ test.describe("browser application tracker", () => {
           }
           return request;
         };
+        window.__restoreLifecycleFailurePatch = () => {
+          IDBObjectStore.prototype.add = originalAdd;
+        };
 
-        window.__pendingLifecycleBlocker = new Promise((resolve, reject) => {
-          const open = indexedDB.open("jobbot3000");
-          open.onerror = () => reject(open.error);
-          open.onsuccess = () => {
-            const db = open.result;
-            const tx = db.transaction(
-              ["applications", "outreachMessages", "lifecycleEvents"],
-              "readwrite",
+        let releaseBlocker;
+        window.__releasePendingLifecycleBlocker = () => releaseBlocker?.();
+        window.__pendingLifecycleBlockerReady = new Promise(
+          (resolveReady, rejectReady) => {
+            window.__pendingLifecycleBlocker = new Promise(
+              (resolve, reject) => {
+                const open = indexedDB.open("jobbot3000");
+                open.onerror = () => {
+                  rejectReady(open.error);
+                  reject(open.error);
+                };
+                open.onsuccess = () => {
+                  const db = open.result;
+                  const tx = db.transaction(
+                    ["applications", "outreachMessages", "lifecycleEvents"],
+                    "readwrite",
+                  );
+                  const store = tx.objectStore("applications");
+                  let released = false;
+                  window.__releasePendingLifecycleBlocker = () => {
+                    released = true;
+                  };
+                  releaseBlocker = window.__releasePendingLifecycleBlocker;
+                  const keepAlive = () => {
+                    const request = store.get(
+                      "__delay_pending_lifecycle_submit__",
+                    );
+                    request.onerror = () => {
+                      rejectReady(request.error);
+                      reject(request.error);
+                    };
+                    request.onsuccess = () => {
+                      resolveReady();
+                      if (!released) keepAlive();
+                    };
+                  };
+                  keepAlive();
+                  tx.oncomplete = () => {
+                    db.close();
+                    resolve();
+                  };
+                  tx.onabort = () => {
+                    rejectReady(tx.error);
+                    reject(tx.error);
+                  };
+                };
+              },
             );
-            const store = tx.objectStore("applications");
-            const until = performance.now() + 500;
-            const keepAlive = () => {
-              const request = store.get("__delay_pending_lifecycle_submit__");
-              request.onerror = () => reject(request.error);
-              request.onsuccess = () => {
-                if (performance.now() < until) keepAlive();
-              };
-            };
-            keepAlive();
-            tx.oncomplete = () => {
-              db.close();
-              resolve();
-            };
-            tx.onabort = () => reject(tx.error);
-          };
-        });
+          },
+        );
       });
+      await page.evaluate(() => window.__pendingLifecycleBlockerReady);
 
-      const outreachForm = page.locator("[data-outreach-form]");
-      await outreachForm.locator('[name="direction"]').selectOption("inbound");
-      await outreachForm.locator('[name="channel"]').selectOption("linkedin");
-      await outreachForm
-        .locator('[name="body"]')
-        .fill("Persist me after failure");
-      const submit = page.getByRole("button", { name: "Add outreach" }).click();
+      try {
+        const outreachForm = page.locator("[data-outreach-form]");
+        await outreachForm
+          .locator('[name="direction"]')
+          .selectOption("inbound");
+        await outreachForm.locator('[name="channel"]').selectOption("linkedin");
+        await outreachForm
+          .locator('[name="body"]')
+          .fill("Persist me after failure");
+        const submit = page
+          .getByRole("button", { name: "Add outreach" })
+          .click();
 
-      await expect(outreachForm.locator('[name="direction"]')).toBeDisabled();
-      await expect(outreachForm.locator('[name="channel"]')).toBeDisabled();
-      await expect(outreachForm.locator('[name="body"]')).toBeDisabled();
-      await expect(
-        page.getByRole("button", { name: "Add outreach" }),
-      ).toBeDisabled();
+        await expect(outreachForm.locator('[name="direction"]')).toBeDisabled();
+        await expect(outreachForm.locator('[name="channel"]')).toBeDisabled();
+        await expect(outreachForm.locator('[name="body"]')).toBeDisabled();
+        await expect(
+          page.getByRole("button", { name: "Add outreach" }),
+        ).toBeDisabled();
 
-      await submit;
-      await expect(outreachForm.getByRole("alert")).toContainText(
-        "Save failed. No changes were written.",
-      );
-      await expect(outreachForm.locator('[name="direction"]')).toBeEnabled();
-      await expect(outreachForm.locator('[name="channel"]')).toBeEnabled();
-      await expect(outreachForm.locator('[name="body"]')).toBeEnabled();
-      await expect(outreachForm.locator('[name="direction"]')).toHaveValue(
-        "inbound",
-      );
-      await expect(outreachForm.locator('[name="channel"]')).toHaveValue(
-        "linkedin",
-      );
-      await expect(outreachForm.locator('[name="body"]')).toHaveValue(
-        "Persist me after failure",
-      );
-      await expect(recordCounts()).resolves.toEqual(before);
+        await page.evaluate(() => window.__releasePendingLifecycleBlocker());
+        await page.evaluate(() => window.__pendingLifecycleBlocker);
+        await submit;
+        await expect(outreachForm.getByRole("alert")).toContainText(
+          "Save failed. No changes were written.",
+        );
+        await expect(outreachForm.locator('[name="direction"]')).toBeEnabled();
+        await expect(outreachForm.locator('[name="channel"]')).toBeEnabled();
+        await expect(outreachForm.locator('[name="body"]')).toBeEnabled();
+        await expect(outreachForm.locator('[name="direction"]')).toHaveValue(
+          "inbound",
+        );
+        await expect(outreachForm.locator('[name="channel"]')).toHaveValue(
+          "linkedin",
+        );
+        await expect(outreachForm.locator('[name="body"]')).toHaveValue(
+          "Persist me after failure",
+        );
+        await expect(recordSnapshots()).resolves.toEqual(before);
+      } finally {
+        await page.evaluate(() => window.__restoreLifecycleFailurePatch?.());
+      }
     },
   );
 });

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -1,4 +1,4 @@
-/* global IDBDatabase, indexedDB */
+/* global IDBDatabase, IDBObjectStore, indexedDB, window */
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -1263,4 +1263,128 @@ test.describe("browser application tracker", () => {
       )
       .toBe(1);
   });
+
+  test(
+    "disables lifecycle form controls during pending submission " +
+      "and recovers after submission failure",
+    async ({ page }) => {
+      await page
+        .getByRole("button", { name: "Applications", exact: true })
+        .click();
+      await page.getByRole("button", { name: "New application" }).click();
+      await page.locator('[name="company"]').fill("Failure Recovery Co");
+      await page.locator('[name="role"]').fill("Lifecycle QA");
+      await page.locator('[name="appliedAt"]').fill("2026-01-10");
+      await page.getByRole("button", { name: "Save application" }).click();
+
+      const recordCounts = async () =>
+        page.evaluate(
+          () =>
+            new Promise((resolve, reject) => {
+              const request = indexedDB.open("jobbot3000");
+              request.onerror = () => reject(request.error);
+              request.onsuccess = () => {
+                const db = request.result;
+                const tx = db.transaction(
+                  ["applications", "outreachMessages", "lifecycleEvents"],
+                  "readonly",
+                );
+                const counts = {};
+                for (const storeName of [
+                  "applications",
+                  "outreachMessages",
+                  "lifecycleEvents",
+                ]) {
+                  const count = tx.objectStore(storeName).count();
+                  count.onerror = () => reject(count.error);
+                  count.onsuccess = () => {
+                    counts[storeName] = count.result;
+                  };
+                }
+                tx.oncomplete = () => {
+                  db.close();
+                  resolve(counts);
+                };
+                tx.onabort = () => reject(tx.error);
+              };
+            }),
+        );
+
+      const before = await recordCounts();
+
+      await page.evaluate(() => {
+        const originalAdd = IDBObjectStore.prototype.add;
+        IDBObjectStore.prototype.add = function delayedFailingAdd(...args) {
+          const request = originalAdd.apply(this, args);
+          if (
+            this.name === "outreachMessages" &&
+            args[0]?.body === "Persist me after failure"
+          ) {
+            this.transaction.abort();
+          }
+          return request;
+        };
+
+        window.__pendingLifecycleBlocker = new Promise((resolve, reject) => {
+          const open = indexedDB.open("jobbot3000");
+          open.onerror = () => reject(open.error);
+          open.onsuccess = () => {
+            const db = open.result;
+            const tx = db.transaction(
+              ["applications", "outreachMessages", "lifecycleEvents"],
+              "readwrite",
+            );
+            const store = tx.objectStore("applications");
+            const until = performance.now() + 500;
+            const keepAlive = () => {
+              const request = store.get("__delay_pending_lifecycle_submit__");
+              request.onerror = () => reject(request.error);
+              request.onsuccess = () => {
+                if (performance.now() < until) keepAlive();
+              };
+            };
+            keepAlive();
+            tx.oncomplete = () => {
+              db.close();
+              resolve();
+            };
+            tx.onabort = () => reject(tx.error);
+          };
+        });
+      });
+
+      const outreachForm = page.locator("[data-outreach-form]");
+      await outreachForm.locator('[name="direction"]').selectOption("inbound");
+      await outreachForm.locator('[name="channel"]').selectOption("linkedin");
+      await outreachForm
+        .locator('[name="body"]')
+        .fill("Persist me after failure");
+      const submit = page.getByRole("button", { name: "Add outreach" }).click();
+
+      await expect(outreachForm.locator('[name="direction"]')).toBeDisabled();
+      await expect(outreachForm.locator('[name="channel"]')).toBeDisabled();
+      await expect(outreachForm.locator('[name="body"]')).toBeDisabled();
+      await expect(
+        page.getByRole("button", { name: "Add outreach" }),
+      ).toBeDisabled();
+
+      await submit;
+      await expect(outreachForm.getByRole("alert")).toContainText(
+        "Save failed. No changes were written.",
+      );
+      await expect(outreachForm.locator('[name="direction"]')).toBeEnabled();
+      await expect(outreachForm.locator('[name="channel"]')).toBeEnabled();
+      await expect(outreachForm.locator('[name="body"]')).toBeEnabled();
+      await expect(outreachForm.locator('[name="direction"]')).toHaveValue(
+        "inbound",
+      );
+      await expect(outreachForm.locator('[name="channel"]')).toHaveValue(
+        "linkedin",
+      );
+      await expect(outreachForm.locator('[name="body"]')).toHaveValue(
+        "Persist me after failure",
+      );
+      await expect(recordCounts()).resolves.toEqual(before);
+    },
+  );
 });

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -1191,4 +1191,76 @@ test.describe("browser application tracker", () => {
 
     expect(mutatingRequests).toEqual([]);
   });
+
+  test("requires application date only for submitted origins and records reopen events", async ({
+    page,
+  }) => {
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "New application" }).click();
+
+    const dateInput = page.locator('[data-core-form] [name="appliedAt"]');
+    await expect(
+      page.getByText("Application date (if applicable).", { exact: true }),
+    ).toBeVisible();
+    await expect(dateInput).toHaveAttribute("required", "");
+    await page
+      .locator('[data-core-form] [name="origin"]')
+      .selectOption("candidate_outreach");
+    await expect(dateInput).not.toHaveAttribute("required", "");
+    await page
+      .locator('[data-core-form] [name="origin"]')
+      .selectOption("application_submitted");
+    await expect(dateInput).toHaveAttribute("required", "");
+
+    await page.locator('[name="company"]').fill("Reopen Coverage Co");
+    await page.locator('[name="role"]').fill("Lifecycle QA");
+    await dateInput.fill("2026-01-10");
+    await page.getByRole("button", { name: "Save application" }).click();
+
+    const countEvents = async () =>
+      page.evaluate(
+        () =>
+          new Promise((resolve, reject) => {
+            const request = indexedDB.open("jobbot3000");
+            request.onerror = () => reject(request.error);
+            request.onsuccess = () => {
+              const db = request.result;
+              const tx = db.transaction("lifecycleEvents", "readonly");
+              const getAll = tx.objectStore("lifecycleEvents").getAll();
+              getAll.onerror = () => reject(getAll.error);
+              getAll.onsuccess = () => resolve(getAll.result);
+              tx.oncomplete = () => db.close();
+            };
+          }),
+      );
+
+    const createdEvents = await countEvents();
+    await page.locator('[name="role"]').fill("Lifecycle QA Updated");
+    await page.getByRole("button", { name: "Save application" }).click();
+    await expect(page.locator('[name="role"]')).toHaveValue(
+      "Lifecycle QA Updated",
+    );
+    await expect
+      .poll(async () => (await countEvents()).length)
+      .toBe(createdEvents.length);
+
+    await page
+      .locator('[data-core-form] [name="status"]')
+      .selectOption("rejected");
+    await page.getByRole("button", { name: "Save application" }).click();
+    await page
+      .locator('[data-core-form] [name="status"]')
+      .selectOption("applied");
+    await page.getByRole("button", { name: "Save application" }).click();
+    await expect
+      .poll(
+        async () =>
+          (await countEvents()).filter(
+            (event) => event.eventType === "application_reopened",
+          ).length,
+      )
+      .toBe(1);
+  });
 });

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -642,7 +642,10 @@ test.describe("browser application tracker", () => {
       const originalTransaction = IDBDatabase.prototype.transaction;
       IDBDatabase.prototype.transaction = function transaction(...args) {
         if (args[1] === "readwrite") {
-          throw new DOMException("simulated quota exceeded", "QuotaExceededError");
+          throw new DOMException(
+            "simulated quota exceeded",
+            "QuotaExceededError",
+          );
         }
         return originalTransaction.apply(this, args);
       };
@@ -810,6 +813,68 @@ test.describe("browser application tracker", () => {
     await expect(page.locator('[data-core-form] [name="status"]')).toHaveValue(
       "technical_screen",
     );
+  });
+
+  test("repeated origin corrections leave one effective origin", async ({
+    page,
+  }) => {
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "New application" }).click();
+    await page.locator('[name="company"]').fill("Origin Corrections Co");
+    await page.locator('[name="role"]').fill("Lifecycle Tester");
+    await page.locator('[name="appliedAt"]').fill("2026-01-10");
+    await page.getByRole("button", { name: "Save application" }).click();
+
+    await page
+      .locator('[data-core-form] [name="origin"]')
+      .selectOption("referral");
+    await page.getByRole("button", { name: "Save application" }).click();
+    await page
+      .locator('[data-core-form] [name="origin"]')
+      .selectOption("application_submitted");
+    await page.locator('[name="appliedAt"]').fill("2026-01-01");
+    await page.getByRole("button", { name: "Save application" }).click();
+    await page
+      .locator('[data-core-form] [name="origin"]')
+      .selectOption("candidate_outreach");
+    await page.getByRole("button", { name: "Save application" }).click();
+
+    const effectiveOrigins = await page.evaluate(
+      () =>
+        new Promise((resolve, reject) => {
+          const request = indexedDB.open("jobbot3000");
+          request.onerror = () => reject(request.error);
+          request.onsuccess = () => {
+            const db = request.result;
+            const tx = db.transaction("lifecycleEvents", "readonly");
+            const getAll = tx.objectStore("lifecycleEvents").getAll();
+            getAll.onerror = () => reject(getAll.error);
+            getAll.onsuccess = () => {
+              const events = getAll.result.filter((event) =>
+                [
+                  "application_submitted",
+                  "recruiter_company_outreach",
+                  "candidate_outreach",
+                  "referral",
+                  "other_unknown",
+                ].includes(event.eventType),
+              );
+              const superseded = new Set(
+                events.map((event) => event.supersedesEventId).filter(Boolean),
+              );
+              resolve(events.filter((event) => !superseded.has(event.id)));
+            };
+            tx.oncomplete = () => db.close();
+          };
+        }),
+    );
+
+    expect(effectiveOrigins).toHaveLength(1);
+    expect(effectiveOrigins[0]).toMatchObject({
+      eventType: "candidate_outreach",
+    });
   });
 
   test("combines status and outcome filters against distinct fields", async ({

--- a/test/web-tracker-lifecycle-persistence.test.js
+++ b/test/web-tracker-lifecycle-persistence.test.js
@@ -1,0 +1,135 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { indexedDB } from "fake-indexeddb";
+import {
+  DATABASE_NAME,
+  createIndexedDbRepository,
+} from "../src/web/storage/indexedDbRepository.js";
+
+const ts = "2026-01-01T00:00:00.000Z";
+const app = {
+  id: "app_fake_001",
+  company: "Fake Co",
+  role: "Fake Role",
+  status: "applied",
+  origin: "application_submitted",
+  appliedAt: ts,
+  createdAt: ts,
+  updatedAt: ts,
+};
+const event = (id, type, status = "applied", extra = {}) => ({
+  id,
+  applicationId: app.id,
+  eventType: type,
+  status,
+  occurredAt: ts,
+  occurredAtPrecision: "instant",
+  inferred: false,
+  source: "manual",
+  createdAt: ts,
+  ...extra,
+});
+const deleteDatabase = () =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(DATABASE_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => resolve();
+  });
+afterEach(deleteDatabase);
+
+describe("atomic lifecycle persistence", () => {
+  it("commits application and origin event atomically with previous persisted status", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await repo.commitLifecycleMutation({
+      application: app,
+      records: {
+        lifecycleEvents: [event("event_fake_origin", "application_submitted")],
+      },
+    });
+    let exported = await repo.exportAllData();
+    expect(exported.applications).toHaveLength(1);
+    expect(exported.lifecycleEvents).toHaveLength(1);
+    await repo.commitLifecycleMutation({
+      application: {
+        ...app,
+        status: "offer",
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      },
+      records: {
+        offers: [
+          {
+            id: "offer_fake_001",
+            applicationId: app.id,
+            status: "received",
+            createdAt: ts,
+            updatedAt: ts,
+          },
+        ],
+        lifecycleEvents: [event("event_fake_offer", "offer_received", "offer")],
+      },
+    });
+    exported = await repo.exportAllData();
+    expect(
+      exported.lifecycleEvents.find((item) => item.id === "event_fake_offer")
+        .previousStatus,
+    ).toBe("applied");
+    expect(exported.offers).toHaveLength(1);
+    repo.close();
+  });
+
+  it("rolls back all records on duplicate child failure", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await repo.commitLifecycleMutation({
+      application: app,
+      records: {
+        lifecycleEvents: [event("event_fake_origin", "application_submitted")],
+      },
+    });
+    await expect(
+      repo.commitLifecycleMutation({
+        application: { ...app, status: "offer" },
+        records: {
+          offers: [
+            {
+              id: "offer_fake_001",
+              applicationId: app.id,
+              status: "received",
+              createdAt: ts,
+              updatedAt: ts,
+            },
+          ],
+          lifecycleEvents: [
+            event("event_fake_origin", "offer_received", "offer"),
+          ],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "operation_failed" });
+    const exported = await repo.exportAllData();
+    expect(exported.applications[0].status).toBe("applied");
+    expect(exported.offers).toHaveLength(0);
+    expect(exported.lifecycleEvents).toHaveLength(1);
+    repo.close();
+  });
+
+  it("rejects cross-application supersession and cycles", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await repo.commitLifecycleMutation({
+      application: app,
+      records: {
+        lifecycleEvents: [event("event_fake_origin", "application_submitted")],
+      },
+    });
+    await expect(
+      repo.commitLifecycleMutation({
+        records: {
+          lifecycleEvents: [
+            event("event_fake_bad", "referral", "applied", {
+              supersedesEventId: "missing_event",
+            }),
+          ],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "schema_validation_failed" });
+    repo.close();
+  });
+});

--- a/test/web-tracker-lifecycle-persistence.test.js
+++ b/test/web-tracker-lifecycle-persistence.test.js
@@ -37,6 +37,36 @@ const deleteDatabase = () =>
   });
 afterEach(deleteDatabase);
 
+const readRawLifecycleEvent = (id) =>
+  new Promise((resolve, reject) => {
+    const openRequest = indexedDB.open(DATABASE_NAME);
+    openRequest.onerror = () => reject(openRequest.error);
+    openRequest.onsuccess = () => {
+      const db = openRequest.result;
+      const tx = db.transaction("lifecycleEvents", "readonly");
+      const getRequest = tx.objectStore("lifecycleEvents").get(id);
+      getRequest.onerror = () => reject(getRequest.error);
+      getRequest.onsuccess = () => resolve(getRequest.result);
+      tx.oncomplete = () => db.close();
+    };
+  });
+
+const writeRawLifecycleEvents = (events) =>
+  new Promise((resolve, reject) => {
+    const openRequest = indexedDB.open(DATABASE_NAME);
+    openRequest.onerror = () => reject(openRequest.error);
+    openRequest.onsuccess = () => {
+      const db = openRequest.result;
+      const tx = db.transaction("lifecycleEvents", "readwrite");
+      tx.oncomplete = () => {
+        db.close();
+        resolve();
+      };
+      tx.onerror = () => reject(tx.error);
+      for (const item of events) tx.objectStore("lifecycleEvents").put(item);
+    };
+  });
+
 describe("atomic lifecycle persistence", () => {
   it("commits application and origin event atomically with previous persisted status", async () => {
     const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
@@ -130,6 +160,40 @@ describe("atomic lifecycle persistence", () => {
         },
       }),
     ).rejects.toMatchObject({ code: "schema_validation_failed" });
+    repo.close();
+  });
+
+  it("uses persisted previous status over caller data and tolerates unrelated cycles", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await repo.commitLifecycleMutation({
+      application: app,
+      records: {
+        lifecycleEvents: [event("event_fake_origin", "application_submitted")],
+      },
+    });
+    await writeRawLifecycleEvents([
+      event("event_fake_cycle_a", "status_changed", "applied", {
+        supersedesEventId: "event_fake_cycle_b",
+      }),
+      event("event_fake_cycle_b", "status_changed", "applied", {
+        supersedesEventId: "event_fake_cycle_a",
+      }),
+    ]);
+    await repo.commitLifecycleMutation({
+      application: { ...app, status: "offer", updatedAt: ts },
+      records: {
+        lifecycleEvents: [
+          event("event_fake_offer", "offer_received", "offer", {
+            previousStatus: "accepted",
+          }),
+        ],
+      },
+    });
+    await expect(
+      readRawLifecycleEvent("event_fake_offer"),
+    ).resolves.toMatchObject({
+      previousStatus: "applied",
+    });
     repo.close();
   });
 });

--- a/test/web-tracker-lifecycle-persistence.test.js
+++ b/test/web-tracker-lifecycle-persistence.test.js
@@ -250,4 +250,225 @@ describe("atomic lifecycle persistence", () => {
     ).resolves.toMatchObject({ status: "offer" });
     repo.close();
   });
+  it("commits every mutation family with matching export records", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await repo.commitLifecycleMutation({
+      application: app,
+      records: {
+        lifecycleEvents: [event("event_fake_origin", "application_submitted")],
+      },
+    });
+    const cases = [
+      {
+        appStatus: "outreach_sent",
+        store: "outreachMessages",
+        child: {
+          id: "msg_fake_out",
+          applicationId: app.id,
+          direction: "outbound",
+          channel: "email",
+          sentAt: ts,
+          createdAt: ts,
+          updatedAt: ts,
+        },
+        ev: event("event_fake_out", "candidate_outreach", "outreach_sent", {
+          sourceArtifact: "msg_fake_out",
+          actionStatus: "outbound",
+        }),
+      },
+      {
+        appStatus: "applied",
+        store: "outreachMessages",
+        child: {
+          id: "msg_fake_in",
+          applicationId: app.id,
+          direction: "inbound",
+          channel: "email",
+          receivedAt: ts,
+          createdAt: ts,
+          updatedAt: ts,
+        },
+        ev: event("event_fake_in", "employer_response_received", "applied", {
+          sourceArtifact: "msg_fake_in",
+          actionStatus: "inbound",
+        }),
+      },
+      {
+        appStatus: "applied",
+        store: "artifacts",
+        child: {
+          id: "artifact_fake_assessment",
+          applicationId: app.id,
+          kind: "take_home",
+          name: "Assessment",
+          private: true,
+          createdAt: ts,
+          updatedAt: ts,
+        },
+        ev: event("event_fake_assessment", "assessment_take_home", "applied", {
+          sourceArtifact: "artifact_fake_assessment",
+        }),
+      },
+      ...[
+        ["scheduled", "technical_interview", "technical_screen"],
+        ["completed", "technical_interview", "technical_screen"],
+        ["cancelled", "status_changed", "applied"],
+        ["no_show", "status_changed", "applied"],
+      ].map(([outcome, type, status]) => ({
+        appStatus: status,
+        store: "interviews",
+        child: {
+          id: `int_fake_${outcome}`,
+          applicationId: app.id,
+          contactIds: [],
+          stage: "technical_screen",
+          startsAt: "2026-01-03T00:00:00.000Z",
+          outcome,
+          createdAt: ts,
+          updatedAt: ts,
+        },
+        ev: event(`event_fake_interview_${outcome}`, type, status, {
+          sourceArtifact: `int_fake_${outcome}`,
+          actionStatus: outcome,
+          dueAt: "2026-01-03T00:00:00.000Z",
+        }),
+      })),
+      ...[
+        ["received", "offer_received", "offer"],
+        ["negotiating", "offer_negotiating", "offer"],
+        ["accepted", "offer_accepted", "accepted"],
+        ["declined", "offer_declined", "offer"],
+        ["expired", "offer_expired_rescinded", "offer"],
+        ["rescinded", "offer_expired_rescinded", "offer"],
+      ].map(([offerStatus, type, status]) => ({
+        appStatus: status,
+        store: "offers",
+        child: {
+          id: `offer_fake_${offerStatus}`,
+          applicationId: app.id,
+          status: offerStatus,
+          createdAt: ts,
+          updatedAt: ts,
+        },
+        ev: event(`event_fake_offer_${offerStatus}`, type, status, {
+          sourceArtifact: `offer_fake_${offerStatus}`,
+          actionStatus: offerStatus,
+        }),
+      })),
+    ];
+    for (const item of cases) {
+      await repo.commitLifecycleMutation({
+        application: { ...app, status: item.appStatus, updatedAt: ts },
+        records: { [item.store]: [item.child], lifecycleEvents: [item.ev] },
+      });
+    }
+    const exported = await repo.exportAllData();
+    expect(exported.outreachMessages.map((x) => x.id).sort()).toEqual([
+      "msg_fake_in",
+      "msg_fake_out",
+    ]);
+    expect(exported.artifacts.map((x) => x.id)).toEqual([
+      "artifact_fake_assessment",
+    ]);
+    expect(exported.interviews).toHaveLength(4);
+    expect(exported.offers).toHaveLength(6);
+    for (const item of cases) {
+      expect(exported[item.store].some((row) => row.id === item.child.id)).toBe(
+        true,
+      );
+      expect(exported.lifecycleEvents).toContainEqual(
+        expect.objectContaining({
+          id: item.ev.id,
+          eventType: item.ev.eventType,
+          status: item.ev.status,
+          sourceArtifact: item.child.id,
+        }),
+      );
+    }
+    repo.close();
+  });
+
+  it("rejects invalid and cross-application child references without partial writes", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await repo.commitLifecycleMutation({
+      application: app,
+      records: {
+        lifecycleEvents: [event("event_fake_origin", "application_submitted")],
+      },
+    });
+    await repo.commitLifecycleMutation({
+      application: { ...app, id: "app_fake_other" },
+      records: {
+        lifecycleEvents: [
+          event("event_fake_other_origin", "application_submitted", "applied", {
+            applicationId: "app_fake_other",
+          }),
+        ],
+        contacts: [
+          {
+            id: "contact_fake_other",
+            applicationId: "app_fake_other",
+            name: "Other",
+            createdAt: ts,
+            updatedAt: ts,
+          },
+        ],
+      },
+    });
+    await expect(
+      repo.commitLifecycleMutation({
+        application: app,
+        records: {
+          interviews: [
+            {
+              id: "int_fake_bad",
+              applicationId: app.id,
+              contactIds: ["contact_fake_other"],
+              stage: "technical_screen",
+              startsAt: ts,
+              outcome: "scheduled",
+              createdAt: ts,
+              updatedAt: ts,
+            },
+          ],
+          lifecycleEvents: [
+            event(
+              "event_fake_bad_contact",
+              "technical_interview",
+              "technical_screen",
+            ),
+          ],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "schema_validation_failed" });
+    await expect(
+      repo.commitLifecycleMutation({
+        records: {
+          outreachMessages: [
+            {
+              id: "msg_fake_missing_app",
+              applicationId: "app_fake_missing",
+              direction: "outbound",
+              channel: "email",
+              sentAt: ts,
+              createdAt: ts,
+              updatedAt: ts,
+            },
+          ],
+          lifecycleEvents: [
+            event(
+              "event_fake_missing_app",
+              "candidate_outreach",
+              "outreach_sent",
+              { applicationId: "app_fake_missing" },
+            ),
+          ],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "schema_validation_failed" });
+    const exported = await repo.exportAllData();
+    expect(exported.interviews).toHaveLength(0);
+    expect(exported.outreachMessages).toHaveLength(0);
+    repo.close();
+  });
 });

--- a/test/web-tracker-lifecycle-persistence.test.js
+++ b/test/web-tracker-lifecycle-persistence.test.js
@@ -196,4 +196,58 @@ describe("atomic lifecycle persistence", () => {
     });
     repo.close();
   });
+
+  it("rejects cyclic partial imports without partial writes", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await repo.commitLifecycleMutation({
+      application: app,
+      records: {
+        lifecycleEvents: [event("event_fake_origin", "application_submitted")],
+      },
+    });
+
+    await expect(
+      repo.importPartialData({
+        lifecycleEvents: [
+          event("event_fake_import_cycle_a", "status_changed", "applied", {
+            supersedesEventId: "event_fake_import_cycle_b",
+          }),
+          event("event_fake_import_cycle_b", "status_changed", "applied", {
+            supersedesEventId: "event_fake_import_cycle_a",
+          }),
+        ],
+      }),
+    ).rejects.toMatchObject({ code: "schema_validation_failed" });
+
+    const exported = await repo.exportAllData();
+    expect(exported.lifecycleEvents.map((item) => item.id).sort()).toEqual([
+      "event_fake_origin",
+    ]);
+
+    await writeRawLifecycleEvents([
+      event("event_fake_legacy_cycle_a", "status_changed", "applied", {
+        supersedesEventId: "event_fake_legacy_cycle_b",
+      }),
+      event("event_fake_legacy_cycle_b", "status_changed", "applied", {
+        supersedesEventId: "event_fake_legacy_cycle_a",
+      }),
+    ]);
+    await repo.commitLifecycleMutation({
+      application: { ...app, status: "offer", updatedAt: ts },
+      records: {
+        lifecycleEvents: [
+          event(
+            "event_fake_valid_after_legacy_cycle",
+            "offer_received",
+            "offer",
+          ),
+        ],
+      },
+    });
+
+    await expect(
+      readRawLifecycleEvent("event_fake_valid_after_legacy_cycle"),
+    ).resolves.toMatchObject({ status: "offer" });
+    repo.close();
+  });
 });

--- a/test/web-tracker-lifecycle-reconciliation.test.js
+++ b/test/web-tracker-lifecycle-reconciliation.test.js
@@ -110,7 +110,6 @@ describe("lifecycle reconciliation planner", () => {
     });
     expect(plan.warnings.map((warning) => warning.code)).toEqual(
       expect.arrayContaining([
-        "status_history_mismatch",
         "status_snapshot_inferred",
         "unknown_occurrence_precision",
       ]),
@@ -125,6 +124,171 @@ describe("lifecycle reconciliation planner", () => {
         (event) => event.eventType === "migration_status_snapshot",
       ).occurredAtPrecision,
     ).toBe("unknown");
+  });
+
+  it("replays effective history before adding a deterministic status snapshot", () => {
+    const bundle = {
+      applications: [
+        {
+          ...app,
+          id: "app_fake_snapshot",
+          status: "applied",
+          updatedAt: "2026-01-04T00:00:00.000Z",
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_fake_origin",
+          applicationId: "app_fake_snapshot",
+          eventType: "application_submitted",
+          status: "applied",
+          occurredAt: "2026-01-01T00:00:00.000Z",
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+        {
+          id: "event_fake_offer",
+          applicationId: "app_fake_snapshot",
+          eventType: "offer_received",
+          status: "offer",
+          occurredAt: "2026-01-02T00:00:00.000Z",
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          createdAt: "2026-01-02T00:00:00.000Z",
+        },
+      ],
+      outreachMessages: [],
+      interviews: [],
+      offers: [],
+    };
+    const plan = planLifecycleReconciliation(bundle);
+    const snapshots = plan.additions.filter(
+      (event) => event.eventType === "migration_status_snapshot",
+    );
+    expect(snapshots).toHaveLength(1);
+    expect(snapshots[0]).toMatchObject({
+      occurredAt: "2026-01-04T00:00:00.000Z",
+      occurredAtPrecision: "unknown",
+      status: "applied",
+    });
+    expect(
+      planLifecycleReconciliation({
+        ...bundle,
+        lifecycleEvents: bundle.lifecycleEvents.concat(plan.additions),
+      }).additions,
+    ).toEqual([]);
+  });
+
+  it("reconciles outreach with missing direction timestamps safely", () => {
+    const plan = planLifecycleReconciliation({
+      applications: [app],
+      lifecycleEvents: [],
+      outreachMessages: [
+        {
+          id: "msg_fake_missing_sent",
+          applicationId: app.id,
+          direction: "outbound",
+          channel: "email",
+          createdAt: "2026-01-06T00:00:00.000Z",
+          body: "private outbound",
+        },
+        {
+          id: "msg_fake_missing_all",
+          applicationId: app.id,
+          direction: "inbound",
+          channel: "email",
+          body: "private inbound",
+        },
+      ],
+      interviews: [],
+      offers: [],
+    });
+    expect(
+      plan.additions.find(
+        (event) => event.sourceArtifact === "msg_fake_missing_sent",
+      ),
+    ).toMatchObject({
+      eventType: "candidate_outreach",
+      occurredAt: "2026-01-06T00:00:00.000Z",
+      occurredAtPrecision: "unknown",
+      actionStatus: "outbound",
+    });
+    expect(
+      plan.additions.some(
+        (event) => event.sourceArtifact === "msg_fake_missing_all",
+      ),
+    ).toBe(false);
+    expect(plan.warnings.map((warning) => warning.code)).toEqual(
+      expect.arrayContaining([
+        "unknown_occurrence_precision",
+        "unreconciled_child_activity",
+      ]),
+    );
+    expect(JSON.stringify(plan.warnings)).not.toContain("private");
+  });
+
+  it("warns when nonterminal history follows a terminal event without reopen", () => {
+    const base = {
+      applications: [{ ...app, id: "app_fake_regressive" }],
+      lifecycleEvents: [
+        {
+          id: "event_fake_rejected",
+          applicationId: "app_fake_regressive",
+          eventType: "employer_rejected",
+          status: "rejected",
+          occurredAt: "2026-01-02T00:00:00.000Z",
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          createdAt: "2026-01-02T00:00:00.000Z",
+        },
+        {
+          id: "event_fake_interview",
+          applicationId: "app_fake_regressive",
+          eventType: "technical_interview",
+          status: "technical_screen",
+          occurredAt: "2026-01-03T00:00:00.000Z",
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          createdAt: "2026-01-03T00:00:00.000Z",
+        },
+      ],
+      outreachMessages: [],
+      interviews: [],
+      offers: [],
+    };
+    expect(planLifecycleReconciliation(base).warnings).toContainEqual(
+      expect.objectContaining({
+        applicationId: "app_fake_regressive",
+        code: "regressive_history",
+      }),
+    );
+    expect(
+      planLifecycleReconciliation({
+        ...base,
+        lifecycleEvents: [
+          base.lifecycleEvents[0],
+          {
+            id: "event_fake_reopen",
+            applicationId: "app_fake_regressive",
+            eventType: "application_reopened",
+            status: "applied",
+            occurredAt: "2026-01-02T12:00:00.000Z",
+            occurredAtPrecision: "instant",
+            inferred: false,
+            source: "manual",
+            createdAt: "2026-01-02T12:00:00.000Z",
+          },
+          base.lifecycleEvents[1],
+        ],
+      }).warnings,
+    ).not.toContainEqual(
+      expect.objectContaining({ code: "regressive_history" }),
+    );
   });
 
   it("keeps cancelled and no-show interviews at current status", () => {

--- a/test/web-tracker-lifecycle-reconciliation.test.js
+++ b/test/web-tracker-lifecycle-reconciliation.test.js
@@ -329,4 +329,48 @@ describe("lifecycle reconciliation planner", () => {
       ["status_changed", "applied"],
     ]);
   });
+
+  it("does not infer duplicate outreach when a matching manual event exists", () => {
+    const bundle = {
+      applications: [app],
+      lifecycleEvents: [
+        {
+          id: "event_fake_manual_outreach",
+          applicationId: app.id,
+          eventType: "candidate_outreach",
+          status: "outreach_sent",
+          occurredAt: "2026-01-02T00:00:00.000Z",
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          sourceArtifact: "msg_fake_manual_outreach",
+          actionStatus: "outbound",
+          createdAt: "2026-01-02T00:00:00.000Z",
+        },
+      ],
+      outreachMessages: [
+        {
+          id: "msg_fake_manual_outreach",
+          applicationId: app.id,
+          direction: "outbound",
+          channel: "email",
+          sentAt: "2026-01-02T00:00:00.000Z",
+          createdAt: "2026-01-02T00:00:00.000Z",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+          body: "private structured body",
+        },
+      ],
+      interviews: [],
+      offers: [],
+    };
+
+    const plan = planLifecycleReconciliation(bundle);
+
+    expect(
+      plan.additions.filter(
+        (event) => event.sourceArtifact === "msg_fake_manual_outreach",
+      ),
+    ).toEqual([]);
+    expect(JSON.stringify(plan.warnings)).not.toContain("private");
+  });
 });

--- a/test/web-tracker-lifecycle-reconciliation.test.js
+++ b/test/web-tracker-lifecycle-reconciliation.test.js
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import { planLifecycleReconciliation } from "../src/web/tracker/lifecycleReconciliation.js";
 
+const ts = "2026-01-01T00:00:00.000Z";
+
 const app = {
   id: "app_fake_001",
   company: "Fake Co",
@@ -294,7 +296,19 @@ describe("lifecycle reconciliation planner", () => {
   it("keeps cancelled and no-show interviews at current status", () => {
     const plan = planLifecycleReconciliation({
       applications: [{ ...app, status: "applied" }],
-      lifecycleEvents: [],
+      lifecycleEvents: [
+        {
+          id: "event_fake_snapshot_warning_origin",
+          applicationId: "app_fake_snapshot_warning",
+          eventType: "application_submitted",
+          status: "applied",
+          occurredAt: "2026-01-01T00:00:00.000Z",
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
       outreachMessages: [],
       interviews: [
         {
@@ -372,5 +386,283 @@ describe("lifecycle reconciliation planner", () => {
       ),
     ).toEqual([]);
     expect(JSON.stringify(plan.warnings)).not.toContain("private");
+  });
+  it("maps every offer state and keeps future startsAt only as dueAt", () => {
+    const offerCases = [
+      ["received", "offer_received", "offer"],
+      ["negotiating", "offer_negotiating", "offer"],
+      ["accepted", "offer_accepted", "accepted"],
+      ["declined", "offer_declined", "offer"],
+      ["expired", "offer_expired_rescinded", "offer"],
+      ["rescinded", "offer_expired_rescinded", "offer"],
+    ];
+    const plan = planLifecycleReconciliation({
+      applications: [app],
+      lifecycleEvents: [],
+      outreachMessages: [],
+      interviews: [
+        {
+          id: "int_fake_future",
+          applicationId: app.id,
+          contactIds: [],
+          stage: "onsite_loop",
+          startsAt: "2099-01-01T00:00:00.000Z",
+          outcome: "scheduled",
+          createdAt: "2026-01-07T00:00:00.000Z",
+          updatedAt: "2026-01-08T00:00:00.000Z",
+        },
+      ],
+      offers: offerCases.map(([status], index) => ({
+        id: `offer_fake_map_${status}`,
+        applicationId: app.id,
+        status,
+        notes: `private note ${index}`,
+        createdAt: `2026-01-1${index}T00:00:00.000Z`,
+        updatedAt: `2026-01-1${index}T00:00:00.000Z`,
+      })),
+    });
+    for (const [status, eventType, eventStatus] of offerCases) {
+      expect(plan.additions).toContainEqual(
+        expect.objectContaining({
+          sourceArtifact: `offer_fake_map_${status}`,
+          actionStatus: status,
+          eventType,
+          status: eventStatus,
+        }),
+      );
+    }
+    const interview = plan.additions.find(
+      (event) => event.sourceArtifact === "int_fake_future",
+    );
+    expect(interview).toMatchObject({
+      eventType: "onsite_final_loop",
+      occurredAt: "2026-01-08T00:00:00.000Z",
+      dueAt: "2099-01-01T00:00:00.000Z",
+    });
+    expect(JSON.stringify(plan)).not.toContain("private note");
+  });
+
+  it("emits every required warning code with identifier-only payloads", () => {
+    const plan = planLifecycleReconciliation({
+      applications: [
+        {
+          ...app,
+          id: "app_fake_warnings",
+          status: "accepted",
+          appliedAt: undefined,
+          company: "Do Not Leak Co",
+          role: "Do Not Leak Role",
+          createdAt: undefined,
+          updatedAt: undefined,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_fake_terminal_warning",
+          applicationId: "app_fake_warnings",
+          eventType: "employer_rejected",
+          status: "rejected",
+          occurredAt: "2026-01-02T00:00:00.000Z",
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          note: "Do Not Leak Note",
+          createdAt: "2026-01-02T00:00:00.000Z",
+        },
+        {
+          id: "event_fake_regressive_warning",
+          applicationId: "app_fake_warnings",
+          eventType: "technical_interview",
+          status: "technical_screen",
+          occurredAt: "2026-01-03T00:00:00.000Z",
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          details: "Do Not Leak Details",
+          createdAt: "2026-01-03T00:00:00.000Z",
+        },
+        {
+          id: "event_fake_existing_snapshot_wrong",
+          applicationId: "app_fake_warnings",
+          eventType: "migration_status_snapshot",
+          status: "offer",
+          occurredAt: "2026-01-04T00:00:00.000Z",
+          occurredAtPrecision: "unknown",
+          inferred: true,
+          source: "reconciliation",
+          createdAt: "1970-01-01T00:00:00.000Z",
+        },
+      ],
+      outreachMessages: [
+        {
+          id: "msg_fake_unknown_direction",
+          applicationId: "app_fake_warnings",
+          direction: "sideways",
+          channel: "email",
+          body: "Do Not Leak Body",
+          createdAt: "2026-01-05T00:00:00.000Z",
+          updatedAt: "2026-01-05T00:00:00.000Z",
+        },
+        {
+          id: "msg_fake_no_time",
+          applicationId: "app_fake_warnings",
+          direction: "outbound",
+          channel: "email",
+          body: "Do Not Leak URL https://private.test",
+        },
+      ],
+      interviews: [],
+      offers: [],
+    });
+    const snapshotPlan = planLifecycleReconciliation({
+      applications: [
+        {
+          ...app,
+          id: "app_fake_snapshot_warning",
+          status: "accepted",
+          appliedAt: undefined,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_fake_snapshot_warning_origin",
+          applicationId: "app_fake_snapshot_warning",
+          eventType: "application_submitted",
+          status: "applied",
+          occurredAt: "2026-01-01T00:00:00.000Z",
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      outreachMessages: [],
+      interviews: [],
+      offers: [],
+    });
+    expect(
+      [...plan.warnings, ...snapshotPlan.warnings].map(
+        (warning) => warning.code,
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        "missing_origin_timestamp",
+        "regressive_history",
+        "status_history_mismatch",
+        "status_snapshot_inferred",
+        "unknown_occurrence_precision",
+        "unreconciled_child_activity",
+      ]),
+    );
+    expect(plan.warnings).toEqual(
+      [...plan.warnings].sort(
+        (a, b) =>
+          a.applicationId.localeCompare(b.applicationId) ||
+          a.code.localeCompare(b.code),
+      ),
+    );
+    const serialized = JSON.stringify([
+      ...plan.warnings,
+      ...snapshotPlan.warnings,
+    ]);
+    for (const leaked of ["Do Not Leak", "private.test"]) {
+      expect(serialized).not.toContain(leaked);
+    }
+  });
+
+  it("uses collision-resistant deterministic IDs", () => {
+    const longPrefix = "shared-prefix-".repeat(8);
+    const planA = planLifecycleReconciliation({
+      applications: [app],
+      lifecycleEvents: [],
+      outreachMessages: [
+        {
+          id: "msg.a",
+          applicationId: app.id,
+          direction: "outbound",
+          channel: "email",
+          sentAt: ts,
+          createdAt: ts,
+          updatedAt: ts,
+        },
+        {
+          id: "msg/a",
+          applicationId: app.id,
+          direction: "outbound",
+          channel: "email",
+          sentAt: ts,
+          createdAt: ts,
+          updatedAt: ts,
+        },
+        {
+          id: `${longPrefix}A`,
+          applicationId: app.id,
+          direction: "inbound",
+          channel: "email",
+          receivedAt: ts,
+          createdAt: ts,
+          updatedAt: ts,
+        },
+        {
+          id: `${longPrefix}B`,
+          applicationId: app.id,
+          direction: "inbound",
+          channel: "email",
+          receivedAt: ts,
+          createdAt: ts,
+          updatedAt: ts,
+        },
+      ],
+      interviews: [],
+      offers: [],
+    });
+    const bundle = {
+      applications: [app],
+      lifecycleEvents: [],
+      outreachMessages: [
+        {
+          id: "msg.a",
+          applicationId: app.id,
+          direction: "outbound",
+          channel: "email",
+          sentAt: ts,
+          createdAt: ts,
+          updatedAt: ts,
+        },
+        {
+          id: "msg/a",
+          applicationId: app.id,
+          direction: "outbound",
+          channel: "email",
+          sentAt: ts,
+          createdAt: ts,
+          updatedAt: ts,
+        },
+        {
+          id: `${longPrefix}A`,
+          applicationId: app.id,
+          direction: "inbound",
+          channel: "email",
+          receivedAt: ts,
+          createdAt: ts,
+          updatedAt: ts,
+        },
+        {
+          id: `${longPrefix}B`,
+          applicationId: app.id,
+          direction: "inbound",
+          channel: "email",
+          receivedAt: ts,
+          createdAt: ts,
+          updatedAt: ts,
+        },
+      ],
+      interviews: [],
+      offers: [],
+    };
+    const planB = planLifecycleReconciliation(bundle);
+    const ids = planA.additions.map((event) => event.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids).toEqual(planB.additions.map((event) => event.id));
   });
 });

--- a/test/web-tracker-lifecycle-reconciliation.test.js
+++ b/test/web-tracker-lifecycle-reconciliation.test.js
@@ -126,4 +126,43 @@ describe("lifecycle reconciliation planner", () => {
       ).occurredAtPrecision,
     ).toBe("unknown");
   });
+
+  it("keeps cancelled and no-show interviews at current status", () => {
+    const plan = planLifecycleReconciliation({
+      applications: [{ ...app, status: "applied" }],
+      lifecycleEvents: [],
+      outreachMessages: [],
+      interviews: [
+        {
+          id: "int_fake_cancelled",
+          applicationId: app.id,
+          contactIds: [],
+          stage: "technical_screen",
+          startsAt: "2026-02-01T00:00:00.000Z",
+          outcome: "cancelled",
+          createdAt: "2026-01-04T00:00:00.000Z",
+          updatedAt: "2026-01-04T00:00:00.000Z",
+        },
+        {
+          id: "int_fake_no_show",
+          applicationId: app.id,
+          contactIds: [],
+          stage: "onsite",
+          startsAt: "2026-02-02T00:00:00.000Z",
+          outcome: "no_show",
+          createdAt: "2026-01-05T00:00:00.000Z",
+          updatedAt: "2026-01-05T00:00:00.000Z",
+        },
+      ],
+      offers: [],
+    });
+    expect(
+      plan.additions
+        .filter((event) => event.sourceArtifact?.startsWith("int_fake_"))
+        .map((event) => [event.eventType, event.status]),
+    ).toEqual([
+      ["status_changed", "applied"],
+      ["status_changed", "applied"],
+    ]);
+  });
 });

--- a/test/web-tracker-lifecycle-reconciliation.test.js
+++ b/test/web-tracker-lifecycle-reconciliation.test.js
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import { planLifecycleReconciliation } from "../src/web/tracker/lifecycleReconciliation.js";
+
+const app = {
+  id: "app_fake_001",
+  company: "Fake Co",
+  role: "Fake Role",
+  status: "offer",
+  origin: "application_submitted",
+  appliedAt: "2026-01-01T00:00:00.000Z",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+};
+
+describe("lifecycle reconciliation planner", () => {
+  it("infers deterministic structured lifecycle history and is idempotent", () => {
+    const bundle = {
+      applications: [app],
+      lifecycleEvents: [],
+      outreachMessages: [
+        {
+          id: "msg_fake_out",
+          applicationId: app.id,
+          direction: "outbound",
+          channel: "email",
+          sentAt: "2026-01-02T00:00:00.000Z",
+          createdAt: "2026-01-02T00:00:00.000Z",
+          updatedAt: "2026-01-02T00:00:00.000Z",
+          body: "private",
+        },
+        {
+          id: "msg_fake_in",
+          applicationId: app.id,
+          direction: "inbound",
+          channel: "email",
+          receivedAt: "2026-01-03T00:00:00.000Z",
+          createdAt: "2026-01-03T00:00:00.000Z",
+          updatedAt: "2026-01-03T00:00:00.000Z",
+          body: "private reply",
+        },
+      ],
+      interviews: [
+        {
+          id: "int_fake_001",
+          applicationId: app.id,
+          contactIds: [],
+          stage: "technical_screen",
+          startsAt: "2026-02-01T00:00:00.000Z",
+          outcome: "scheduled",
+          createdAt: "2026-01-04T00:00:00.000Z",
+          updatedAt: "2026-01-04T00:00:00.000Z",
+          preparationNotes: "private prep",
+        },
+      ],
+      offers: [
+        {
+          id: "offer_fake_001",
+          applicationId: app.id,
+          status: "declined",
+          createdAt: "2026-01-05T00:00:00.000Z",
+          updatedAt: "2026-01-05T00:00:00.000Z",
+          notes: "private offer",
+        },
+      ],
+    };
+    const plan = planLifecycleReconciliation(bundle);
+    expect(plan.additions.map((event) => event.eventType)).toEqual(
+      [
+        "candidate_outreach",
+        "employer_response_received",
+        "application_submitted",
+        "technical_interview",
+        "offer_declined",
+      ].sort(),
+    );
+    expect(JSON.stringify(plan.warnings)).not.toContain("private");
+    const second = planLifecycleReconciliation({
+      ...bundle,
+      lifecycleEvents: plan.additions,
+    });
+    expect(second.additions).toEqual([]);
+  });
+
+  it("adds one unknown-precision status snapshot and safe warnings", () => {
+    const plan = planLifecycleReconciliation({
+      applications: [
+        {
+          ...app,
+          id: "app_fake_002",
+          status: "accepted",
+          appliedAt: undefined,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_fake_existing_origin",
+          applicationId: "app_fake_002",
+          eventType: "application_submitted",
+          status: "applied",
+          occurredAt: "2026-01-01T00:00:00.000Z",
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          createdAt: "2026-01-01T00:00:00.000Z",
+        },
+      ],
+      outreachMessages: [],
+      interviews: [],
+      offers: [],
+    });
+    expect(plan.warnings.map((warning) => warning.code)).toEqual(
+      expect.arrayContaining([
+        "status_history_mismatch",
+        "status_snapshot_inferred",
+        "unknown_occurrence_precision",
+      ]),
+    );
+    expect(
+      plan.additions.filter(
+        (event) => event.eventType === "migration_status_snapshot",
+      ),
+    ).toHaveLength(1);
+    expect(
+      plan.additions.find(
+        (event) => event.eventType === "migration_status_snapshot",
+      ).occurredAtPrecision,
+    ).toBe("unknown");
+  });
+});


### PR DESCRIPTION
### Motivation
- Make lifecycle events the append-only historical truth for every lifecycle-changing browser action and keep application status as the materialized projection.
- Ensure any operation that touches an application and lifecycle/child records writes atomically with pre-validation, previous-status capture, and strict supersession rules.
- Provide a conservative, deterministic reconciliation planner that infers only from structured child records and applies planned additions idempotently.

### Description
- Added atomic lifecycle mutation API `commitLifecycleMutation` with `normalizeMutation` and `assertSupersessionIsValid` to `src/web/storage/indexedDbRepository.js`, validating cross-application references, rejecting supersession cycles, deriving persisted `previousStatus`, and performing a single required-store transaction that `add`s lifecycle/outreach records and `put`s other child records.
- Introduced a pure reconciliation planner `src/web/tracker/lifecycleReconciliation.js` that produces deterministic, idempotent plans and safe warnings (missing origin, unknown precision, unreconciled child activity, status snapshot inference, history mismatch, regressive history) and stable reconciliation IDs.
- Wired reconciliation into the tracker (`src/web/tracker/tracker.js`) so plans are applied (atomically via `commitLifecycleMutation`) before the UI `refresh`, preserved warning summaries, and filtered reconciled/inferred events out of the visible timeline.
- Updated tracker UI/submission flows in `src/web/tracker/tracker.js` to: add Origin select, preserve origin on edit and create origin events on initial save, support outreach Direction (inbound/outbound), add compact assessment form, record interview outcomes and starts metadata, widen offer outcomes (including `rescinded` mapped to `offer_expired_rescinded`), disable forms during submission, and restore values + show an accessible error on failure.
- Extended schema to include `rescinded` offer state in `src/domain/browserApplication.js` and added tests: `test/web-tracker-lifecycle-persistence.test.js` and `test/web-tracker-lifecycle-reconciliation.test.js` covering atomic commits, rollback on failure, supersession rejection, reconciliation rules, idempotency, and warnings.

### Testing
- Lint/typecheck/format checks: `npm run lint` (passed), `npm run typecheck` (passed), targeted `npx prettier --check` for changed files (passed), `npm run format:check` reported pre-existing repository-wide warnings outside this change set (not caused by this PR).
- Unit tests: `npx vitest run test/web-storage-indexeddb-repository.test.js test/web-tracker-lifecycle-persistence.test.js test/web-tracker-lifecycle-reconciliation.test.js test/web-spreadsheet-import-export.test.js` — all passed.
- End-to-end browser tests: `npx playwright test test/playwright/browser-tracker.spec.js` — all Playwright tracker scenarios passed in CI runs.
- Full CI: `npm run build` (passed) and `npm run test:ci` (passed).
- Repository checks: `git diff --check` produced no errors for the committed files.

Commands run (high-level):
- `npm run lint` — passed
- `npm run typecheck` — passed
- `npx vitest run <focused tests>` — passed
- `npx playwright test test/playwright/browser-tracker.spec.js` — passed
- `npm run build` — passed
- `npm run test:ci` — passed

Notes / follow-ups
- `npm run format:check` reports pre-existing formatting warnings across many unrelated files; changed files are formatted by Prettier in this PR and targeted checks pass.
- The reconciliation module is intentionally conservative: it never infers from free-text fields and preserves unknown-precision snapshots as required by the design contract.

Files added/modified (high level):
- Modified: `src/web/storage/indexedDbRepository.js`, `src/web/tracker/tracker.js`, `src/domain/browserApplication.js`.
- Added: `src/web/tracker/lifecycleReconciliation.js`, `test/web-tracker-lifecycle-persistence.test.js`, `test/web-tracker-lifecycle-reconciliation.test.js`.

This change is committed on the current branch with the message: "Complete tracker lifecycle persistence".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51c7a94084832fab7d9ce926fd818b)