### PR TITLE
Add lifecycle projection engine

### DIFF
--- a/src/web/tracker/lifecycleProjection.js
+++ b/src/web/tracker/lifecycleProjection.js
@@ -1,0 +1,392 @@
+import { classifyLifecycleEventType } from "./lifecycleClassification.js";
+
+const ORIGINS = [
+  ["application_submitted", "application submitted"],
+  ["recruiter_company_outreach", "recruiter/company outreach"],
+  ["candidate_outreach", "candidate outreach"],
+  ["referral", "referral"],
+  ["other_unknown", "other/unknown"],
+];
+const MILESTONES = [
+  ["recruiter_screen", "recruiter screen"],
+  ["assessment_take_home", "assessment/take-home"],
+  ["technical_interview", "technical interview"],
+  ["onsite_final_loop", "onsite/final loop"],
+  ["offer_received", "offer received"],
+];
+const ENDPOINTS = [
+  ["awaiting_response", "awaiting response", false],
+  ["interviewing", "interviewing", false],
+  ["assessment_in_progress", "assessment in progress", false],
+  ["offer_negotiating", "offer/negotiating", false],
+  ["employer_rejected", "employer rejected", true],
+  ["candidate_withdrew", "candidate withdrew", true],
+  ["offer_declined", "offer declined", true],
+  ["offer_expired_rescinded", "offer expired/rescinded", true],
+  ["offer_accepted", "offer accepted", true],
+  ["closed_archived", "closed/archived", true],
+  ["unknown", "unknown", false],
+];
+const deepFreeze = (value) => {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const child of Object.values(value)) deepFreeze(child);
+    Object.freeze(value);
+  }
+  return value;
+};
+const items = (rows, ns) =>
+  rows.map(([id, label, terminal], rank) => ({
+    id,
+    nodeId: `${ns}:${id}`,
+    label,
+    rank,
+    ...(terminal == null ? {} : { terminal }),
+  }));
+export const LIFECYCLE_DIAGRAM_TAXONOMY = deepFreeze({
+  origins: items(ORIGINS, "origin"),
+  milestones: items(MILESTONES, "milestone"),
+  endpoints: items(ENDPOINTS, "endpoint"),
+});
+const ORIGIN_IDS = new Set(ORIGINS.map(([id]) => id));
+const MILESTONE_IDS = new Set(MILESTONES.map(([id]) => id));
+const TERMINAL_STATUS = new Set([
+  "accepted",
+  "rejected",
+  "withdrawn",
+  "closed_archived",
+]);
+const TERMINAL_ENDPOINTS = new Set(
+  ENDPOINTS.filter((x) => x[2]).map(([id]) => id),
+);
+const cmp = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
+const byId = (a, b) => cmp(String(a?.id ?? ""), String(b?.id ?? ""));
+const countCodes = (warnings) =>
+  warnings.reduce(
+    (out, w) => ({ ...out, [w.code]: (out[w.code] ?? 0) + 1 }),
+    {},
+  );
+const parseTime = (event, warnings) => {
+  if (!event?.occurredAt || event.occurredAtPrecision === "unknown")
+    return { known: false, key: "unknown", date: undefined };
+  if (event.occurredAtPrecision === "date") {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(event.occurredAt))
+      return {
+        known: true,
+        key: `date:${event.occurredAt}`,
+        date: event.occurredAt,
+        instant: `${event.occurredAt}T00:00:00.000Z`,
+      };
+  } else {
+    const t = Date.parse(event.occurredAt);
+    if (!Number.isNaN(t)) {
+      const iso = new Date(t).toISOString();
+      return {
+        known: true,
+        key: `instant:${iso}`,
+        date: iso.slice(0, 10),
+        instant: iso,
+      };
+    }
+  }
+  warnings.push({
+    code: "invalid_timestamp",
+    applicationId: event.applicationId,
+    eventId: event.id,
+  });
+  return { known: false, key: "unknown", date: undefined };
+};
+const effective = (events) => {
+  const superseded = new Set(
+    events.map((e) => e?.supersedesEventId).filter(Boolean),
+  );
+  return events
+    .filter((e) => e && !superseded.has(e.id))
+    .sort(
+      (a, b) =>
+        cmp(String(a.applicationId), String(b.applicationId)) ||
+        cmp(timeSort(a), timeSort(b)) ||
+        cmp(String(a.id), String(b.id)),
+    );
+};
+const timeSort = (e) =>
+  e?.occurredAtPrecision === "date"
+    ? `0:${e.occurredAt}`
+    : e?.occurredAtPrecision === "instant" &&
+        !Number.isNaN(Date.parse(e.occurredAt))
+      ? `1:${new Date(Date.parse(e.occurredAt)).toISOString()}`
+      : `2:${e?.occurredAt ?? ""}`;
+const endpointFor = (events, app) => {
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    const e = events[i];
+    if (
+      [
+        "offer_accepted",
+        "employer_rejected",
+        "candidate_withdrew",
+        "offer_declined",
+        "offer_expired_rescinded",
+        "closed_archived",
+        "offer_negotiating",
+      ].includes(e.eventType)
+    )
+      return e.eventType;
+    if (e.eventType === "offer_received") return "offer_negotiating";
+    if (
+      e.eventType === "assessment_take_home" &&
+      !["submitted", "completed"].includes(String(e.actionStatus ?? ""))
+    )
+      return "assessment_in_progress";
+    if (
+      ["recruiter_screen", "technical_interview", "onsite_final_loop"].includes(
+        e.eventType,
+      )
+    )
+      return "interviewing";
+  }
+  const status = app?.status;
+  return (
+    {
+      accepted: "offer_accepted",
+      rejected: "employer_rejected",
+      withdrawn: "candidate_withdrew",
+      closed_archived: "closed_archived",
+      offer: "offer_negotiating",
+      recruiter_screen: "interviewing",
+      technical_screen: "interviewing",
+      onsite_loop: "interviewing",
+      outreach_sent: "awaiting_response",
+      applied: "awaiting_response",
+    }[status] ?? "unknown"
+  );
+};
+const project = (bundle, cutoff) => {
+  const warnings = [];
+  const apps = [...(bundle.applications ?? [])].filter((a) => a?.id).sort(byId);
+  const appIds = new Set(apps.map((a) => a.id));
+  let events = effective([...(bundle.lifecycleEvents ?? [])]);
+  for (const e of events)
+    if (!appIds.has(e.applicationId))
+      warnings.push({
+        code: "orphaned_event",
+        applicationId: e.applicationId,
+        eventId: e.id,
+      });
+  events = events.filter((e) => appIds.has(e.applicationId));
+  const timed = new Map(events.map((e) => [e.id, parseTime(e, warnings)]));
+  if (cutoff !== "current")
+    events = events.filter((e) =>
+      cutoff === "unknown"
+        ? !timed.get(e.id).known
+        : timed.get(e.id).known && timed.get(e.id).key <= cutoff,
+    );
+  const byApp = new Map(events.map((e) => [e.applicationId, []]));
+  for (const e of events) byApp.get(e.applicationId).push(e);
+  const includedApps = apps.filter(
+    (a) => cutoff === "current" || byApp.get(a.id)?.length,
+  );
+  const paths = [];
+  for (const app of includedApps) {
+    const evs = (byApp.get(app.id) ?? []).sort(
+      (a, b) =>
+        cmp(timeSort(a), timeSort(b)) || cmp(String(a.id), String(b.id)),
+    );
+    for (const e of evs) {
+      const c = classifyLifecycleEventType(e.eventType);
+      if (e.inferred)
+        warnings.push({
+          code: "inferred_event",
+          applicationId: app.id,
+          eventId: e.id,
+        });
+      if (c.status && e.status && c.status !== e.status)
+        warnings.push({
+          code: "status_mismatch",
+          applicationId: app.id,
+          eventId: e.id,
+        });
+    }
+    let origin =
+      evs.find((e) => ORIGIN_IDS.has(e.eventType))?.eventType ??
+      app.origin ??
+      "other_unknown";
+    if (!ORIGIN_IDS.has(origin)) origin = "other_unknown";
+    const seen = new Set();
+    let lastRank = -1;
+    const milestones = [];
+    let terminal = false;
+    for (const e of evs) {
+      if (e.eventType === "application_reopened") terminal = false;
+      if (terminal && !TERMINAL_STATUS.has(e.status))
+        warnings.push({
+          code: "terminal_without_reopen",
+          applicationId: app.id,
+          eventId: e.id,
+        });
+      if (MILESTONE_IDS.has(e.eventType) && !seen.has(e.eventType)) {
+        const rank = MILESTONES.findIndex(([id]) => id === e.eventType);
+        if (rank < lastRank)
+          warnings.push({
+            code: "regressive_history",
+            applicationId: app.id,
+            eventId: e.id,
+          });
+        else {
+          milestones.push(e.eventType);
+          seen.add(e.eventType);
+          lastRank = rank;
+        }
+      }
+      if (TERMINAL_STATUS.has(e.status)) terminal = true;
+    }
+    const endpoint = endpointFor(evs, app);
+    paths.push({
+      applicationId: app.id,
+      origin,
+      milestones,
+      endpoint,
+      nodes: [
+        `origin:${origin}`,
+        ...milestones.map((m) => `milestone:${m}`),
+        `endpoint:${endpoint}`,
+      ],
+    });
+  }
+  const linkMap = new Map();
+  for (const p of paths)
+    for (let i = 0; i < p.nodes.length - 1; i += 1) {
+      const id = `${p.nodes[i]}=>${p.nodes[i + 1]}`;
+      const l = linkMap.get(id) ?? {
+        id,
+        source: p.nodes[i],
+        target: p.nodes[i + 1],
+        value: 0,
+        applicationIds: [],
+      };
+      l.value += 1;
+      l.applicationIds.push(p.applicationId);
+      linkMap.set(id, l);
+    }
+  const links = [...linkMap.values()]
+    .map((l) => ({
+      ...l,
+      applicationIds: [...new Set(l.applicationIds)].sort(cmp),
+    }))
+    .sort((a, b) => cmp(a.id, b.id));
+  const nodeIds = new Set(paths.flatMap((p) => p.nodes));
+  const nodes = [
+    ...LIFECYCLE_DIAGRAM_TAXONOMY.origins,
+    ...LIFECYCLE_DIAGRAM_TAXONOMY.milestones,
+    ...LIFECYCLE_DIAGRAM_TAXONOMY.endpoints,
+  ]
+    .map((n) => ({
+      id: n.nodeId,
+      taxonomyId: n.id,
+      label: n.label,
+      rank: n.rank,
+      value: paths.filter((p) => p.nodes.includes(n.nodeId)).length,
+    }))
+    .filter((n) => nodeIds.has(n.id));
+  const endpointTotals = Object.fromEntries(
+    ENDPOINTS.map(([id]) => [
+      id,
+      paths.filter((p) => p.endpoint === id).length,
+    ]),
+  );
+  return {
+    includedApplications: paths.length,
+    totalApplications: apps.length,
+    paths,
+    nodes,
+    links,
+    totals: {
+      origins: Object.fromEntries(
+        ORIGINS.map(([id]) => [
+          id,
+          paths.filter((p) => p.origin === id).length,
+        ]),
+      ),
+      milestones: Object.fromEntries(
+        MILESTONES.map(([id]) => [
+          id,
+          paths.filter((p) => p.milestones.includes(id)).length,
+        ]),
+      ),
+      endpoints: endpointTotals,
+      active: Object.entries(endpointTotals)
+        .filter(([id]) => !TERMINAL_ENDPOINTS.has(id))
+        .reduce((n, [, v]) => n + v, 0),
+      terminal: Object.entries(endpointTotals)
+        .filter(([id]) => TERMINAL_ENDPOINTS.has(id))
+        .reduce((n, [, v]) => n + v, 0),
+    },
+    warnings: warnings.sort(
+      (a, b) =>
+        cmp(a.applicationId, b.applicationId) ||
+        cmp(a.code, b.code) ||
+        cmp(String(a.eventId), String(b.eventId)),
+    ),
+    counts: { warnings: warnings.length, warningCodes: countCodes(warnings) },
+  };
+};
+export function buildLifecycleTimeline(bundle = {}) {
+  const warnings = [];
+  const buckets = new Map();
+  for (const e of effective([...(bundle.lifecycleEvents ?? [])])) {
+    const t = parseTime(e, warnings);
+    const id = t.known ? t.key : "unknown";
+    buckets.set(id, {
+      id,
+      label:
+        id === "unknown" ? "Unknown date" : id.replace(/^(date|instant):/, ""),
+      cutoff: id,
+      eventIds: [...(buckets.get(id)?.eventIds ?? []), e.id].sort(cmp),
+    });
+  }
+  const dated = [...buckets.values()]
+    .filter((b) => b.id !== "unknown")
+    .sort((a, b) => cmp(a.id, b.id));
+  return {
+    buckets: [
+      {
+        id: "unknown-date",
+        label: "Unknown date",
+        cutoff: "unknown",
+        eventIds: buckets.get("unknown")?.eventIds ?? [],
+      },
+      ...dated,
+      {
+        id: "current",
+        label: "Current",
+        cutoff: "current",
+        eventIds: [...(bundle.lifecycleEvents ?? [])]
+          .map((e) => e.id)
+          .filter(Boolean)
+          .sort(cmp),
+      },
+    ],
+    warnings,
+    counts: { buckets: dated.length + 2, warnings: warnings.length },
+  };
+}
+export function projectLifecycleAt(bundle = {}, bucketId = "current") {
+  const timeline = buildLifecycleTimeline(bundle);
+  const bucket =
+    timeline.buckets.find((b) => b.id === bucketId || b.cutoff === bucketId) ??
+    timeline.buckets.at(-1);
+  const projection = project(bundle, bucket.cutoff);
+  return {
+    bucket: {
+      id: bucket.id,
+      label: bucket.label,
+      cutoff: bucket.cutoff,
+      eventIds: bucket.eventIds,
+    },
+    ...projection,
+    boundaryEvents: bucket.eventIds,
+    warnings: [...timeline.warnings, ...projection.warnings].sort(
+      (a, b) =>
+        cmp(a.applicationId ?? "", b.applicationId ?? "") ||
+        cmp(a.code, b.code),
+    ),
+  };
+}

--- a/test/web-tracker-lifecycle-projection.test.js
+++ b/test/web-tracker-lifecycle-projection.test.js
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+import {
+  LIFECYCLE_DIAGRAM_TAXONOMY,
+  buildLifecycleTimeline,
+  projectLifecycleAt,
+} from "../src/web/tracker/lifecycleProjection.js";
+
+const app = (id, extra = {}) => ({
+  id,
+  company: `Company ${id}`,
+  role: "Engineer",
+  status: "applied",
+  origin: "application_submitted",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  ...extra,
+});
+const event = (id, applicationId, eventType, occurredAt, extra = {}) => ({
+  id,
+  applicationId,
+  eventType,
+  status: extra.status ?? "applied",
+  occurredAt,
+  occurredAtPrecision: occurredAt?.includes?.("T") ? "instant" : "date",
+  source: "manual",
+  inferred: false,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  ...extra,
+});
+
+describe("lifecycle projection", () => {
+  it("exports the frozen diagram taxonomy with namespaced node IDs", () => {
+    expect(Object.isFrozen(LIFECYCLE_DIAGRAM_TAXONOMY)).toBe(true);
+    expect(LIFECYCLE_DIAGRAM_TAXONOMY.origins.map((item) => item.id)).toEqual([
+      "application_submitted",
+      "recruiter_company_outreach",
+      "candidate_outreach",
+      "referral",
+      "other_unknown",
+    ]);
+    expect(
+      LIFECYCLE_DIAGRAM_TAXONOMY.milestones.map((item) => item.nodeId),
+    ).toEqual([
+      "milestone:recruiter_screen",
+      "milestone:assessment_take_home",
+      "milestone:technical_interview",
+      "milestone:onsite_final_loop",
+      "milestone:offer_received",
+    ]);
+    expect(LIFECYCLE_DIAGRAM_TAXONOMY.endpoints.map((item) => item.id)).toEqual(
+      [
+        "awaiting_response",
+        "interviewing",
+        "assessment_in_progress",
+        "offer_negotiating",
+        "employer_rejected",
+        "candidate_withdrew",
+        "offer_declined",
+        "offer_expired_rescinded",
+        "offer_accepted",
+        "closed_archived",
+        "unknown",
+      ],
+    );
+  });
+
+  it("handles empty bundles and a single skipped-stage application", () => {
+    expect(projectLifecycleAt()).toMatchObject({
+      includedApplications: 0,
+      totalApplications: 0,
+      paths: [],
+      links: [],
+    });
+    const result = projectLifecycleAt({ applications: [app("a1")] });
+    expect(result.paths).toEqual([
+      {
+        applicationId: "a1",
+        origin: "application_submitted",
+        milestones: [],
+        endpoint: "awaiting_response",
+        nodes: ["origin:application_submitted", "endpoint:awaiting_response"],
+      },
+    ]);
+    expect(result.links).toEqual([
+      {
+        id: "origin:application_submitted=>endpoint:awaiting_response",
+        source: "origin:application_submitted",
+        target: "endpoint:awaiting_response",
+        value: 1,
+        applicationIds: ["a1"],
+      },
+    ]);
+  });
+
+  it("collapses repeated milestones and preserves forward order", () => {
+    const bundle = {
+      applications: [app("a1")],
+      lifecycleEvents: [
+        event("e1", "a1", "application_submitted", "2026-01-01"),
+        event("e2", "a1", "recruiter_screen", "2026-01-02", {
+          status: "recruiter_screen",
+        }),
+        event("e3", "a1", "recruiter_screen", "2026-01-03", {
+          status: "recruiter_screen",
+        }),
+        event("e4", "a1", "technical_interview", "2026-01-04", {
+          status: "technical_screen",
+        }),
+      ],
+    };
+    const result = projectLifecycleAt(bundle);
+    expect(result.paths[0].milestones).toEqual([
+      "recruiter_screen",
+      "technical_interview",
+    ]);
+    expect(result.links).toContainEqual({
+      id: "origin:application_submitted=>milestone:recruiter_screen",
+      source: "origin:application_submitted",
+      target: "milestone:recruiter_screen",
+      value: 1,
+      applicationIds: ["a1"],
+    });
+  });
+
+  it("maps every origin and terminal endpoint", () => {
+    const origins = LIFECYCLE_DIAGRAM_TAXONOMY.origins.map((item) => item.id);
+    const terminals = [
+      "employer_rejected",
+      "candidate_withdrew",
+      "offer_declined",
+      "offer_expired_rescinded",
+      "offer_accepted",
+      "closed_archived",
+    ];
+    const applications = terminals.map((endpoint, index) =>
+      app(`a${index}`, { origin: origins[index % origins.length] }),
+    );
+    const lifecycleEvents = applications.flatMap((application, index) => [
+      event(`origin${index}`, application.id, application.origin, "2026-01-01"),
+      event(`end${index}`, application.id, terminals[index], "2026-01-02", {
+        status:
+          terminals[index] === "offer_accepted"
+            ? "accepted"
+            : terminals[index] === "candidate_withdrew"
+              ? "withdrawn"
+              : terminals[index] === "closed_archived"
+                ? "closed_archived"
+                : "rejected",
+      }),
+    ]);
+    const result = projectLifecycleAt({ applications, lifecycleEvents });
+    expect(result.totals.terminal).toBe(applications.length);
+    expect(result.paths.map((path) => path.endpoint)).toEqual(terminals);
+  });
+
+  it("builds deterministic time buckets for all precision types", () => {
+    const bundle = {
+      applications: [app("a1"), app("a2")],
+      lifecycleEvents: [
+        event("unknown", "a1", "application_submitted", "2026-01-01", {
+          occurredAtPrecision: "unknown",
+        }),
+        event(
+          "instant-b",
+          "a1",
+          "recruiter_screen",
+          "2026-01-02T01:00:00+01:00",
+          {
+            status: "recruiter_screen",
+          },
+        ),
+        event("date", "a2", "application_submitted", "2026-01-02"),
+        event(
+          "instant-a",
+          "a2",
+          "technical_interview",
+          "2026-01-01T16:00:00-08:00",
+          {
+            status: "technical_screen",
+          },
+        ),
+      ],
+    };
+    const timeline = buildLifecycleTimeline(bundle);
+    expect(timeline.buckets.map((bucket) => bucket.id)).toEqual([
+      "unknown-date",
+      "date:2026-01-02",
+      "instant:2026-01-02T00:00:00.000Z",
+      "current",
+    ]);
+    expect(timeline.buckets[2].eventIds).toEqual(["instant-a", "instant-b"]);
+    expect(
+      projectLifecycleAt(bundle, "date:2026-01-02").paths.map(
+        (path) => path.applicationId,
+      ),
+    ).toEqual(["a2"]);
+    expect(
+      projectLifecycleAt(bundle, "unknown-date").paths.map(
+        (path) => path.applicationId,
+      ),
+    ).toEqual(["a1"]);
+    expect(projectLifecycleAt(bundle, "current").includedApplications).toBe(2);
+  });
+
+  it("does not mutate inputs and is stable for shuffled arrays", () => {
+    const applications = [app("b"), app("a")];
+    const lifecycleEvents = [
+      event("e2", "a", "recruiter_screen", "2026-01-02", {
+        status: "recruiter_screen",
+      }),
+      event("e1", "a", "application_submitted", "2026-01-01"),
+      event("e3", "b", "candidate_outreach", "2026-01-01", {
+        status: "outreach_sent",
+      }),
+    ];
+    const bundle = { applications, lifecycleEvents };
+    const before = structuredClone(bundle);
+    const first = projectLifecycleAt(bundle);
+    const second = projectLifecycleAt({
+      applications: [...applications].reverse(),
+      lifecycleEvents: [...lifecycleEvents].reverse(),
+    });
+    expect(bundle).toEqual(before);
+    expect(second).toEqual(first);
+  });
+
+  it("reports orphan, inferred, mismatch, terminal-without-reopen, and regression warnings", () => {
+    const result = projectLifecycleAt({
+      applications: [app("a1", { status: "rejected" })],
+      lifecycleEvents: [
+        event("e1", "a1", "application_submitted", "2026-01-01", {
+          inferred: true,
+        }),
+        event("e2", "a1", "technical_interview", "2026-01-02", {
+          status: "technical_screen",
+        }),
+        event("e3", "a1", "recruiter_screen", "2026-01-03", {
+          status: "recruiter_screen",
+        }),
+        event("e4", "a1", "employer_rejected", "2026-01-04", {
+          status: "rejected",
+        }),
+        event("e5", "a1", "offer_received", "2026-01-05", {
+          status: "rejected",
+        }),
+        event("e6", "a1", "status_changed", "2026-01-06", {
+          status: "applied",
+        }),
+        event("orphan", "missing", "application_submitted", "2026-01-01"),
+      ],
+    });
+    expect(result.warnings.map((warning) => warning.code)).toEqual(
+      expect.arrayContaining([
+        "orphaned_event",
+        "inferred_event",
+        "status_mismatch",
+        "regressive_history",
+        "terminal_without_reopen",
+      ]),
+    );
+    expect(result.paths[0].milestones).toEqual([
+      "technical_interview",
+      "offer_received",
+    ]);
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a pure, renderer-neutral, deterministic lifecycle projection engine for the Diagram tab that reuses existing classification logic and does not touch DOM, D3, storage, schema, or legacy CLI Sankey code.
- Produce a stable, namespaced node/link model and snapshot timeline so future UI work (P5) can render charts and tables entirely from projection output.

### Description

- Added `src/web/tracker/lifecycleProjection.js` which exports a deeply frozen `LIFECYCLE_DIAGRAM_TAXONOMY`, `buildLifecycleTimeline(bundle = {})`, and `projectLifecycleAt(bundle = {}, bucketId = "current")` and implements deterministic event supersession, time-bucketing, and path projection rules.
- Implemented deterministic time parsing and buckets (`unknown-date`, dated buckets, `current`), stable ordering keys, and `effective` event supersession to ensure projections do not depend on input ordering or locale/timezone.
- Project logic produces one normalized path per included application, collapses repeated milestones, enforces fixed milestone order, maps endpoints with precedence, produces stable namespaced node IDs (`origin:<id>`, `milestone:<id>`, `endpoint:<id>`), stable link IDs and application ID lists, and emits structured `warnings` and `counts`.
- Added `test/web-tracker-lifecycle-projection.test.js` with focused coverage for taxonomy, empty/single bundles, skipped/repeated milestones, every origin/terminal endpoint, time-bucket behavior (date vs instant vs unknown), determinism/shuffle stability, no mutation, and warning cases.

### Testing

- Ran `npx vitest run test/web-tracker-lifecycle-projection.test.js` and the added test file passed (all tests green).
- Ran `npx prettier --check src/web/tracker/lifecycleProjection.js test/web-tracker-lifecycle-projection.test.js` and the new files conform to Prettier; a full `npm run format:check` reported pre-existing formatting drift elsewhere in the repo (unrelated to this change).
- Ran `npm run lint` and `npm run typecheck` which passed for the modified files.
- Executed `npm run test:ci` (repository CI script) and the test suite completed successfully in this environment.
- Verified `git diff --cached --check` produced no staged whitespace errors for the patched files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5281368168832fb66a5bba54e15fa6)