### PR TITLE
Add pure lifecycle projection engine

### DIFF
--- a/src/web/tracker/lifecycleProjection.js
+++ b/src/web/tracker/lifecycleProjection.js
@@ -1,0 +1,459 @@
+import { classifyLifecycleEventType } from "./lifecycleClassification.js";
+
+const codeCompare = (a, b) => (a < b ? -1 : a > b ? 1 : 0);
+const byId = (a, b) => codeCompare(a.id, b.id);
+const norm = (v) => String(v ?? "").trim();
+const keyNorm = (v) =>
+  norm(v)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+
+const deepFreeze = (value) => {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const child of Object.values(value)) deepFreeze(child);
+  }
+  return value;
+};
+
+const origins = [
+  ["application_submitted", "Application submitted"],
+  ["recruiter_company_outreach", "Recruiter/company outreach"],
+  ["candidate_outreach", "Candidate outreach"],
+  ["referral", "Referral"],
+  ["other_unknown", "Other/unknown"],
+];
+const milestones = [
+  ["recruiter_screen", "Recruiter screen"],
+  ["assessment_take_home", "Assessment/take-home"],
+  ["technical_interview", "Technical interview"],
+  ["onsite_final_loop", "Onsite/final loop"],
+  ["offer_received", "Offer received"],
+];
+const endpoints = [
+  ["awaiting_response", "Awaiting response"],
+  ["interviewing", "Interviewing"],
+  ["assessment_in_progress", "Assessment in progress"],
+  ["offer_negotiating", "Offer/negotiating"],
+  ["employer_rejected", "Employer rejected"],
+  ["candidate_withdrew", "Candidate withdrew"],
+  ["offer_declined", "Offer declined"],
+  ["offer_expired_rescinded", "Offer expired/rescinded"],
+  ["offer_accepted", "Offer accepted"],
+  ["closed_archived", "Closed/archived"],
+  ["unknown", "Unknown"],
+];
+const makeTaxon = (prefix, rows) =>
+  rows.map(([id, label], rank) => ({
+    id,
+    namespacedId: `${prefix}:${id}`,
+    label,
+    rank,
+  }));
+export const LIFECYCLE_DIAGRAM_TAXONOMY = deepFreeze({
+  origins: makeTaxon("origin", origins),
+  milestones: makeTaxon("milestone", milestones),
+  endpoints: makeTaxon("endpoint", endpoints),
+});
+
+const ORIGIN = new Set(origins.map(([id]) => id));
+const MILESTONE_RANK = new Map(milestones.map(([id], i) => [id, i]));
+const TERMINAL = new Set([
+  "employer_rejected",
+  "candidate_withdrew",
+  "offer_declined",
+  "offer_expired_rescinded",
+  "offer_accepted",
+  "closed_archived",
+]);
+const STATUS_ENDPOINT = new Map(
+  Object.entries({
+    applied: "awaiting_response",
+    outreach_sent: "awaiting_response",
+    recruiter_screen: "interviewing",
+    technical_screen: "interviewing",
+    onsite_loop: "interviewing",
+    offer: "offer_negotiating",
+    accepted: "offer_accepted",
+    rejected: "employer_rejected",
+    withdrawn: "candidate_withdrew",
+    closed_archived: "closed_archived",
+  }),
+);
+const ASSESSMENT_ACTIVE = new Set([
+  "requested",
+  "pending",
+  "started",
+  "in_progress",
+]);
+const ASSESSMENT_DONE = new Set(["submitted", "completed", "done"]);
+
+const addWarning = (warnings, code, details = {}) =>
+  warnings.push({ code, ...details });
+const countWarnings = (warnings) =>
+  warnings.reduce(
+    (acc, w) => ({ ...acc, [w.code]: (acc[w.code] ?? 0) + 1 }),
+    {},
+  );
+
+const parseTemporal = (event, warnings) => {
+  const precision =
+    event.occurredAtPrecision === "date" ||
+    event.occurredAtPrecision === "unknown" ||
+    event.occurredAtPrecision === "instant"
+      ? event.occurredAtPrecision
+      : "unknown";
+  const raw = norm(event.occurredAt);
+  if (precision === "unknown" || raw.startsWith("1970-01-01"))
+    return { kind: "unknown", sort: "" };
+  if (precision === "date") {
+    if (/^\d{4}-\d{2}-\d{2}$/.test(raw))
+      return { kind: "date", date: raw, sort: `${raw}T00:00:00.000Z` };
+    addWarning(warnings, "invalid_timestamp", { eventId: event.id });
+    return { kind: "unknown", sort: "" };
+  }
+  const ms = Date.parse(raw);
+  if (!Number.isFinite(ms)) {
+    addWarning(warnings, "invalid_timestamp", { eventId: event.id });
+    return { kind: "unknown", sort: "" };
+  }
+  const iso = new Date(ms).toISOString();
+  return { kind: "instant", instant: iso, date: iso.slice(0, 10), sort: iso };
+};
+
+const canonicalEventType = (event) =>
+  classifyLifecycleEventType(event.eventType).eventType ||
+  keyNorm(event.eventType);
+const eventSort = (a, b) =>
+  codeCompare(a.temporal.sort, b.temporal.sort) || codeCompare(a.id, b.id);
+
+const prepare = (bundle) => {
+  const warnings = [];
+  const apps = (Array.isArray(bundle.applications) ? bundle.applications : [])
+    .map((a) => ({ ...a, id: norm(a.id) }))
+    .filter((a) => a.id)
+    .sort(byId);
+  const appIds = new Set(apps.map((a) => a.id));
+  const rawEvents = (
+    Array.isArray(bundle.lifecycleEvents) ? bundle.lifecycleEvents : []
+  )
+    .map((e) => ({
+      ...e,
+      id: norm(e.id),
+      applicationId: norm(e.applicationId),
+    }))
+    .filter((e) => e.id)
+    .sort(byId);
+  const superseded = new Set(
+    rawEvents.map((e) => norm(e.supersedesEventId)).filter(Boolean),
+  );
+  const events = [];
+  for (const e of rawEvents) {
+    if (superseded.has(e.id)) continue;
+    if (!appIds.has(e.applicationId)) {
+      addWarning(warnings, "orphaned_event", {
+        eventId: e.id,
+        applicationId: e.applicationId,
+      });
+      continue;
+    }
+    const temporal = parseTemporal(e, warnings);
+    const eventType = canonicalEventType(e);
+    const known = [
+      ...ORIGIN,
+      ...MILESTONE_RANK.keys(),
+      "employer_response_received",
+      "offer_negotiating",
+      ...TERMINAL,
+      "application_reopened",
+      "status_changed",
+      "migration_status_snapshot",
+    ].includes(eventType);
+    if (!known)
+      addWarning(warnings, "unknown_event_type", { eventId: e.id, eventType });
+    if (e.inferred) addWarning(warnings, "inferred_event", { eventId: e.id });
+    events.push({ ...e, eventType, temporal });
+  }
+  return { apps, events: events.sort(eventSort), warnings };
+};
+
+const selectEvents = (events, bucket) => {
+  if (bucket.id === "current") return events;
+  if (bucket.id === "unknown-date")
+    return events.filter((e) => e.temporal.kind === "unknown");
+  return events.filter(
+    (e) =>
+      e.temporal.kind !== "unknown" &&
+      codeCompare(e.temporal.sort, bucket.cutoffSort) <= 0,
+  );
+};
+
+const nodeId = (type, id) => `${type}:${id}`;
+
+const projectWithPrepared = (prepared, bucket) => {
+  const warnings = [...prepared.warnings];
+  const selectedEvents = selectEvents(prepared.events, bucket);
+  const eventsByApp = new Map();
+  for (const e of selectedEvents)
+    (
+      eventsByApp.get(e.applicationId) ??
+      eventsByApp.set(e.applicationId, []).get(e.applicationId)
+    ).push(e);
+  const historical = bucket.id !== "current";
+  const includedApps = prepared.apps.filter(
+    (a) =>
+      !historical ||
+      (eventsByApp.get(a.id) ?? []).some((e) =>
+        bucket.id === "unknown-date"
+          ? e.temporal.kind === "unknown"
+          : e.temporal.kind !== "unknown",
+      ),
+  );
+  const paths = [];
+  for (const app of includedApps) {
+    const appEvents = (eventsByApp.get(app.id) ?? []).sort(eventSort);
+    let origin = ORIGIN.has(app.origin) ? app.origin : "other_unknown";
+    const originEvent = appEvents.find((e) => ORIGIN.has(e.eventType));
+    if (originEvent) origin = originEvent.eventType;
+    else if (keyNorm(app.source) === "referral") origin = "referral";
+    if (app.origin && app.origin !== origin)
+      addWarning(warnings, "origin_conflict", { applicationId: app.id });
+    const seen = new Set();
+    let endpoint = "unknown",
+      terminal = null,
+      activeAssessment = false,
+      activeInterview = false,
+      awaiting = false,
+      offer = false;
+    for (const e of appEvents) {
+      const previousRank = seen.size
+        ? Math.max(...[...seen].map((id) => MILESTONE_RANK.get(id)))
+        : -1;
+      let milestone = MILESTONE_RANK.has(e.eventType) ? e.eventType : undefined;
+      if (e.status === "technical_screen" || e.stage === "technical_screen")
+        milestone = "technical_interview";
+      if (e.status === "onsite_loop" || e.stage === "onsite_loop")
+        milestone = "onsite_final_loop";
+      if (e.status === "offer") milestone = "offer_received";
+      if (milestone) {
+        if (MILESTONE_RANK.get(milestone) < previousRank)
+          addWarning(warnings, "regressive_history", {
+            applicationId: app.id,
+            eventId: e.id,
+          });
+        seen.add(milestone);
+      }
+      const action = keyNorm(e.actionStatus);
+      if (
+        e.eventType === "assessment_take_home" &&
+        ASSESSMENT_ACTIVE.has(action)
+      )
+        activeAssessment = true;
+      if (e.eventType === "assessment_take_home" && ASSESSMENT_DONE.has(action))
+        activeAssessment = false;
+      if (
+        [
+          "recruiter_screen",
+          "technical_interview",
+          "onsite_final_loop",
+        ].includes(e.eventType)
+      )
+        activeInterview = true;
+      if ([...ORIGIN, "employer_response_received"].includes(e.eventType))
+        awaiting = true;
+      if (["offer_received", "offer_negotiating"].includes(e.eventType))
+        offer = true;
+      if (e.eventType === "application_reopened") {
+        terminal = null;
+        continue;
+      }
+      if (TERMINAL.has(e.eventType)) terminal = e.eventType;
+      else if (
+        terminal &&
+        (milestone || activeAssessment || activeInterview || awaiting || offer)
+      )
+        addWarning(warnings, "terminal_without_reopen", {
+          applicationId: app.id,
+          eventId: e.id,
+        });
+    }
+    const milestoneIds = [...seen].sort(
+      (a, b) => MILESTONE_RANK.get(a) - MILESTONE_RANK.get(b),
+    );
+    if (terminal) endpoint = terminal;
+    else if (offer) endpoint = "offer_negotiating";
+    else if (activeAssessment) endpoint = "assessment_in_progress";
+    else if (activeInterview) endpoint = "interviewing";
+    else if (awaiting) endpoint = "awaiting_response";
+    else endpoint = STATUS_ENDPOINT.get(app.status) ?? "unknown";
+    if (
+      bucket.id === "current" &&
+      STATUS_ENDPOINT.has(app.status) &&
+      STATUS_ENDPOINT.get(app.status) !== endpoint
+    )
+      addWarning(warnings, "status_mismatch", {
+        applicationId: app.id,
+        status: app.status,
+        endpoint,
+      });
+    const nodes = [
+      nodeId("origin", origin),
+      ...milestoneIds.map((m) => nodeId("milestone", m)),
+      nodeId("endpoint", endpoint),
+    ];
+    paths.push({
+      applicationId: app.id,
+      origin: nodeId("origin", origin),
+      milestones: milestoneIds.map((m) => nodeId("milestone", m)),
+      endpoint: nodeId("endpoint", endpoint),
+      nodes,
+      events: appEvents.map((e) => e.id),
+    });
+  }
+  paths.sort((a, b) => codeCompare(a.applicationId, b.applicationId));
+  const linkMap = new Map();
+  for (const p of paths)
+    for (let i = 0; i < p.nodes.length - 1; i += 1) {
+      const source = p.nodes[i],
+        target = p.nodes[i + 1];
+      if (source === target) continue;
+      const id = `${source}->${target}`;
+      const link = linkMap.get(id) ?? {
+        id,
+        source,
+        target,
+        value: 0,
+        applicationIds: [],
+      };
+      link.value += 1;
+      link.applicationIds.push(p.applicationId);
+      linkMap.set(id, link);
+    }
+  const links = [...linkMap.values()]
+    .map((l) => ({
+      ...l,
+      applicationIds: [...new Set(l.applicationIds)].sort(codeCompare),
+    }))
+    .sort((a, b) => codeCompare(a.id, b.id));
+  const makeTotals = (prefix, rows) =>
+    Object.fromEntries(rows.map(([id]) => [nodeId(prefix, id), 0]));
+  const totals = {
+    origins: makeTotals("origin", origins),
+    milestones: makeTotals("milestone", milestones),
+    endpoints: makeTotals("endpoint", endpoints),
+    active: 0,
+    terminal: 0,
+  };
+  for (const p of paths) {
+    totals.origins[p.origin] += 1;
+    for (const m of p.milestones) totals.milestones[m] += 1;
+    totals.endpoints[p.endpoint] += 1;
+    if (TERMINAL.has(p.endpoint.replace("endpoint:", ""))) totals.terminal += 1;
+    else totals.active += 1;
+  }
+  const allNodeIds = new Set([
+    ...Object.keys(totals.origins),
+    ...Object.keys(totals.milestones),
+    ...Object.keys(totals.endpoints),
+  ]);
+  const nodes = [...allNodeIds].sort(codeCompare).map((id) => ({
+    id,
+    value:
+      totals.origins[id] ?? totals.milestones[id] ?? totals.endpoints[id] ?? 0,
+  }));
+  const resultWarnings = warnings.sort((a, b) =>
+    codeCompare(JSON.stringify(a), JSON.stringify(b)),
+  );
+  return deepFreeze({
+    bucket,
+    includedApplications: paths.length,
+    totalApplications: prepared.apps.length,
+    paths,
+    nodes,
+    links,
+    totals,
+    boundaryEvents: selectedEvents.map((e) => e.id).sort(codeCompare),
+    warnings: resultWarnings,
+    warningCounts: countWarnings(resultWarnings),
+  });
+};
+
+const bucketFor = (id) =>
+  id === "current"
+    ? { id: "current", label: "Current" }
+    : id === "unknown-date"
+      ? { id: "unknown-date", label: "Unknown date" }
+      : null;
+
+export const buildLifecycleTimeline = (bundle = {}) => {
+  const prepared = prepare(bundle);
+  const bucketMap = new Map();
+  for (const e of prepared.events) {
+    if (e.temporal.kind === "unknown") continue;
+    const id =
+      e.temporal.kind === "date"
+        ? `date:${e.temporal.date}`
+        : `instant:${e.temporal.instant}`;
+    const b = bucketMap.get(id) ?? {
+      id,
+      kind: e.temporal.kind,
+      date: e.temporal.date,
+      instant: e.temporal.instant,
+      cutoffSort: e.temporal.sort,
+      eventIds: [],
+    };
+    b.eventIds.push(e.id);
+    bucketMap.set(id, b);
+  }
+  const dated = [...bucketMap.values()]
+    .map((b) => ({
+      ...b,
+      eventIds: b.eventIds.sort(codeCompare),
+      label: b.kind === "date" ? `${b.date} (time not recorded)` : b.instant,
+    }))
+    .sort(
+      (a, b) =>
+        codeCompare(a.date, b.date) ||
+        (a.kind === b.kind
+          ? codeCompare(a.cutoffSort, b.cutoffSort)
+          : a.kind === "date"
+            ? -1
+            : 1),
+    );
+  const buckets = [
+    {
+      id: "unknown-date",
+      label: "Unknown date",
+      kind: "unknown",
+      eventIds: prepared.events
+        .filter((e) => e.temporal.kind === "unknown")
+        .map((e) => e.id)
+        .sort(codeCompare),
+    },
+    ...dated,
+    {
+      id: "current",
+      label: "Current",
+      kind: "current",
+      eventIds: prepared.events.map((e) => e.id).sort(codeCompare),
+    },
+  ];
+  return deepFreeze({
+    buckets,
+    warnings: prepared.warnings.sort((a, b) =>
+      codeCompare(JSON.stringify(a), JSON.stringify(b)),
+    ),
+    warningCounts: countWarnings(prepared.warnings),
+  });
+};
+
+export const projectLifecycleAt = (bundle = {}, bucketId = "current") => {
+  const prepared = prepare(bundle);
+  const timeline = buildLifecycleTimeline(bundle);
+  const bucket =
+    timeline.buckets.find((b) => b.id === bucketId) ??
+    bucketFor(bucketId) ??
+    timeline.buckets.at(-1);
+  return projectWithPrepared(prepared, bucket);
+};

--- a/test/web-tracker-lifecycle-projection.test.js
+++ b/test/web-tracker-lifecycle-projection.test.js
@@ -1,0 +1,355 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLifecycleTimeline,
+  LIFECYCLE_DIAGRAM_TAXONOMY,
+  projectLifecycleAt,
+} from "../src/web/tracker/lifecycleProjection.js";
+
+const app = (id, extra = {}) => ({
+  id,
+  company: id,
+  role: "Role",
+  origin: "application_submitted",
+  status: "applied",
+  createdAt: "2025-01-01T00:00:00.000Z",
+  updatedAt: "2025-01-01T00:00:00.000Z",
+  ...extra,
+});
+const ev = (
+  id,
+  applicationId,
+  eventType,
+  occurredAt = "2025-01-01T00:00:00.000Z",
+  extra = {},
+) => ({
+  id,
+  applicationId,
+  eventType,
+  status: "applied",
+  occurredAt,
+  occurredAtPrecision: occurredAt.includes("T") ? "instant" : "date",
+  source: "manual",
+  inferred: false,
+  createdAt: "2025-01-01T00:00:00.000Z",
+  ...extra,
+});
+describe("lifecycle projection", () => {
+  it("exports the exact deeply frozen diagram taxonomy", () => {
+    expect(Object.isFrozen(LIFECYCLE_DIAGRAM_TAXONOMY.origins[0])).toBe(true);
+    expect(LIFECYCLE_DIAGRAM_TAXONOMY.origins.map((x) => x.id)).toEqual([
+      "application_submitted",
+      "recruiter_company_outreach",
+      "candidate_outreach",
+      "referral",
+      "other_unknown",
+    ]);
+    expect(LIFECYCLE_DIAGRAM_TAXONOMY.milestones.map((x) => x.id)).toEqual([
+      "recruiter_screen",
+      "assessment_take_home",
+      "technical_interview",
+      "onsite_final_loop",
+      "offer_received",
+    ]);
+    expect(LIFECYCLE_DIAGRAM_TAXONOMY.endpoints.map((x) => x.id)).toEqual([
+      "awaiting_response",
+      "interviewing",
+      "assessment_in_progress",
+      "offer_negotiating",
+      "employer_rejected",
+      "candidate_withdrew",
+      "offer_declined",
+      "offer_expired_rescinded",
+      "offer_accepted",
+      "closed_archived",
+      "unknown",
+    ]);
+  });
+
+  it("handles empty and single bundles with namespaced nodes and links", () => {
+    expect(projectLifecycleAt()).toMatchObject({
+      includedApplications: 0,
+      totalApplications: 0,
+      links: [],
+    });
+    const result = projectLifecycleAt({
+      applications: [app("a1")],
+      lifecycleEvents: [],
+    });
+    expect(result.paths[0].nodes).toEqual([
+      "origin:application_submitted",
+      "endpoint:awaiting_response",
+    ]);
+    expect(result.links[0]).toEqual({
+      id: "origin:application_submitted->endpoint:awaiting_response",
+      source: "origin:application_submitted",
+      target: "endpoint:awaiting_response",
+      value: 1,
+      applicationIds: ["a1"],
+    });
+  });
+
+  it("covers every origin and endpoint with aggregation by application", () => {
+    const origins = LIFECYCLE_DIAGRAM_TAXONOMY.origins.map((x) => x.id);
+    const endpoints = [
+      "employer_rejected",
+      "candidate_withdrew",
+      "offer_declined",
+      "offer_expired_rescinded",
+      "offer_accepted",
+      "closed_archived",
+      "offer_negotiating",
+      "assessment_in_progress",
+      "interviewing",
+      "awaiting_response",
+      "unknown",
+    ];
+    const applications = endpoints.map((endpoint, index) =>
+      app(`a${index}`, {
+        origin: origins[index % origins.length],
+        status: endpoint === "unknown" ? "mystery" : "applied",
+      }),
+    );
+    const lifecycleEvents = applications.flatMap((a, index) =>
+      endpoints[index] === "unknown"
+        ? []
+        : [
+            ev(
+              `e${index}`,
+              a.id,
+              endpoints[index] === "interviewing"
+                ? "recruiter_screen"
+                : endpoints[index] === "assessment_in_progress"
+                  ? "assessment_take_home"
+                  : endpoints[index] === "awaiting_response"
+                    ? a.origin
+                    : endpoints[index],
+              "2025-01-01T00:00:00.000Z",
+              endpoints[index] === "assessment_in_progress"
+                ? { actionStatus: "in_progress" }
+                : {},
+            ),
+          ],
+    );
+    const result = projectLifecycleAt({ applications, lifecycleEvents });
+    expect(result.includedApplications).toBe(endpoints.length);
+    expect(result.totals.active + result.totals.terminal).toBe(
+      endpoints.length,
+    );
+    for (const endpoint of endpoints)
+      expect(result.totals.endpoints[`endpoint:${endpoint}`]).toBe(1);
+  });
+
+  it(
+    "collapses repeated milestones, avoids skipped-stage invention, and warns on regressions " +
+      "without backward links",
+    () => {
+      const result = projectLifecycleAt({
+        applications: [app("a")],
+        lifecycleEvents: [
+          ev("e1", "a", "technical_interview"),
+          ev("e2", "a", "technical_interview"),
+          ev("e3", "a", "recruiter_screen", "2025-01-02T00:00:00.000Z"),
+        ],
+      });
+      expect(result.paths[0].milestones).toEqual([
+        "milestone:recruiter_screen",
+        "milestone:technical_interview",
+      ]);
+      expect(result.warningCounts.regressive_history).toBe(1);
+      expect(
+        result.links.every(
+          (l) =>
+            !l.id.includes("technical_interview->milestone:recruiter_screen"),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it("implements assessment action-status behavior", () => {
+    expect(
+      projectLifecycleAt({
+        applications: [app("a")],
+        lifecycleEvents: [
+          ev("e", "a", "assessment_take_home", "2025-01-01T00:00:00.000Z", {
+            actionStatus: "pending",
+          }),
+        ],
+      }).paths[0].endpoint,
+    ).toBe("endpoint:assessment_in_progress");
+    expect(
+      projectLifecycleAt({
+        applications: [app("a")],
+        lifecycleEvents: [
+          ev("e", "a", "assessment_take_home", "2025-01-01T00:00:00.000Z", {
+            actionStatus: "submitted",
+          }),
+        ],
+      }).paths[0].endpoint,
+    ).toBe("endpoint:awaiting_response");
+  });
+
+  it(
+    "builds deterministic atomic timeline buckets for equal instants, offsets, " +
+      "inclusive cutoffs, and date-only ordering",
+    () => {
+      const bundle = {
+        applications: [app("a"), app("b")],
+        lifecycleEvents: [
+          ev(
+            "z",
+            "a",
+            "application_submitted",
+            "2025-01-02T01:00:00.000+01:00",
+          ),
+          ev("a", "b", "application_submitted", "2025-01-02T00:00:00.000Z"),
+          ev("d", "a", "recruiter_screen", "2025-01-02", {
+            occurredAtPrecision: "date",
+          }),
+        ],
+      };
+      const timeline = buildLifecycleTimeline(bundle);
+      expect(timeline.buckets.map((b) => b.id)).toEqual([
+        "unknown-date",
+        "date:2025-01-02",
+        "instant:2025-01-02T00:00:00.000Z",
+        "current",
+      ]);
+      expect(timeline.buckets[2].eventIds).toEqual(["a", "z"]);
+      expect(
+        projectLifecycleAt(bundle, "instant:2025-01-02T00:00:00.000Z")
+          .includedApplications,
+      ).toBe(2);
+    },
+  );
+
+  it(
+    "isolates unknown-date, excludes unknown historically, includes it in current, " +
+      "and prevents future leakage",
+    () => {
+      const bundle = {
+        applications: [app("a"), app("b")],
+        lifecycleEvents: [
+          ev("u", "a", "application_submitted", "1970-01-01", {
+            occurredAtPrecision: "unknown",
+          }),
+          ev("d", "b", "application_submitted", "2025-01-01"),
+          ev("f", "b", "offer_accepted", "2025-01-03T00:00:00.000Z"),
+        ],
+      };
+      expect(
+        projectLifecycleAt(bundle, "unknown-date").paths.map(
+          (p) => p.applicationId,
+        ),
+      ).toEqual(["a"]);
+      expect(
+        projectLifecycleAt(bundle, "date:2025-01-01").paths.map(
+          (p) => p.applicationId,
+        ),
+      ).toEqual(["b"]);
+      expect(
+        projectLifecycleAt(bundle, "date:2025-01-01").paths[0].endpoint,
+      ).toBe("endpoint:awaiting_response");
+      expect(projectLifecycleAt(bundle).includedApplications).toBe(2);
+    },
+  );
+
+  it("keeps terminal state until explicit reopen and flags lower-stage activity", () => {
+    const closed = projectLifecycleAt({
+      applications: [app("a")],
+      lifecycleEvents: [
+        ev("r", "a", "employer_rejected"),
+        ev("i", "a", "technical_interview", "2025-01-02T00:00:00.000Z"),
+      ],
+    });
+    expect(closed.paths[0].endpoint).toBe("endpoint:employer_rejected");
+    expect(closed.warningCounts.terminal_without_reopen).toBe(1);
+    const reopened = projectLifecycleAt({
+      applications: [app("a")],
+      lifecycleEvents: [
+        ev("r", "a", "employer_rejected"),
+        ev("o", "a", "application_reopened", "2025-01-02T00:00:00.000Z"),
+        ev("i", "a", "technical_interview", "2025-01-03T00:00:00.000Z"),
+      ],
+    });
+    expect(reopened.paths[0].endpoint).toBe("endpoint:interviewing");
+  });
+
+  it(
+    "reports inferred, status mismatch, invalid, unknown, orphan, and supersession " +
+      "handling",
+    () => {
+      const bundle = {
+        applications: [
+          app("a", { status: "accepted" }),
+          app("b", { status: "accepted" }),
+        ],
+        lifecycleEvents: [
+          ev("old", "a", "employer_rejected"),
+          ev("new", "a", "unknown_weird", "bad", {
+            occurredAtPrecision: "instant",
+            supersedesEventId: "old",
+            inferred: true,
+          }),
+          ev("mismatch", "b", "application_submitted"),
+          ev("orphan", "missing", "application_submitted"),
+        ],
+      };
+      const result = projectLifecycleAt(bundle);
+      expect(result.paths[0].endpoint).toBe("endpoint:offer_accepted");
+      expect(result.warningCounts.inferred_event).toBe(1);
+      expect(result.warningCounts.status_mismatch).toBe(1);
+      expect(result.warningCounts.invalid_timestamp).toBe(1);
+      expect(result.warningCounts.unknown_event_type).toBe(1);
+      expect(result.warningCounts.orphaned_event).toBe(1);
+    },
+  );
+
+  it("is independent of input order and never mutates input or prior results", () => {
+    const bundle = {
+      applications: [app("b"), app("a")],
+      lifecycleEvents: [
+        ev("2", "b", "offer_received"),
+        ev("1", "a", "application_submitted"),
+      ],
+    };
+    const before = JSON.stringify(bundle);
+    const r1 = projectLifecycleAt(bundle);
+    const r2 = projectLifecycleAt({
+      applications: [...bundle.applications].reverse(),
+      lifecycleEvents: [...bundle.lifecycleEvents].reverse(),
+    });
+    expect(r2).toEqual(r1);
+    expect(JSON.stringify(bundle)).toBe(before);
+    expect(() => r1.paths.push({})).toThrow();
+  });
+
+  it("satisfies core graph invariants for a large aggregate fixture", () => {
+    const applications = Array.from({ length: 120 }, (_, i) =>
+      app(`app-${String(i).padStart(3, "0")}`),
+    );
+    const lifecycleEvents = applications.flatMap((a, i) => [
+      ev(`s-${i}`, a.id, "application_submitted"),
+      ...(i % 2 ? [ev(`r-${i}`, a.id, "recruiter_screen")] : []),
+      ...(i % 3 ? [ev(`t-${i}`, a.id, "technical_interview")] : []),
+      ...(i % 5 ? [ev(`o-${i}`, a.id, "offer_received")] : []),
+    ]);
+    const result = projectLifecycleAt({ applications, lifecycleEvents });
+    expect(result.paths).toHaveLength(120);
+    expect(
+      Object.values(result.totals.origins).reduce((a, b) => a + b, 0),
+    ).toBe(120);
+    expect(
+      Object.values(result.totals.endpoints).reduce((a, b) => a + b, 0),
+    ).toBe(120);
+    for (const link of result.links) {
+      expect(Number.isInteger(link.value) && link.value > 0).toBe(true);
+      expect(link.source).not.toBe(link.target);
+      expect(new Set(link.applicationIds).size).toBe(
+        link.applicationIds.length,
+      );
+      expect(link.value).toBe(link.applicationIds.length);
+    }
+    for (const path of result.paths)
+      expect(new Set(path.milestones).size).toBe(path.milestones.length);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a renderer-independent, deterministic projection engine for the future Diagram tab that computes application paths, nodes, links, timeline buckets, endpoints, and structured warnings from a browser tracker bundle.
- Implement the P1/P2 design contract rules: fixed-rank milestones, origin/endpoint taxonomy, supersession/orphan handling, date/instant/unknown bucketing, and deterministic sorting without mutating inputs.

### Description
- Added `src/web/tracker/lifecycleProjection.js` which exports a deeply frozen `LIFECYCLE_DIAGRAM_TAXONOMY`, `buildLifecycleTimeline(bundle = {})`, and `projectLifecycleAt(bundle = {}, bucketId = "current")`, and returns deterministic namespaced node IDs, links, totals, boundary events, warnings, and counts.
- Projection implements canonical event classification reuse, supersession filtering, unknown/orphan detection, date/instant/unknown bucketing rules, fixed milestone collapse, terminal/reopen logic, assessment action-status handling, and stable, de-duplicated link application IDs.
- Results are deep-frozen to prevent mutation and use stable code-point comparisons for determinism, and all outputs preserve invariants required by the design document (conserved flow, positive integer link values, no self/backward links, etc.).
- Added test coverage in `test/web-tracker-lifecycle-projection.test.js` that asserts taxonomy, empty/single bundles, every origin/endpoint, repeated/skipped/regressive milestone behavior, timeline bucketing rules, unknown/current isolation, terminal/reopen semantics, warnings, determinism, immutability, and large-fixture invariants.

### Testing
- Ran `npx vitest run test/web-tracker-lifecycle-projection.test.js` and the new focused suite passed (11 tests passed). 
- Ran repository checks: `npx eslint src/web/tracker/lifecycleProjection.js test/web-tracker-lifecycle-projection.test.js`, `npm run typecheck`, and `npm run test:ci` and they completed successfully in this environment. 
- Ran formatting checks: targeted files pass Prettier after `npx prettier --write`, while `npm run format:check` reports pre-existing formatting warnings across unrelated repository files (these are pre-existing and not introduced by this change). 
- Performed `git diff --check` and committed the two new files; staged/committed changes are ready for review.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52814613a4832f83949174bf11468a)