### PR TITLE
Add lifecycle projection engine

### DIFF
--- a/src/web/tracker/lifecycleProjection.js
+++ b/src/web/tracker/lifecycleProjection.js
@@ -1,0 +1,450 @@
+import { classifyLifecycleEventType } from "./lifecycleClassification.js";
+
+const cmp = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
+const byId = (a, b) => cmp(String(a.id ?? ""), String(b.id ?? ""));
+const freezeDeep = (value) => {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    for (const child of Object.values(value)) freezeDeep(child);
+    Object.freeze(value);
+  }
+  return value;
+};
+
+const ORIGINS = [
+  ["application_submitted", "Application submitted"],
+  ["recruiter_company_outreach", "Recruiter/company reached out"],
+  ["candidate_outreach", "Candidate outreach"],
+  ["referral", "Referral"],
+  ["other_unknown", "Other/unknown"],
+];
+const MILESTONES = [
+  ["recruiter_screen", "Recruiter screen"],
+  ["assessment_take_home", "Assessment/take-home"],
+  ["technical_interview", "Technical interview"],
+  ["onsite_final_loop", "Onsite/final loop"],
+  ["offer_received", "Offer received"],
+];
+const ENDPOINTS = [
+  ["awaiting_response", "Awaiting response"],
+  ["interviewing", "Interviewing"],
+  ["assessment_in_progress", "Assessment in progress"],
+  ["offer_negotiating", "Offer/negotiating"],
+  ["employer_rejected", "Employer rejected"],
+  ["candidate_withdrew", "Candidate withdrew"],
+  ["offer_declined", "Offer declined"],
+  ["offer_expired_rescinded", "Offer expired/rescinded"],
+  ["offer_accepted", "Offer accepted"],
+  ["closed_archived", "Closed/archived"],
+  ["unknown", "Unknown"],
+];
+export const LIFECYCLE_DIAGRAM_TAXONOMY = freezeDeep({
+  origins: ORIGINS.map(([id, label], rank) => ({ id, label, rank })),
+  milestones: MILESTONES.map(([id, label], rank) => ({ id, label, rank })),
+  endpoints: ENDPOINTS.map(([id, label], rank) => ({ id, label, rank })),
+});
+
+const originIds = new Set(ORIGINS.map(([id]) => id));
+const milestoneRank = new Map(MILESTONES.map(([id], rank) => [id, rank]));
+const endpointIds = new Set(ENDPOINTS.map(([id]) => id));
+const terminal = new Set([
+  "employer_rejected",
+  "candidate_withdrew",
+  "offer_declined",
+  "offer_expired_rescinded",
+  "offer_accepted",
+  "closed_archived",
+]);
+const statusEndpoint = {
+  applied: "awaiting_response",
+  outreach_sent: "awaiting_response",
+  recruiter_screen: "interviewing",
+  technical_screen: "interviewing",
+  onsite_loop: "interviewing",
+  offer: "offer_negotiating",
+  accepted: "offer_accepted",
+  rejected: "employer_rejected",
+  withdrawn: "candidate_withdrew",
+  closed_archived: "closed_archived",
+};
+const statusMilestone = {
+  recruiter_screen: "recruiter_screen",
+  technical_screen: "technical_interview",
+  onsite_loop: "onsite_final_loop",
+  offer: "offer_received",
+};
+const stageMilestone = {
+  recruiter_screen: "recruiter_screen",
+  technical_screen: "technical_interview",
+  onsite_loop: "onsite_final_loop",
+  offer: "offer_received",
+};
+const normalize = (v) =>
+  String(v ?? "")
+    .trim()
+    .toLowerCase();
+const dateKey = (value, precision) => {
+  if (precision === "unknown" || value === "1970-01-01")
+    return { kind: "unknown" };
+  if (precision === "date")
+    return /^\d{4}-\d{2}-\d{2}$/.test(String(value))
+      ? { kind: "date", key: value }
+      : null;
+  const time = Date.parse(value);
+  if (!Number.isFinite(time)) return null;
+  const iso = new Date(time).toISOString();
+  return { kind: "instant", key: iso, day: iso.slice(0, 10) };
+};
+const eventType = (event) =>
+  classifyLifecycleEventType(event.eventType).eventType;
+const canonicalEvent = (event) => {
+  const type = eventType(event);
+  if (
+    [
+      "written_assessment",
+      "written_assessment_requested",
+      "written_assessment_submitted",
+      "take_home",
+      "take_home_requested",
+      "take_home_submitted",
+    ].includes(type)
+  )
+    return "assessment_take_home";
+  if (type === "next_tracking_step") return "status_changed";
+  return type;
+};
+const addWarn = (warnings, code, context = {}) =>
+  warnings.push({ code, ...context });
+
+const canonicalEvents = (bundle, cutoff) => {
+  const apps = [...(bundle.applications ?? [])].filter((a) => a?.id).sort(byId);
+  const appIds = new Set(apps.map((a) => String(a.id)));
+  const warnings = [];
+  const superseded = new Set(
+    (bundle.lifecycleEvents ?? [])
+      .map((e) => e?.supersedesEventId)
+      .filter(Boolean)
+      .map(String),
+  );
+  let events = [];
+  for (const e of bundle.lifecycleEvents ?? []) {
+    if (!e?.id || !e.applicationId || !appIds.has(String(e.applicationId))) {
+      addWarn(warnings, "orphaned_event", { eventId: e?.id });
+      continue;
+    }
+    if (superseded.has(String(e.id))) continue;
+    const dk = dateKey(e.occurredAt, e.occurredAtPrecision);
+    if (!dk) {
+      addWarn(warnings, "invalid_timestamp", { eventId: e.id });
+      continue;
+    }
+    if (cutoff?.kind === "unknown" && dk.kind !== "unknown") continue;
+    if (
+      cutoff?.kind === "date" &&
+      (dk.kind === "unknown" || cmp(dk.key, cutoff.key) > 0)
+    )
+      continue;
+    if (cutoff?.kind === "instant") {
+      if (dk.kind === "unknown") continue;
+      if (dk.kind === "date" && cmp(dk.key, cutoff.day) > 0) continue;
+      if (dk.kind === "instant" && cmp(dk.key, cutoff.key) > 0) continue;
+    }
+    const canonicalType = canonicalEvent(e);
+    if (
+      canonicalType === "status_changed" &&
+      !["status_changed", "next_tracking_step"].includes(eventType(e))
+    )
+      addWarn(warnings, "unknown_event_type", { eventId: e.id });
+    events.push({
+      ...e,
+      id: String(e.id),
+      applicationId: String(e.applicationId),
+      canonicalType,
+      dateKey: dk,
+    });
+  }
+  events.sort(
+    (a, b) =>
+      cmp(String(a.applicationId), String(b.applicationId)) ||
+      cmp(bucketSort(a.dateKey), bucketSort(b.dateKey)) ||
+      cmp(a.id, b.id),
+  );
+  return { apps, events, warnings };
+};
+const bucketSort = (dk) =>
+  dk.kind === "unknown"
+    ? "0:"
+    : dk.kind === "date"
+      ? `1:${dk.key}:0`
+      : `1:${dk.day}:1:${dk.key}`;
+const bucketId = (dk) =>
+  dk.kind === "unknown"
+    ? "unknown-date"
+    : dk.kind === "date"
+      ? `date:${dk.key}`
+      : `instant:${dk.key}`;
+const nodeId = (kind, id) => `${kind}:${id}`;
+const warningCounts = (warnings) => {
+  const counts = {};
+  for (const warning of warnings)
+    counts[warning.code] = (counts[warning.code] ?? 0) + 1;
+  return counts;
+};
+
+function build(cApps, cEvents, warnings, current) {
+  const byApp = new Map();
+  for (const e of cEvents) {
+    const list = byApp.get(e.applicationId) ?? [];
+    list.push(e);
+    byApp.set(e.applicationId, list);
+  }
+  const includedApps = current
+    ? cApps
+    : cApps.filter((a) => byApp.has(String(a.id)));
+  const paths = [],
+    linkApps = new Map();
+  const totals = {
+    origins: {},
+    milestones: {},
+    endpoints: {},
+    active: 0,
+    terminal: 0,
+  };
+  for (const app of includedApps) {
+    const appId = String(app.id);
+    const events = byApp.get(appId) ?? [];
+    let origin = originIds.has(app.origin) ? app.origin : "other_unknown";
+    const originEvent = events.find((e) => originIds.has(e.canonicalType));
+    if (originEvent) origin = originEvent.canonicalType;
+    const seen = new Set();
+    let endpoint = "unknown";
+    let terminalEndpoint = null;
+    let best = -1;
+    const details = [];
+    for (const e of events) {
+      const type = e.canonicalType;
+      const ms = milestoneRank.has(type)
+        ? type
+        : statusMilestone[e.status] || stageMilestone[e.stage];
+      if (ms) {
+        const rank = milestoneRank.get(ms);
+        if (rank < best)
+          addWarn(warnings, "regressive_history", {
+            applicationId: appId,
+            eventId: e.id,
+          });
+        best = Math.max(best, rank);
+        seen.add(ms);
+      } else if (
+        (e.status && !statusEndpoint[e.status]) ||
+        (e.stage && e.stage !== "other" && !stageMilestone[e.stage])
+      )
+        addWarn(warnings, "unknown_structured_value", {
+          applicationId: appId,
+          eventId: e.id,
+        });
+      if (e.inferred)
+        addWarn(warnings, "inferred_event", {
+          applicationId: appId,
+          eventId: e.id,
+        });
+      if (type === "application_reopened") {
+        terminalEndpoint = null;
+        endpoint = "awaiting_response";
+      } else if (terminal.has(type)) {
+        terminalEndpoint = type;
+        endpoint = type;
+      } else if (terminalEndpoint)
+        addWarn(warnings, "terminal_without_reopen", {
+          applicationId: appId,
+          eventId: e.id,
+        });
+      else if (
+        ["offer_received", "offer_negotiating"].includes(type) ||
+        e.status === "offer"
+      )
+        endpoint = "offer_negotiating";
+      else if (
+        type === "assessment_take_home" &&
+        ["requested", "pending", "started", "in_progress"].includes(
+          normalize(e.actionStatus),
+        )
+      )
+        endpoint = "assessment_in_progress";
+      else if (
+        [
+          "recruiter_screen",
+          "technical_interview",
+          "onsite_final_loop",
+        ].includes(type) ||
+        ["recruiter_screen", "technical_screen", "onsite_loop"].includes(
+          e.status,
+        )
+      )
+        endpoint = "interviewing";
+      else if (
+        [
+          "application_submitted",
+          "recruiter_company_outreach",
+          "candidate_outreach",
+          "referral",
+          "other_unknown",
+          "employer_response_received",
+        ].includes(type)
+      )
+        endpoint = "awaiting_response";
+      details.push({
+        id: e.id,
+        eventType: type,
+        occurredAt: e.occurredAt,
+        occurredAtPrecision: e.occurredAtPrecision,
+      });
+    }
+    if (
+      current &&
+      app.status &&
+      statusEndpoint[app.status] &&
+      statusEndpoint[app.status] !== endpoint
+    )
+      addWarn(warnings, "status_history_mismatch", {
+        applicationId: appId,
+        status: app.status,
+        endpoint,
+      });
+    if (!endpointIds.has(endpoint)) endpoint = "unknown";
+    const milestones = [...seen].sort(
+      (a, b) => milestoneRank.get(a) - milestoneRank.get(b),
+    );
+    const ids = [
+      nodeId("origin", origin),
+      ...milestones.map((m) => nodeId("milestone", m)),
+      nodeId("endpoint", endpoint),
+    ];
+    for (let i = 0; i < ids.length - 1; i++) {
+      const key = `${ids[i]}→${ids[i + 1]}`;
+      if (!linkApps.has(key))
+        linkApps.set(key, {
+          source: ids[i],
+          target: ids[i + 1],
+          apps: new Set(),
+        });
+      linkApps.get(key).apps.add(appId);
+    }
+    totals.origins[origin] = (totals.origins[origin] ?? 0) + 1;
+    for (const m of milestones)
+      totals.milestones[m] = (totals.milestones[m] ?? 0) + 1;
+    totals.endpoints[endpoint] = (totals.endpoints[endpoint] ?? 0) + 1;
+    terminal.has(endpoint) ? totals.terminal++ : totals.active++;
+    paths.push({
+      applicationId: appId,
+      origin,
+      milestones,
+      endpoint,
+      nodeIds: ids,
+      events: details,
+    });
+  }
+  paths.sort((a, b) => cmp(a.applicationId, b.applicationId));
+  const nodeTotals = new Map();
+  for (const p of paths)
+    for (const id of p.nodeIds)
+      nodeTotals.set(id, (nodeTotals.get(id) ?? 0) + 1);
+  const nodes = [...nodeTotals]
+    .map(([id, value]) => ({
+      id,
+      kind: id.split(":")[0],
+      taxonomyId: id.slice(id.indexOf(":") + 1),
+      value,
+    }))
+    .sort((a, b) => cmp(a.id, b.id));
+  const links = [...linkApps.values()]
+    .map((l) => ({
+      id: `${l.source}->${l.target}`,
+      source: l.source,
+      target: l.target,
+      value: l.apps.size,
+      applicationIds: [...l.apps].sort(cmp),
+    }))
+    .sort((a, b) => cmp(a.id, b.id));
+  warnings.sort(
+    (a, b) =>
+      cmp(a.code, b.code) ||
+      cmp(a.applicationId ?? "", b.applicationId ?? "") ||
+      cmp(a.eventId ?? "", b.eventId ?? ""),
+  );
+  return freezeDeep({
+    includedApplications: includedApps.length,
+    totalApplications: cApps.length,
+    paths,
+    nodes,
+    links,
+    totals,
+    warnings,
+    warningCounts: warningCounts(warnings),
+  });
+}
+
+export function buildLifecycleTimeline(bundle = {}) {
+  const { events, warnings } = canonicalEvents(bundle);
+  const map = new Map([
+    [
+      "unknown-date",
+      {
+        id: "unknown-date",
+        label: "Unknown date",
+        kind: "unknown",
+        eventIds: [],
+      },
+    ],
+  ]);
+  for (const e of events) {
+    const id = bucketId(e.dateKey);
+    if (id === "unknown-date") map.get(id).eventIds.push(e.id);
+    else if (!map.has(id))
+      map.set(id, {
+        id,
+        label:
+          e.dateKey.kind === "date"
+            ? `${e.dateKey.key} (time not recorded)`
+            : e.dateKey.key,
+        kind: e.dateKey.kind,
+        cutoff: e.dateKey,
+        eventIds: [e.id],
+      });
+    else map.get(id).eventIds.push(e.id);
+  }
+  const buckets = [...map.values()]
+    .map((b) => ({ ...b, eventIds: b.eventIds.sort(cmp) }))
+    .sort((a, b) =>
+      a.id === "unknown-date"
+        ? -1
+        : b.id === "unknown-date"
+          ? 1
+          : cmp(bucketSort(a.cutoff), bucketSort(b.cutoff)),
+    );
+  buckets.push({
+    id: "current",
+    label: "Current",
+    kind: "current",
+    eventIds: events.map((e) => e.id).sort(cmp),
+  });
+  return freezeDeep({ buckets, warnings });
+}
+
+export function projectLifecycleAt(bundle = {}, bucketIdValue = "current") {
+  const timeline = buildLifecycleTimeline(bundle);
+  const selectedBucket =
+    timeline.buckets.find((b) => b.id === bucketIdValue) ??
+    timeline.buckets.at(-1);
+  const cutoff =
+    selectedBucket.kind === "current"
+      ? null
+      : selectedBucket.kind === "unknown"
+        ? { kind: "unknown" }
+        : selectedBucket.cutoff;
+  const { apps, events, warnings } = canonicalEvents(bundle, cutoff);
+  return freezeDeep({
+    selectedBucket,
+    ...build(apps, events, warnings, selectedBucket.kind === "current"),
+    boundaryEvents: selectedBucket.eventIds ?? [],
+  });
+}

--- a/test/web-tracker-lifecycle-projection.test.js
+++ b/test/web-tracker-lifecycle-projection.test.js
@@ -1,0 +1,410 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  LIFECYCLE_DIAGRAM_TAXONOMY,
+  buildLifecycleTimeline,
+  projectLifecycleAt,
+} from "../src/web/tracker/lifecycleProjection.js";
+
+const app = (id, extra = {}) => ({
+  id,
+  company: `Company ${id}`,
+  role: "Engineer",
+  origin: "application_submitted",
+  status: "applied",
+  ...extra,
+});
+const ev = (id, applicationId, eventType, occurredAt, extra = {}) => ({
+  id,
+  applicationId,
+  eventType,
+  status: extra.status ?? "applied",
+  occurredAt,
+  occurredAtPrecision:
+    extra.occurredAtPrecision ?? (occurredAt ? "instant" : "unknown"),
+  inferred: false,
+  source: "manual",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  ...extra,
+});
+const ids = (items) => items.map((item) => item.id);
+
+const expectInvariants = (projection) => {
+  expect(projection.paths).toHaveLength(projection.includedApplications);
+  expect(
+    Object.values(projection.totals.origins).reduce((a, b) => a + b, 0),
+  ).toBe(projection.includedApplications);
+  expect(
+    Object.values(projection.totals.endpoints).reduce((a, b) => a + b, 0),
+  ).toBe(projection.includedApplications);
+  expect(projection.totals.active + projection.totals.terminal).toBe(
+    projection.includedApplications,
+  );
+  const rank = (node) =>
+    ({ origin: 0, milestone: 1, endpoint: 2 })[node.split(":")[0]];
+  for (const link of projection.links) {
+    expect(link.value).toBeGreaterThan(0);
+    expect(Number.isInteger(link.value)).toBe(true);
+    expect(link.source).not.toBe(link.target);
+    expect(rank(link.source)).toBeLessThanOrEqual(rank(link.target));
+    expect(new Set(link.applicationIds).size).toBe(link.applicationIds.length);
+  }
+  for (const path of projection.paths) {
+    expect(new Set(path.milestones).size).toBe(path.milestones.length);
+    expect(path.nodeIds.at(0)).toBe(`origin:${path.origin}`);
+    expect(path.nodeIds.at(-1)).toBe(`endpoint:${path.endpoint}`);
+  }
+};
+
+describe("lifecycle projection taxonomy", () => {
+  it("exports the exact frozen diagram taxonomy", () => {
+    expect(Object.isFrozen(LIFECYCLE_DIAGRAM_TAXONOMY)).toBe(true);
+    expect(ids(LIFECYCLE_DIAGRAM_TAXONOMY.origins)).toEqual([
+      "application_submitted",
+      "recruiter_company_outreach",
+      "candidate_outreach",
+      "referral",
+      "other_unknown",
+    ]);
+    expect(ids(LIFECYCLE_DIAGRAM_TAXONOMY.milestones)).toEqual([
+      "recruiter_screen",
+      "assessment_take_home",
+      "technical_interview",
+      "onsite_final_loop",
+      "offer_received",
+    ]);
+    expect(ids(LIFECYCLE_DIAGRAM_TAXONOMY.endpoints)).toEqual([
+      "awaiting_response",
+      "interviewing",
+      "assessment_in_progress",
+      "offer_negotiating",
+      "employer_rejected",
+      "candidate_withdrew",
+      "offer_declined",
+      "offer_expired_rescinded",
+      "offer_accepted",
+      "closed_archived",
+      "unknown",
+    ]);
+  });
+
+  it("handles empty bundles", () => {
+    const projection = projectLifecycleAt();
+    expect(projection).toMatchObject({
+      includedApplications: 0,
+      totalApplications: 0,
+      paths: [],
+      nodes: [],
+      links: [],
+    });
+    expect(buildLifecycleTimeline().buckets.map((b) => b.id)).toEqual([
+      "unknown-date",
+      "current",
+    ]);
+  });
+});
+
+describe("lifecycle path projection", () => {
+  it("projects every origin and endpoint without inventing skipped milestones", () => {
+    const endpoints = [
+      ["awaiting_response", "application_submitted", "applied"],
+      ["interviewing", "technical_interview", "technical_screen"],
+      [
+        "assessment_in_progress",
+        "assessment_take_home",
+        "applied",
+        { actionStatus: "started" },
+      ],
+      ["offer_negotiating", "offer_received", "offer"],
+      ["employer_rejected", "employer_rejected", "rejected"],
+      ["candidate_withdrew", "candidate_withdrew", "withdrawn"],
+      ["offer_declined", "offer_declined", "offer"],
+      ["offer_expired_rescinded", "offer_expired_rescinded", "offer"],
+      ["offer_accepted", "offer_accepted", "accepted"],
+      ["closed_archived", "closed_archived", "closed_archived"],
+      ["unknown", "status_changed", "applied"],
+    ];
+    const origins = LIFECYCLE_DIAGRAM_TAXONOMY.origins.map((o) => o.id);
+    const bundle = {
+      applications: endpoints.map(([endpoint], index) =>
+        app(`app_${endpoint}`, {
+          origin: origins[index % origins.length],
+          status: endpoint === "unknown" ? "applied" : endpoints[index][2],
+        }),
+      ),
+      lifecycleEvents: endpoints.map(([endpoint, type, status, extra], index) =>
+        ev(
+          `event_${endpoint}`,
+          `app_${endpoint}`,
+          type,
+          `2026-02-${String(index + 1).padStart(2, "0")}T12:00:00.000Z`,
+          { status, ...(extra ?? {}) },
+        ),
+      ),
+    };
+    const projection = projectLifecycleAt(bundle);
+    expect(Object.keys(projection.totals.origins).sort()).toEqual(
+      origins.sort(),
+    );
+    expect(Object.keys(projection.totals.endpoints).sort()).toEqual(
+      endpoints.map(([endpoint]) => endpoint).sort(),
+    );
+    expect(
+      projection.paths.find((p) => p.endpoint === "offer_negotiating")
+        .milestones,
+    ).toEqual(["offer_received"]);
+    expectInvariants(projection);
+  });
+
+  it("collapses repeats, aggregates by app, and keeps all-milestone order", () => {
+    const bundle = {
+      applications: [app("a", { status: "offer" })],
+      lifecycleEvents: [
+        ev("e1", "a", "onsite_final_loop", "2026-01-04T00:00:00Z", {
+          status: "onsite_loop",
+        }),
+        ev("e2", "a", "recruiter_screen", "2026-01-02T00:00:00Z", {
+          status: "recruiter_screen",
+        }),
+        ev("e3", "a", "assessment_take_home", "2026-01-03T00:00:00Z", {
+          actionStatus: "submitted",
+        }),
+        ev("e4", "a", "technical_interview", "2026-01-03T01:00:00Z", {
+          status: "technical_screen",
+        }),
+        ev("e5", "a", "recruiter_screen", "2026-01-02T01:00:00Z", {
+          status: "recruiter_screen",
+        }),
+        ev("e6", "a", "offer_received", "2026-01-05T00:00:00Z", {
+          status: "offer",
+        }),
+      ],
+    };
+    const projection = projectLifecycleAt(bundle);
+    expect(projection.paths[0].milestones).toEqual([
+      "recruiter_screen",
+      "assessment_take_home",
+      "technical_interview",
+      "onsite_final_loop",
+      "offer_received",
+    ]);
+    expect(projection.links.every((link) => link.value === 1)).toBe(true);
+    expectInvariants(projection);
+  });
+
+  it("keeps assessment submissions out of assessment-in-progress", () => {
+    const projection = projectLifecycleAt({
+      applications: [app("a")],
+      lifecycleEvents: [
+        ev("e", "a", "assessment_take_home", "2026-01-01T00:00:00Z", {
+          actionStatus: "completed",
+        }),
+      ],
+    });
+    expect(projection.paths[0]).toMatchObject({
+      milestones: ["assessment_take_home"],
+      endpoint: "unknown",
+    });
+  });
+
+  it("warns for terminal activity without reopen and clears terminal after explicit reopen", () => {
+    const noReopen = projectLifecycleAt({
+      applications: [app("a", { status: "rejected" })],
+      lifecycleEvents: [
+        ev("t", "a", "employer_rejected", "2026-01-01T00:00:00Z", {
+          status: "rejected",
+        }),
+        ev("i", "a", "technical_interview", "2026-01-02T00:00:00Z", {
+          status: "technical_screen",
+        }),
+      ],
+    });
+    expect(noReopen.paths[0].endpoint).toBe("employer_rejected");
+    expect(noReopen.warningCounts.terminal_without_reopen).toBe(1);
+
+    const reopened = projectLifecycleAt({
+      applications: [app("a", { status: "technical_screen" })],
+      lifecycleEvents: [
+        ev("t", "a", "employer_rejected", "2026-01-01T00:00:00Z", {
+          status: "rejected",
+        }),
+        ev("r", "a", "application_reopened", "2026-01-02T00:00:00Z"),
+        ev("i", "a", "technical_interview", "2026-01-03T00:00:00Z", {
+          status: "technical_screen",
+        }),
+      ],
+    });
+    expect(reopened.paths[0].endpoint).toBe("interviewing");
+  });
+
+  it("reports regressions and does not create backward links", () => {
+    const projection = projectLifecycleAt({
+      applications: [app("a", { status: "technical_screen" })],
+      lifecycleEvents: [
+        ev("tech", "a", "technical_interview", "2026-01-01T00:00:00Z", {
+          status: "technical_screen",
+        }),
+        ev("rec", "a", "recruiter_screen", "2026-01-02T00:00:00Z", {
+          status: "recruiter_screen",
+        }),
+      ],
+    });
+    expect(projection.warningCounts.regressive_history).toBe(1);
+    expect(
+      projection.links.some(
+        (link) =>
+          link.source === "milestone:technical_interview" &&
+          link.target === "milestone:recruiter_screen",
+      ),
+    ).toBe(false);
+    expectInvariants(projection);
+  });
+});
+
+describe("lifecycle timeline", () => {
+  it("groups equal instants, simultaneous events, cutoffs, and date-only order", () => {
+    const bundle = {
+      applications: [app("a"), app("b"), app("c")],
+      lifecycleEvents: [
+        ev("date", "a", "application_submitted", "2026-03-01", {
+          occurredAtPrecision: "date",
+        }),
+        ev("same1", "a", "recruiter_screen", "2026-03-01T12:00:00+00:00", {
+          status: "recruiter_screen",
+        }),
+        ev("same2", "b", "application_submitted", "2026-03-01T07:00:00-05:00"),
+        ev("future", "c", "application_submitted", "2026-03-02T00:00:00Z"),
+      ],
+    };
+    const timeline = buildLifecycleTimeline(bundle);
+    expect(timeline.buckets.map((b) => b.id)).toEqual([
+      "unknown-date",
+      "date:2026-03-01",
+      "instant:2026-03-01T12:00:00.000Z",
+      "instant:2026-03-02T00:00:00.000Z",
+      "current",
+    ]);
+    expect(timeline.buckets[2].eventIds).toEqual(["same1", "same2"]);
+    expect(
+      projectLifecycleAt(bundle, "instant:2026-03-01T12:00:00.000Z")
+        .includedApplications,
+    ).toBe(2);
+  });
+
+  it("isolates unknown-date history and includes it in current", () => {
+    const bundle = {
+      applications: [app("a"), app("b")],
+      lifecycleEvents: [
+        ev("u", "a", "application_submitted", "1970-01-01", {
+          occurredAtPrecision: "unknown",
+        }),
+        ev("d", "b", "application_submitted", "2026-01-01", {
+          occurredAtPrecision: "date",
+        }),
+      ],
+    };
+    expect(
+      projectLifecycleAt(bundle, "unknown-date").paths.map(
+        (p) => p.applicationId,
+      ),
+    ).toEqual(["a"]);
+    expect(
+      projectLifecycleAt(bundle, "date:2026-01-01").paths.map(
+        (p) => p.applicationId,
+      ),
+    ).toEqual(["b"]);
+    expect(projectLifecycleAt(bundle).includedApplications).toBe(2);
+  });
+});
+
+describe("lifecycle projection safety and determinism", () => {
+  it("warns for inferred, mismatch, invalid and orphan records without mutating inputs", () => {
+    const bundle = {
+      applications: [app("a", { status: "accepted" })],
+      lifecycleEvents: [
+        ev("bad", "a", "application_submitted", "not-a-date"),
+        ev("inf", "a", "application_submitted", "2026-01-01T00:00:00Z", {
+          inferred: true,
+        }),
+        ev("orphan", "missing", "offer_accepted", "2026-01-01T00:00:00Z"),
+      ],
+    };
+    const before = structuredClone(bundle);
+    const projection = projectLifecycleAt(bundle);
+    expect(bundle).toEqual(before);
+    expect(projection.warningCounts).toMatchObject({
+      invalid_timestamp: 1,
+      orphaned_event: 1,
+      inferred_event: 1,
+      status_history_mismatch: 1,
+    });
+  });
+
+  it("is independent of application and event input order", () => {
+    const applications = [
+      app("b", { status: "offer" }),
+      app("a", { status: "technical_screen" }),
+    ];
+    const lifecycleEvents = [
+      ev("b2", "b", "offer_received", "2026-01-03T00:00:00Z", {
+        status: "offer",
+      }),
+      ev("a1", "a", "technical_interview", "2026-01-02T00:00:00Z", {
+        status: "technical_screen",
+      }),
+      ev("b1", "b", "application_submitted", "2026-01-01T00:00:00Z"),
+    ];
+    expect(projectLifecycleAt({ applications, lifecycleEvents })).toEqual(
+      projectLifecycleAt({
+        applications: [...applications].reverse(),
+        lifecycleEvents: [...lifecycleEvents].reverse(),
+      }),
+    );
+  });
+
+  it("handles a large aggregate fixture and every invariant", () => {
+    const applications = Array.from({ length: 120 }, (_, index) =>
+      app(`app_${String(index).padStart(3, "0")}`, {
+        status:
+          index % 5 === 0
+            ? "accepted"
+            : index % 3 === 0
+              ? "technical_screen"
+              : "applied",
+      }),
+    );
+    const lifecycleEvents = applications.flatMap((application, index) => [
+      ev(
+        `submit_${application.id}`,
+        application.id,
+        "application_submitted",
+        `2026-01-${String((index % 28) + 1).padStart(2, "0")}T00:00:00Z`,
+      ),
+      ...(index % 3 === 0
+        ? [
+            ev(
+              `tech_${application.id}`,
+              application.id,
+              "technical_interview",
+              "2026-02-01T00:00:00Z",
+              { status: "technical_screen" },
+            ),
+          ]
+        : []),
+      ...(index % 5 === 0
+        ? [
+            ev(
+              `offer_${application.id}`,
+              application.id,
+              "offer_accepted",
+              "2026-03-01T00:00:00Z",
+              { status: "accepted" },
+            ),
+          ]
+        : []),
+    ]);
+    const projection = projectLifecycleAt({ applications, lifecycleEvents });
+    expect(projection.includedApplications).toBe(120);
+    expectInvariants(projection);
+  });
+});


### PR DESCRIPTION
### Motivation
- Implement a pure, renderer-independent, deterministic lifecycle projection layer required by the Diagram tab design contract. 
- Provide projection outputs (timeline buckets, per-application paths, deterministic nodes/links, totals, and warnings) without introducing rendering, DOM, storage writes, or schema changes. 
- Ensure strict invariants and determinism (stable IDs, code-point sorting, no invented milestones, no backward/self-links) so P5 UI rendering can consume the projection data reliably.

### Description
- Added `src/web/tracker/lifecycleProjection.js` which exports a deeply frozen `LIFECYCLE_DIAGRAM_TAXONOMY`, `buildLifecycleTimeline(bundle = {})`, and `projectLifecycleAt(bundle = {}, bucketId = "current")`, and implements deterministic canonicalization, supersession handling, timestamp bucketing, milestone collapse, endpoint precedence, terminal/reopen logic, namespaced node IDs (`origin:<id>`, `milestone:<id>`, `endpoint:<id>`), aggregated links, totals, and structured warnings. 
- Timeline rules implement `unknown-date`, dated buckets (date/instant semantics and inclusive cutoffs), and `current` snapshot; bucket IDs are stable and deterministic. 
- Path projection produces one normalized path per included application, conserves flow, yields positive integer link values and sorted, unique `applicationIds`, and stores event details per path without mutating inputs. 
- Added unit tests in `test/web-tracker-lifecycle-projection.test.js` that exercise taxonomy, empty bundles, every origin/endpoint, repeated/skipped milestones, assessment-action behavior, equal-instant grouping, unknown-date isolation, terminal/reopen/regression warnings, determinism (shuffled inputs), immutability, and a large aggregate fixture.

### Testing
- Ran `npx vitest run test/web-tracker-lifecycle-projection.test.js` which passed (12 tests). 
- Ran `npx prettier --write src/web/tracker/lifecycleProjection.js test/web-tracker-lifecycle-projection.test.js` to format the new files. 
- `npm run format:check` reported pre-existing Prettier issues in unrelated files (status: failed) while the two new files were written with Prettier. 
- `npm run lint` succeeded after minor test-line-length adjustments. 
- `npm run typecheck` (`tsc -p tsconfig.json`) succeeded. 
- `npm run test:ci` succeeded (full CI test suite passed locally). 
- `git diff --check` / index checks passed for the staged files. 

Residual notes: `format:check` failure is due to pre-existing repository-wide formatting warnings outside these changes; the new files were formatted and lint errors introduced by the new test were fixed prior to committing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52813e7240832fb849259438eeaebe)