### PR TITLE
Add pure lifecycle projection engine

### DIFF
--- a/src/web/tracker/lifecycleProjection.js
+++ b/src/web/tracker/lifecycleProjection.js
@@ -416,7 +416,7 @@ const projectApp = (app, appEvents, isCurrent) => {
       else if (["submitted", "completed", "done"].includes(assessmentStatus)) {
         assessmentActive = false;
         awaitingActive = true;
-      } else markEndpoint("assessment_in_progress");
+      }
     } else if (
       ["recruiter_screen", "technical_interview", "onsite_final_loop"].includes(
         type,

--- a/src/web/tracker/lifecycleProjection.js
+++ b/src/web/tracker/lifecycleProjection.js
@@ -127,8 +127,9 @@ const normalize = (value) =>
     .replace(/&/g, " and ")
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_+|_+$/g, "");
+const rawEventType = (event) => normalize(event?.eventType);
 const canonicalEventType = (event) =>
-  LEGACY[normalize(event?.eventType)] ?? normalize(event?.eventType);
+  LEGACY[rawEventType(event)] ?? rawEventType(event);
 const eventId = (event, index) => String(event?.id ?? `missing_event_${index}`);
 const appId = (app, index) => String(app?.id ?? `missing_application_${index}`);
 const isUnknownTime = (event) =>
@@ -140,7 +141,7 @@ const instantMs = (value) => {
   return Number.isFinite(ms) ? ms : undefined;
 };
 const eventTime = (event) => {
-  if (isUnknownTime(event)) return { kind: "unknown", sort: "" };
+  if (isUnknownTime(event)) return { kind: "unknown", sort: "~unknown" };
   if (event?.occurredAtPrecision === "date") {
     const date = /^\d{4}-\d{2}-\d{2}$/u.test(String(event.occurredAt))
       ? String(event.occurredAt)
@@ -182,6 +183,7 @@ const prepare = (bundle) => {
       ...event,
       id: eventId(event, index),
       applicationId: String(event?.applicationId ?? ""),
+      rawType: rawEventType(event),
       canonicalType: canonicalEventType(event),
       time: eventTime(event),
     }))
@@ -243,6 +245,24 @@ const originFor = (app, events, details) => {
 const endpointFromStatusEvent = (event) =>
   STATUS_ENDPOINT[normalize(event.status)] ??
   STATUS_ENDPOINT[normalize(event.currentStatus)];
+const ENDPOINT_PRECEDENCE = new Map(
+  ENDPOINTS.map(([id], index) => [id, index]),
+);
+const endpointPrecedence = (endpoint) =>
+  ENDPOINT_PRECEDENCE.get(endpoint) ?? Number.MAX_SAFE_INTEGER;
+const shouldApplyEndpoint = (nextEndpoint, endpoint, sameMoment) =>
+  !sameMoment ||
+  endpointPrecedence(nextEndpoint) >= endpointPrecedence(endpoint);
+const eventsByApplicationId = (events) => {
+  const map = new Map();
+  for (const event of events) {
+    const group = map.get(event.applicationId) ?? [];
+    group.push(event);
+    map.set(event.applicationId, group);
+  }
+  return map;
+};
+
 const projectApp = (app, appEvents, isCurrent) => {
   const details = [];
   const events = [...appEvents].sort(
@@ -253,9 +273,23 @@ const projectApp = (app, appEvents, isCurrent) => {
   let highestObservedMilestoneRank = -1;
   let endpoint = "unknown";
   let terminal = undefined;
+  let lastEndpointSort = undefined;
+  const applyEndpoint = (nextEndpoint, event) => {
+    if (!nextEndpoint) return;
+    if (
+      shouldApplyEndpoint(
+        nextEndpoint,
+        endpoint,
+        event.time.sort === lastEndpointSort,
+      )
+    ) {
+      endpoint = nextEndpoint;
+      lastEndpointSort = event.time.sort;
+    }
+  };
   for (const event of events) {
     const type = event.canonicalType;
-    const classified = classifyLifecycleEventType(type);
+    const classified = classifyLifecycleEventType(event.rawType);
     if (event.inferred)
       details.push(
         makeWarning("inferred_event", app.id, { eventId: event.id }),
@@ -284,6 +318,7 @@ const projectApp = (app, appEvents, isCurrent) => {
     if (type === "application_reopened") {
       terminal = undefined;
       endpoint = "awaiting_response";
+      lastEndpointSort = event.time.sort;
       continue;
     }
     if (
@@ -299,25 +334,30 @@ const projectApp = (app, appEvents, isCurrent) => {
     if (TERMINAL_EVENT_ENDPOINT[type]) {
       endpoint = TERMINAL_EVENT_ENDPOINT[type];
       terminal = endpoint;
+      lastEndpointSort = event.time.sort;
       continue;
     }
     if (type === "offer_received" || type === "offer_negotiating")
-      endpoint = "offer_negotiating";
+      applyEndpoint("offer_negotiating", event);
     else if (
       type === "assessment_take_home" &&
       ASSESSMENT_IN_PROGRESS.has(normalize(event.actionStatus ?? event.action))
     )
-      endpoint = "assessment_in_progress";
+      applyEndpoint("assessment_in_progress", event);
     else if (
       ["recruiter_screen", "technical_interview", "onsite_final_loop"].includes(
         type,
       )
     )
-      endpoint = "interviewing";
+      applyEndpoint("interviewing", event);
     else if (ORIGIN_IDS.has(type) || type === "employer_response_received")
-      endpoint = "awaiting_response";
-    else if (endpointFromStatusEvent(event))
-      endpoint = endpointFromStatusEvent(event);
+      applyEndpoint("awaiting_response", event);
+    else if (endpointFromStatusEvent(event)) {
+      const statusEndpoint = endpointFromStatusEvent(event);
+      applyEndpoint(statusEndpoint, event);
+      if (TERMINAL_IDS.has(statusEndpoint) && endpoint === statusEndpoint)
+        terminal = statusEndpoint;
+    }
     if (classified.eventType !== type)
       details.push(
         makeWarning("event_type_normalized", app.id, { eventId: event.id }),
@@ -384,16 +424,19 @@ const makeLinks = (paths) => {
         source,
         target,
         value: 0,
-        applicationIds: [],
+        applicationIds: new Set(),
       };
-      if (!link.applicationIds.includes(path.applicationId)) {
-        link.applicationIds.push(path.applicationId);
+      if (!link.applicationIds.has(path.applicationId)) {
+        link.applicationIds.add(path.applicationId);
         link.value += 1;
       }
       map.set(key, link);
     }
   return [...map.values()]
-    .map((l) => ({ ...l, applicationIds: l.applicationIds.sort(codeCompare) }))
+    .map((l) => ({
+      ...l,
+      applicationIds: [...l.applicationIds].sort(codeCompare),
+    }))
     .sort((a, b) => codeCompare(a.id, b.id));
 };
 const countBy = (paths, key, order = []) => {
@@ -429,10 +472,11 @@ export function projectLifecycleAt(bundle = {}, bucketId = "current") {
     bucketId === "current"
       ? apps
       : apps.filter((app) => eventAppIds.has(app.id));
+  const selectedEventsByApp = eventsByApplicationId(selectedEvents);
   const paths = includedApps.map((app) =>
     projectApp(
       app,
-      selectedEvents.filter((event) => event.applicationId === app.id),
+      selectedEventsByApp.get(app.id) ?? [],
       bucketId === "current",
     ),
   );

--- a/src/web/tracker/lifecycleProjection.js
+++ b/src/web/tracker/lifecycleProjection.js
@@ -1,0 +1,540 @@
+import { classifyLifecycleEventType } from "./lifecycleClassification.js";
+
+const codeCompare = (a, b) =>
+  String(a) < String(b) ? -1 : String(a) > String(b) ? 1 : 0;
+
+const deepFreeze = (value) => {
+  if (!value || typeof value !== "object" || Object.isFrozen(value))
+    return value;
+  for (const child of Object.values(value)) deepFreeze(child);
+  return Object.freeze(value);
+};
+
+const ORIGINS = [
+  ["application_submitted", "Application submitted"],
+  ["recruiter_company_outreach", "Recruiter/company reached out"],
+  ["candidate_outreach", "Candidate outreach"],
+  ["referral", "Referral"],
+  ["other_unknown", "Other/unknown"],
+];
+const MILESTONES = [
+  ["recruiter_screen", "Recruiter screen"],
+  ["assessment_take_home", "Assessment/take-home"],
+  ["technical_interview", "Technical interview"],
+  ["onsite_final_loop", "Onsite/final loop"],
+  ["offer_received", "Offer received"],
+];
+const ENDPOINTS = [
+  ["awaiting_response", "Awaiting response"],
+  ["interviewing", "Interviewing"],
+  ["assessment_in_progress", "Assessment in progress"],
+  ["offer_negotiating", "Offer/negotiating"],
+  ["employer_rejected", "Employer rejected"],
+  ["candidate_withdrew", "Candidate withdrew"],
+  ["offer_declined", "Offer declined"],
+  ["offer_expired_rescinded", "Offer expired/rescinded"],
+  ["offer_accepted", "Offer accepted"],
+  ["closed_archived", "Closed/archived"],
+  ["unknown", "Unknown"],
+];
+
+const toItems = (entries, namespace) =>
+  entries.map(([id, label], rank) => ({
+    id,
+    nodeId: `${namespace}:${id}`,
+    label,
+    rank,
+  }));
+export const LIFECYCLE_DIAGRAM_TAXONOMY = deepFreeze({
+  origins: toItems(ORIGINS, "origin"),
+  milestones: toItems(MILESTONES, "milestone"),
+  endpoints: toItems(ENDPOINTS, "endpoint"),
+});
+
+const ORIGIN_IDS = new Set(ORIGINS.map(([id]) => id));
+const MILESTONE_IDS = new Set(MILESTONES.map(([id]) => id));
+const KNOWN_EVENT_IDS = new Set([
+  ...ORIGINS.map(([id]) => id),
+  ...MILESTONES.map(([id]) => id),
+  ...ENDPOINTS.map(([id]) => id),
+  "employer_response_received",
+  "offer_negotiating",
+  "application_reopened",
+  "status_changed",
+  "migration_status_snapshot",
+]);
+const TERMINAL_IDS = new Set([
+  "employer_rejected",
+  "candidate_withdrew",
+  "offer_declined",
+  "offer_expired_rescinded",
+  "offer_accepted",
+  "closed_archived",
+]);
+const STATUS_ENDPOINT = {
+  applied: "awaiting_response",
+  outreach_sent: "awaiting_response",
+  recruiter_screen: "interviewing",
+  technical_screen: "interviewing",
+  onsite_loop: "interviewing",
+  offer: "offer_negotiating",
+  accepted: "offer_accepted",
+  rejected: "employer_rejected",
+  withdrawn: "candidate_withdrew",
+  closed_archived: "closed_archived",
+};
+const TERMINAL_EVENT_ENDPOINT = {
+  employer_rejected: "employer_rejected",
+  candidate_withdrew: "candidate_withdrew",
+  offer_declined: "offer_declined",
+  offer_expired_rescinded: "offer_expired_rescinded",
+  offer_accepted: "offer_accepted",
+  closed_archived: "closed_archived",
+};
+const LEGACY = {
+  hiring_manager_reply: "employer_response_received",
+  recruiter_screen_scheduled: "recruiter_screen",
+  recruiter_screen_completed: "recruiter_screen",
+  devops_interview_scheduled: "technical_interview",
+  devops_interview_completed: "technical_interview",
+  technical_interview_scheduled: "technical_interview",
+  technical_interview_completed: "technical_interview",
+  technical_screen_scheduled: "technical_interview",
+  technical_screen_completed: "technical_interview",
+  onsite_interview_scheduled: "onsite_final_loop",
+  onsite_interview_completed: "onsite_final_loop",
+  final_interview_scheduled: "onsite_final_loop",
+  final_interview_completed: "onsite_final_loop",
+  written_assessment: "assessment_take_home",
+  written_assessment_requested: "assessment_take_home",
+  written_assessment_submitted: "assessment_take_home",
+  take_home: "assessment_take_home",
+  take_home_requested: "assessment_take_home",
+  take_home_submitted: "assessment_take_home",
+  next_tracking_step: "status_changed",
+};
+const ASSESSMENT_IN_PROGRESS = new Set([
+  "requested",
+  "pending",
+  "started",
+  "in_progress",
+]);
+const MILESTONE_RANK = new Map(MILESTONES.map(([id], index) => [id, index]));
+const normalize = (value) =>
+  String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/&/g, " and ")
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+const canonicalEventType = (event) =>
+  LEGACY[normalize(event?.eventType)] ?? normalize(event?.eventType);
+const eventId = (event, index) => String(event?.id ?? `missing_event_${index}`);
+const appId = (app, index) => String(app?.id ?? `missing_application_${index}`);
+const isUnknownTime = (event) =>
+  event?.occurredAtPrecision === "unknown" ||
+  String(event?.occurredAt ?? "").startsWith("1970-01-01");
+const dateKey = (value) => /^\d{4}-\d{2}-\d{2}/u.exec(String(value ?? ""))?.[0];
+const instantMs = (value) => {
+  const ms = Date.parse(String(value ?? ""));
+  return Number.isFinite(ms) ? ms : undefined;
+};
+const eventTime = (event) => {
+  if (isUnknownTime(event)) return { kind: "unknown", sort: "" };
+  if (event?.occurredAtPrecision === "date") {
+    const date = /^\d{4}-\d{2}-\d{2}$/u.test(String(event.occurredAt))
+      ? String(event.occurredAt)
+      : dateKey(event.occurredAt);
+    return date
+      ? { kind: "date", date, sort: `${date}|0` }
+      : { kind: "invalid", sort: "" };
+  }
+  const ms = instantMs(event?.occurredAt);
+  if (ms === undefined) return { kind: "invalid", sort: "" };
+  const iso = new Date(ms).toISOString();
+  return {
+    kind: "instant",
+    instant: iso,
+    date: iso.slice(0, 10),
+    sort: `${iso.slice(0, 10)}|1|${iso}`,
+  };
+};
+const makeWarning = (code, applicationId, extra = {}) => ({
+  code,
+  applicationId,
+  ...extra,
+});
+
+const prepare = (bundle) => {
+  const warnings = [];
+  const apps = (bundle.applications ?? [])
+    .map((app, index) => ({ ...app, id: appId(app, index) }))
+    .sort((a, b) => codeCompare(a.id, b.id));
+  const knownApps = new Set(apps.map((app) => app.id));
+  const superseded = new Set(
+    (bundle.lifecycleEvents ?? [])
+      .map((event) => event?.supersedesEventId)
+      .filter(Boolean)
+      .map(String),
+  );
+  const events = (bundle.lifecycleEvents ?? [])
+    .map((event, index) => ({
+      ...event,
+      id: eventId(event, index),
+      applicationId: String(event?.applicationId ?? ""),
+      canonicalType: canonicalEventType(event),
+      time: eventTime(event),
+    }))
+    .filter((event) => !superseded.has(event.id))
+    .sort(
+      (a, b) =>
+        codeCompare(a.time.sort, b.time.sort) || codeCompare(a.id, b.id),
+    );
+  for (const event of events) {
+    if (!knownApps.has(event.applicationId))
+      warnings.push(
+        makeWarning("orphan_event", event.applicationId || undefined, {
+          eventId: event.id,
+        }),
+      );
+    if (event.time.kind === "invalid")
+      warnings.push(
+        makeWarning("invalid_timestamp", event.applicationId || undefined, {
+          eventId: event.id,
+        }),
+      );
+    if (!KNOWN_EVENT_IDS.has(event.canonicalType))
+      warnings.push(
+        makeWarning("unknown_event_type", event.applicationId || undefined, {
+          eventId: event.id,
+          eventType: event.eventType,
+        }),
+      );
+  }
+  return {
+    apps,
+    events: events.filter((event) => knownApps.has(event.applicationId)),
+    warnings,
+  };
+};
+
+const bucketEvents = (events, bucketId) => {
+  if (bucketId === "current") return events;
+  if (bucketId === "unknown-date")
+    return events.filter((event) => event.time.kind === "unknown");
+  return events.filter(
+    (event) =>
+      event.time.kind !== "unknown" &&
+      event.time.kind !== "invalid" &&
+      codeCompare(event.time.sort, bucketId) <= 0,
+  );
+};
+
+const originFor = (app, events, details) => {
+  const origin = events.find((event) =>
+    ORIGIN_IDS.has(event.canonicalType),
+  )?.canonicalType;
+  if (origin) return origin;
+  if (ORIGIN_IDS.has(app.origin)) return app.origin;
+  if (normalize(app.source) === "referral") return "referral";
+  details.push(makeWarning("inferred_origin", app.id));
+  return "other_unknown";
+};
+const endpointFromStatusEvent = (event) =>
+  STATUS_ENDPOINT[normalize(event.status)] ??
+  STATUS_ENDPOINT[normalize(event.currentStatus)];
+const projectApp = (app, appEvents, isCurrent) => {
+  const details = [];
+  const events = [...appEvents].sort(
+    (a, b) => codeCompare(a.time.sort, b.time.sort) || codeCompare(a.id, b.id),
+  );
+  const origin = originFor(app, events, details);
+  const milestoneSet = new Set();
+  let highestObservedMilestoneRank = -1;
+  let endpoint = "unknown";
+  let terminal = undefined;
+  for (const event of events) {
+    const type = event.canonicalType;
+    const classified = classifyLifecycleEventType(type);
+    if (event.inferred)
+      details.push(
+        makeWarning("inferred_event", app.id, { eventId: event.id }),
+      );
+    let milestone = undefined;
+    if (MILESTONE_IDS.has(type)) milestone = type;
+    else if (
+      ["technical_screen", "onsite_loop"].includes(normalize(event.stage))
+    )
+      milestone =
+        normalize(event.stage) === "technical_screen"
+          ? "technical_interview"
+          : "onsite_final_loop";
+    if (milestone) {
+      const rank = MILESTONE_RANK.get(milestone) ?? 0;
+      if (rank < highestObservedMilestoneRank)
+        details.push(
+          makeWarning("regressive_history", app.id, { eventId: event.id }),
+        );
+      highestObservedMilestoneRank = Math.max(
+        highestObservedMilestoneRank,
+        rank,
+      );
+      milestoneSet.add(milestone);
+    }
+    if (type === "application_reopened") {
+      terminal = undefined;
+      endpoint = "awaiting_response";
+      continue;
+    }
+    if (
+      terminal &&
+      !TERMINAL_EVENT_ENDPOINT[type] &&
+      !TERMINAL_IDS.has(endpointFromStatusEvent(event))
+    ) {
+      details.push(
+        makeWarning("terminal_without_reopen", app.id, { eventId: event.id }),
+      );
+      continue;
+    }
+    if (TERMINAL_EVENT_ENDPOINT[type]) {
+      endpoint = TERMINAL_EVENT_ENDPOINT[type];
+      terminal = endpoint;
+      continue;
+    }
+    if (type === "offer_received" || type === "offer_negotiating")
+      endpoint = "offer_negotiating";
+    else if (
+      type === "assessment_take_home" &&
+      ASSESSMENT_IN_PROGRESS.has(normalize(event.actionStatus ?? event.action))
+    )
+      endpoint = "assessment_in_progress";
+    else if (
+      ["recruiter_screen", "technical_interview", "onsite_final_loop"].includes(
+        type,
+      )
+    )
+      endpoint = "interviewing";
+    else if (ORIGIN_IDS.has(type) || type === "employer_response_received")
+      endpoint = "awaiting_response";
+    else if (endpointFromStatusEvent(event))
+      endpoint = endpointFromStatusEvent(event);
+    if (classified.eventType !== type)
+      details.push(
+        makeWarning("event_type_normalized", app.id, { eventId: event.id }),
+      );
+  }
+  const milestones = [...milestoneSet].sort(
+    (a, b) => (MILESTONE_RANK.get(a) ?? 0) - (MILESTONE_RANK.get(b) ?? 0),
+  );
+  if (
+    isCurrent &&
+    STATUS_ENDPOINT[normalize(app.status)] &&
+    endpoint !== STATUS_ENDPOINT[normalize(app.status)]
+  )
+    details.push(
+      makeWarning("status_mismatch", app.id, {
+        replayEndpoint: endpoint,
+        statusEndpoint: STATUS_ENDPOINT[normalize(app.status)],
+      }),
+    );
+  return {
+    applicationId: app.id,
+    origin,
+    milestones,
+    endpoint,
+    nodeIds: [
+      `origin:${origin}`,
+      ...milestones.map((id) => `milestone:${id}`),
+      `endpoint:${endpoint}`,
+    ],
+    details,
+  };
+};
+
+const makeNodes = (paths) => {
+  const totals = new Map();
+  for (const path of paths)
+    for (const nodeId of path.nodeIds)
+      totals.set(nodeId, (totals.get(nodeId) ?? 0) + 1);
+  const tax = [
+    ...LIFECYCLE_DIAGRAM_TAXONOMY.origins,
+    ...LIFECYCLE_DIAGRAM_TAXONOMY.milestones,
+    ...LIFECYCLE_DIAGRAM_TAXONOMY.endpoints,
+  ];
+  return tax
+    .filter((item) => totals.has(item.nodeId))
+    .map((item) => ({
+      id: item.nodeId,
+      taxonomyId: item.id,
+      label: item.label,
+      rank: item.rank,
+      total: totals.get(item.nodeId),
+    }));
+};
+const makeLinks = (paths) => {
+  const map = new Map();
+  for (const path of paths)
+    for (let i = 0; i < path.nodeIds.length - 1; i += 1) {
+      const source = path.nodeIds[i],
+        target = path.nodeIds[i + 1];
+      if (source === target) continue;
+      const key = `${source}->${target}`;
+      const link = map.get(key) ?? {
+        id: `link:${key}`,
+        source,
+        target,
+        value: 0,
+        applicationIds: [],
+      };
+      if (!link.applicationIds.includes(path.applicationId)) {
+        link.applicationIds.push(path.applicationId);
+        link.value += 1;
+      }
+      map.set(key, link);
+    }
+  return [...map.values()]
+    .map((l) => ({ ...l, applicationIds: l.applicationIds.sort(codeCompare) }))
+    .sort((a, b) => codeCompare(a.id, b.id));
+};
+const countBy = (paths, key, order = []) => {
+  const map = paths.reduce(
+    (m, p) => m.set(p[key], (m.get(p[key]) ?? 0) + 1),
+    new Map(),
+  );
+  const rank = new Map(order.map((id, index) => [id, index]));
+  return Object.fromEntries(
+    [...map.entries()].sort(
+      ([a], [b]) =>
+        (rank.get(a) ?? Number.MAX_SAFE_INTEGER) -
+          (rank.get(b) ?? Number.MAX_SAFE_INTEGER) || codeCompare(a, b),
+    ),
+  );
+};
+const warningCounts = (warnings) =>
+  Object.fromEntries(
+    [
+      ...warnings
+        .reduce((m, w) => m.set(w.code, (m.get(w.code) ?? 0) + 1), new Map())
+        .entries(),
+    ].sort(([a], [b]) => codeCompare(a, b)),
+  );
+
+export function projectLifecycleAt(bundle = {}, bucketId = "current") {
+  const { apps, events, warnings: globalWarnings } = prepare(bundle);
+  const selectedEvents = bucketEvents(events, bucketId);
+  const eventAppIds = new Set(
+    selectedEvents.map((event) => event.applicationId),
+  );
+  const includedApps =
+    bucketId === "current"
+      ? apps
+      : apps.filter((app) => eventAppIds.has(app.id));
+  const paths = includedApps.map((app) =>
+    projectApp(
+      app,
+      selectedEvents.filter((event) => event.applicationId === app.id),
+      bucketId === "current",
+    ),
+  );
+  const warnings = [
+    ...globalWarnings,
+    ...paths.flatMap((path) => path.details),
+  ];
+  const terminalTotal = paths.filter((path) =>
+    TERMINAL_IDS.has(path.endpoint),
+  ).length;
+  const projection = {
+    bucket: buildBucketMetadata(bucketId, events),
+    includedApplications: paths.length,
+    totalApplications: apps.length,
+    paths,
+    nodes: makeNodes(paths),
+    links: makeLinks(paths),
+    totals: {
+      origins: countBy(
+        paths,
+        "origin",
+        LIFECYCLE_DIAGRAM_TAXONOMY.origins.map((x) => x.id),
+      ),
+      milestones: countBy(
+        paths.flatMap((path) =>
+          path.milestones.map((milestone) => ({ milestone })),
+        ),
+        "milestone",
+      ),
+      endpoints: countBy(
+        paths,
+        "endpoint",
+        LIFECYCLE_DIAGRAM_TAXONOMY.endpoints.map((x) => x.id),
+      ),
+      active: paths.length - terminalTotal,
+      terminal: terminalTotal,
+    },
+    events: selectedEvents
+      .map((event) => ({
+        id: event.id,
+        applicationId: event.applicationId,
+        eventType: event.canonicalType,
+        occurredAt: event.occurredAt,
+        occurredAtPrecision: event.occurredAtPrecision,
+      }))
+      .sort((a, b) => codeCompare(a.id, b.id)),
+    warnings,
+    warningCounts: warningCounts(warnings),
+  };
+  return deepFreeze(projection);
+}
+
+function buildBucketMetadata(bucketId, events) {
+  if (bucketId === "current")
+    return { id: "current", label: "Current", kind: "current" };
+  if (bucketId === "unknown-date")
+    return { id: "unknown-date", label: "Unknown date", kind: "unknown-date" };
+  const event = events.find((candidate) => candidate.time.sort === bucketId);
+  return {
+    id: bucketId,
+    label:
+      event?.time.kind === "date"
+        ? `${event.time.date} (time not recorded)`
+        : (event?.time.instant ?? bucketId),
+    kind: event?.time.kind ?? "instant",
+    cutoff: bucketId,
+  };
+}
+
+export function buildLifecycleTimeline(bundle = {}) {
+  const { apps, events, warnings } = prepare(bundle);
+  const datedKeys = [
+    ...new Set(
+      events
+        .filter(
+          (event) =>
+            event.time.kind !== "unknown" && event.time.kind !== "invalid",
+        )
+        .map((event) => event.time.sort),
+    ),
+  ].sort(codeCompare);
+  const buckets = ["unknown-date", ...datedKeys, "current"].map((id) => {
+    const selected = bucketEvents(events, id);
+    const included =
+      id === "current"
+        ? apps.length
+        : new Set(selected.map((event) => event.applicationId)).size;
+    return {
+      ...buildBucketMetadata(id, events),
+      includedApplications: included,
+      totalApplications: apps.length,
+      eventIds: (id === "current" || id === "unknown-date"
+        ? selected
+        : events.filter((event) => event.time.sort === id)
+      )
+        .map((event) => event.id)
+        .sort(codeCompare),
+    };
+  });
+  return deepFreeze({
+    buckets,
+    warnings,
+    warningCounts: warningCounts(warnings),
+  });
+}

--- a/src/web/tracker/lifecycleProjection.js
+++ b/src/web/tracker/lifecycleProjection.js
@@ -120,6 +120,13 @@ const ASSESSMENT_IN_PROGRESS = new Set([
   "in_progress",
 ]);
 const MILESTONE_RANK = new Map(MILESTONES.map(([id], index) => [id, index]));
+
+const ORIGIN_RANK = new Map(ORIGINS.map(([id], index) => [id, index]));
+const isLowerStageActivity = (type) =>
+  ORIGIN_IDS.has(type) ||
+  MILESTONE_IDS.has(type) ||
+  type === "employer_response_received" ||
+  type === "offer_negotiating";
 const normalize = (value) =>
   String(value ?? "")
     .trim()
@@ -133,8 +140,9 @@ const canonicalEventType = (event) =>
 const eventId = (event, index) => String(event?.id ?? `missing_event_${index}`);
 const appId = (app, index) => String(app?.id ?? `missing_application_${index}`);
 const isUnknownTime = (event) =>
-  event?.occurredAtPrecision === "unknown" ||
-  String(event?.occurredAt ?? "").startsWith("1970-01-01");
+  ["unknown", "legacy-placeholder", "legacy_placeholder"].includes(
+    event?.occurredAtPrecision,
+  );
 const dateKey = (value) => /^\d{4}-\d{2}-\d{2}/u.exec(String(value ?? ""))?.[0];
 const instantMs = (value) => {
   const ms = Date.parse(String(value ?? ""));
@@ -148,10 +156,17 @@ const eventTime = (event) => {
       : dateKey(event.occurredAt);
     return date
       ? { kind: "date", date, sort: `${date}|0` }
-      : { kind: "invalid", sort: "" };
+      : {
+          kind: "invalid",
+          sort: `~~invalid|${String(event.occurredAt ?? "")}`,
+        };
   }
   const ms = instantMs(event?.occurredAt);
-  if (ms === undefined) return { kind: "invalid", sort: "" };
+  if (ms === undefined)
+    return {
+      kind: "invalid",
+      sort: `~~invalid|${String(event?.occurredAt ?? "")}`,
+    };
   const iso = new Date(ms).toISOString();
   return {
     kind: "instant",
@@ -172,12 +187,6 @@ const prepare = (bundle) => {
     .map((app, index) => ({ ...app, id: appId(app, index) }))
     .sort((a, b) => codeCompare(a.id, b.id));
   const knownApps = new Set(apps.map((app) => app.id));
-  const superseded = new Set(
-    (bundle.lifecycleEvents ?? [])
-      .map((event) => event?.supersedesEventId)
-      .filter(Boolean)
-      .map(String),
-  );
   const events = (bundle.lifecycleEvents ?? [])
     .map((event, index) => ({
       ...event,
@@ -187,7 +196,6 @@ const prepare = (bundle) => {
       canonicalType: canonicalEventType(event),
       time: eventTime(event),
     }))
-    .filter((event) => !superseded.has(event.id))
     .sort(
       (a, b) =>
         codeCompare(a.time.sort, b.time.sort) || codeCompare(a.id, b.id),
@@ -220,22 +228,47 @@ const prepare = (bundle) => {
   };
 };
 
-const bucketEvents = (events, bucketId) => {
-  if (bucketId === "current") return events;
-  if (bucketId === "unknown-date")
-    return events.filter((event) => event.time.kind === "unknown");
-  return events.filter(
-    (event) =>
-      event.time.kind !== "unknown" &&
-      event.time.kind !== "invalid" &&
-      codeCompare(event.time.sort, bucketId) <= 0,
+const withoutSuperseded = (events) => {
+  const superseded = new Set(
+    events
+      .map((event) => event.supersedesEventId)
+      .filter(Boolean)
+      .map(String),
   );
+  return events.filter((event) => !superseded.has(event.id));
+};
+
+const bucketEvents = (events, bucketId) => {
+  const selected =
+    bucketId === "current"
+      ? events
+      : bucketId === "unknown-date"
+        ? events.filter((event) => event.time.kind === "unknown")
+        : events.filter(
+            (event) =>
+              event.time.kind !== "unknown" &&
+              event.time.kind !== "invalid" &&
+              codeCompare(event.time.sort, bucketId) <= 0,
+          );
+  return withoutSuperseded(selected);
+};
+
+const boundaryEvents = (events, bucketId) => {
+  if (bucketId === "current") return events;
+  if (bucketId === "unknown-date") return events;
+  return events.filter((event) => event.time.sort === bucketId);
 };
 
 const originFor = (app, events, details) => {
-  const origin = events.find((event) =>
-    ORIGIN_IDS.has(event.canonicalType),
-  )?.canonicalType;
+  const origin = events
+    .filter((event) => ORIGIN_IDS.has(event.canonicalType))
+    .sort(
+      (a, b) =>
+        codeCompare(a.time.sort, b.time.sort) ||
+        (ORIGIN_RANK.get(a.canonicalType) ?? Number.MAX_SAFE_INTEGER) -
+          (ORIGIN_RANK.get(b.canonicalType) ?? Number.MAX_SAFE_INTEGER) ||
+        codeCompare(a.id, b.id),
+    )[0]?.canonicalType;
   if (origin) return origin;
   if (ORIGIN_IDS.has(app.origin)) return app.origin;
   if (normalize(app.source) === "referral") return "referral";
@@ -297,12 +330,25 @@ const projectApp = (app, appEvents, isCurrent) => {
     let milestone = undefined;
     if (MILESTONE_IDS.has(type)) milestone = type;
     else if (
-      ["technical_screen", "onsite_loop"].includes(normalize(event.stage))
+      ["technical_screen", "onsite_loop"].includes(normalize(event.stageLabel))
     )
       milestone =
-        normalize(event.stage) === "technical_screen"
+        normalize(event.stageLabel) === "technical_screen"
           ? "technical_interview"
           : "onsite_final_loop";
+    else if (
+      ["recruiter_screen", "technical_screen", "onsite_loop", "offer"].includes(
+        normalize(event.status),
+      )
+    )
+      milestone =
+        normalize(event.status) === "recruiter_screen"
+          ? "recruiter_screen"
+          : normalize(event.status) === "technical_screen"
+            ? "technical_interview"
+            : normalize(event.status) === "onsite_loop"
+              ? "onsite_final_loop"
+              : "offer_received";
     if (milestone) {
       const rank = MILESTONE_RANK.get(milestone) ?? 0;
       if (rank < highestObservedMilestoneRank)
@@ -324,7 +370,8 @@ const projectApp = (app, appEvents, isCurrent) => {
     if (
       terminal &&
       !TERMINAL_EVENT_ENDPOINT[type] &&
-      !TERMINAL_IDS.has(endpointFromStatusEvent(event))
+      !TERMINAL_IDS.has(endpointFromStatusEvent(event)) &&
+      isLowerStageActivity(type)
     ) {
       details.push(
         makeWarning("terminal_without_reopen", app.id, { eventId: event.id }),
@@ -339,12 +386,13 @@ const projectApp = (app, appEvents, isCurrent) => {
     }
     if (type === "offer_received" || type === "offer_negotiating")
       applyEndpoint("offer_negotiating", event);
-    else if (
-      type === "assessment_take_home" &&
-      ASSESSMENT_IN_PROGRESS.has(normalize(event.actionStatus ?? event.action))
-    )
-      applyEndpoint("assessment_in_progress", event);
-    else if (
+    else if (type === "assessment_take_home") {
+      const assessmentStatus = normalize(event.actionStatus ?? event.action);
+      if (ASSESSMENT_IN_PROGRESS.has(assessmentStatus))
+        applyEndpoint("assessment_in_progress", event);
+      else if (["submitted", "completed", "done"].includes(assessmentStatus))
+        applyEndpoint("awaiting_response", event);
+    } else if (
       ["recruiter_screen", "technical_interview", "onsite_final_loop"].includes(
         type,
       )
@@ -453,6 +501,18 @@ const countBy = (paths, key, order = []) => {
     ),
   );
 };
+const sortWarnings = (warnings) =>
+  [...warnings].sort(
+    (a, b) =>
+      codeCompare(a.code, b.code) ||
+      codeCompare(a.applicationId ?? "", b.applicationId ?? "") ||
+      codeCompare(a.eventId ?? "", b.eventId ?? "") ||
+      codeCompare(
+        a.eventType ?? a.replayEndpoint ?? "",
+        b.eventType ?? b.replayEndpoint ?? "",
+      ) ||
+      codeCompare(a.statusEndpoint ?? "", b.statusEndpoint ?? ""),
+  );
 const warningCounts = (warnings) =>
   Object.fromEntries(
     [
@@ -472,6 +532,7 @@ export function projectLifecycleAt(bundle = {}, bucketId = "current") {
     bucketId === "current"
       ? apps
       : apps.filter((app) => eventAppIds.has(app.id));
+  const boundarySelectedEvents = boundaryEvents(selectedEvents, bucketId);
   const selectedEventsByApp = eventsByApplicationId(selectedEvents);
   const paths = includedApps.map((app) =>
     projectApp(
@@ -514,7 +575,7 @@ export function projectLifecycleAt(bundle = {}, bucketId = "current") {
       active: paths.length - terminalTotal,
       terminal: terminalTotal,
     },
-    events: selectedEvents
+    events: boundarySelectedEvents
       .map((event) => ({
         id: event.id,
         applicationId: event.applicationId,
@@ -523,7 +584,7 @@ export function projectLifecycleAt(bundle = {}, bucketId = "current") {
         occurredAtPrecision: event.occurredAtPrecision,
       }))
       .sort((a, b) => codeCompare(a.id, b.id)),
-    warnings,
+    warnings: sortWarnings(warnings),
     warningCounts: warningCounts(warnings),
   };
   return deepFreeze(projection);
@@ -578,7 +639,7 @@ export function buildLifecycleTimeline(bundle = {}) {
   });
   return deepFreeze({
     buckets,
-    warnings,
+    warnings: sortWarnings(warnings),
     warningCounts: warningCounts(warnings),
   });
 }

--- a/src/web/tracker/lifecycleProjection.js
+++ b/src/web/tracker/lifecycleProjection.js
@@ -278,14 +278,6 @@ const originFor = (app, events, details) => {
 const endpointFromStatusEvent = (event) =>
   STATUS_ENDPOINT[normalize(event.status)] ??
   STATUS_ENDPOINT[normalize(event.currentStatus)];
-const ENDPOINT_PRECEDENCE = new Map(
-  ENDPOINTS.map(([id], index) => [id, index]),
-);
-const endpointPrecedence = (endpoint) =>
-  ENDPOINT_PRECEDENCE.get(endpoint) ?? Number.MAX_SAFE_INTEGER;
-const shouldApplyEndpoint = (nextEndpoint, endpoint, sameMoment) =>
-  !sameMoment ||
-  endpointPrecedence(nextEndpoint) >= endpointPrecedence(endpoint);
 const eventsByApplicationId = (events) => {
   const map = new Map();
   for (const event of events) {
@@ -304,25 +296,32 @@ const projectApp = (app, appEvents, isCurrent) => {
   const origin = originFor(app, events, details);
   const milestoneSet = new Set();
   let highestObservedMilestoneRank = -1;
-  let endpoint = "unknown";
   let terminal = undefined;
-  let lastEndpointSort = undefined;
-  const applyEndpoint = (nextEndpoint, event) => {
-    if (!nextEndpoint) return;
-    if (
-      shouldApplyEndpoint(
-        nextEndpoint,
-        endpoint,
-        event.time.sort === lastEndpointSort,
-      )
-    ) {
-      endpoint = nextEndpoint;
-      lastEndpointSort = event.time.sort;
-    }
+  let awaitingActive = false;
+  let interviewActive = false;
+  let assessmentActive = false;
+  let offerActive = false;
+  const endpointFromState = () => {
+    if (terminal) return terminal;
+    if (offerActive) return "offer_negotiating";
+    if (assessmentActive) return "assessment_in_progress";
+    if (interviewActive) return "interviewing";
+    if (awaitingActive) return "awaiting_response";
+    return "unknown";
   };
+  const markEndpoint = (nextEndpoint) => {
+    if (nextEndpoint === "offer_negotiating") offerActive = true;
+    else if (nextEndpoint === "assessment_in_progress") assessmentActive = true;
+    else if (nextEndpoint === "interviewing") interviewActive = true;
+    else if (nextEndpoint === "awaiting_response") awaitingActive = true;
+  };
+  const isResumedActivity = (event, statusEndpoint) =>
+    isLowerStageActivity(event.canonicalType) ||
+    (statusEndpoint && !TERMINAL_IDS.has(statusEndpoint));
   for (const event of events) {
     const type = event.canonicalType;
     const classified = classifyLifecycleEventType(event.rawType);
+    const statusEndpoint = endpointFromStatusEvent(event);
     if (event.inferred)
       details.push(
         makeWarning("inferred_event", app.id, { eventId: event.id }),
@@ -363,49 +362,46 @@ const projectApp = (app, appEvents, isCurrent) => {
     }
     if (type === "application_reopened") {
       terminal = undefined;
-      endpoint = "awaiting_response";
-      lastEndpointSort = event.time.sort;
+      awaitingActive = true;
+      interviewActive = false;
+      assessmentActive = false;
+      offerActive = false;
       continue;
     }
-    if (
-      terminal &&
-      !TERMINAL_EVENT_ENDPOINT[type] &&
-      !TERMINAL_IDS.has(endpointFromStatusEvent(event)) &&
-      isLowerStageActivity(type)
-    ) {
-      details.push(
-        makeWarning("terminal_without_reopen", app.id, { eventId: event.id }),
-      );
+    const terminalEndpoint = TERMINAL_EVENT_ENDPOINT[type] ?? statusEndpoint;
+    if (terminal && TERMINAL_IDS.has(terminalEndpoint)) {
+      terminal = terminalEndpoint;
       continue;
     }
-    if (TERMINAL_EVENT_ENDPOINT[type]) {
-      endpoint = TERMINAL_EVENT_ENDPOINT[type];
-      terminal = endpoint;
-      lastEndpointSort = event.time.sort;
+    if (terminal) {
+      if (isResumedActivity(event, statusEndpoint))
+        details.push(
+          makeWarning("terminal_without_reopen", app.id, { eventId: event.id }),
+        );
+      continue;
+    }
+    if (TERMINAL_IDS.has(terminalEndpoint)) {
+      terminal = terminalEndpoint;
       continue;
     }
     if (type === "offer_received" || type === "offer_negotiating")
-      applyEndpoint("offer_negotiating", event);
+      offerActive = true;
     else if (type === "assessment_take_home") {
       const assessmentStatus = normalize(event.actionStatus ?? event.action);
-      if (ASSESSMENT_IN_PROGRESS.has(assessmentStatus))
-        applyEndpoint("assessment_in_progress", event);
-      else if (["submitted", "completed", "done"].includes(assessmentStatus))
-        applyEndpoint("awaiting_response", event);
+      if (ASSESSMENT_IN_PROGRESS.has(assessmentStatus)) assessmentActive = true;
+      else if (["submitted", "completed", "done"].includes(assessmentStatus)) {
+        assessmentActive = false;
+        awaitingActive = true;
+      } else markEndpoint("assessment_in_progress");
     } else if (
       ["recruiter_screen", "technical_interview", "onsite_final_loop"].includes(
         type,
       )
     )
-      applyEndpoint("interviewing", event);
+      interviewActive = true;
     else if (ORIGIN_IDS.has(type) || type === "employer_response_received")
-      applyEndpoint("awaiting_response", event);
-    else if (endpointFromStatusEvent(event)) {
-      const statusEndpoint = endpointFromStatusEvent(event);
-      applyEndpoint(statusEndpoint, event);
-      if (TERMINAL_IDS.has(statusEndpoint) && endpoint === statusEndpoint)
-        terminal = statusEndpoint;
-    }
+      awaitingActive = true;
+    else markEndpoint(statusEndpoint);
     if (classified.eventType !== type)
       details.push(
         makeWarning("event_type_normalized", app.id, { eventId: event.id }),
@@ -414,6 +410,7 @@ const projectApp = (app, appEvents, isCurrent) => {
   const milestones = [...milestoneSet].sort(
     (a, b) => (MILESTONE_RANK.get(a) ?? 0) - (MILESTONE_RANK.get(b) ?? 0),
   );
+  const endpoint = endpointFromState();
   if (
     isCurrent &&
     STATUS_ENDPOINT[normalize(app.status)] &&
@@ -629,10 +626,7 @@ export function buildLifecycleTimeline(bundle = {}) {
       ...buildBucketMetadata(id, events),
       includedApplications: included,
       totalApplications: apps.length,
-      eventIds: (id === "current" || id === "unknown-date"
-        ? selected
-        : events.filter((event) => event.time.sort === id)
-      )
+      eventIds: boundaryEvents(selected, id)
         .map((event) => event.id)
         .sort(codeCompare),
     };

--- a/src/web/tracker/lifecycleProjection.js
+++ b/src/web/tracker/lifecycleProjection.js
@@ -148,6 +148,14 @@ const instantMs = (value) => {
   const ms = Date.parse(String(value ?? ""));
   return Number.isFinite(ms) ? ms : undefined;
 };
+const fallbackKnownSort = (event) => {
+  const occurredAt = String(event?.occurredAt ?? "");
+  if (!occurredAt.includes("T")) {
+    const date = dateKey(occurredAt);
+    if (date) return `${date}|0`;
+  }
+  return eventTime({ ...event, occurredAtPrecision: undefined }).sort;
+};
 const eventTime = (event) => {
   if (isUnknownTime(event)) return { kind: "unknown", sort: "~unknown" };
   if (event?.occurredAtPrecision === "date") {
@@ -293,6 +301,13 @@ const projectApp = (app, appEvents, isCurrent) => {
   const events = [...appEvents].sort(
     (a, b) => codeCompare(a.time.sort, b.time.sort) || codeCompare(a.id, b.id),
   );
+  const knownReopenSorts = events
+    .filter(
+      (event) =>
+        event.canonicalType === "application_reopened" &&
+        ["date", "instant"].includes(event.time.kind),
+    )
+    .map((event) => event.time.sort);
   const origin = originFor(app, events, details);
   const milestoneSet = new Set();
   let highestObservedMilestoneRank = -1;
@@ -381,6 +396,15 @@ const projectApp = (app, appEvents, isCurrent) => {
       continue;
     }
     if (TERMINAL_IDS.has(terminalEndpoint)) {
+      if (
+        event.time.kind === "unknown" &&
+        (type === "status_changed" || type === "migration_status_snapshot") &&
+        knownReopenSorts.some(
+          (reopenSort) =>
+            codeCompare(fallbackKnownSort(event), reopenSort) <= 0,
+        )
+      )
+        continue;
       terminal = terminalEndpoint;
       continue;
     }

--- a/test/web-tracker-lifecycle-projection.test.js
+++ b/test/web-tracker-lifecycle-projection.test.js
@@ -186,6 +186,94 @@ describe("lifecycle projection", () => {
     expect(submitted.paths[0].endpoint).toBe("awaiting_response");
   });
 
+  it("preserves bare assessment milestones without activating progress", () => {
+    const projection = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "applied" })],
+        [
+          ev("origin", "a", "application_submitted", "2026-01-01"),
+          ev("assessment", "a", "assessment_take_home", "2026-01-02"),
+        ],
+      ),
+    );
+
+    expect(projection.paths[0].milestones).toEqual(["assessment_take_home"]);
+    expect(projection.paths[0].endpoint).toBe("awaiting_response");
+    expect(projection.totals.endpoints.assessment_in_progress).toBeUndefined();
+  });
+
+  it("normalizes bare legacy assessment aliases without activating progress", () => {
+    for (const eventType of ["written_assessment", "take_home"]) {
+      const projection = projectLifecycleAt(
+        bundle(
+          [app(`a_${eventType}`, { status: "applied" })],
+          [
+            ev(
+              "origin",
+              `a_${eventType}`,
+              "application_submitted",
+              "2026-01-01",
+            ),
+            ev("assessment", `a_${eventType}`, eventType, "2026-01-02"),
+          ],
+        ),
+      );
+
+      expect(projection.paths[0].milestones).toEqual(["assessment_take_home"]);
+      expect(projection.paths[0].endpoint).toBe("awaiting_response");
+      expect(projection.warningCounts.event_type_normalized).toBe(1);
+    }
+  });
+
+  it("ignores unsupported assessment actions while preserving milestone state", () => {
+    const projection = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "applied" })],
+        [
+          ev("origin", "a", "application_submitted", "2026-01-01"),
+          ev("assessment", "a", "assessment_take_home", "2026-01-02", {
+            actionStatus: "needs_review",
+          }),
+        ],
+      ),
+    );
+
+    expect(projection.paths[0].milestones).toEqual(["assessment_take_home"]);
+    expect(projection.paths[0].endpoint).toBe("awaiting_response");
+  });
+
+  it("activates requested assessments and clears them when done", () => {
+    const requested = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "technical_screen" })],
+        [
+          ev("origin", "a", "application_submitted", "2026-01-01"),
+          ev("request", "a", "assessment_take_home", "2026-01-02", {
+            actionStatus: "requested",
+          }),
+        ],
+      ),
+    );
+    expect(requested.paths[0].endpoint).toBe("assessment_in_progress");
+
+    const done = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "applied" })],
+        [
+          ev("origin", "a", "application_submitted", "2026-01-01"),
+          ev("request", "a", "assessment_take_home", "2026-01-02", {
+            actionStatus: "requested",
+          }),
+          ev("done", "a", "assessment_take_home", "2026-01-03", {
+            actionStatus: "done",
+          }),
+        ],
+      ),
+    );
+    expect(done.paths[0].milestones).toEqual(["assessment_take_home"]);
+    expect(done.paths[0].endpoint).toBe("awaiting_response");
+  });
+
   it("builds deterministic atomic timeline buckets", () => {
     const b = bundle(
       [app("a"), app("b"), app("c")],

--- a/test/web-tracker-lifecycle-projection.test.js
+++ b/test/web-tracker-lifecycle-projection.test.js
@@ -454,6 +454,156 @@ describe("lifecycle projection", () => {
     expect(projection.events.map((event) => event.id)).toEqual(["screen"]);
   });
 
+  it("preserves status-derived terminals against active status events until reopen", () => {
+    const noReopen = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "rejected" })],
+        [
+          ev("origin", "a", "application_submitted", "2026-01-01"),
+          ev("reject", "a", "status_changed", "2026-01-02", {
+            status: "rejected",
+          }),
+          ev("active_status", "a", "status_changed", "2026-01-03", {
+            status: "technical_screen",
+          }),
+          ev(
+            "active_snapshot",
+            "a",
+            "migration_status_snapshot",
+            "2026-01-04",
+            {
+              currentStatus: "technical_screen",
+            },
+          ),
+        ],
+      ),
+    );
+
+    expect(noReopen.paths[0].endpoint).toBe("employer_rejected");
+    expect(noReopen.warningCounts.terminal_without_reopen).toBe(2);
+
+    const reopened = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "technical_screen" })],
+        [
+          ev("origin", "a", "application_submitted", "2026-01-01"),
+          ev("reject", "a", "status_changed", "2026-01-02", {
+            status: "rejected",
+          }),
+          ev("reopen", "a", "application_reopened", "2026-01-03"),
+          ev(
+            "active_snapshot",
+            "a",
+            "migration_status_snapshot",
+            "2026-01-04",
+            {
+              currentStatus: "technical_screen",
+            },
+          ),
+        ],
+      ),
+    );
+
+    expect(reopened.paths[0].endpoint).toBe("interviewing");
+    expect(reopened.warningCounts.terminal_without_reopen).toBeUndefined();
+  });
+
+  it("clears same-bucket assessment activity when submitted or completed", () => {
+    for (const actionStatus of ["submitted", "completed"]) {
+      const projection = projectLifecycleAt(
+        bundle(
+          [app(`a_${actionStatus}`, { status: "applied" })],
+          [
+            ev(
+              "origin",
+              `a_${actionStatus}`,
+              "application_submitted",
+              "2026-01-01",
+            ),
+            ev(
+              "request",
+              `a_${actionStatus}`,
+              "assessment_take_home",
+              "2026-01-02",
+              {
+                actionStatus: "requested",
+              },
+            ),
+            ev(
+              "submit",
+              `a_${actionStatus}`,
+              "assessment_take_home",
+              "2026-01-02",
+              {
+                actionStatus,
+              },
+            ),
+          ],
+        ),
+      );
+
+      expect(projection.paths[0].milestones).toEqual(["assessment_take_home"]);
+      expect(projection.paths[0].endpoint).toBe("awaiting_response");
+    }
+  });
+
+  it("lets the latest same-bucket status-derived terminal win by stable event id", () => {
+    const rejectedWins = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "rejected" })],
+        [
+          ev("a_accept", "a", "status_changed", "2026-01-01", {
+            status: "accepted",
+          }),
+          ev("z_reject", "a", "status_changed", "2026-01-01", {
+            status: "rejected",
+          }),
+        ],
+      ),
+    );
+    expect(rejectedWins.paths[0].endpoint).toBe("employer_rejected");
+
+    const acceptedWins = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "accepted" })],
+        [
+          ev("a_reject", "a", "status_changed", "2026-01-01", {
+            status: "rejected",
+          }),
+          ev("z_accept", "a", "status_changed", "2026-01-01", {
+            status: "accepted",
+          }),
+        ],
+      ),
+    );
+    expect(acceptedWins.paths[0].endpoint).toBe("offer_accepted");
+  });
+
+  it("exposes only effective same-bucket replacement events in timelines and projections", () => {
+    const b = bundle(
+      [app("a", { status: "offer" })],
+      [
+        ev("origin", "a", "application_submitted", "2026-01-01"),
+        ev("old", "a", "technical_interview", "2026-01-02"),
+        ev("replacement", "a", "offer_received", "2026-01-02", {
+          supersedesEventId: "old",
+        }),
+      ],
+    );
+
+    const timelineBucket = buildLifecycleTimeline(b).buckets.find(
+      (bucket) => bucket.id === "2026-01-02|0",
+    );
+    const projection = projectLifecycleAt(b, "2026-01-02|0");
+
+    expect(timelineBucket.eventIds).toEqual(["replacement"]);
+    expect(projection.events.map((event) => event.id)).toEqual(["replacement"]);
+    expect(projection.paths[0]).toMatchObject({
+      milestones: ["offer_received"],
+      endpoint: "offer_negotiating",
+    });
+  });
+
   it("reports deterministic structured warnings", () => {
     const projection = projectLifecycleAt(
       bundle(

--- a/test/web-tracker-lifecycle-projection.test.js
+++ b/test/web-tracker-lifecycle-projection.test.js
@@ -299,6 +299,30 @@ describe("lifecycle projection", () => {
     expect(projection.warningCounts.status_mismatch).toBeUndefined();
   });
 
+  it("does not let stale unknown terminal snapshots undo a dated reopen", () => {
+    const projection = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "technical_screen" })],
+        [
+          ev("origin", "a", "application_submitted", "2026-01-01"),
+          ev("reject", "a", "status_changed", "2026-01-02", {
+            status: "rejected",
+          }),
+          ev("reopen", "a", "application_reopened", "2026-01-03"),
+          ev("screen", "a", "technical_interview", "2026-01-04"),
+          ev("snapshot", "a", "migration_status_snapshot", "2026-01-01", {
+            occurredAtPrecision: "unknown",
+            currentStatus: "rejected",
+          }),
+        ],
+      ),
+    );
+
+    expect(projection.paths[0].endpoint).toBe("interviewing");
+    expect(projection.totals.terminal).toBe(0);
+    expect(projection.warningCounts.terminal_without_reopen).toBeUndefined();
+  });
+
   it("keeps higher-precedence endpoints within the same timestamp bucket", () => {
     const projection = projectLifecycleAt(
       bundle(

--- a/test/web-tracker-lifecycle-projection.test.js
+++ b/test/web-tracker-lifecycle-projection.test.js
@@ -326,6 +326,134 @@ describe("lifecycle projection", () => {
     expect(projection.warningCounts.event_type_normalized).toBe(1);
   });
 
+  it("applies supersession only after the replacement is included", () => {
+    const b = bundle(
+      [app("a", { status: "offer" })],
+      [
+        ev("origin", "a", "application_submitted", "2026-01-01"),
+        ev("screen", "a", "technical_interview", "2026-01-02"),
+        ev("screen_fix", "a", "offer_received", "2026-01-03", {
+          supersedesEventId: "screen",
+        }),
+      ],
+    );
+
+    expect(projectLifecycleAt(b, "2026-01-02|0").paths[0]).toMatchObject({
+      milestones: ["technical_interview"],
+      endpoint: "interviewing",
+    });
+    expect(projectLifecycleAt(b, "2026-01-03|0").paths[0]).toMatchObject({
+      milestones: ["offer_received"],
+      endpoint: "offer_negotiating",
+    });
+    expect(projectLifecycleAt(b).paths[0]).toMatchObject({
+      milestones: ["offer_received"],
+      endpoint: "offer_negotiating",
+    });
+  });
+
+  it("keeps explicit 1970 date precision separate from unknown and invalid timestamps", () => {
+    const b = bundle(
+      [app("dated"), app("unknown"), app("invalid")],
+      [
+        ev("dated_epoch", "dated", "application_submitted", "1970-01-01", {
+          occurredAtPrecision: "date",
+        }),
+        ev("unknown_epoch", "unknown", "application_submitted", "1970-01-01", {
+          occurredAtPrecision: "unknown",
+        }),
+        ev("bad", "invalid", "application_submitted", "not-a-date", {
+          occurredAtPrecision: "instant",
+        }),
+      ],
+    );
+    const timeline = buildLifecycleTimeline(b);
+
+    expect(timeline.buckets.map((bucket) => bucket.id)).toEqual([
+      "unknown-date",
+      "1970-01-01|0",
+      "current",
+    ]);
+    expect(
+      projectLifecycleAt(b, "unknown-date").events.map((e) => e.id),
+    ).toEqual(["unknown_epoch"]);
+    expect(
+      projectLifecycleAt(b, "1970-01-01|0").events.map((e) => e.id),
+    ).toEqual(["dated_epoch"]);
+    expect(projectLifecycleAt(b).warningCounts.invalid_timestamp).toBe(1);
+  });
+
+  it("uses status and stageLabel aliases without free-form stage inference", () => {
+    const projection = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "offer" })],
+        [
+          ev("status_alias", "a", "migration_status_snapshot", "2026-01-01", {
+            status: "technical_screen",
+          }),
+          ev(
+            "stage_label_alias",
+            "a",
+            "migration_status_snapshot",
+            "2026-01-02",
+            {
+              stageLabel: "onsite_loop",
+            },
+          ),
+          ev(
+            "free_form_stage",
+            "a",
+            "migration_status_snapshot",
+            "2026-01-03",
+            {
+              stage: "offer",
+            },
+          ),
+        ],
+      ),
+    );
+
+    expect(projection.paths[0].milestones).toEqual([
+      "technical_interview",
+      "onsite_final_loop",
+    ]);
+    expect(projection.paths[0].milestones).not.toContain("offer_received");
+  });
+
+  it("does not warn terminal_without_reopen for metadata-only events", () => {
+    const projection = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "rejected" })],
+        [
+          ev("origin", "a", "application_submitted", "2026-01-01"),
+          ev("reject", "a", "status_changed", "2026-01-02", {
+            status: "rejected",
+          }),
+          ev("snapshot", "a", "migration_status_snapshot", "2026-01-03", {
+            currentStatus: "rejected",
+          }),
+        ],
+      ),
+    );
+
+    expect(projection.paths[0].endpoint).toBe("employer_rejected");
+    expect(projection.warningCounts.terminal_without_reopen).toBeUndefined();
+  });
+
+  it("returns boundary events for dated projection buckets", () => {
+    const b = bundle(
+      [app("a")],
+      [
+        ev("origin", "a", "application_submitted", "2026-01-01"),
+        ev("screen", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+    const projection = projectLifecycleAt(b, "2026-01-02|0");
+
+    expect(projection.paths[0].milestones).toEqual(["technical_interview"]);
+    expect(projection.events.map((event) => event.id)).toEqual(["screen"]);
+  });
+
   it("reports deterministic structured warnings", () => {
     const projection = projectLifecycleAt(
       bundle(

--- a/test/web-tracker-lifecycle-projection.test.js
+++ b/test/web-tracker-lifecycle-projection.test.js
@@ -1,0 +1,333 @@
+import { describe, expect, it } from "vitest";
+import {
+  LIFECYCLE_DIAGRAM_TAXONOMY,
+  buildLifecycleTimeline,
+  projectLifecycleAt,
+} from "../src/web/tracker/lifecycleProjection.js";
+
+const app = (id, extra = {}) => ({
+  id,
+  company: `Company ${id}`,
+  role: "Engineer",
+  status: "applied",
+  origin: "application_submitted",
+  appliedAt: "2026-01-01",
+  ...extra,
+});
+const ev = (id, applicationId, eventType, occurredAt, extra = {}) => ({
+  id,
+  applicationId,
+  eventType,
+  occurredAt,
+  occurredAtPrecision: occurredAt.includes("T") ? "instant" : "date",
+  inferred: false,
+  createdAt: occurredAt,
+  ...extra,
+});
+const bundle = (applications, lifecycleEvents) => ({
+  applications,
+  lifecycleEvents,
+});
+const shuffled = (b) => ({
+  applications: [...b.applications].reverse(),
+  lifecycleEvents: [...b.lifecycleEvents].reverse(),
+});
+
+const expectInvariants = (projection) => {
+  expect(projection.paths).toHaveLength(projection.includedApplications);
+  expect(
+    Object.values(projection.totals.origins).reduce(
+      (sum, value) => sum + value,
+      0,
+    ),
+  ).toBe(projection.includedApplications);
+  expect(
+    Object.values(projection.totals.endpoints).reduce(
+      (sum, value) => sum + value,
+      0,
+    ),
+  ).toBe(projection.includedApplications);
+  expect(projection.totals.active + projection.totals.terminal).toBe(
+    projection.includedApplications,
+  );
+  for (const link of projection.links) {
+    expect(link.value).toBeGreaterThan(0);
+    expect(link.value).toBe(link.applicationIds.length);
+    expect(new Set(link.applicationIds).size).toBe(link.applicationIds.length);
+    expect(link.source).not.toBe(link.target);
+    expect(link.source.startsWith("endpoint:")).toBe(false);
+  }
+  for (const path of projection.paths) {
+    expect(new Set(path.milestones).size).toBe(path.milestones.length);
+    expect(path.nodeIds[0]).toBe(`origin:${path.origin}`);
+    expect(path.nodeIds.at(-1)).toBe(`endpoint:${path.endpoint}`);
+  }
+};
+
+describe("lifecycle projection", () => {
+  it("exports the deeply frozen exact taxonomy", () => {
+    expect(Object.isFrozen(LIFECYCLE_DIAGRAM_TAXONOMY.origins[0])).toBe(true);
+    expect(LIFECYCLE_DIAGRAM_TAXONOMY.origins.map((x) => x.id)).toEqual([
+      "application_submitted",
+      "recruiter_company_outreach",
+      "candidate_outreach",
+      "referral",
+      "other_unknown",
+    ]);
+    expect(LIFECYCLE_DIAGRAM_TAXONOMY.endpoints.map((x) => x.id)).toContain(
+      "offer_expired_rescinded",
+    );
+  });
+
+  it("handles empty and single bundles without mutation", () => {
+    expect(projectLifecycleAt()).toMatchObject({
+      includedApplications: 0,
+      totalApplications: 0,
+      paths: [],
+      links: [],
+    });
+    const input = bundle([app("a1")], []);
+    const before = structuredClone(input);
+    const projection = projectLifecycleAt(input);
+    expect(projection.paths[0].nodeIds).toEqual([
+      "origin:application_submitted",
+      "endpoint:unknown",
+    ]);
+    expect(input).toEqual(before);
+    expect(() => projection.paths.push({})).toThrow();
+    expectInvariants(projection);
+  });
+
+  it("projects every origin and endpoint exactly once", () => {
+    const origins = LIFECYCLE_DIAGRAM_TAXONOMY.origins.map((x) => x.id);
+    const terminalEvents = [
+      "employer_rejected",
+      "candidate_withdrew",
+      "offer_declined",
+      "offer_expired_rescinded",
+      "offer_accepted",
+      "closed_archived",
+    ];
+    const applications = origins.map((origin) =>
+      app(`origin_${origin}`, { origin, status: "applied" }),
+    );
+    const events = applications.flatMap((application, i) => [
+      ev(`o_${i}`, application.id, application.origin, "2026-01-01"),
+      ev(
+        `e_${i}`,
+        application.id,
+        terminalEvents[i] ?? "offer_negotiating",
+        "2026-01-02",
+      ),
+    ]);
+    const projection = projectLifecycleAt(bundle(applications, events));
+    expect(Object.keys(projection.totals.origins)).toEqual(origins);
+    expect(projection.totals.endpoints).toMatchObject({
+      employer_rejected: 1,
+      candidate_withdrew: 1,
+      offer_declined: 1,
+      offer_expired_rescinded: 1,
+      offer_accepted: 1,
+    });
+    expectInvariants(projection);
+  });
+
+  it("collapses repeated milestones and aggregates by application", () => {
+    const b = bundle(
+      [app("a1", { status: "offer" }), app("a2", { status: "offer" })],
+      [
+        ev("a1_o", "a1", "application_submitted", "2026-01-01"),
+        ev("a1_t1", "a1", "technical_interview", "2026-01-02"),
+        ev("a1_t2", "a1", "technical_interview", "2026-01-03"),
+        ev("a1_offer", "a1", "offer_received", "2026-01-04"),
+        ev("a2_o", "a2", "application_submitted", "2026-01-01"),
+        ev("a2_t", "a2", "technical_interview", "2026-01-02"),
+      ],
+    );
+    const projection = projectLifecycleAt(b);
+    expect(
+      projection.paths.find((p) => p.applicationId === "a1").milestones,
+    ).toEqual(["technical_interview", "offer_received"]);
+    expect(
+      projection.links.find(
+        (link) =>
+          link.source === "origin:application_submitted" &&
+          link.target === "milestone:technical_interview",
+      ),
+    ).toMatchObject({ value: 2, applicationIds: ["a1", "a2"] });
+    expectInvariants(projection);
+  });
+
+  it("uses assessment action status for in-progress behavior", () => {
+    const requested = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "technical_screen" })],
+        [
+          ev("o", "a", "application_submitted", "2026-01-01"),
+          ev("assess", "a", "assessment_take_home", "2026-01-02", {
+            actionStatus: "requested",
+          }),
+        ],
+      ),
+    );
+    expect(requested.paths[0].endpoint).toBe("assessment_in_progress");
+    const submitted = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "technical_screen" })],
+        [
+          ev("o", "a", "application_submitted", "2026-01-01"),
+          ev("assess", "a", "assessment_take_home", "2026-01-02", {
+            actionStatus: "submitted",
+          }),
+        ],
+      ),
+    );
+    expect(submitted.paths[0].milestones).toEqual(["assessment_take_home"]);
+    expect(submitted.paths[0].endpoint).toBe("awaiting_response");
+  });
+
+  it("builds deterministic atomic timeline buckets", () => {
+    const b = bundle(
+      [app("a"), app("b"), app("c")],
+      [
+        ev("date", "a", "application_submitted", "2026-01-02"),
+        ev("same1", "a", "technical_interview", "2026-01-02T10:00:00+02:00"),
+        ev("same2", "b", "application_submitted", "2026-01-02T08:00:00.000Z"),
+        ev("future", "c", "application_submitted", "2026-01-03T00:00:00.000Z"),
+        ev("unknown", "c", "application_submitted", "1970-01-01", {
+          occurredAtPrecision: "unknown",
+        }),
+      ],
+    );
+    const timeline = buildLifecycleTimeline(b);
+    expect(timeline.buckets.map((bucket) => bucket.id)).toEqual([
+      "unknown-date",
+      "2026-01-02|0",
+      "2026-01-02|1|2026-01-02T08:00:00.000Z",
+      "2026-01-03|1|2026-01-03T00:00:00.000Z",
+      "current",
+    ]);
+    expect(timeline.buckets[2].eventIds).toEqual(["same1", "same2"]);
+    expect(projectLifecycleAt(b, "2026-01-02|0").includedApplications).toBe(1);
+    expect(
+      projectLifecycleAt(b, timeline.buckets[2].id).includedApplications,
+    ).toBe(2);
+    expect(
+      projectLifecycleAt(b, "unknown-date").paths.map((p) => p.applicationId),
+    ).toEqual(["c"]);
+  });
+
+  it("keeps future and unknown activity out of dated snapshots", () => {
+    const b = bundle(
+      [app("a", { status: "offer" })],
+      [
+        ev("origin", "a", "application_submitted", "2026-01-01"),
+        ev("unknown_offer", "a", "offer_received", "1970-01-01", {
+          occurredAtPrecision: "unknown",
+        }),
+        ev("accepted", "a", "offer_accepted", "2026-02-01"),
+      ],
+    );
+    expect(projectLifecycleAt(b, "2026-01-01|0").paths[0].endpoint).toBe(
+      "awaiting_response",
+    );
+    expect(projectLifecycleAt(b).paths[0].endpoint).toBe("offer_accepted");
+  });
+
+  it("preserves terminal state until explicit reopen", () => {
+    const noReopen = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "rejected" })],
+        [
+          ev("origin", "a", "application_submitted", "2026-01-01"),
+          ev("reject", "a", "employer_rejected", "2026-01-02"),
+          ev("screen", "a", "recruiter_screen", "2026-01-03"),
+        ],
+      ),
+    );
+    expect(noReopen.paths[0].endpoint).toBe("employer_rejected");
+    expect(noReopen.warningCounts.terminal_without_reopen).toBe(1);
+    const reopened = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "recruiter_screen" })],
+        [
+          ev("origin", "a", "application_submitted", "2026-01-01"),
+          ev("reject", "a", "employer_rejected", "2026-01-02"),
+          ev("reopen", "a", "application_reopened", "2026-01-03"),
+          ev("screen", "a", "recruiter_screen", "2026-01-04"),
+        ],
+      ),
+    );
+    expect(reopened.paths[0].endpoint).toBe("interviewing");
+  });
+
+  it("reports deterministic structured warnings", () => {
+    const projection = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "accepted" })],
+        [
+          ev("origin", "a", "application_submitted", "not-a-date", {
+            occurredAtPrecision: "instant",
+            inferred: true,
+          }),
+          ev("late", "a", "onsite_final_loop", "2026-01-01"),
+          ev("early", "a", "recruiter_screen", "2026-01-02"),
+          ev("mystery", "a", "totally_new", "2026-01-03"),
+          ev("orphan", "missing", "application_submitted", "2026-01-01"),
+        ],
+      ),
+    );
+    expect(projection.warningCounts).toMatchObject({
+      invalid_timestamp: 1,
+      inferred_event: 1,
+      status_mismatch: 1,
+      unknown_event_type: 1,
+      orphan_event: 1,
+      regressive_history: 1,
+    });
+    expect(
+      projection.links.some(
+        (l) => l.source.includes("onsite") && l.target.includes("recruiter"),
+      ),
+    ).toBe(false);
+  });
+
+  it("is deterministic for shuffled arrays and a large aggregate fixture", () => {
+    const applications = Array.from({ length: 120 }, (_, index) =>
+      app(`app_${String(index).padStart(3, "0")}`, {
+        status: index % 3 === 0 ? "offer" : "technical_screen",
+        origin: index % 2 === 0 ? "referral" : "candidate_outreach",
+      }),
+    );
+    const events = applications.flatMap((application, index) => [
+      ev(
+        `o_${application.id}`,
+        application.id,
+        application.origin,
+        "2026-01-01",
+      ),
+      ev(
+        `t_${application.id}`,
+        application.id,
+        "technical_interview",
+        "2026-01-02",
+      ),
+      ...(index % 3 === 0
+        ? [
+            ev(
+              `offer_${application.id}`,
+              application.id,
+              "offer_received",
+              "2026-01-03",
+            ),
+          ]
+        : []),
+    ]);
+    const b = bundle(applications, events);
+    expect(projectLifecycleAt(shuffled(b))).toEqual(projectLifecycleAt(b));
+    expect(buildLifecycleTimeline(shuffled(b))).toEqual(
+      buildLifecycleTimeline(b),
+    );
+    expectInvariants(projectLifecycleAt(b));
+  });
+});

--- a/test/web-tracker-lifecycle-projection.test.js
+++ b/test/web-tracker-lifecycle-projection.test.js
@@ -261,6 +261,71 @@ describe("lifecycle projection", () => {
     expect(reopened.paths[0].endpoint).toBe("interviewing");
   });
 
+  it("locks terminal endpoints from status-derived events until reopen", () => {
+    const projection = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "accepted" })],
+        [
+          ev("origin", "a", "application_submitted", "2026-01-01"),
+          ev("accepted", "a", "status_changed", "2026-01-02", {
+            status: "accepted",
+          }),
+          ev("screen", "a", "recruiter_screen", "2026-01-03"),
+        ],
+      ),
+    );
+
+    expect(projection.paths[0].endpoint).toBe("offer_accepted");
+    expect(projection.warningCounts.terminal_without_reopen).toBe(1);
+    expect(projection.totals.terminal).toBe(1);
+  });
+
+  it("replays unknown-precision status snapshots after dated history", () => {
+    const projection = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "accepted" })],
+        [
+          ev("origin", "a", "application_submitted", "2026-01-01"),
+          ev("screen", "a", "technical_interview", "2026-01-02"),
+          ev("snapshot", "a", "migration_status_snapshot", "2026-01-01", {
+            occurredAtPrecision: "unknown",
+            currentStatus: "accepted",
+          }),
+        ],
+      ),
+    );
+
+    expect(projection.paths[0].endpoint).toBe("offer_accepted");
+    expect(projection.warningCounts.status_mismatch).toBeUndefined();
+  });
+
+  it("keeps higher-precedence endpoints within the same timestamp bucket", () => {
+    const projection = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "offer" })],
+        [
+          ev("z_origin", "a", "application_submitted", "2026-01-01"),
+          ev("a_offer", "a", "offer_received", "2026-01-01"),
+        ],
+      ),
+    );
+
+    expect(projection.paths[0].endpoint).toBe("offer_negotiating");
+    expect(projection.paths[0].nodeIds).toContain("endpoint:offer_negotiating");
+  });
+
+  it("reports normalized legacy event types", () => {
+    const projection = projectLifecycleAt(
+      bundle(
+        [app("a", { status: "recruiter_screen" })],
+        [ev("legacy", "a", "recruiter_screen_scheduled", "2026-01-01")],
+      ),
+    );
+
+    expect(projection.paths[0].milestones).toEqual(["recruiter_screen"]);
+    expect(projection.warningCounts.event_type_normalized).toBe(1);
+  });
+
   it("reports deterministic structured warnings", () => {
     const projection = projectLifecycleAt(
       bundle(


### PR DESCRIPTION
### Motivation
- Implement a renderer-independent, deterministic lifecycle projection engine for the Diagram tab that produces stable, audit-friendly projection data independent of rendering concerns.

### Description
- Added `src/web/tracker/lifecycleProjection.js` which exports a deeply frozen `LIFECYCLE_DIAGRAM_TAXONOMY`, `buildLifecycleTimeline(bundle = {})`, and `projectLifecycleAt(bundle = {}, bucketId = "current")` and returns namespaced node IDs, deterministic nodes/links, totals, selected events, and structured warnings.
- Implemented deterministic event preparation with supersession filtering, legacy event normalization, timestamp normalization (instant/date/unknown), inclusive dated cutoffs, and stable tie-breaking by explicit keys.
- Implemented per-application projection rules including deterministic origin inference, persisted-milestone collapsing, fixed-rank ordering, endpoint precedence (including assessment in-progress and terminal/reopen handling), regression/terminal warnings, and no invented/skipped stages.
- Implemented deterministic timeline bucket builder (`unknown-date`, dated atomic buckets, `current`), node/link aggregation with positive integer link values and sorted unique `applicationIds`, and deep-frozen outputs suitable for P5 rendering.

### Testing
- Ran `npx vitest run test/web-tracker-lifecycle-projection.test.js` and the new projection tests passed (10 tests passed). 
- Ran `npm run lint` and `npm run typecheck` which both succeeded with no errors. 
- Ran `git diff --check` which returned clean. 
- Ran `npm run format:check` which reported Prettier warnings in 259 unrelated existing files (repository-wide formatting issues) and therefore reported as failing; this is pre-existing and not caused by this change. 
- Ran `npm run test:ci` which failed due to an existing tight performance threshold in `test/scoring.perf.test.js` (observed 400.050ms vs threshold < 400ms) while the lifecycle projection tests passed during that run; this is an unrelated CI perf flake and not caused by the projection implementation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52811eba64832fba89d0d4b006af78)