### PR TITLE
feat: persist tracker lifecycle mutations atomically

### DIFF
--- a/src/web/storage/indexedDbRepository.js
+++ b/src/web/storage/indexedDbRepository.js
@@ -462,6 +462,43 @@ const validateImport = (data) => {
   return { parsed: result.data, warnings: upgraded.warnings };
 };
 
+const toArray = (value) => (Array.isArray(value) ? value : []);
+
+const validateSupersessionGraph = (events) => {
+  const byId = new Map(events.map((event) => [event.id, event]));
+  for (const event of events) {
+    if (!event.supersedesEventId) continue;
+    const target = byId.get(event.supersedesEventId);
+    if (!target) {
+      throw new IndexedDbRepositoryError(
+        "schema_validation_failed",
+        "supersedesEventId must reference an existing lifecycle event.",
+        { details: { supersedesEventId: event.supersedesEventId } },
+      );
+    }
+    if (target.applicationId !== event.applicationId) {
+      throw new IndexedDbRepositoryError(
+        "schema_validation_failed",
+        "supersedesEventId must reference the same application.",
+        { details: { supersedesEventId: event.supersedesEventId } },
+      );
+    }
+    const seen = new Set([event.id]);
+    let cursor = target;
+    while (cursor?.supersedesEventId) {
+      if (seen.has(cursor.supersedesEventId)) {
+        throw new IndexedDbRepositoryError(
+          "schema_validation_failed",
+          "Lifecycle supersession chains must be acyclic.",
+          { details: { supersedesEventId: event.supersedesEventId } },
+        );
+      }
+      seen.add(cursor.supersedesEventId);
+      cursor = byId.get(cursor.supersedesEventId);
+    }
+  }
+};
+
 export const createIndexedDbRepository = async (options = {}) => {
   let db;
   try {
@@ -491,6 +528,94 @@ export const createIndexedDbRepository = async (options = {}) => {
     },
     updateApplication(application) {
       return safe(() => putRecord(db, "applications", application));
+    },
+    async commitLifecycleMutation(mutation = {}) {
+      return safe(async () => {
+        const requiredStores = [
+          "applications",
+          "lifecycleEvents",
+          ...Object.keys(mutation.put ?? {}),
+          ...Object.keys(mutation.add ?? {}),
+        ].filter(
+          (value, index, array) =>
+            STORE_NAMES.includes(value) && array.indexOf(value) === index,
+        );
+        const existing = Object.fromEntries(
+          await Promise.all(
+            STORE_NAMES.map(async (name) => [name, await getAll(db, name)]),
+          ),
+        );
+        const previousApplication = mutation.applicationId
+          ? (existing.applications.find(
+              ({ id }) => id === mutation.applicationId,
+            ) ?? null)
+          : null;
+        const operationTime =
+          mutation.operationTime ?? new Date().toISOString();
+        const additions = Object.fromEntries(
+          Object.entries(mutation.add ?? {}).map(([storeName, rows]) => [
+            storeName,
+            toArray(rows).map((row) => parseRecord(storeName, row)),
+          ]),
+        );
+        const puts = Object.fromEntries(
+          Object.entries(mutation.put ?? {}).map(([storeName, rows]) => [
+            storeName,
+            toArray(rows).map((row) => parseRecord(storeName, row)),
+          ]),
+        );
+        const merged = Object.fromEntries(
+          STORE_NAMES.map((name) => {
+            const byId = new Map(
+              existing[name].map((record) => [record.id, record]),
+            );
+            for (const row of puts[name] ?? []) byId.set(row.id, row);
+            for (const row of additions[name] ?? []) {
+              if (byId.has(row.id))
+                throw new IndexedDbRepositoryError(
+                  "constraint_failed",
+                  `Duplicate ${name} id in lifecycle mutation.`,
+                  { details: { storeName: name, id: row.id } },
+                );
+              byId.set(row.id, row);
+            }
+            return [name, [...byId.values()]];
+          }),
+        );
+        validateSupersessionGraph(merged.lifecycleEvents);
+        const validation = browserApplicationExportSchema.safeParse({
+          schemaVersion: BROWSER_BACKUP_SCHEMA_VERSION,
+          exportedAt: operationTime,
+          applications: merged.applications,
+          contacts: merged.contacts,
+          outreachMessages: merged.outreachMessages,
+          lifecycleEvents: merged.lifecycleEvents,
+          interviews: merged.interviews,
+          offers: merged.offers,
+          artifacts: merged.artifacts,
+          reminders: merged.reminders,
+          settings: merged.settings[0]
+            ? {
+                ...merged.settings[0],
+                schemaVersion: LOCAL_SETTINGS_SCHEMA_VERSION,
+              }
+            : undefined,
+        });
+        if (!validation.success)
+          throw new IndexedDbRepositoryError(
+            "schema_validation_failed",
+            "Lifecycle mutation would violate browser application schema.",
+            { details: validation.error.flatten() },
+          );
+        const tx = db.transaction(requiredStores, "readwrite");
+        const done = transactionDone(tx);
+        for (const [storeName, rows] of Object.entries(puts))
+          for (const row of rows) tx.objectStore(storeName).put(row);
+        for (const [storeName, rows] of Object.entries(additions))
+          for (const row of rows) tx.objectStore(storeName).add(row);
+        await done;
+        return { operationTime, previousStatus: previousApplication?.status };
+      });
     },
     async deleteApplication(id) {
       return safe(async () => {

--- a/src/web/tracker/lifecycleReconciliation.js
+++ b/src/web/tracker/lifecycleReconciliation.js
@@ -1,0 +1,298 @@
+const ORIGIN_TYPES = new Set([
+  "application_submitted",
+  "recruiter_company_outreach",
+  "candidate_outreach",
+  "referral",
+  "other_unknown",
+]);
+const TERMINAL_TYPES = new Set([
+  "employer_rejected",
+  "candidate_withdrew",
+  "offer_declined",
+  "offer_expired_rescinded",
+  "offer_accepted",
+  "closed_archived",
+]);
+const STATUS_ENDPOINT = {
+  applied: "awaiting_response",
+  outreach_sent: "awaiting_response",
+  recruiter_screen: "interviewing",
+  technical_screen: "interviewing",
+  onsite_loop: "interviewing",
+  offer: "offer_negotiating",
+  accepted: "offer_accepted",
+  rejected: "employer_rejected",
+  withdrawn: "candidate_withdrew",
+  closed_archived: "closed_archived",
+};
+const OFFER_EVENT = {
+  received: "offer_received",
+  negotiating: "offer_negotiating",
+  accepted: "offer_accepted",
+  declined: "offer_declined",
+  expired: "offer_expired_rescinded",
+  rescinded: "offer_expired_rescinded",
+};
+const INTERVIEW_EVENT = {
+  recruiter_screen: "recruiter_screen",
+  technical_screen: "technical_interview",
+  onsite_loop: "onsite_final_loop",
+};
+const orderById = (a, b) => String(a.id).localeCompare(String(b.id));
+const effectiveEvents = (events) => {
+  const superseded = new Set(
+    events.map((e) => e.supersedesEventId).filter(Boolean),
+  );
+  return events
+    .filter((e) => !superseded.has(e.id))
+    .sort(
+      (a, b) =>
+        String(a.occurredAt).localeCompare(String(b.occurredAt)) ||
+        orderById(a, b),
+    );
+};
+const stableId = (...parts) =>
+  `event_${parts
+    .map(
+      (part) =>
+        String(part ?? "none")
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "_")
+          .replace(/^_+|_+$/g, "") || "none",
+    )
+    .join("_")}`.slice(0, 180);
+const warn = (warnings, code, applicationId, extra = {}) => {
+  warnings.push({ code, applicationId, ...extra });
+};
+const eventFor = ({
+  application,
+  type,
+  child,
+  state,
+  at,
+  status,
+  operationTime,
+}) => ({
+  id: stableId("reconcile", application.id, type, child?.id, state),
+  applicationId: application.id,
+  eventType: type,
+  status: status ?? application.status,
+  previousStatus: application.status,
+  occurredAt: at ?? "1970-01-01",
+  occurredAtPrecision: at
+    ? String(at).length === 10
+      ? "date"
+      : "instant"
+    : "unknown",
+  inferred: true,
+  source: "reconciliation",
+  createdAt: operationTime,
+  ...(child?.id ? { sourceArtifact: child.id } : {}),
+  ...(state ? { actionStatus: state } : {}),
+  ...(child?.dueAt ? { dueAt: child.dueAt } : {}),
+});
+const endpointForReplay = (events) => {
+  let terminal = null;
+  let active = "unknown";
+  for (const e of effectiveEvents(events)) {
+    if (e.eventType === "application_reopened") terminal = null;
+    if (TERMINAL_TYPES.has(e.eventType)) terminal = e.eventType;
+    else if (!terminal) {
+      if (["offer_received", "offer_negotiating"].includes(e.eventType))
+        active = "offer_negotiating";
+      else if (
+        [
+          "recruiter_screen",
+          "technical_interview",
+          "onsite_final_loop",
+        ].includes(e.eventType)
+      )
+        active = "interviewing";
+      else if (
+        [
+          "application_submitted",
+          "candidate_outreach",
+          "employer_response_received",
+          "recruiter_company_outreach",
+          "referral",
+        ].includes(e.eventType)
+      )
+        active = "awaiting_response";
+    }
+  }
+  return terminal ?? active;
+};
+export const planLifecycleReconciliation = (
+  bundle = {},
+  { operationTime = "1970-01-01T00:00:00.000Z" } = {},
+) => {
+  const additions = [];
+  const warnings = [];
+  const apps = [...(bundle.applications ?? [])].sort(orderById);
+  const events = bundle.lifecycleEvents ?? [];
+  const existingKeys = new Set(
+    events.map((e) =>
+      [
+        e.applicationId,
+        e.eventType,
+        e.sourceArtifact || "",
+        e.actionStatus || "",
+      ].join("|"),
+    ),
+  );
+  const add = (event) => {
+    const key = [
+      event.applicationId,
+      event.eventType,
+      event.sourceArtifact || "",
+      event.actionStatus || "",
+    ].join("|");
+    if (existingKeys.has(key)) return;
+    existingKeys.add(key);
+    additions.push(event);
+  };
+  for (const application of apps) {
+    const appEvents = events.filter((e) => e.applicationId === application.id);
+    const effective = effectiveEvents(appEvents);
+    if (!effective.some((e) => ORIGIN_TYPES.has(e.eventType))) {
+      const at = application.appliedAt;
+      if (!at) warn(warnings, "missing_origin_timestamp", application.id);
+      add(
+        eventFor({
+          application,
+          type: application.origin || "other_unknown",
+          at,
+          operationTime,
+        }),
+      );
+    }
+    for (const msg of (bundle.outreachMessages ?? [])
+      .filter((x) => x.applicationId === application.id)
+      .sort(orderById)) {
+      const type =
+        msg.direction === "inbound"
+          ? "employer_response_received"
+          : msg.direction === "outbound"
+            ? "candidate_outreach"
+            : null;
+      const at = msg.direction === "inbound" ? msg.receivedAt : msg.sentAt;
+      if (!type) {
+        warn(warnings, "unreconciled_child_activity", application.id, {
+          childStore: "outreachMessages",
+          childId: msg.id,
+        });
+        continue;
+      }
+      if (!at)
+        warn(warnings, "unknown_occurrence_precision", application.id, {
+          childStore: "outreachMessages",
+          childId: msg.id,
+        });
+      add(
+        eventFor({
+          application,
+          type,
+          child: msg,
+          state: msg.direction,
+          at,
+          operationTime,
+        }),
+      );
+    }
+    for (const interview of (bundle.interviews ?? [])
+      .filter((x) => x.applicationId === application.id)
+      .sort(orderById)) {
+      const type = ["cancelled", "no_show"].includes(interview.outcome)
+        ? "status_changed"
+        : INTERVIEW_EVENT[interview.stage] || "status_changed";
+      if (type === "status_changed")
+        warn(warnings, "unreconciled_child_activity", application.id, {
+          childStore: "interviews",
+          childId: interview.id,
+        });
+      add(
+        eventFor({
+          application,
+          type,
+          child: interview,
+          state: interview.outcome,
+          at: interview.startsAt,
+          operationTime,
+        }),
+      );
+    }
+    for (const offer of (bundle.offers ?? [])
+      .filter((x) => x.applicationId === application.id)
+      .sort(orderById)) {
+      const type = OFFER_EVENT[offer.status];
+      if (!type) {
+        warn(warnings, "unreconciled_child_activity", application.id, {
+          childStore: "offers",
+          childId: offer.id,
+        });
+        continue;
+      }
+      add(
+        eventFor({
+          application,
+          type,
+          child: offer,
+          state: offer.status,
+          at: offer.updatedAt || offer.createdAt,
+          status: offer.status === "accepted" ? "accepted" : "offer",
+          operationTime,
+        }),
+      );
+    }
+    const replay = endpointForReplay([
+      ...appEvents,
+      ...additions.filter((e) => e.applicationId === application.id),
+    ]);
+    if (
+      STATUS_ENDPOINT[application.status] &&
+      replay !== STATUS_ENDPOINT[application.status]
+    ) {
+      warn(warnings, "status_history_mismatch", application.id);
+      warn(warnings, "status_snapshot_inferred", application.id);
+      warn(warnings, "unknown_occurrence_precision", application.id);
+      add(
+        eventFor({
+          application,
+          type: "migration_status_snapshot",
+          state: application.status,
+          status: application.status,
+          operationTime,
+        }),
+      );
+    }
+    if (
+      effective.some(
+        (e, i) =>
+          i &&
+          String(e.occurredAt).localeCompare(
+            String(effective[i - 1].occurredAt),
+          ) < 0,
+      )
+    )
+      warn(warnings, "regressive_history", application.id);
+  }
+  additions.sort(
+    (a, b) =>
+      String(a.applicationId).localeCompare(String(b.applicationId)) ||
+      String(a.eventType).localeCompare(String(b.eventType)) ||
+      orderById(a, b),
+  );
+  return {
+    additions,
+    warnings: warnings.sort(
+      (a, b) =>
+        a.code.localeCompare(b.code) ||
+        String(a.applicationId).localeCompare(String(b.applicationId)),
+    ),
+    counts: {
+      applications: apps.length,
+      additions: additions.length,
+      warnings: warnings.length,
+    },
+  };
+};

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -25,6 +25,7 @@ import {
   selectDashboardMetrics,
 } from "./metrics.js";
 import { createIndexedDbRepository } from "../storage/indexedDbRepository.js";
+import { planLifecycleReconciliation } from "./lifecycleReconciliation.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
 const ARRAY_STORES = [
@@ -36,6 +37,13 @@ const ARRAY_STORES = [
   "offers",
   "artifacts",
   "reminders",
+];
+const ORIGINS = [
+  "application_submitted",
+  "recruiter_company_outreach",
+  "candidate_outreach",
+  "referral",
+  "other_unknown",
 ];
 const STATUSES = [
   "applied",
@@ -104,6 +112,8 @@ const repo = {
   },
   clear: async () => (await getRepository()).clearAllData(),
   exportAll: async () => (await getRepository()).exportAllData(),
+  commitLifecycleMutation: async (mutation) =>
+    (await getRepository()).commitLifecycleMutation(mutation),
 };
 async function batchImport(recordsByStore) {
   return (await getRepository()).importPartialData(recordsByStore);
@@ -117,6 +127,7 @@ const state = {
   dir: -1,
   current: null,
   detailSave: Promise.resolve(),
+  reconciliationWarnings: [],
 };
 function weekBucket(value) {
   const d = day(value);
@@ -273,8 +284,14 @@ const metadataText = (app) =>
   metadataEntries(app)
     .map(([label, value]) => `${label}: ${value}`)
     .join(" · ");
+
+function updateLifecycleReconciliationWarnings(bundle) {
+  const plan = planLifecycleReconciliation(bundle, { operationTime: now() });
+  state.reconciliationWarnings = plan.warnings;
+}
 async function refresh() {
   state.bundle = await repo.exportAll();
+  updateLifecycleReconciliationWarnings(state.bundle);
   state.apps = state.bundle.applications.sort((a, b) =>
     String(b.appliedAt || "").localeCompare(a.appliedAt || ""),
   );
@@ -658,7 +675,7 @@ function detailForm(app) {
         "Compact CSV assessment signal",
     });
   }
-  return `<div class="tracker-detail"><article class="card"><h2>${esc(app.company || "New application")} — ${esc(app.role || "Unsaved")}</h2><form class="tracker-form" data-core-form>${input("company", app.company, true)}${input("role", app.role, true)}${input("postingUrl", app.postingUrl, "url")}<label>Status<select name="status" required>${STATUSES.map((s) => `<option ${app.status === s ? "selected" : ""}>${s}</option>`).join("")}</select></label>${input("source", app.source, "text")}${input("appliedAt", day(app.appliedAt), "date", true)}${input("followUpDate", day(app.followUpDate), "date")}<label>Notes<textarea name="notes">${esc(app.notes)}</textarea></label><button class="button">Save application</button></form></article><article class="card"><h3>Compact CSV metadata</h3>${metadataSection(app)}</article><article class="card wide-card"><h3>Lifecycle timeline</h3><p class="muted">Events are sorted by occurred date, then due date, then stable ID. All data stays local in this browser.</p><ul class="timeline">${events.map(timelineItem).join("") || '<li class="muted">No lifecycle events for this application yet.</li>'}</ul></article><article class="card"><h3>Assessments/take-homes</h3>${assessments.length ? `<ul>${assessments.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No written assessments or take-homes yet.</p>'}</article><article class="card"><h3>Recruiter screens</h3>${recruiterScreens.length ? `<ul>${recruiterScreens.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No recruiter screens yet.</p>'}</article><article class="card"><h3>Interviews</h3><form class="tracker-form" data-interview-form><label>Stage<select name="stage"><option>recruiter_screen</option><option>technical_screen</option><option>onsite_loop</option><option>other</option></select></label>${input("startsAt", day(now()), "date")}<button class="button">Log interview</button></form><ul>${otherInterviews.map((i) => `<li>${day(i.startsAt)} ${esc(i.stage)} ${esc(i.outcome)}</li>`).join("") || '<li class="muted">No non-recruiter interviews yet.</li>'}</ul></article><article class="card"><h3>Links/artifacts</h3><form class="tracker-form" data-artifact-form>${input("name", "", true)}${input("url", "")}<button class="button">Add link/artifact</button></form><ul>${m.artifacts.map((a) => `<li>${linkForArtifact(a)}</li>`).join("")}</ul></article><article class="card"><h3>Outreach messages</h3><form class="tracker-form" data-outreach-form><label>Channel<select name="channel"><option>email</option><option>linkedin</option><option>phone</option><option>sms</option><option>other</option></select></label><label>Message<textarea name="body" required></textarea></label><button class="button">Add outreach</button></form><ul>${m.outreach.map((o) => `<li>${day(o.sentAt)} ${esc(o.channel)} ${esc(o.body)}</li>`).join("")}</ul></article><article class="card"><h3>Offers</h3><form class="tracker-form" data-offer-form><label>Status<select name="status"><option>received</option><option>negotiating</option><option>accepted</option><option>declined</option></select></label>${input("notes", "")}<button class="button">Log offer</button></form><ul>${m.offers.map((o) => `<li>${esc(o.status)} ${esc(o.notes || "")}</li>`).join("")}</ul></article></div>`;
+  return `<div class="tracker-detail"><article class="card"><h2>${esc(app.company || "New application")} — ${esc(app.role || "Unsaved")}</h2><form class="tracker-form" data-core-form>${input("company", app.company, true)}${input("role", app.role, true)}${input("postingUrl", app.postingUrl, "url")}<label>Status<select name="status" required>${STATUSES.map((s) => `<option ${app.status === s ? "selected" : ""}>${s}</option>`).join("")}</select></label><label>Origin<select name="origin" required>${ORIGINS.map((origin) => `<option value="${origin}" ${app.origin === origin ? "selected" : ""}>${origin}</option>`).join("")}</select></label><label>Source<input name="source" type="text" value="${esc(app.source)}"></label><label>Application date (if applicable)<input name="appliedAt" type="date" value="${esc(day(app.appliedAt))}" ${app.origin === "application_submitted" ? "required" : ""}></label>${input("followUpDate", day(app.followUpDate), "date")}<div data-form-error role="alert" class="error" aria-live="polite"></div><label>Notes<textarea name="notes">${esc(app.notes)}</textarea></label><button class="button">Save application</button></form></article><article class="card"><h3>Compact CSV metadata</h3>${metadataSection(app)}</article><article class="card wide-card"><h3>Lifecycle timeline</h3><p class="muted">Events are sorted by occurred date, then due date, then stable ID. All data stays local in this browser.</p><ul class="timeline">${events.map(timelineItem).join("") || '<li class="muted">No lifecycle events for this application yet.</li>'}</ul></article><article class="card"><h3>Assessments/take-homes</h3>${assessments.length ? `<ul>${assessments.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No written assessments or take-homes yet.</p>'}</article><article class="card"><h3>Record assessment</h3><form class="tracker-form" data-assessment-form><label>Action status<select name="actionStatus"><option>requested</option><option>pending</option><option>started</option><option>in_progress</option><option>submitted</option><option>completed</option></select></label>${input("dueAt", "", "date")}<label>Details<textarea name="details"></textarea></label><button class="button">Log assessment</button></form></article><article class="card"><h3>Recruiter screens</h3>${recruiterScreens.length ? `<ul>${recruiterScreens.map((item) => `<li>${esc(item.date)} ${esc(item.label)}</li>`).join("")}</ul>` : '<p class="muted">No recruiter screens yet.</p>'}</article><article class="card"><h3>Interviews</h3><form class="tracker-form" data-interview-form><label>Stage<select name="stage"><option>recruiter_screen</option><option>technical_screen</option><option>onsite_loop</option><option>other</option></select></label><label>Outcome<select name="outcome"><option>scheduled</option><option>completed</option><option>cancelled</option><option>no_show</option></select></label>${input("startsAt", day(now()), "date")}<button class="button">Log interview</button></form><ul>${otherInterviews.map((i) => `<li>${day(i.startsAt)} ${esc(i.stage)} ${esc(i.outcome)}</li>`).join("") || '<li class="muted">No non-recruiter interviews yet.</li>'}</ul></article><article class="card"><h3>Links/artifacts</h3><form class="tracker-form" data-artifact-form>${input("name", "", true)}${input("url", "")}<button class="button">Add link/artifact</button></form><ul>${m.artifacts.map((a) => `<li>${linkForArtifact(a)}</li>`).join("")}</ul></article><article class="card"><h3>Outreach messages</h3><form class="tracker-form" data-outreach-form><label>Direction<select name="direction"><option value="outbound">Outbound</option><option value="inbound">Inbound</option></select></label><label>Channel<select name="channel"><option>email</option><option>linkedin</option><option>phone</option><option>sms</option><option>other</option></select></label><label>Message<textarea name="body" required></textarea></label><button class="button">Add outreach</button></form><ul>${m.outreach.map((o) => `<li>${day(o.sentAt)} ${esc(o.channel)} ${esc(o.body)}</li>`).join("")}</ul></article><article class="card"><h3>Offers</h3><form class="tracker-form" data-offer-form><label>Status<select name="status"><option>received</option><option>negotiating</option><option>accepted</option><option>declined</option><option>expired</option></select></label>${input("notes", "")}<button class="button">Log offer</button></form><ul>${m.offers.map((o) => `<li>${esc(o.status)} ${esc(o.notes || "")}</li>`).join("")}</ul></article></div>`;
 }
 function input(n, v = "", type = "text", required = false) {
   const req = type === true || required ? "required" : "";
@@ -692,14 +709,90 @@ function openUnsavedDetail(app) {
 function isoDate(v) {
   return v ? new Date(v).toISOString() : undefined;
 }
+
+const STATUS_EVENT_TYPE = {
+  outreach_sent: "candidate_outreach",
+  recruiter_screen: "recruiter_screen",
+  technical_screen: "technical_interview",
+  onsite_loop: "onsite_final_loop",
+  offer: "offer_received",
+  accepted: "offer_accepted",
+  rejected: "employer_rejected",
+  withdrawn: "candidate_withdrew",
+  closed_archived: "closed_archived",
+};
+const TERMINAL_STATUS = new Set([
+  "accepted",
+  "rejected",
+  "withdrawn",
+  "closed_archived",
+]);
+const offerEventType = (status) =>
+  ({
+    received: "offer_received",
+    negotiating: "offer_negotiating",
+    accepted: "offer_accepted",
+    declined: "offer_declined",
+    expired: "offer_expired_rescinded",
+  })[status] || "offer_received";
+const interviewEventType = (stage, outcome) =>
+  ["cancelled", "no_show"].includes(outcome)
+    ? "status_changed"
+    : {
+        recruiter_screen: "recruiter_screen",
+        technical_screen: "technical_interview",
+        onsite_loop: "onsite_final_loop",
+      }[stage] || "status_changed";
+function lifecycleEventRecord({
+  applicationId,
+  eventType,
+  status,
+  previousStatus,
+  operationTime,
+  extra = {},
+}) {
+  return {
+    id: id("event"),
+    applicationId,
+    eventType,
+    status,
+    previousStatus,
+    occurredAt: operationTime,
+    occurredAtPrecision: "instant",
+    inferred: false,
+    source: "manual",
+    createdAt: operationTime,
+    ...extra,
+  };
+}
+function statusEventType(previousStatus, nextStatus) {
+  if (TERMINAL_STATUS.has(previousStatus) && !TERMINAL_STATUS.has(nextStatus))
+    return "application_reopened";
+  if (nextStatus === "applied")
+    return previousStatus === nextStatus
+      ? "application_submitted"
+      : "status_changed";
+  return STATUS_EVENT_TYPE[nextStatus] || "status_changed";
+}
 function bindDetail(app) {
   const persisted = !app.unsaved;
   const latestApp = () => state.apps.find((a) => a.id === app.id) || app;
-  $("[data-core-form]").onsubmit = async (e) => {
+  $(`[data-core-form] [name="origin"]`).onchange = (event) => {
+    const required = event.target.value === "application_submitted";
+    $(`[data-core-form] [name="appliedAt"]`).required = required;
+  };
+  $(`[data-core-form]`).onsubmit = async (e) => {
     e.preventDefault();
     const form = e.target;
+    const errorTarget = $("[data-form-error]", form);
     const v = values(form);
+    if (v.origin === "application_submitted" && !v.appliedAt) {
+      errorTarget.textContent =
+        "Application date is required for submitted applications.";
+      return;
+    }
     setFormDisabled(form, true);
+    const operationTime = now();
     state.detailSave = state.detailSave
       .catch(() => {})
       .then(async () => {
@@ -710,32 +803,62 @@ function bindDetail(app) {
           source: optionalBlankToUndefined(v.source),
           postingUrl: optionalBlankToUndefined(v.postingUrl),
           notes: optionalBlankToUndefined(v.notes),
-          origin: current.origin ?? "other_unknown",
+          origin: v.origin,
           appliedAt: isoDate(v.appliedAt),
           followUpDate: isoDate(v.followUpDate),
-          updatedAt: now(),
+          updatedAt: operationTime,
         };
         delete saved.unsaved;
-        await repo.put("applications", saved);
-        if (!persisted || v.status !== current.status)
-          await repo.add("lifecycleEvents", {
-            id: id("event"),
-            applicationId: app.id,
-            eventType:
-              v.status === "applied" ? "application_submitted" : "status_changed",
-            status: v.status,
-            occurredAt: now(),
-            occurredAtPrecision: "instant",
-            inferred: false,
-            source: "manual",
-            createdAt: now(),
-          });
+        const events = [];
+        if (!persisted) {
+          events.push(
+            lifecycleEventRecord({
+              applicationId: app.id,
+              eventType: v.origin,
+              status: v.status,
+              operationTime,
+            }),
+          );
+        } else if (v.origin !== current.origin) {
+          const priorOrigin = sortedLifecycleEvents(app.id)
+            .filter((event) => ORIGINS.includes(event.eventType))
+            .at(-1);
+          events.push(
+            lifecycleEventRecord({
+              applicationId: app.id,
+              eventType: v.origin,
+              status: v.status,
+              previousStatus: current.status,
+              operationTime,
+              extra: priorOrigin ? { supersedesEventId: priorOrigin.id } : {},
+            }),
+          );
+        }
+        if (persisted && v.status !== current.status) {
+          events.push(
+            lifecycleEventRecord({
+              applicationId: app.id,
+              eventType: statusEventType(current.status, v.status),
+              status: v.status,
+              previousStatus: current.status,
+              operationTime,
+            }),
+          );
+        }
+        await repo.commitLifecycleMutation({
+          applicationId: app.id,
+          operationTime,
+          put: { applications: [saved] },
+          add: { lifecycleEvents: events },
+        });
         await refresh();
         openDetail(app.id);
       });
     try {
       await state.detailSave;
     } catch (error) {
+      errorTarget.textContent =
+        "Save failed. Your entered values were not changed; please try again.";
       setFormDisabled(form, false);
       throw error;
     }
@@ -760,24 +883,48 @@ function bindDetail(app) {
     e.preventDefault();
     const v = values(e.target);
     const current = latestApp();
-    await repo.add("outreachMessages", {
+    const operationTime = now();
+    const msg = {
       id: id("msg"),
       applicationId: app.id,
-      direction: "outbound",
+      direction: v.direction,
       channel: v.channel,
       body: v.body,
-      sentAt: now(),
-      createdAt: now(),
-      updatedAt: now(),
-    });
+      ...(v.direction === "inbound"
+        ? { receivedAt: operationTime }
+        : { sentAt: operationTime }),
+      createdAt: operationTime,
+      updatedAt: operationTime,
+    };
     const nextStatus =
-      STATUS_RANK[current.status] >= STATUS_RANK.outreach_sent
-        ? current.status
-        : "outreach_sent";
-    await repo.put("applications", {
-      ...current,
-      status: nextStatus,
-      updatedAt: now(),
+      v.direction === "outbound" &&
+      STATUS_RANK[current.status] < STATUS_RANK.outreach_sent
+        ? "outreach_sent"
+        : current.status;
+    await repo.commitLifecycleMutation({
+      applicationId: app.id,
+      operationTime,
+      put: {
+        applications: [
+          { ...current, status: nextStatus, updatedAt: operationTime },
+        ],
+      },
+      add: {
+        outreachMessages: [msg],
+        lifecycleEvents: [
+          lifecycleEventRecord({
+            applicationId: app.id,
+            eventType:
+              v.direction === "inbound"
+                ? "employer_response_received"
+                : "candidate_outreach",
+            status: nextStatus,
+            previousStatus: current.status,
+            operationTime,
+            extra: { channel: v.channel, actor: v.direction },
+          }),
+        ],
+      },
     });
     await refresh();
     openDetail(app.id);
@@ -786,24 +933,72 @@ function bindDetail(app) {
     e.preventDefault();
     const v = values(e.target);
     const current = latestApp();
-    await repo.add("interviews", {
+    const operationTime = now();
+    const interview = {
       id: id("interview"),
       applicationId: app.id,
       contactIds: [],
       stage: v.stage,
       startsAt: isoDate(v.startsAt),
-      outcome: "scheduled",
+      outcome: v.outcome,
       createdAt: now(),
-      updatedAt: now(),
-    });
+      updatedAt: operationTime,
+    };
     const nextStatus =
-      v.stage !== "other" && STATUS_RANK[v.stage] > STATUS_RANK[current.status]
+      !["cancelled", "no_show"].includes(v.outcome) &&
+      v.stage !== "other" &&
+      STATUS_RANK[v.stage] > STATUS_RANK[current.status]
         ? v.stage
         : current.status;
-    await repo.put("applications", {
-      ...current,
-      status: nextStatus,
-      updatedAt: now(),
+    await repo.commitLifecycleMutation({
+      applicationId: app.id,
+      operationTime,
+      put: {
+        applications: [
+          { ...current, status: nextStatus, updatedAt: operationTime },
+        ],
+      },
+      add: {
+        interviews: [interview],
+        lifecycleEvents: [
+          lifecycleEventRecord({
+            applicationId: app.id,
+            eventType: interviewEventType(v.stage, v.outcome),
+            status: nextStatus,
+            previousStatus: current.status,
+            operationTime,
+            extra: { stageLabel: v.stage, actionStatus: v.outcome },
+          }),
+        ],
+      },
+    });
+    await refresh();
+    openDetail(app.id);
+  };
+  $("[data-assessment-form]").onsubmit = async (e) => {
+    e.preventDefault();
+    const v = values(e.target);
+    const current = latestApp();
+    const operationTime = now();
+    await repo.commitLifecycleMutation({
+      applicationId: app.id,
+      operationTime,
+      add: {
+        lifecycleEvents: [
+          lifecycleEventRecord({
+            applicationId: app.id,
+            eventType: "assessment_take_home",
+            status: current.status,
+            previousStatus: current.status,
+            operationTime,
+            extra: {
+              actionStatus: v.actionStatus,
+              dueAt: isoDate(v.dueAt),
+              details: optionalBlankToUndefined(v.details),
+            },
+          }),
+        ],
+      },
     });
     await refresh();
     openDetail(app.id);
@@ -812,18 +1007,37 @@ function bindDetail(app) {
     e.preventDefault();
     const v = values(e.target);
     const current = latestApp();
-    await repo.add("offers", {
+    const operationTime = now();
+    const offer = {
       id: id("offer"),
       applicationId: app.id,
       status: v.status,
       notes: v.notes || undefined,
-      createdAt: now(),
-      updatedAt: now(),
-    });
-    await repo.put("applications", {
-      ...current,
-      status: v.status === "accepted" ? "accepted" : "offer",
-      updatedAt: now(),
+      createdAt: operationTime,
+      updatedAt: operationTime,
+    };
+    const nextStatus = v.status === "accepted" ? "accepted" : "offer";
+    await repo.commitLifecycleMutation({
+      applicationId: app.id,
+      operationTime,
+      put: {
+        applications: [
+          { ...current, status: nextStatus, updatedAt: operationTime },
+        ],
+      },
+      add: {
+        offers: [offer],
+        lifecycleEvents: [
+          lifecycleEventRecord({
+            applicationId: app.id,
+            eventType: offerEventType(v.status),
+            status: nextStatus,
+            previousStatus: current.status,
+            operationTime,
+            extra: { actionStatus: v.status },
+          }),
+        ],
+      },
     });
     await refresh();
     openDetail(app.id);
@@ -838,6 +1052,7 @@ async function newApplication() {
     status: "applied",
     source: "",
     postingUrl: "",
+    origin: "application_submitted",
     appliedAt: day(ts),
     createdAt: ts,
     updatedAt: ts,

--- a/test/web-tracker-lifecycle-persistence.test.js
+++ b/test/web-tracker-lifecycle-persistence.test.js
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { indexedDB } from "fake-indexeddb";
+
+import {
+  DATABASE_NAME,
+  createIndexedDbRepository,
+} from "../src/web/storage/indexedDbRepository.js";
+
+const ts = "2026-02-03T04:05:06.000Z";
+const app = {
+  id: "app_atomic_fake",
+  company: "Example Co",
+  role: "Engineer",
+  status: "applied",
+  origin: "application_submitted",
+  appliedAt: ts,
+  createdAt: ts,
+  updatedAt: ts,
+};
+const event = (id, overrides = {}) => ({
+  id,
+  applicationId: app.id,
+  status: "applied",
+  occurredAt: ts,
+  source: "manual",
+  eventType: "application_submitted",
+  occurredAtPrecision: "instant",
+  inferred: false,
+  createdAt: ts,
+  ...overrides,
+});
+
+const deleteDatabase = () =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(DATABASE_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => resolve();
+  });
+
+afterEach(deleteDatabase);
+
+describe("tracker lifecycle atomic persistence", () => {
+  it("commits application and origin event in one atomic mutation", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+
+    await repo.commitLifecycleMutation({
+      applicationId: app.id,
+      operationTime: ts,
+      put: { applications: [app] },
+      add: { lifecycleEvents: [event("event_origin")] },
+    });
+
+    const exported = await repo.exportAllData();
+    expect(exported.applications).toHaveLength(1);
+    expect(exported.lifecycleEvents).toEqual([
+      expect.objectContaining({ id: "event_origin", inferred: false }),
+    ]);
+    repo.close();
+  });
+
+  it("rolls back every store when a child insert fails validation", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+
+    await expect(
+      repo.commitLifecycleMutation({
+        applicationId: app.id,
+        operationTime: ts,
+        put: { applications: [app] },
+        add: {
+          lifecycleEvents: [event("event_origin")],
+          outreachMessages: [
+            {
+              id: "message_bad_reference",
+              applicationId: "different_app",
+              direction: "outbound",
+              channel: "email",
+              sentAt: ts,
+              createdAt: ts,
+              updatedAt: ts,
+            },
+          ],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "schema_validation_failed" });
+
+    const exported = await repo.exportAllData();
+    expect(exported.applications).toHaveLength(0);
+    expect(exported.lifecycleEvents).toHaveLength(0);
+    expect(exported.outreachMessages).toHaveLength(0);
+    repo.close();
+  });
+
+  it("rejects cross-application supersession references", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const other = { ...app, id: "app_other_fake" };
+
+    await expect(
+      repo.commitLifecycleMutation({
+        applicationId: app.id,
+        operationTime: ts,
+        put: { applications: [app, other] },
+        add: {
+          lifecycleEvents: [
+            event("event_origin"),
+            event("event_other", { applicationId: other.id }),
+            event("event_replacement", {
+              eventType: "referral",
+              supersedesEventId: "event_other",
+            }),
+          ],
+        },
+      }),
+    ).rejects.toMatchObject({ code: "schema_validation_failed" });
+    repo.close();
+  });
+});

--- a/test/web-tracker-lifecycle-reconciliation.test.js
+++ b/test/web-tracker-lifecycle-reconciliation.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import { planLifecycleReconciliation } from "../src/web/tracker/lifecycleReconciliation.js";
+
+const ts = "2026-02-03T04:05:06.000Z";
+const app = {
+  id: "app_reconcile_fake",
+  company: "Example Co",
+  role: "Engineer",
+  status: "offer",
+  origin: "application_submitted",
+  appliedAt: ts,
+  createdAt: ts,
+  updatedAt: ts,
+};
+const baseBundle = {
+  applications: [app],
+  contacts: [],
+  outreachMessages: [],
+  lifecycleEvents: [],
+  interviews: [],
+  offers: [],
+  artifacts: [],
+  reminders: [],
+};
+
+describe("lifecycle reconciliation planner", () => {
+  it("plans deterministic child-derived additions without free-text inference", () => {
+    const plan = planLifecycleReconciliation({
+      ...baseBundle,
+      outreachMessages: [
+        {
+          id: "msg_outbound",
+          applicationId: app.id,
+          direction: "outbound",
+          channel: "email",
+          body: "private text mentioning onsite and offer",
+          sentAt: ts,
+          createdAt: ts,
+          updatedAt: ts,
+        },
+      ],
+      interviews: [
+        {
+          id: "interview_future",
+          applicationId: app.id,
+          contactIds: [],
+          stage: "technical_screen",
+          startsAt: "2026-12-01T12:00:00.000Z",
+          outcome: "scheduled",
+          createdAt: ts,
+          updatedAt: ts,
+        },
+      ],
+      offers: [
+        {
+          id: "offer_declined",
+          applicationId: app.id,
+          status: "declined",
+          createdAt: ts,
+          updatedAt: ts,
+        },
+      ],
+    });
+
+    expect(plan.additions.map((event) => event.eventType)).toEqual([
+      "application_submitted",
+      "candidate_outreach",
+      "migration_status_snapshot",
+      "offer_declined",
+      "technical_interview",
+    ]);
+    expect(JSON.stringify(plan.warnings)).not.toContain("private text");
+    expect(plan.warnings.map((warning) => warning.code)).toContain(
+      "status_snapshot_inferred",
+    );
+  });
+
+  it("is idempotent when planned additions already exist", () => {
+    const first = planLifecycleReconciliation(baseBundle);
+    const second = planLifecycleReconciliation({
+      ...baseBundle,
+      lifecycleEvents: first.additions,
+    });
+
+    expect(second.additions).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
### Motivation
- Ensure every lifecycle-changing tracker action writes canonical lifecycle events as the append-only historical truth while keeping the application record as the materialized current projection.
- Make writes that touch an application and its lifecycle/child records atomic, validated, and reject invalid/cross-application supersession cycles.
- Provide a conservative, deterministic reconciliation planner to infer only from structured child records and surface safe warnings for migration/diagram use.

### Description
- Added `commitLifecycleMutation` to the IndexedDB repository to pre-validate merged application/child/event state, detect duplicate IDs, validate supersession graphs (same-application and acyclic), and perform a single required-store `readwrite` transaction that `put`s application updates and `add`s child/event records atomically (see `src/web/storage/indexedDbRepository.js`).
- Implemented a pure, deterministic reconciliation planner `planLifecycleReconciliation` that infers missing origin events, structured outreach/interview/offer-derived events, migration status snapshots when replay disagrees with current status, and returns planned additions plus safe warning codes without mutating history (see `src/web/tracker/lifecycleReconciliation.js`).
- Updated tracker UI logic and forms to use canonical origins and lifecycle mappings: added Origin select, made new application default origin `application_submitted`, preserved origin on edit, labeled application date as “Application date (if applicable)”, added outreach Direction (inbound/outbound), compact assessment form, interview outcome handling, expanded offer outcomes, and switched lifecycle-changing flows (application save/edit, outreach, interview, assessment, offer) to call `commitLifecycleMutation` so related records + lifecycle events are written atomically (see `src/web/tracker/tracker.js`).
- Added focused unit tests for atomic persistence and reconciliation planner behavior: `test/web-tracker-lifecycle-persistence.test.js` and `test/web-tracker-lifecycle-reconciliation.test.js`.

### Testing
- `npx prettier --check src/web/storage/indexedDbRepository.js src/web/tracker/tracker.js src/web/tracker/lifecycleReconciliation.js test/web-tracker-lifecycle-persistence.test.js test/web-tracker-lifecycle-reconciliation.test.js` — passed for modified files (note: `npm run format:check` reports pre-existing unrelated formatting warnings across the repo).
- `npm run lint` — passed.
- `npm run typecheck` — passed.
- `npx vitest run test/web-storage-indexeddb-repository.test.js test/web-tracker-lifecycle-persistence.test.js test/web-tracker-lifecycle-reconciliation.test.js test/web-spreadsheet-import-export.test.js` — all specified Vitest suites passed.
- `PLAYWRIGHT_BROWSERS_PATH=.cache/ms-playwright npx playwright test test/playwright/browser-tracker.spec.js` — Playwright browser runs for the tracker spec passed after ensuring Playwright browser artifacts (the repo includes the repository test helper used in CI to mirror/download browsers when needed).
- `npm run build` — passed (static tracker built successfully).
- `npm run test:ci` — full CI test run (including Vitest and Playwright) completed successfully in the final verification iteration.

Files changed/added (high level):
- Modified: `src/web/storage/indexedDbRepository.js` (add `commitLifecycleMutation` + validation helpers).
- Modified: `src/web/tracker/tracker.js` (form/UI updates and switching lifecycle writes to atomic mutations).
- Added: `src/web/tracker/lifecycleReconciliation.js` (planner implementation).
- Added tests: `test/web-tracker-lifecycle-persistence.test.js`, `test/web-tracker-lifecycle-reconciliation.test.js`.

Residual notes / follow-ups
- `npm run format:check` still reports many unrelated repo-wide Prettier warnings; the changes here were formatted and the focused `prettier --check` for modified files passed. If repo-wide formatting is desired, run Prettier across the repo in a separate change.
- The reconciliation planner is conservative and intentionally avoids inferring from free-text; future diagram/projection UI will use `state.reconciliationWarnings` populated during `refresh()`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51c7bbc7ec832f96ab3d0d70b860c4)