### PR TITLE
Add atomic lifecycle persistence reconciliation

### DIFF
--- a/src/web/storage/indexedDbRepository.js
+++ b/src/web/storage/indexedDbRepository.js
@@ -449,6 +449,51 @@ const deleteMatchingFromStore = async (store, indexName, value) => {
   });
 };
 
+const validateLifecycleBundle = (records) => {
+  const result = browserApplicationExportSchema.safeParse({
+    schemaVersion: BROWSER_BACKUP_SCHEMA_VERSION,
+    exportedAt: new Date(0).toISOString(),
+    applications: records.applications ?? [],
+    contacts: records.contacts ?? [],
+    outreachMessages: records.outreachMessages ?? [],
+    lifecycleEvents: records.lifecycleEvents ?? [],
+    interviews: records.interviews ?? [],
+    offers: records.offers ?? [],
+    artifacts: records.artifacts ?? [],
+    reminders: records.reminders ?? [],
+    settings: records.settings?.[0]
+      ? {
+          ...records.settings[0],
+          schemaVersion: LOCAL_SETTINGS_SCHEMA_VERSION,
+        }
+      : undefined,
+  });
+  if (!result.success) {
+    throw new IndexedDbRepositoryError(
+      "schema_validation_failed",
+      "Lifecycle mutation would violate browser application data integrity.",
+      { details: result.error.flatten() },
+    );
+  }
+  return result.data;
+};
+
+const mergeById = (existing, additions = [], puts = []) => {
+  const byId = new Map(existing.map((record) => [record.id, record]));
+  for (const record of puts) byId.set(record.id, record);
+  for (const record of additions) {
+    if (byId.has(record.id)) {
+      throw new IndexedDbRepositoryError(
+        "duplicate_key",
+        "Lifecycle mutation would add a duplicate record.",
+        { details: { id: record.id } },
+      );
+    }
+    byId.set(record.id, record);
+  }
+  return [...byId.values()];
+};
+
 const validateImport = (data) => {
   const upgraded = upgradeBrowserExportToV2(data);
   const result = browserApplicationExportSchema.safeParse(upgraded.data);
@@ -707,6 +752,63 @@ export const createIndexedDbRepository = async (options = {}) => {
     },
     createOffer(record) {
       return safe(() => addChildRecord(db, "offers", record));
+    },
+
+    async commitLifecycleMutation(mutation) {
+      return safe(async () => {
+        const add = mutation.add ?? {};
+        const put = mutation.put ?? {};
+        const records = Object.fromEntries(
+          await Promise.all(
+            STORE_NAMES.map(async (name) => [name, await getAll(db, name)]),
+          ),
+        );
+        const parsedAdd = Object.fromEntries(
+          STORE_NAMES.map((storeName) => [
+            storeName,
+            (add[storeName] ?? []).map((row) => parseRecord(storeName, row)),
+          ]),
+        );
+        const parsedPut = Object.fromEntries(
+          STORE_NAMES.map((storeName) => [
+            storeName,
+            (put[storeName] ?? []).map((row) => parseRecord(storeName, row)),
+          ]),
+        );
+        const merged = Object.fromEntries(
+          STORE_NAMES.map((storeName) => [
+            storeName,
+            mergeById(
+              records[storeName],
+              parsedAdd[storeName],
+              parsedPut[storeName],
+            ),
+          ]),
+        );
+        validateLifecycleBundle(merged);
+        const touchedStores = STORE_NAMES.filter(
+          (storeName) =>
+            parsedAdd[storeName].length > 0 || parsedPut[storeName].length > 0,
+        );
+        if (!touchedStores.length) return { committed: true, counts: {} };
+        const tx = db.transaction(touchedStores, "readwrite");
+        const done = transactionDone(tx);
+        for (const storeName of touchedStores) {
+          const store = tx.objectStore(storeName);
+          for (const row of parsedPut[storeName]) store.put(row);
+          for (const row of parsedAdd[storeName]) store.add(row);
+        }
+        await done;
+        return {
+          committed: true,
+          counts: Object.fromEntries(
+            touchedStores.map((storeName) => [
+              storeName,
+              parsedAdd[storeName].length + parsedPut[storeName].length,
+            ]),
+          ),
+        };
+      });
     },
     async importPartialData(recordsByStore) {
       return safe(async () => {

--- a/src/web/tracker/lifecycleReconciliation.js
+++ b/src/web/tracker/lifecycleReconciliation.js
@@ -1,0 +1,211 @@
+const ORIGINS = new Set([
+  "application_submitted",
+  "recruiter_company_outreach",
+  "candidate_outreach",
+  "referral",
+  "other_unknown",
+]);
+const STATUS_EVENTS = {
+  applied: "application_submitted",
+  outreach_sent: "candidate_outreach",
+  recruiter_screen: "recruiter_screen",
+  technical_screen: "technical_interview",
+  onsite_loop: "onsite_final_loop",
+  offer: "offer_received",
+  accepted: "offer_accepted",
+  rejected: "employer_rejected",
+  withdrawn: "candidate_withdrew",
+  closed_archived: "closed_archived",
+};
+const INTERVIEW_EVENTS = {
+  recruiter_screen: "recruiter_screen",
+  technical_screen: "technical_interview",
+  onsite_loop: "onsite_final_loop",
+};
+const OFFER_EVENTS = {
+  received: "offer_received",
+  negotiating: "offer_negotiating",
+  accepted: "offer_accepted",
+  declined: "offer_declined",
+  expired: "offer_expired_rescinded",
+};
+const terminal = new Set([
+  "accepted",
+  "rejected",
+  "withdrawn",
+  "closed_archived",
+]);
+const safeWarn = (warnings, code, applicationId, childId) =>
+  warnings.push({ code, applicationId, childId });
+const sid = (...parts) =>
+  parts
+    .map((p) => String(p ?? "none").replace(/[^a-zA-Z0-9_-]+/g, "_"))
+    .join("__");
+const event = (app, type, at, createdAt, extra = {}) => ({
+  id: sid("reconcile", app.id, type, extra.childId, extra.state),
+  applicationId: app.id,
+  status: extra.status ?? app.status,
+  eventType: type,
+  occurredAt: at,
+  occurredAtPrecision: extra.precision ?? "instant",
+  inferred: true,
+  source: "reconciliation",
+  createdAt,
+  ...(extra.previousStatus ? { previousStatus: extra.previousStatus } : {}),
+  ...(extra.actionStatus ? { actionStatus: extra.actionStatus } : {}),
+  ...(extra.dueAt ? { dueAt: extra.dueAt } : {}),
+});
+const effectiveEvents = (events) => {
+  const superseded = new Set(
+    events.map((e) => e.supersedesEventId).filter(Boolean),
+  );
+  return events.filter((e) => !superseded.has(e.id));
+};
+const eventKey = (e) =>
+  `${e.applicationId}|${e.eventType}|${e.id}|${e.actionStatus ?? e.status}`;
+export function planLifecycleReconciliation(
+  bundle,
+  { createdAt = "1970-01-01T00:00:00.000Z" } = {},
+) {
+  const warnings = [];
+  const additions = [];
+  const apps = [...(bundle.applications ?? [])].sort((a, b) =>
+    a.id.localeCompare(b.id),
+  );
+  const existing = effectiveEvents(bundle.lifecycleEvents ?? []);
+  const existingIds = new Set((bundle.lifecycleEvents ?? []).map((e) => e.id));
+  const existingTypes = new Map();
+  for (const e of existing)
+    existingTypes.set(`${e.applicationId}|${e.eventType}`, e);
+  const addOnce = (ev, app) => {
+    if (existingIds.has(ev.id) || additions.some((a) => a.id === ev.id)) return;
+    const key = eventKey(ev);
+    if (
+      existing.some((e) => eventKey(e) === key) ||
+      additions.some((e) => eventKey(e) === key)
+    )
+      return;
+    additions.push(ev);
+    if (ev.occurredAtPrecision === "unknown")
+      safeWarn(warnings, "unknown_occurrence_precision", app.id);
+  };
+  for (const app of apps) {
+    const appEvents = existing.filter((e) => e.applicationId === app.id);
+    if (!appEvents.some((e) => ORIGINS.has(e.eventType))) {
+      const at = app.appliedAt ?? createdAt;
+      addOnce(
+        event(app, app.origin ?? "other_unknown", at, createdAt, {
+          precision: app.appliedAt ? "instant" : "unknown",
+        }),
+        app,
+      );
+      if (!app.appliedAt)
+        safeWarn(warnings, "missing_origin_timestamp", app.id);
+    }
+    for (const msg of [...(bundle.outreachMessages ?? [])]
+      .filter((m) => m.applicationId === app.id)
+      .sort((a, b) => a.id.localeCompare(b.id))) {
+      const type =
+        msg.direction === "inbound"
+          ? "employer_response_received"
+          : msg.direction === "outbound"
+            ? "candidate_outreach"
+            : null;
+      const at = msg.receivedAt ?? msg.sentAt;
+      if (!type || !at) {
+        safeWarn(warnings, "unreconciled_child_activity", app.id, msg.id);
+        continue;
+      }
+      addOnce(
+        event(app, type, at, createdAt, {
+          childId: msg.id,
+          state: msg.direction,
+        }),
+        app,
+      );
+    }
+    for (const i of [...(bundle.interviews ?? [])]
+      .filter((x) => x.applicationId === app.id)
+      .sort((a, b) => a.id.localeCompare(b.id))) {
+      const type =
+        i.outcome === "cancelled" || i.outcome === "no_show"
+          ? "status_changed"
+          : (INTERVIEW_EVENTS[i.stage] ?? "status_changed");
+      addOnce(
+        event(app, type, i.startsAt, createdAt, {
+          childId: i.id,
+          state: `${i.stage}_${i.outcome}`,
+          status: INTERVIEW_EVENTS[i.stage]
+            ? {
+                recruiter_screen: "recruiter_screen",
+                technical_screen: "technical_screen",
+                onsite_loop: "onsite_loop",
+              }[i.stage]
+            : app.status,
+        }),
+        app,
+      );
+      if (type === "status_changed")
+        safeWarn(warnings, "unreconciled_child_activity", app.id, i.id);
+    }
+    for (const o of [...(bundle.offers ?? [])]
+      .filter((x) => x.applicationId === app.id)
+      .sort((a, b) => a.id.localeCompare(b.id))) {
+      const type = OFFER_EVENTS[o.status];
+      if (!type) {
+        safeWarn(warnings, "unreconciled_child_activity", app.id, o.id);
+        continue;
+      }
+      addOnce(
+        event(app, type, o.updatedAt ?? o.createdAt, createdAt, {
+          childId: o.id,
+          state: o.status,
+          status: o.status === "accepted" ? "accepted" : "offer",
+        }),
+        app,
+      );
+    }
+    const statusType = STATUS_EVENTS[app.status] ?? "status_changed";
+    if (
+      !existingTypes.has(`${app.id}|${statusType}`) &&
+      !additions.some(
+        (e) =>
+          e.applicationId === app.id &&
+          e.eventType === "migration_status_snapshot",
+      )
+    ) {
+      addOnce(
+        event(app, "migration_status_snapshot", createdAt, createdAt, {
+          precision: "unknown",
+          state: app.status,
+        }),
+        app,
+      );
+      safeWarn(warnings, "status_snapshot_inferred", app.id);
+      safeWarn(warnings, "status_history_mismatch", app.id);
+    }
+    const sorted = appEvents.sort(
+      (a, b) =>
+        String(a.occurredAt).localeCompare(String(b.occurredAt)) ||
+        a.id.localeCompare(b.id),
+    );
+    let sawTerminal = false;
+    for (const e of sorted) {
+      if (terminal.has(e.status)) sawTerminal = true;
+      else if (sawTerminal && e.eventType !== "application_reopened")
+        safeWarn(warnings, "regressive_history", app.id);
+    }
+  }
+  additions.sort(
+    (a, b) =>
+      a.applicationId.localeCompare(b.applicationId) ||
+      a.eventType.localeCompare(b.eventType) ||
+      a.id.localeCompare(b.id),
+  );
+  return {
+    additions,
+    warnings,
+    counts: { additions: additions.length, warnings: warnings.length },
+  };
+}
+export default planLifecycleReconciliation;

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -24,6 +24,7 @@ import {
   recruiterScreenTimestamp,
   selectDashboardMetrics,
 } from "./metrics.js";
+import { planLifecycleReconciliation } from "./lifecycleReconciliation.js";
 import { createIndexedDbRepository } from "../storage/indexedDbRepository.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
@@ -49,6 +50,23 @@ const STATUSES = [
   "withdrawn",
   "closed_archived",
 ];
+const STATUS_EVENT_TYPES = {
+  outreach_sent: "candidate_outreach",
+  recruiter_screen: "recruiter_screen",
+  technical_screen: "technical_interview",
+  onsite_loop: "onsite_final_loop",
+  offer: "offer_received",
+  accepted: "offer_accepted",
+  rejected: "employer_rejected",
+  withdrawn: "candidate_withdrew",
+  closed_archived: "closed_archived",
+};
+const TERMINAL_STATUSES = new Set([
+  "accepted",
+  "rejected",
+  "withdrawn",
+  "closed_archived",
+]);
 const OUTCOMES = new Set([
   "offer",
   "accepted",
@@ -104,6 +122,8 @@ const repo = {
   },
   clear: async () => (await getRepository()).clearAllData(),
   exportAll: async () => (await getRepository()).exportAllData(),
+  commitLifecycleMutation: async (mutation) =>
+    (await getRepository()).commitLifecycleMutation(mutation),
 };
 async function batchImport(recordsByStore) {
   return (await getRepository()).importPartialData(recordsByStore);
@@ -116,6 +136,7 @@ const state = {
   sort: "appliedAt",
   dir: -1,
   current: null,
+  reconciliationWarnings: [],
   detailSave: Promise.resolve(),
 };
 function weekBucket(value) {
@@ -273,6 +294,16 @@ const metadataText = (app) =>
   metadataEntries(app)
     .map(([label, value]) => `${label}: ${value}`)
     .join(" · ");
+async function applyLifecycleReconciliation() {
+  const bundle = await repo.exportAll();
+  const plan = planLifecycleReconciliation(bundle);
+  state.reconciliationWarnings = plan.warnings;
+  if (plan.additions.length > 0) {
+    await repo.commitLifecycleMutation({
+      add: { lifecycleEvents: plan.additions },
+    });
+  }
+}
 async function refresh() {
   state.bundle = await repo.exportAll();
   state.apps = state.bundle.applications.sort((a, b) =>
@@ -318,6 +349,7 @@ async function refreshWithRetry() {
     }
   };
   try {
+    await applyLifecycleReconciliation();
     await refresh();
     clearInitializationRetry(retry, retryWhenVisible);
   } catch (error) {
@@ -692,6 +724,28 @@ function openUnsavedDetail(app) {
 function isoDate(v) {
   return v ? new Date(v).toISOString() : undefined;
 }
+function lifecycleEventRecord(
+  app,
+  current,
+  status,
+  eventType,
+  operationTime,
+  extra = {},
+) {
+  return {
+    id: id("event"),
+    applicationId: app.id,
+    eventType,
+    status,
+    previousStatus: current.status,
+    occurredAt: operationTime,
+    occurredAtPrecision: "instant",
+    inferred: false,
+    source: "manual",
+    createdAt: operationTime,
+    ...extra,
+  };
+}
 function bindDetail(app) {
   const persisted = !app.unsaved;
   const latestApp = () => state.apps.find((a) => a.id === app.id) || app;
@@ -716,20 +770,30 @@ function bindDetail(app) {
           updatedAt: now(),
         };
         delete saved.unsaved;
-        await repo.put("applications", saved);
-        if (!persisted || v.status !== current.status)
-          await repo.add("lifecycleEvents", {
-            id: id("event"),
-            applicationId: app.id,
-            eventType:
-              v.status === "applied" ? "application_submitted" : "status_changed",
-            status: v.status,
-            occurredAt: now(),
-            occurredAtPrecision: "instant",
-            inferred: false,
-            source: "manual",
-            createdAt: now(),
-          });
+        const operationTime = now();
+        const events = [];
+        if (!persisted || v.status !== current.status) {
+          const reopening =
+            TERMINAL_STATUSES.has(current.status) &&
+            !TERMINAL_STATUSES.has(v.status);
+          events.push(
+            lifecycleEventRecord(
+              app,
+              current,
+              v.status,
+              reopening
+                ? "application_reopened"
+                : v.status === "applied"
+                  ? "application_submitted"
+                  : (STATUS_EVENT_TYPES[v.status] ?? "status_changed"),
+              operationTime,
+            ),
+          );
+        }
+        await repo.commitLifecycleMutation({
+          [persisted ? "put" : "add"]: { applications: [saved] },
+          add: { lifecycleEvents: events },
+        });
         await refresh();
         openDetail(app.id);
       });
@@ -760,24 +824,39 @@ function bindDetail(app) {
     e.preventDefault();
     const v = values(e.target);
     const current = latestApp();
-    await repo.add("outreachMessages", {
+    const operationTime = now();
+    const message = {
       id: id("msg"),
       applicationId: app.id,
       direction: "outbound",
       channel: v.channel,
       body: v.body,
-      sentAt: now(),
-      createdAt: now(),
-      updatedAt: now(),
-    });
+      sentAt: operationTime,
+      createdAt: operationTime,
+      updatedAt: operationTime,
+    };
     const nextStatus =
       STATUS_RANK[current.status] >= STATUS_RANK.outreach_sent
         ? current.status
         : "outreach_sent";
-    await repo.put("applications", {
-      ...current,
-      status: nextStatus,
-      updatedAt: now(),
+    await repo.commitLifecycleMutation({
+      put: {
+        applications: [
+          { ...current, status: nextStatus, updatedAt: operationTime },
+        ],
+      },
+      add: {
+        outreachMessages: [message],
+        lifecycleEvents: [
+          lifecycleEventRecord(
+            app,
+            current,
+            nextStatus,
+            "candidate_outreach",
+            operationTime,
+          ),
+        ],
+      },
     });
     await refresh();
     openDetail(app.id);
@@ -786,24 +865,46 @@ function bindDetail(app) {
     e.preventDefault();
     const v = values(e.target);
     const current = latestApp();
-    await repo.add("interviews", {
-      id: id("interview"),
-      applicationId: app.id,
-      contactIds: [],
-      stage: v.stage,
-      startsAt: isoDate(v.startsAt),
-      outcome: "scheduled",
-      createdAt: now(),
-      updatedAt: now(),
-    });
+    const operationTime = now();
     const nextStatus =
       v.stage !== "other" && STATUS_RANK[v.stage] > STATUS_RANK[current.status]
         ? v.stage
         : current.status;
-    await repo.put("applications", {
-      ...current,
-      status: nextStatus,
-      updatedAt: now(),
+    await repo.commitLifecycleMutation({
+      put: {
+        applications: [
+          { ...current, status: nextStatus, updatedAt: operationTime },
+        ],
+      },
+      add: {
+        interviews: [
+          {
+            id: id("interview"),
+            applicationId: app.id,
+            contactIds: [],
+            stage: v.stage,
+            startsAt: isoDate(v.startsAt),
+            outcome: "scheduled",
+            createdAt: operationTime,
+            updatedAt: operationTime,
+          },
+        ],
+        lifecycleEvents: [
+          lifecycleEventRecord(
+            app,
+            current,
+            nextStatus,
+            v.stage === "recruiter_screen"
+              ? "recruiter_screen"
+              : v.stage === "technical_screen"
+                ? "technical_interview"
+                : v.stage === "onsite_loop"
+                  ? "onsite_final_loop"
+                  : "status_changed",
+            operationTime,
+          ),
+        ],
+      },
     });
     await refresh();
     openDetail(app.id);
@@ -812,18 +913,41 @@ function bindDetail(app) {
     e.preventDefault();
     const v = values(e.target);
     const current = latestApp();
-    await repo.add("offers", {
-      id: id("offer"),
-      applicationId: app.id,
-      status: v.status,
-      notes: v.notes || undefined,
-      createdAt: now(),
-      updatedAt: now(),
-    });
-    await repo.put("applications", {
-      ...current,
-      status: v.status === "accepted" ? "accepted" : "offer",
-      updatedAt: now(),
+    const operationTime = now();
+    const nextStatus = v.status === "accepted" ? "accepted" : "offer";
+    const offerEventTypes = {
+      received: "offer_received",
+      negotiating: "offer_negotiating",
+      accepted: "offer_accepted",
+      declined: "offer_declined",
+    };
+    await repo.commitLifecycleMutation({
+      put: {
+        applications: [
+          { ...current, status: nextStatus, updatedAt: operationTime },
+        ],
+      },
+      add: {
+        offers: [
+          {
+            id: id("offer"),
+            applicationId: app.id,
+            status: v.status,
+            notes: v.notes || undefined,
+            createdAt: operationTime,
+            updatedAt: operationTime,
+          },
+        ],
+        lifecycleEvents: [
+          lifecycleEventRecord(
+            app,
+            current,
+            nextStatus,
+            offerEventTypes[v.status] ?? "offer_received",
+            operationTime,
+          ),
+        ],
+      },
     });
     await refresh();
     openDetail(app.id);
@@ -1058,6 +1182,7 @@ async function applyImport() {
   }
   try {
     await batchImport(state.preview);
+    await applyLifecycleReconciliation();
   } catch (err) {
     $("[data-import-result]").textContent =
       `Import failed: ${err?.message ?? err}`;

--- a/test/web-tracker-lifecycle-persistence.test.js
+++ b/test/web-tracker-lifecycle-persistence.test.js
@@ -1,0 +1,90 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { indexedDB } from "fake-indexeddb";
+import {
+  DATABASE_NAME,
+  createIndexedDbRepository,
+} from "../src/web/storage/indexedDbRepository.js";
+
+const ts = "2026-01-02T03:04:05.000Z";
+const app = {
+  id: "app_fake_001",
+  company: "Fake Co",
+  role: "Engineer",
+  status: "applied",
+  origin: "application_submitted",
+  appliedAt: ts,
+  createdAt: ts,
+  updatedAt: ts,
+};
+const event = {
+  id: "event_fake_001",
+  applicationId: app.id,
+  status: "applied",
+  previousStatus: "applied",
+  eventType: "application_submitted",
+  occurredAt: ts,
+  occurredAtPrecision: "instant",
+  inferred: false,
+  source: "manual",
+  createdAt: ts,
+};
+const deleteDatabase = () =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(DATABASE_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => resolve();
+  });
+afterEach(deleteDatabase);
+
+describe("lifecycle persistence", () => {
+  it("commits application and lifecycle event in one atomic mutation", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await repo.commitLifecycleMutation({
+      add: { applications: [app], lifecycleEvents: [event] },
+    });
+    const exported = await repo.exportAllData();
+    expect(exported.applications).toEqual([app]);
+    expect(exported.lifecycleEvents).toEqual([event]);
+    repo.close();
+  });
+
+  it("rolls back all stores when validation fails", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await expect(
+      repo.commitLifecycleMutation({
+        add: {
+          applications: [app],
+          lifecycleEvents: [{ ...event, applicationId: "missing_app" }],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "schema_validation_failed" });
+    const exported = await repo.exportAllData();
+    expect(exported.applications).toEqual([]);
+    expect(exported.lifecycleEvents).toEqual([]);
+    repo.close();
+  });
+
+  it("rejects cross-application supersession references", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const other = { ...app, id: "app_fake_002" };
+    await expect(
+      repo.commitLifecycleMutation({
+        add: {
+          applications: [app, other],
+          lifecycleEvents: [
+            event,
+            {
+              ...event,
+              id: "event_fake_002",
+              applicationId: other.id,
+              supersedesEventId: event.id,
+            },
+          ],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "schema_validation_failed" });
+    expect((await repo.exportAllData()).lifecycleEvents).toEqual([]);
+    repo.close();
+  });
+});

--- a/test/web-tracker-lifecycle-reconciliation.test.js
+++ b/test/web-tracker-lifecycle-reconciliation.test.js
@@ -1,0 +1,146 @@
+import { describe, expect, it } from "vitest";
+import { planLifecycleReconciliation } from "../src/web/tracker/lifecycleReconciliation.js";
+
+const ts = "2026-01-02T03:04:05.000Z";
+const app = (overrides = {}) => ({
+  id: "app_fake_001",
+  company: "Fake Co",
+  role: "Engineer",
+  status: "offer",
+  origin: "application_submitted",
+  appliedAt: ts,
+  createdAt: ts,
+  updatedAt: ts,
+  ...overrides,
+});
+const bundle = (overrides = {}) => ({
+  applications: [app()],
+  outreachMessages: [],
+  lifecycleEvents: [],
+  interviews: [],
+  offers: [],
+  ...overrides,
+});
+
+describe("lifecycle reconciliation planner", () => {
+  it("infers only structured child records with deterministic IDs and no-op second run", () => {
+    const input = bundle({
+      outreachMessages: [
+        {
+          id: "msg_fake_001",
+          applicationId: "app_fake_001",
+          direction: "inbound",
+          channel: "email",
+          body: "private text ignored",
+          receivedAt: "2026-01-03T00:00:00.000Z",
+          createdAt: ts,
+          updatedAt: ts,
+        },
+        {
+          id: "msg_fake_002",
+          applicationId: "app_fake_001",
+          direction: "outbound",
+          channel: "email",
+          body: "private text ignored",
+          sentAt: "2026-01-04T00:00:00.000Z",
+          createdAt: ts,
+          updatedAt: ts,
+        },
+      ],
+      interviews: [
+        {
+          id: "interview_fake_001",
+          applicationId: "app_fake_001",
+          contactIds: [],
+          stage: "technical_screen",
+          startsAt: "2026-02-01T00:00:00.000Z",
+          outcome: "scheduled",
+          preparationNotes: "private text ignored",
+          createdAt: ts,
+          updatedAt: ts,
+        },
+      ],
+      offers: [
+        {
+          id: "offer_fake_001",
+          applicationId: "app_fake_001",
+          status: "declined",
+          notes: "private text ignored",
+          createdAt: ts,
+          updatedAt: "2026-03-01T00:00:00.000Z",
+        },
+      ],
+    });
+    const plan = planLifecycleReconciliation(input, { createdAt: ts });
+    expect(plan.additions.map((e) => e.eventType)).toEqual([
+      "application_submitted",
+      "candidate_outreach",
+      "employer_response_received",
+      "migration_status_snapshot",
+      "offer_declined",
+      "technical_interview",
+    ]);
+    expect(JSON.stringify(plan.warnings)).not.toContain("private text");
+    expect(plan.warnings.map((w) => w.code)).toContain(
+      "status_snapshot_inferred",
+    );
+
+    const second = planLifecycleReconciliation(
+      { ...input, lifecycleEvents: plan.additions },
+      { createdAt: ts },
+    );
+    expect(second.additions).toEqual([]);
+  });
+
+  it("emits safe warnings for missing precision and regressive history", () => {
+    const input = bundle({
+      applications: [app({ appliedAt: undefined, status: "applied" })],
+      outreachMessages: [
+        {
+          id: "msg_fake_001",
+          applicationId: "app_fake_001",
+          direction: "outbound",
+          channel: "email",
+          body: "do not leak",
+          createdAt: ts,
+          updatedAt: ts,
+        },
+      ],
+      lifecycleEvents: [
+        {
+          id: "event_terminal",
+          applicationId: "app_fake_001",
+          status: "accepted",
+          eventType: "offer_accepted",
+          occurredAt: "2026-01-01T00:00:00.000Z",
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          createdAt: ts,
+        },
+        {
+          id: "event_regress",
+          applicationId: "app_fake_001",
+          status: "applied",
+          eventType: "status_changed",
+          occurredAt: "2026-01-02T00:00:00.000Z",
+          occurredAtPrecision: "instant",
+          inferred: false,
+          source: "manual",
+          createdAt: ts,
+        },
+      ],
+    });
+    const codes = planLifecycleReconciliation(input, {
+      createdAt: ts,
+    }).warnings.map((w) => w.code);
+    expect(codes).toEqual(
+      expect.arrayContaining([
+        "missing_origin_timestamp",
+        "unknown_occurrence_precision",
+        "unreconciled_child_activity",
+        "regressive_history",
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Make browser tracker lifecycle changes append-only and ensure any operation that touches an application plus lifecycle/child records is written atomically and validated as a single bundle.
- Provide a conservative, deterministic reconciliation planner that infers missing canonical lifecycle events only from structured child records and records safe, non-private warnings.

### Description
- Add `commitLifecycleMutation` to the IndexedDB repository that parses `add`/`put` records, validates the full projected export bundle against `browserApplicationExportSchema`, rejects duplicate/add integrity problems, and writes all touched stores in a single required-store transaction using `add` for appended records (file: `src/web/storage/indexedDbRepository.js`).
- Add a pure, deterministic reconciliation planner `planLifecycleReconciliation` that returns `additions`, `warnings`, and counts and implements the required rules (supersession resolution, deterministic IDs, no free-text inference, safe warning codes) (file: `src/web/tracker/lifecycleReconciliation.js`).
- Wire tracker flows to use atomic lifecycle commits and a startup/import reconciliation pass, capture a single operation time for each user action, and preserve reconciliation warnings in tracker state (file: `src/web/tracker/tracker.js`).
- Add focused tests covering atomic lifecycle persistence and rollback, cross-application supersession rejection, deterministic reconciliation inference and second-run no-op behavior, and safe warning emission (files: `test/web-tracker-lifecycle-persistence.test.js`, `test/web-tracker-lifecycle-reconciliation.test.js`).

### Testing
- Ran lint and targeted ESLint checks: `npx eslint src/web/storage/indexedDbRepository.js src/web/tracker/lifecycleReconciliation.js src/web/tracker/tracker.js test/web-tracker-lifecycle-persistence.test.js test/web-tracker-lifecycle-reconciliation.test.js` — passed after fixes.
- Ran unit tests: `npx vitest run test/web-storage-indexeddb-repository.test.js test/web-tracker-lifecycle-persistence.test.js test/web-tracker-lifecycle-reconciliation.test.js test/web-spreadsheet-import-export.test.js` — all specified test files passed (total tests run in these suites passed).
- Ran typecheck: `npm run typecheck` — passed with no errors.
- Ran format check: `npm run format:check` — reported pre-existing formatting drift across unrelated repository files; changed files were formatted directly with Prettier prior to tests.

Modified/added files
- Added: `src/web/tracker/lifecycleReconciliation.js`, `test/web-tracker-lifecycle-persistence.test.js`, `test/web-tracker-lifecycle-reconciliation.test.js`.
- Updated: `src/web/storage/indexedDbRepository.js`, `src/web/tracker/tracker.js`.

Notes and residuals
- `commitLifecycleMutation` validates the merged bundle before writing and will abort the write on validation failure to ensure no partial state remains.
- `planLifecycleReconciliation` is conservative and idempotent; it never exposes private text or URLs in warnings.
- `npm run format:check` warnings are from pre-existing files outside this change and should be addressed in a follow-up if desired.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51c7b29904832fbf8e187fe8b593d7)