### PR TITLE
Add static tracker observability smoke checks

### DIFF
--- a/charts/jobbot3000/templates/_helpers.tpl
+++ b/charts/jobbot3000/templates/_helpers.tpl
@@ -21,6 +21,8 @@ app.kubernetes.io/name: {{ include "jobbot3000.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: static-tracker
+app.kubernetes.io/part-of: jobbot3000
 {{- end -}}
 
 {{- define "jobbot3000.selectorLabels" -}}

--- a/charts/jobbot3000/values.yaml
+++ b/charts/jobbot3000/values.yaml
@@ -39,7 +39,13 @@ ingress:
   annotations: {}
   tls: []
 
-resources: {}
+resources:
+  requests:
+    cpu: 25m
+    memory: 32Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
 
 probes:
   readiness:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,47 @@
+# Observability Contract
+
+jobbot3000 production deployments are intentionally observable from the outside in. The server is a static asset and health service; private tracker state remains in browser-owned IndexedDB and is not collected by the server.
+
+## Blackbox signals
+
+Use blackbox checks for the production promotion gate:
+
+- `GET /` returns the static status hub HTML.
+- `GET /tracker` returns the browser-only tracker HTML.
+- `GET /healthz` returns a small `no-store` JSON health response.
+- `GET /livez` returns the same small `no-store` JSON liveness response.
+- `GET /manifest.webmanifest` returns the web manifest.
+- At least one JavaScript or CSS asset referenced by deployed HTML returns successfully.
+
+Invalid health subpaths such as `/healthz/not-real` must fail; the SPA/static fallback must not turn them into probe successes. The read-only promotion smoke writes a JSON summary under `test-results/` with route, status, duration, final URL, content type, and pass/fail only.
+
+## Kubernetes signals
+
+The Helm chart sets conservative default container resources for small nodes and Raspberry Pi-style clusters:
+
+- requests: `25m` CPU and `32Mi` memory;
+- limits: `200m` CPU and `128Mi` memory.
+
+These values are deliberately modest because the container only serves static assets and health JSON. They also make CPU and memory saturation visible to Kubernetes and cluster dashboards instead of leaving pods unbounded. Operators should watch pod restarts, readiness/liveness probe failures, CPU throttling, memory working set, OOM kills, and rollout status.
+
+## Server health vs. IndexedDB journeys
+
+`/healthz` and `/livez` prove only that the container can serve deterministic JSON. They do not prove that a user's browser profile can create, persist, import, export, or clear tracker records. Those workflows happen in IndexedDB after static assets load in the browser.
+
+## Safe staging synthetic tests
+
+Synthetic user journeys are staging-only and must use a fresh browser profile. They may create only clearly synthetic records, verify persistence across reload, export a synthetic JSON or NDJSON backup, and then delete the profile or clear all state. Synthetic record contents must never be emitted into logs, metrics, screenshots, or test summaries; summaries may include only safe route/status/timing/content-type/pass-fail metadata.
+
+Run synthetic mode only against local or staging-style targets:
+
+```sh
+npm run smoke:promotion -- http://127.0.0.1:8080 --synthetic
+```
+
+## Privacy boundaries
+
+Do not add telemetry that collects applications, employers, contacts, compensation, notes, resumes, artifact links, imported files, browser identifiers, local storage contents, IndexedDB contents, or backup payloads. Expected production traffic is static navigation/assets and health checks; browser exports use local `blob:` downloads.
+
+## Why custom server metrics are deferred
+
+Custom server metrics are intentionally deferred because the static production server has no private-data backend, queue, database, or user session model. Blackbox probes plus Kubernetes resource/restart signals provide useful operational coverage without creating a new telemetry surface that could accidentally normalize collection of browser-local tracker data.

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -73,11 +73,15 @@ Secrets, PVCs, logs, repo fixtures, or public object storage.
 4. If data was cleared or replaced locally, restore the last known-good JSON or
    NDJSON backup through the browser UI.
 
+## Observability
+
+See [Observability Contract](observability.md) for blackbox promotion checks, Kubernetes resource signals, staging-only synthetic journeys, and privacy boundaries.
+
 ## Verification checklist
 
 - `npm ci`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, and
   `npm run build` pass.
-- Container smoke covers `/`, `/tracker`, `/healthz`, and `/livez`.
+- Read-only promotion smoke covers `/`, `/tracker`, `/healthz`, `/livez`, the web manifest, and a referenced JS/CSS asset.
 - Helm lint/template tests confirm probes, image repository, and no user-data PVC
   or Secret defaults.
 - No real data appears in fixtures, chart values, `.env`, Docker context, or

--- a/docs/staging-tracker-verification.md
+++ b/docs/staging-tracker-verification.md
@@ -1,13 +1,13 @@
 # Static Tracker Staging Verification Checklist
 
-Use this checklist after deploying a staging image or chart update for the browser-only tracker. Use only anonymized fixtures or private local backups; never commit real backups, screenshots, application notes, company names, candidate names, private URLs, or artifact links.
+Use this checklist after deploying a staging image or chart update for the browser-only tracker. The [observability contract](observability.md) defines safe blackbox checks and staging-only synthetic journeys. Use only anonymized fixtures or private local backups; never commit real backups, screenshots, application notes, company names, candidate names, private URLs, or artifact links.
 
 ## Deploy and smoke-check staging
 
 1. Deploy staging with the intended immutable image tag.
 2. Open `/` and confirm the static browser-only landing page loads.
 3. Open `/tracker` and confirm the tracker loads without a login or server-backed data prompt.
-4. Check `/healthz` and `/livez`; both should return healthy static responses.
+4. Check `/healthz` and `/livez`; both should return healthy `no-store` JSON static responses, and invalid health subpaths must not pass via the SPA fallback.
 5. Confirm build metadata is visible in the tracker footer/header area and identifies `static/browser-only` mode.
 
 ## Compact CSV import and dashboard sanity

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "postinstall": "node scripts/install-console-font.js",
     "build": "node scripts/build-static.js",
     "start:static": "node scripts/static-server.js",
-    "smoke:container": "bash scripts/smoke-container.sh"
+    "smoke:container": "bash scripts/smoke-container.sh",
+    "smoke:promotion": "node scripts/promotion-smoke.js"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/promotion-smoke.js
+++ b/scripts/promotion-smoke.js
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { chromium } from "playwright";
+
+const args = process.argv.slice(2);
+const baseUrlArg = args.find((arg) => !arg.startsWith("--"));
+const synthetic = args.includes("--synthetic");
+const outDir = path.resolve("test-results");
+const startedAt = new Date().toISOString();
+
+if (!baseUrlArg) {
+  console.error("Usage: node scripts/promotion-smoke.js <base-url> [--synthetic]");
+  process.exit(2);
+}
+
+const baseUrl = new URL(baseUrlArg);
+baseUrl.pathname = baseUrl.pathname.replace(/\/$/, "");
+baseUrl.search = "";
+baseUrl.hash = "";
+
+const summary = {
+  mode: synthetic ? "staging-synthetic" : "readonly",
+  startedAt,
+  baseUrl: baseUrl.toString(),
+  checks: [],
+  synthetic: synthetic
+    ? { isolatedProfile: true, cleanedUp: false, exportedBackup: false }
+    : undefined,
+};
+
+const safeRoute = (url) => {
+  const parsed = new URL(url);
+  return `${parsed.pathname}${parsed.search}`;
+};
+
+async function record(route, fn) {
+  const start = performance.now();
+  const entry = { route, pass: false };
+  try {
+    const result = await fn();
+    Object.assign(entry, result);
+    entry.pass = true;
+  } catch (error) {
+    entry.error = error.message;
+  } finally {
+    entry.durationMs = Math.round(performance.now() - start);
+    summary.checks.push(entry);
+  }
+  if (!entry.pass) throw new Error(`${route}: ${entry.error}`);
+  return entry;
+}
+
+async function responseCheck(
+  request,
+  route,
+  predicate = () => true,
+  { requireOk = true } = {},
+) {
+  return await record(route, async () => {
+    const response = await request.get(new URL(route, baseUrl).toString(), {
+      maxRedirects: 2,
+    });
+    const headers = response.headers();
+    const finalUrl = response.url();
+    const status = response.status();
+    const contentType = headers["content-type"] ?? "";
+    const result = { status, contentType, finalUrl: safeRoute(finalUrl) };
+    if (requireOk && !response.ok()) throw new Error(`HTTP ${status}`);
+    await predicate({ response, headers, status, contentType, finalUrl });
+    return result;
+  });
+}
+
+let userDataDir;
+let context;
+try {
+  await fs.mkdir(outDir, { recursive: true });
+  userDataDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "jobbot-smoke-profile-"),
+  );
+  context = await chromium.launchPersistentContext(userDataDir, {
+    headless: true,
+    acceptDownloads: true,
+  });
+  const page = await context.newPage();
+  const request = context.request;
+
+  await responseCheck(request, "/", async ({ contentType }) => {
+    if (!contentType.includes("text/html")) throw new Error("root is not HTML");
+  });
+  await responseCheck(request, "/tracker", async ({ contentType }) => {
+    if (!contentType.includes("text/html")) throw new Error("tracker is not HTML");
+  });
+  for (const route of ["/healthz", "/livez"]) {
+    await responseCheck(
+      request,
+      route,
+      async ({ response, headers, contentType }) => {
+        if (!contentType.includes("application/json"))
+          throw new Error("health is not JSON");
+        if (!headers["cache-control"]?.includes("no-store"))
+          throw new Error("health is cacheable");
+        const body = await response.json();
+        if (body.status !== "ok" || body.persistence !== "browser-indexeddb")
+          throw new Error("unexpected health body");
+      },
+    );
+  }
+  await responseCheck(
+    request,
+    "/healthz/not-real",
+    async ({ status, contentType }) => {
+      if (status !== 404) throw new Error(`expected HTTP 404, got ${status}`);
+      if (contentType.includes("application/json"))
+        throw new Error("invalid health path returned JSON");
+    },
+    { requireOk: false },
+  );
+  await responseCheck(request, "/manifest.webmanifest", async ({ contentType }) => {
+    if (
+      !contentType.includes("manifest") &&
+      !contentType.includes("json")
+    ) {
+      throw new Error("manifest content type mismatch");
+    }
+  });
+
+  await page.goto(baseUrl.toString(), { waitUntil: "domcontentloaded" });
+  const assetPath = await page
+    .locator('link[rel="stylesheet"][href], script[src]')
+    .first()
+    .evaluate((el) => el.getAttribute("href") || el.getAttribute("src"));
+  if (!assetPath) throw new Error("No JS or CSS asset reference found");
+  await responseCheck(request, assetPath, async ({ contentType }) => {
+    if (!/(javascript|css)/.test(contentType))
+      throw new Error("asset content type mismatch");
+  });
+
+  if (synthetic) {
+    await record("/tracker#synthetic-journey", async () => {
+      await page.goto(new URL("/tracker", baseUrl).toString(), {
+        waitUntil: "domcontentloaded",
+      });
+      await page.getByRole("button", { name: "Applications" }).click();
+      await page.getByRole("button", { name: "New application" }).click();
+      await page.locator('[name="company"]').fill(`Synthetic Smoke ${Date.now()}`);
+      await page.locator('[name="role"]').fill("Synthetic Browser Persistence Check");
+      await page.locator('[name="appliedAt"]').fill("2026-01-01");
+      await page
+        .getByRole("textbox", { name: "Notes", exact: true })
+        .fill("Synthetic staging-only smoke record; no private data.");
+      await page.getByRole("button", { name: "Save application" }).click();
+      await page.reload({ waitUntil: "domcontentloaded" });
+      await page.getByRole("button", { name: "Applications" }).click();
+      const rows = await page.locator("[data-applications-table] tbody tr").count();
+      if (rows < 1) throw new Error("synthetic record did not persist after reload");
+      const downloadPromise = page.waitForEvent("download");
+      await page.getByRole("button", { name: "Import/Export" }).click();
+      await page.locator('[data-export="json"]').first().click();
+      const download = await downloadPromise;
+      await download.saveAs(
+        path.join(outDir, "promotion-smoke-synthetic-backup.json"),
+      );
+      summary.synthetic.exportedBackup = true;
+      return {
+        status: 200,
+        contentType: "browser/indexeddb",
+        finalUrl: "/tracker",
+      };
+    });
+  }
+} finally {
+  if (context) await context.close();
+  if (userDataDir) {
+    await fs.rm(userDataDir, { recursive: true, force: true });
+    if (summary.synthetic) summary.synthetic.cleanedUp = true;
+  }
+  summary.finishedAt = new Date().toISOString();
+  summary.pass =
+    summary.checks.every((check) => check.pass) &&
+    (!summary.synthetic || summary.synthetic.cleanedUp);
+  await fs.mkdir(outDir, { recursive: true });
+  await fs.writeFile(
+    path.join(outDir, `promotion-smoke-${summary.mode}.json`),
+    `${JSON.stringify(summary, null, 2)}\n`,
+  );
+}
+
+process.exit(summary.pass ? 0 : 1);

--- a/scripts/promotion-smoke.js
+++ b/scripts/promotion-smoke.js
@@ -192,12 +192,16 @@ async function runReadonlyChecks() {
     },
     { requireOk: false },
   );
-  await responseCheck("/manifest.webmanifest", async ({ response, contentType }) => {
+  await responseCheck("/manifest.webmanifest", async ({ response, contentType, finalUrl }) => {
     if (!contentType.includes("manifest") && !contentType.includes("json")) {
       throw fail("MANIFEST_CONTENT_TYPE_MISMATCH");
     }
     const manifest = await response.json();
     if (!manifest.name || !manifest.start_url) throw fail("MANIFEST_JSON_MISMATCH");
+    const manifestStartUrl = new URL(manifest.start_url, finalUrl);
+    if (!pathWithinExpectedBase(manifestStartUrl)) {
+      throw fail("MANIFEST_START_URL_ESCAPED_BASE_PATH");
+    }
   });
 
   await record("asset-reference", async () => {

--- a/scripts/promotion-smoke.js
+++ b/scripts/promotion-smoke.js
@@ -2,7 +2,6 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { chromium } from "playwright";
 
 const args = process.argv.slice(2);
 const baseUrlArg = args.find((arg) => !arg.startsWith("--"));
@@ -15,12 +14,15 @@ if (!baseUrlArg) {
   process.exit(2);
 }
 
+const normalizeDirectoryPath = (pathname) =>
+  pathname === "/" ? "/" : `${pathname.replace(/\/$/, "")}/`;
+
 const baseUrl = new URL(baseUrlArg);
 baseUrl.search = "";
 baseUrl.hash = "";
-const basePath = baseUrl.pathname.replace(/\/$/, "");
-const baseDirectoryUrl = new URL(baseUrl.toString());
-baseDirectoryUrl.pathname = `${basePath}/`;
+baseUrl.pathname = normalizeDirectoryPath(baseUrl.pathname);
+const expectedBasePath = baseUrl.pathname;
+const baseOrigin = baseUrl.origin;
 
 if (
   synthetic &&
@@ -36,28 +38,48 @@ if (
 const summary = {
   mode: synthetic ? "staging-synthetic" : "readonly",
   startedAt,
-  baseUrl: baseUrl.toString(),
+  baseUrl: `${baseOrigin}${expectedBasePath}`,
   checks: [],
   synthetic: synthetic
-    ? { isolatedProfile: true, cleanedUp: false, exportedBackup: false }
+    ? {
+        isolatedProfile: true,
+        cleanedUp: false,
+        exportedBackup: false,
+        cleanupCode: undefined,
+      }
     : undefined,
 };
 
-let topLevelFailure = false;
-let topLevelFailureMessage = "";
+let topLevelFailureCode = "";
+let pageDocumentUrl = "";
 
-const safeRoute = (url) => {
+const safeFinalUrl = (url) => {
   const parsed = new URL(url);
-  return `${parsed.pathname}${parsed.search}`;
+  return `${parsed.origin}${parsed.pathname}`;
+};
+
+const pathWithinExpectedBase = (url) => {
+  const parsed = new URL(url);
+  return (
+    parsed.origin === baseOrigin &&
+    (parsed.pathname === expectedBasePath.replace(/\/$/, "") ||
+      parsed.pathname.startsWith(expectedBasePath))
+  );
 };
 
 const resolveSmokeUrl = (route) => {
   if (route.startsWith("/")) {
     const url = new URL(baseUrl.toString());
-    url.pathname = `${basePath}${route}`;
+    url.pathname = `${expectedBasePath.replace(/\/$/, "")}${route}`;
     return url;
   }
-  return new URL(route, baseDirectoryUrl);
+  return new URL(route, pageDocumentUrl || baseUrl.toString());
+};
+
+const fail = (code) => {
+  const error = new Error(code);
+  error.smokeCode = code;
+  return error;
 };
 
 async function record(route, fn) {
@@ -69,125 +91,145 @@ async function record(route, fn) {
     entry.pass = true;
   } catch (error) {
     if (error.smokeMeta) Object.assign(entry, error.smokeMeta);
+    entry.code = error.smokeCode || "SMOKE_STEP_FAILED";
   } finally {
     entry.durationMs = Math.round(performance.now() - start);
     summary.checks.push(entry);
   }
-  if (!entry.pass) throw new Error(route);
+  if (!entry.pass) throw fail(entry.code);
   return entry;
 }
 
+async function fetchWithRedirects(url) {
+  let current = new URL(url);
+  for (let redirect = 0; redirect <= 2; redirect += 1) {
+    const response = await fetch(current, { redirect: "manual" });
+    if (![301, 302, 303, 307, 308].includes(response.status)) {
+      return response;
+    }
+    const location = response.headers.get("location");
+    if (!location) throw fail("REDIRECT_WITHOUT_LOCATION");
+    current = new URL(location, current);
+    if (!pathWithinExpectedBase(current)) throw fail("REDIRECT_ESCAPED_BASE_PATH");
+  }
+  throw fail("TOO_MANY_REDIRECTS");
+}
+
 async function responseCheck(
-  request,
   route,
   predicate = () => true,
-  { requireOk = true } = {},
+  { requireOk = true, documentUrl = false } = {},
 ) {
   return await record(route, async () => {
-    const response = await request.get(resolveSmokeUrl(route).toString(), {
-      maxRedirects: 2,
-    });
-    const headers = response.headers();
-    const finalUrl = response.url();
-    const status = response.status();
-    const contentType = headers["content-type"] ?? "";
-    const result = { status, contentType, finalUrl: safeRoute(finalUrl) };
+    const response = await fetchWithRedirects(resolveSmokeUrl(route));
+    const finalUrl = response.url;
+    const status = response.status;
+    const contentType = response.headers.get("content-type") ?? "";
+    const result = { status, contentType, finalUrl: safeFinalUrl(finalUrl) };
     const throwWithMeta = (error) => {
       error.smokeMeta = result;
       throw error;
     };
-    if (requireOk && !response.ok()) throwWithMeta(new Error(`HTTP ${status}`));
+    if (!pathWithinExpectedBase(finalUrl)) throwWithMeta(fail("FINAL_URL_ESCAPED_BASE_PATH"));
+    if (requireOk && !response.ok) throwWithMeta(fail("HTTP_NOT_OK"));
     try {
-      await predicate({ response, headers, status, contentType, finalUrl });
+      await predicate({ response, headers: response.headers, status, contentType, finalUrl });
     } catch (error) {
-      throwWithMeta(error);
+      throwWithMeta(error.smokeCode ? error : fail("RESPONSE_CONTRACT_FAILED"));
     }
+    if (documentUrl) pageDocumentUrl = finalUrl;
     return result;
   });
 }
 
-let userDataDir;
-let context;
-try {
-  await fs.mkdir(outDir, { recursive: true });
-  userDataDir = await fs.mkdtemp(
-    path.join(os.tmpdir(), "jobbot-smoke-profile-"),
-  );
-  context = await chromium.launchPersistentContext(userDataDir, {
-    headless: true,
-    acceptDownloads: true,
-  });
-  const page = await context.newPage();
-  const request = context.request;
+async function textIncludes(response, markers) {
+  const body = await response.text();
+  for (const marker of markers) {
+    if (!body.includes(marker)) throw fail("HTML_MARKER_MISSING");
+  }
+  return body;
+}
 
-  await responseCheck(request, "/", async ({ contentType }) => {
-    if (!contentType.includes("text/html")) throw new Error("root is not HTML");
-  });
-  await responseCheck(request, "/tracker", async ({ contentType }) => {
-    if (!contentType.includes("text/html")) throw new Error("tracker is not HTML");
+async function runReadonlyChecks() {
+  let rootHtml = "";
+  await responseCheck(
+    "/",
+    async ({ response, contentType }) => {
+      if (!contentType.includes("text/html")) throw fail("HTML_CONTENT_TYPE_MISMATCH");
+      rootHtml = await textIncludes(response, [
+        "Browser-only application tracker",
+        "static/browser-only",
+      ]);
+    },
+    { documentUrl: true },
+  );
+  await responseCheck("/tracker", async ({ response, contentType }) => {
+    if (!contentType.includes("text/html")) throw fail("HTML_CONTENT_TYPE_MISMATCH");
+    await textIncludes(response, ["Application tracker", "jobbot-build-metadata"]);
   });
   for (const route of ["/healthz", "/livez"]) {
-    await responseCheck(
-      request,
-      route,
-      async ({ response, headers, contentType }) => {
-        if (!contentType.includes("application/json"))
-          throw new Error("health is not JSON");
-        if (!headers["cache-control"]?.includes("no-store"))
-          throw new Error("health is cacheable");
-        const body = await response.json();
-        if (body.status !== "ok" || body.persistence !== "browser-indexeddb")
-          throw new Error("unexpected health body");
-      },
-    );
+    await responseCheck(route, async ({ response, headers, contentType }) => {
+      if (!contentType.includes("application/json")) throw fail("HEALTH_CONTENT_TYPE_MISMATCH");
+      if (headers.get("cache-control") !== "no-store") throw fail("HEALTH_CACHE_CONTROL_MISMATCH");
+      const body = await response.json();
+      if (
+        JSON.stringify(body) !==
+        JSON.stringify({ status: "ok", mode: "static", persistence: "browser-indexeddb" })
+      ) {
+        throw fail("HEALTH_JSON_MISMATCH");
+      }
+    });
   }
   await responseCheck(
-    request,
     "/healthz/not-real",
-    async ({ status, contentType }) => {
-      if (status !== 404) throw new Error(`expected HTTP 404, got ${status}`);
-      if (contentType.includes("application/json"))
-        throw new Error("invalid health path returned JSON");
+    async ({ response, status, contentType }) => {
+      if (status !== 404) throw fail("INVALID_HEALTH_STATUS_MISMATCH");
+      if (contentType.includes("application/json")) throw fail("INVALID_HEALTH_JSON_FALLBACK");
+      const body = await response.text();
+      if (body.includes('"persistence":"browser-indexeddb"')) {
+        throw fail("INVALID_HEALTH_BODY_FALLBACK");
+      }
     },
     { requireOk: false },
   );
-  await responseCheck(request, "/manifest.webmanifest", async ({ contentType }) => {
-    if (
-      !contentType.includes("manifest") &&
-      !contentType.includes("json")
-    ) {
-      throw new Error("manifest content type mismatch");
+  await responseCheck("/manifest.webmanifest", async ({ response, contentType }) => {
+    if (!contentType.includes("manifest") && !contentType.includes("json")) {
+      throw fail("MANIFEST_CONTENT_TYPE_MISMATCH");
     }
+    const manifest = await response.json();
+    if (!manifest.name || !manifest.start_url) throw fail("MANIFEST_JSON_MISMATCH");
   });
 
-  await page.goto(baseDirectoryUrl.toString(), { waitUntil: "domcontentloaded" });
-  let assetPath;
   await record("asset-reference", async () => {
-    const value = await page
-      .locator('link[rel="stylesheet"][href], script[src]')
-      .first()
-      .evaluate((el) => el.getAttribute("href") || el.getAttribute("src"));
-    if (!value) throw new Error("No JS or CSS asset reference found");
-    assetPath = value;
-    return {
-      status: 200,
-      contentType: "text/html",
-      finalUrl: safeRoute(page.url()),
-    };
+    const match = rootHtml.match(/<(?:link|script)[^>]+(?:href|src)=["']([^"']+)["']/i);
+    if (!match) throw fail("ASSET_REFERENCE_MISSING");
+    return { status: 200, contentType: "text/html", finalUrl: safeFinalUrl(pageDocumentUrl) };
   });
-  await responseCheck(request, assetPath, async ({ contentType }) => {
-    if (!/(javascript|css)/.test(contentType))
-      throw new Error("asset content type mismatch");
+  const assetPath = rootHtml.match(/<(?:link|script)[^>]+(?:href|src)=["']([^"']+)["']/i)?.[1];
+  await responseCheck(assetPath, async ({ contentType }) => {
+    if (!/(javascript|css)/.test(contentType)) throw fail("ASSET_CONTENT_TYPE_MISMATCH");
   });
+}
 
-  if (synthetic) {
+async function runSyntheticChecks() {
+  const { chromium } = await import("playwright");
+  const userDataDir = await fs.mkdtemp(path.join(os.tmpdir(), "jobbot-smoke-profile-"));
+  const backupPath = path.join(userDataDir, "promotion-smoke-synthetic-backup.json");
+  let context;
+  const uniqueCompany = `Synthetic Smoke ${crypto.randomUUID()}`;
+  try {
+    context = await chromium.launchPersistentContext(userDataDir, {
+      headless: true,
+      acceptDownloads: true,
+    });
+    const page = await context.newPage();
     await record("/tracker#synthetic-journey", async () => {
       await page.goto(resolveSmokeUrl("/tracker").toString(), {
         waitUntil: "domcontentloaded",
       });
-      await page.getByRole("button", { name: "Applications" }).click();
+      await page.getByRole("button", { name: "Applications", exact: true }).click();
       await page.getByRole("button", { name: "New application" }).click();
-      await page.locator('[name="company"]').fill(`Synthetic Smoke ${Date.now()}`);
+      await page.locator('[name="company"]').fill(uniqueCompany);
       await page.locator('[name="role"]').fill("Synthetic Browser Persistence Check");
       await page.locator('[name="appliedAt"]').fill("2026-01-01");
       await page
@@ -195,38 +237,58 @@ try {
         .fill("Synthetic staging-only smoke record; no private data.");
       await page.getByRole("button", { name: "Save application" }).click();
       await page.reload({ waitUntil: "domcontentloaded" });
-      await page.getByRole("button", { name: "Applications" }).click();
-      const rows = await page.locator("[data-applications-table] tbody tr").count();
-      if (rows < 1) throw new Error("synthetic record did not persist after reload");
-      const downloadPromise = page.waitForEvent("download");
+      await page.getByRole("button", { name: "Applications", exact: true }).click();
+      const row = page.locator("[data-applications-table] tbody tr", {
+        hasText: uniqueCompany,
+      });
+      await row.waitFor({ state: "visible", timeout: 5000 });
+      if ((await row.count()) !== 1) throw fail("SYNTHETIC_RECORD_MISSING");
       await page.getByRole("button", { name: "Import/Export" }).click();
-      await page.locator('[data-export="json"]').first().click();
+      const downloadPromise = page.waitForEvent("download");
+      await page.getByRole("button", { name: "Backup now" }).click();
       const download = await downloadPromise;
-      await download.saveAs(
-        path.join(outDir, "promotion-smoke-synthetic-backup.json"),
-      );
+      await download.saveAs(backupPath);
+      const backup = JSON.parse(await fs.readFile(backupPath, "utf8"));
+      if (!Array.isArray(backup.applications)) throw fail("SYNTHETIC_BACKUP_SCHEMA_MISMATCH");
+      if (!backup.applications.some((app) => app.company === uniqueCompany)) {
+        throw fail("SYNTHETIC_BACKUP_RECORD_MISSING");
+      }
+      await fs.rm(backupPath, { force: true });
       summary.synthetic.exportedBackup = true;
-      return {
-        status: 200,
-        contentType: "browser/indexeddb",
-        finalUrl: "/tracker",
-      };
+      return { status: 200, contentType: "browser/indexeddb", finalUrl: safeFinalUrl(page.url()) };
     });
+  } finally {
+    try {
+      if (context) await context.close();
+    } catch {
+      summary.synthetic.cleanupCode = "CONTEXT_CLOSE_FAILED";
+    }
+    try {
+      await fs.rm(backupPath, { force: true });
+      await fs.rm(userDataDir, { recursive: true, force: true });
+      summary.synthetic.cleanedUp = true;
+    } catch {
+      summary.synthetic.cleanedUp = false;
+      summary.synthetic.cleanupCode = summary.synthetic.cleanupCode || "PROFILE_DELETE_FAILED";
+    }
   }
+}
+
+try {
+  await fs.mkdir(outDir, { recursive: true });
+  await runReadonlyChecks();
+  if (synthetic) await runSyntheticChecks();
 } catch (error) {
-  topLevelFailure = true;
-  topLevelFailureMessage = error.message;
+  topLevelFailureCode = error.smokeCode || "SMOKE_FAILED";
 } finally {
-  if (context) await context.close();
-  if (userDataDir) {
-    await fs.rm(userDataDir, { recursive: true, force: true });
-    if (summary.synthetic) summary.synthetic.cleanedUp = true;
-  }
   summary.finishedAt = new Date().toISOString();
   summary.pass =
-    !topLevelFailure &&
+    !topLevelFailureCode &&
     summary.checks.every((check) => check.pass) &&
-    (!summary.synthetic || summary.synthetic.cleanedUp);
+    (!summary.synthetic || (summary.synthetic.cleanedUp && !summary.synthetic.cleanupCode));
+  if (topLevelFailureCode && !summary.checks.some((check) => !check.pass)) {
+    summary.checks.push({ route: "smoke", pass: false, code: topLevelFailureCode, durationMs: 0 });
+  }
   await fs.mkdir(outDir, { recursive: true });
   await fs.writeFile(
     path.join(outDir, `promotion-smoke-${summary.mode}.json`),
@@ -234,7 +296,7 @@ try {
   );
 }
 
-if (topLevelFailureMessage) {
-  console.error(`Promotion smoke failed: ${topLevelFailureMessage}`);
+if (topLevelFailureCode) {
+  console.error(`Promotion smoke failed: ${topLevelFailureCode}`);
 }
 process.exit(summary.pass ? 0 : 1);

--- a/scripts/promotion-smoke.js
+++ b/scripts/promotion-smoke.js
@@ -16,9 +16,22 @@ if (!baseUrlArg) {
 }
 
 const baseUrl = new URL(baseUrlArg);
-baseUrl.pathname = baseUrl.pathname.replace(/\/$/, "");
 baseUrl.search = "";
 baseUrl.hash = "";
+const basePath = baseUrl.pathname.replace(/\/$/, "");
+const baseDirectoryUrl = new URL(baseUrl.toString());
+baseDirectoryUrl.pathname = `${basePath}/`;
+
+if (
+  synthetic &&
+  process.env.JOBBOT_ALLOW_SYNTHETIC_PROMOTION !== "1" &&
+  !["localhost", "127.0.0.1", "::1"].includes(baseUrl.hostname)
+) {
+  console.error(
+    "Refusing --synthetic against a non-local host without JOBBOT_ALLOW_SYNTHETIC_PROMOTION=1.",
+  );
+  process.exit(2);
+}
 
 const summary = {
   mode: synthetic ? "staging-synthetic" : "readonly",
@@ -30,9 +43,21 @@ const summary = {
     : undefined,
 };
 
+let topLevelFailure = false;
+let topLevelFailureMessage = "";
+
 const safeRoute = (url) => {
   const parsed = new URL(url);
   return `${parsed.pathname}${parsed.search}`;
+};
+
+const resolveSmokeUrl = (route) => {
+  if (route.startsWith("/")) {
+    const url = new URL(baseUrl.toString());
+    url.pathname = `${basePath}${route}`;
+    return url;
+  }
+  return new URL(route, baseDirectoryUrl);
 };
 
 async function record(route, fn) {
@@ -43,12 +68,12 @@ async function record(route, fn) {
     Object.assign(entry, result);
     entry.pass = true;
   } catch (error) {
-    entry.error = error.message;
+    if (error.smokeMeta) Object.assign(entry, error.smokeMeta);
   } finally {
     entry.durationMs = Math.round(performance.now() - start);
     summary.checks.push(entry);
   }
-  if (!entry.pass) throw new Error(`${route}: ${entry.error}`);
+  if (!entry.pass) throw new Error(route);
   return entry;
 }
 
@@ -59,7 +84,7 @@ async function responseCheck(
   { requireOk = true } = {},
 ) {
   return await record(route, async () => {
-    const response = await request.get(new URL(route, baseUrl).toString(), {
+    const response = await request.get(resolveSmokeUrl(route).toString(), {
       maxRedirects: 2,
     });
     const headers = response.headers();
@@ -67,8 +92,16 @@ async function responseCheck(
     const status = response.status();
     const contentType = headers["content-type"] ?? "";
     const result = { status, contentType, finalUrl: safeRoute(finalUrl) };
-    if (requireOk && !response.ok()) throw new Error(`HTTP ${status}`);
-    await predicate({ response, headers, status, contentType, finalUrl });
+    const throwWithMeta = (error) => {
+      error.smokeMeta = result;
+      throw error;
+    };
+    if (requireOk && !response.ok()) throwWithMeta(new Error(`HTTP ${status}`));
+    try {
+      await predicate({ response, headers, status, contentType, finalUrl });
+    } catch (error) {
+      throwWithMeta(error);
+    }
     return result;
   });
 }
@@ -127,12 +160,21 @@ try {
     }
   });
 
-  await page.goto(baseUrl.toString(), { waitUntil: "domcontentloaded" });
-  const assetPath = await page
-    .locator('link[rel="stylesheet"][href], script[src]')
-    .first()
-    .evaluate((el) => el.getAttribute("href") || el.getAttribute("src"));
-  if (!assetPath) throw new Error("No JS or CSS asset reference found");
+  await page.goto(baseDirectoryUrl.toString(), { waitUntil: "domcontentloaded" });
+  let assetPath;
+  await record("asset-reference", async () => {
+    const value = await page
+      .locator('link[rel="stylesheet"][href], script[src]')
+      .first()
+      .evaluate((el) => el.getAttribute("href") || el.getAttribute("src"));
+    if (!value) throw new Error("No JS or CSS asset reference found");
+    assetPath = value;
+    return {
+      status: 200,
+      contentType: "text/html",
+      finalUrl: safeRoute(page.url()),
+    };
+  });
   await responseCheck(request, assetPath, async ({ contentType }) => {
     if (!/(javascript|css)/.test(contentType))
       throw new Error("asset content type mismatch");
@@ -140,7 +182,7 @@ try {
 
   if (synthetic) {
     await record("/tracker#synthetic-journey", async () => {
-      await page.goto(new URL("/tracker", baseUrl).toString(), {
+      await page.goto(resolveSmokeUrl("/tracker").toString(), {
         waitUntil: "domcontentloaded",
       });
       await page.getByRole("button", { name: "Applications" }).click();
@@ -171,6 +213,9 @@ try {
       };
     });
   }
+} catch (error) {
+  topLevelFailure = true;
+  topLevelFailureMessage = error.message;
 } finally {
   if (context) await context.close();
   if (userDataDir) {
@@ -179,6 +224,7 @@ try {
   }
   summary.finishedAt = new Date().toISOString();
   summary.pass =
+    !topLevelFailure &&
     summary.checks.every((check) => check.pass) &&
     (!summary.synthetic || summary.synthetic.cleanedUp);
   await fs.mkdir(outDir, { recursive: true });
@@ -188,4 +234,7 @@ try {
   );
 }
 
+if (topLevelFailureMessage) {
+  console.error(`Promotion smoke failed: ${topLevelFailureMessage}`);
+}
 process.exit(summary.pass ? 0 : 1);

--- a/scripts/smoke-container.sh
+++ b/scripts/smoke-container.sh
@@ -31,6 +31,4 @@ for _ in $(seq 1 30); do
 done
 
 test "${ready}" = 1
-curl -fsS "http://127.0.0.1:${port}/" >/dev/null
-curl -fsS "http://127.0.0.1:${port}/healthz" >/dev/null
-curl -fsS "http://127.0.0.1:${port}/livez" >/dev/null
+npm run smoke:promotion -- "http://127.0.0.1:${port}/"

--- a/scripts/static-server.js
+++ b/scripts/static-server.js
@@ -68,6 +68,7 @@ app.use((req, res, next) => {
 const health = (_req, res) =>
   res
     .status(200)
+    .set("Cache-Control", "no-store")
     .json({ status: "ok", mode: "static", persistence: "browser-indexeddb" });
 app.get("/healthz", health);
 app.get("/livez", health);

--- a/test/helm-chart-contract.test.js
+++ b/test/helm-chart-contract.test.js
@@ -22,6 +22,11 @@ describe("Helm chart production contract", () => {
     expect(values).toContain("readOnlyRootFilesystem: true");
     expect(deployment).toContain("JOBBOT_WEB_PORT");
     expect(deployment).not.toContain("persistentVolumeClaim");
+    expect(values).toContain("cpu: 25m");
+    expect(values).toContain("memory: 32Mi");
+    expect(values).toContain("cpu: 200m");
+    expect(values).toContain("memory: 128Mi");
+    expect(deployment).toContain("resources:");
   });
 
   it("does not define PVCs or user-data Secrets by default", async () => {
@@ -30,11 +35,14 @@ describe("Helm chart production contract", () => {
       read("charts/jobbot3000/templates/service.yaml"),
       read("charts/jobbot3000/templates/ingress.yaml"),
       read("scripts/validate-helm.sh"),
+      read("charts/jobbot3000/templates/_helpers.tpl"),
     ]);
     const combined = chartFiles.join("\n");
     expect(combined).not.toMatch(/kind:\s*PersistentVolumeClaim/);
     expect(combined).not.toMatch(/kind:\s*Secret/);
     expect(combined).toContain("helm lint");
+    expect(combined).toContain("app.kubernetes.io/component: static-tracker");
+    expect(combined).toContain("app.kubernetes.io/part-of: jobbot3000");
     expect(combined).toContain("--set image.tag=main-TESTSHA");
     expect(combined).toContain(
       "--set ingress.host=jobbot3000.staging.example.test",

--- a/test/playwright/static-smoke.spec.js
+++ b/test/playwright/static-smoke.spec.js
@@ -133,6 +133,7 @@ test.describe("static tracker smoke", () => {
   }) => {
     const health = await page.request.get(`${baseUrl}/healthz`);
     expect(health.ok()).toBe(true);
+    expect(health.headers()["cache-control"]).toContain("no-store");
     await expect(health.json()).resolves.toEqual({
       status: "ok",
       mode: "static",
@@ -141,6 +142,11 @@ test.describe("static tracker smoke", () => {
 
     const live = await page.request.get(`${baseUrl}/livez`);
     expect(live.ok()).toBe(true);
+    expect(live.headers()["cache-control"]).toContain("no-store");
+
+    const invalidHealth = await page.request.get(`${baseUrl}/healthz/not-real`);
+    expect(invalidHealth.status()).toBe(404);
+    expect(invalidHealth.headers()["content-type"]).not.toContain("application/json");
 
     await page.goto(baseUrl);
     await expect(

--- a/test/web-deployment.test.js
+++ b/test/web-deployment.test.js
@@ -1,10 +1,98 @@
+import http from "node:http";
+import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { readFile } from "node:fs/promises";
+import { readFile, rm } from "node:fs/promises";
 import { describe, it, expect } from "vitest";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, "..");
+
+function runPromotionSmoke(baseUrl) {
+  return new Promise((resolve) => {
+    const child = spawn("node", ["scripts/promotion-smoke.js", baseUrl], {
+      cwd: repoRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => { stdout += chunk; });
+    child.stderr.on("data", (chunk) => { stderr += chunk; });
+    child.on("close", (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+function startPrefixedSmokeServer({
+  badInvalidHealth = false,
+  badTrackerRedirect = false,
+} = {}) {
+  const rootHtml = [
+    "<!doctype html><h1>Browser-only application tracker</h1>",
+    '<p>static/browser-only</p><link rel="stylesheet" href="assets/app.css">',
+  ].join("");
+  const trackerHtml = [
+    "<!doctype html><h1>Application tracker</h1>",
+    '<script id="jobbot-build-metadata" type="application/json">{}</script>',
+  ].join("");
+  const health = JSON.stringify({
+    status: "ok",
+    mode: "static",
+    persistence: "browser-indexeddb",
+  });
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url, "http://127.0.0.1");
+    if (badTrackerRedirect && url.pathname === "/jobbot/tracker") {
+      res.writeHead(302, { location: "/login?token=secret" });
+      res.end();
+      return;
+    }
+    if (url.pathname === "/jobbot/" || url.pathname === "/jobbot") {
+      res.writeHead(200, { "content-type": "text/html" });
+      res.end(rootHtml);
+      return;
+    }
+    if (url.pathname === "/jobbot/tracker") {
+      res.writeHead(200, { "content-type": "text/html" });
+      res.end(trackerHtml);
+      return;
+    }
+    if (["/jobbot/healthz", "/jobbot/livez"].includes(url.pathname)) {
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "cache-control": "no-store",
+      });
+      res.end(health);
+      return;
+    }
+    if (url.pathname === "/jobbot/healthz/not-real") {
+      res.writeHead(404, { "content-type": badInvalidHealth ? "application/json" : "text/html" });
+      res.end(badInvalidHealth ? health : "not found");
+      return;
+    }
+    if (url.pathname === "/jobbot/manifest.webmanifest") {
+      res.writeHead(200, { "content-type": "application/manifest+json" });
+      res.end(JSON.stringify({ name: "jobbot3000", start_url: "/tracker" }));
+      return;
+    }
+    if (url.pathname === "/jobbot/assets/app.css") {
+      res.writeHead(200, { "content-type": "text/css" });
+      res.end("body{}");
+      return;
+    }
+    res.writeHead(404, { "content-type": "text/html" });
+    res.end("not found");
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      resolve({
+        baseUrl: `http://127.0.0.1:${address.port}/jobbot/?private=secret#frag`,
+        close: () => new Promise((done) => server.close(done)),
+      });
+    });
+  });
+}
+
 
 describe("web deployment artifacts", () => {
   it("ships a Dockerfile for the web server", async () => {
@@ -112,11 +200,22 @@ describe("web deployment artifacts", () => {
       "utf8",
     );
     expect(promotionSmoke).toContain("const resolveSmokeUrl = (route) =>");
-    expect(promotionSmoke).toContain("`${basePath}${route}`");
-    expect(promotionSmoke).toContain("JOBBOT_ALLOW_SYNTHETIC_PROMOTION");
-    expect(promotionSmoke).toContain("topLevelFailure");
-    expect(promotionSmoke).toContain("error.smokeMeta");
+    expect(promotionSmoke).toContain("expectedBasePath");
+    expect(promotionSmoke).toContain("pathWithinExpectedBase");
+    expect(promotionSmoke).toContain("REDIRECT_ESCAPED_BASE_PATH");
+    expect(promotionSmoke).toContain("INVALID_HEALTH_BODY_FALLBACK");
+    expect(promotionSmoke).toContain("topLevelFailureCode");
+    expect(promotionSmoke).toContain("await import(\"playwright\")");
+    expect(promotionSmoke).not.toContain("import { chromium } from \"playwright\"");
     expect(promotionSmoke).not.toContain("entry.error");
+    expect(promotionSmoke).not.toContain("error.message");
+
+    const smokeContainer = await readFile(
+      path.join(repoRoot, "scripts", "smoke-container.sh"),
+      "utf8",
+    );
+    expect(smokeContainer).toContain("npm run smoke:promotion --");
+    expect(smokeContainer).not.toContain("--synthetic");
 
     const staticServer = await readFile(
       path.join(repoRoot, "scripts", "static-server.js"),
@@ -146,6 +245,90 @@ describe("web deployment artifacts", () => {
     expect(staticServer).not.toMatch(
       /JOBBOT_(GREENHOUSE|LEVER|SMARTRECRUITERS|WORKABLE).*TOKEN/,
     );
+  });
+
+
+
+  it("runs promotion smoke safely against path-prefixed deployments", async () => {
+    await rm(
+      path.join(repoRoot, "test-results", "promotion-smoke-readonly.json"),
+      { force: true },
+    );
+    const server = await startPrefixedSmokeServer();
+    try {
+      const result = await runPromotionSmoke(server.baseUrl);
+      expect(result).toMatchObject({ code: 0 });
+      const summary = JSON.parse(
+        await readFile(
+          path.join(repoRoot, "test-results", "promotion-smoke-readonly.json"),
+          "utf8",
+        ),
+      );
+      expect(summary.pass).toBe(true);
+      expect(summary.baseUrl).toMatch(/\/jobbot\/$/);
+      expect(summary.baseUrl).not.toContain("private=secret");
+      expect(summary.checks.map((check) => check.finalUrl).filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/\/jobbot\/$/),
+          expect.stringMatching(/\/jobbot\/tracker$/),
+          expect.stringMatching(/\/jobbot\/assets\/app\.css$/),
+        ]),
+      );
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("writes failed privacy-safe summaries for bad smoke responses", async () => {
+    await rm(
+      path.join(repoRoot, "test-results", "promotion-smoke-readonly.json"),
+      { force: true },
+    );
+    const invalidHealthServer = await startPrefixedSmokeServer({ badInvalidHealth: true });
+    try {
+      const result = await runPromotionSmoke(invalidHealthServer.baseUrl);
+      expect(result.code).toBe(1);
+      expect(result.stderr).toContain("Promotion smoke failed:");
+      const summaryText = await readFile(
+        path.join(repoRoot, "test-results", "promotion-smoke-readonly.json"),
+        "utf8",
+      );
+      expect(summaryText).not.toContain("private=secret");
+      expect(summaryText).not.toContain("Synthetic Smoke");
+      expect(summaryText).not.toContain("Error:");
+      const summary = JSON.parse(summaryText);
+      expect(summary.pass).toBe(false);
+      expect(
+        summary.checks.some(
+          (check) => check.code === "INVALID_HEALTH_JSON_FALLBACK",
+        ),
+      ).toBe(true);
+    } finally {
+      await invalidHealthServer.close();
+    }
+
+    const redirectServer = await startPrefixedSmokeServer({
+      badTrackerRedirect: true,
+    });
+    try {
+      const result = await runPromotionSmoke(redirectServer.baseUrl);
+      expect(result.code).toBe(1);
+      const summary = JSON.parse(
+        await readFile(
+          path.join(repoRoot, "test-results", "promotion-smoke-readonly.json"),
+          "utf8",
+        ),
+      );
+      expect(summary.pass).toBe(false);
+      expect(
+        summary.checks.some(
+          (check) => check.code === "REDIRECT_ESCAPED_BASE_PATH",
+        ),
+      ).toBe(true);
+      expect(JSON.stringify(summary)).not.toContain("token=secret");
+    } finally {
+      await redirectServer.close();
+    }
   });
 
   it("documents static privacy boundaries and IndexedDB backup guidance", async () => {

--- a/test/web-deployment.test.js
+++ b/test/web-deployment.test.js
@@ -25,6 +25,7 @@ function runPromotionSmoke(baseUrl) {
 function startPrefixedSmokeServer({
   badInvalidHealth = false,
   badTrackerRedirect = false,
+  badManifestStartUrl = false,
 } = {}) {
   const rootHtml = [
     "<!doctype html><h1>Browser-only application tracker</h1>",
@@ -71,7 +72,10 @@ function startPrefixedSmokeServer({
     }
     if (url.pathname === "/jobbot/manifest.webmanifest") {
       res.writeHead(200, { "content-type": "application/manifest+json" });
-      res.end(JSON.stringify({ name: "jobbot3000", start_url: "/tracker" }));
+      res.end(JSON.stringify({
+        name: "jobbot3000",
+        start_url: badManifestStartUrl ? "/tracker" : "/jobbot/tracker",
+      }));
       return;
     }
     if (url.pathname === "/jobbot/assets/app.css") {
@@ -329,6 +333,29 @@ describe("web deployment artifacts", () => {
     } finally {
       await redirectServer.close();
     }
+
+    const manifestServer = await startPrefixedSmokeServer({
+      badManifestStartUrl: true,
+    });
+    try {
+      const result = await runPromotionSmoke(manifestServer.baseUrl);
+      expect(result.code).toBe(1);
+      const summaryText = await readFile(
+        path.join(repoRoot, "test-results", "promotion-smoke-readonly.json"),
+        "utf8",
+      );
+      expect(summaryText).not.toContain("private=secret");
+      const summary = JSON.parse(summaryText);
+      expect(summary.pass).toBe(false);
+      expect(
+        summary.checks.some(
+          (check) => check.code === "MANIFEST_START_URL_ESCAPED_BASE_PATH",
+        ),
+      ).toBe(true);
+    } finally {
+      await manifestServer.close();
+    }
+
   });
 
   it("documents static privacy boundaries and IndexedDB backup guidance", async () => {

--- a/test/web-deployment.test.js
+++ b/test/web-deployment.test.js
@@ -103,6 +103,9 @@ describe("web deployment artifacts", () => {
     expect(packageJson.scripts["smoke:container"]).toBe(
       "bash scripts/smoke-container.sh",
     );
+    expect(packageJson.scripts["smoke:promotion"]).toBe(
+      "node scripts/promotion-smoke.js",
+    );
 
     const staticServer = await readFile(
       path.join(repoRoot, "scripts", "static-server.js"),
@@ -121,8 +124,9 @@ describe("web deployment artifacts", () => {
       'app.get("/manifest.webmanifest", sendNoStoreFile("manifest.webmanifest"))',
     );
     expect(staticServer).toContain(
-      'res.setHeader("Cache-Control", "no-store")',
+      '.set("Cache-Control", "no-store")',
     );
+    expect(staticServer).toContain('res.setHeader("Cache-Control", "no-store")');
     expect(staticServer).not.toContain("immutable");
     expect(staticServer).toContain("Content-Security-Policy");
     expect(staticServer).not.toContain("/commands");

--- a/test/web-deployment.test.js
+++ b/test/web-deployment.test.js
@@ -107,6 +107,17 @@ describe("web deployment artifacts", () => {
       "node scripts/promotion-smoke.js",
     );
 
+    const promotionSmoke = await readFile(
+      path.join(repoRoot, "scripts", "promotion-smoke.js"),
+      "utf8",
+    );
+    expect(promotionSmoke).toContain("const resolveSmokeUrl = (route) =>");
+    expect(promotionSmoke).toContain("`${basePath}${route}`");
+    expect(promotionSmoke).toContain("JOBBOT_ALLOW_SYNTHETIC_PROMOTION");
+    expect(promotionSmoke).toContain("topLevelFailure");
+    expect(promotionSmoke).toContain("error.smokeMeta");
+    expect(promotionSmoke).not.toContain("entry.error");
+
     const staticServer = await readFile(
       path.join(repoRoot, "scripts", "static-server.js"),
       "utf8",


### PR DESCRIPTION
### Motivation

- Provide a production-appropriate observability contract for the browser-first static tracker that keeps private tracker data in browser-owned IndexedDB and avoids server-side telemetry of user data.
- Ensure health endpoints are deterministic and cannot be satisfied by the SPA fallback so probes and promotion gates are reliable.
- Add a read-only promotion smoke and an explicit staging-only synthetic journey to validate blackbox signals and IndexedDB persistence without leaking private records.
- Supply conservative Helm resource defaults and standard Kubernetes labels so cluster-level saturation and restart signals are visible by default.

### Description

- Added a Playwright-driven promotion smoke CLI at `scripts/promotion-smoke.js` that accepts a base URL, performs read-only checks for `/`, `/tracker`, `/healthz`, `/livez`, `/manifest.webmanifest`, and at least one HTML-referenced JS/CSS asset, verifies invalid health subpaths fail, and writes a safe machine-readable JSON summary to `test-results/` containing route, status, duration, final URL, content type, and pass/fail only.
- Added a staging-only `--synthetic` mode to the promotion smoke that uses a fresh persistent browser profile, creates clearly synthetic records, verifies persistence across reload, exports a synthetic JSON backup into `test-results/`, and removes the profile; synthetic contents are never emitted into logs, metrics, screenshots, or the summary (summary contains only safe metadata).
- Hardened the static server responses to be deterministic/no-store by setting `Cache-Control: no-store` on the health endpoints in `scripts/static-server.js`, and preserved the browser-first IndexedDB persistence contract.
- Added conservative Helm defaults in `charts/jobbot3000/values.yaml` (requests: `25m` CPU / `32Mi` memory; limits: `200m` CPU / `128Mi` memory) and added standard labels in `charts/jobbot3000/templates/_helpers.tpl` (`app.kubernetes.io/component: static-tracker` and `app.kubernetes.io/part-of: jobbot3000`).
- Added `docs/observability.md` describing blackbox signals, Kubernetes resource/restart signals, the difference between server health and IndexedDB user journeys, safe staging synthetic tests, privacy boundaries, and rationale for deferring custom server metrics; linked it from `docs/production-readiness.md` and `docs/staging-tracker-verification.md`.
- Registered `smoke:promotion` in `package.json` and updated Playwright/Vitest smoke tests to assert `no-store` on health, invalid-health-path 404 behavior, smoke script presence, and Helm resource/label expectations.
- Files changed (high-level): `scripts/promotion-smoke.js`, `scripts/static-server.js`, `charts/jobbot3000/values.yaml`, `charts/jobbot3000/templates/_helpers.tpl`, `docs/observability.md`, updates to `docs/production-readiness.md` and `docs/staging-tracker-verification.md`, small test updates and `package.json` script registration.

### Testing

- Ran lint: `npm run lint` — passed.
- Ran full CI unit suite: `npm run test:ci` — passed (Vitest run completed; all tests passed in this environment: 1079/1079 tests shown passing in the run output).
- Ran focused unit tests: `npx vitest run test/helm-chart-contract.test.js test/web-deployment.test.js` — passed.
- Ran Playwright static smoke: `PLAYWRIGHT_BROWSERS_PATH=.cache/ms-playwright npx playwright test test/playwright/static-smoke.spec.js` — passed.
- Built static assets and started a local static server: `npm run build` and `HOST=127.0.0.1 PORT=8080 node scripts/static-server.js` and then ran the read-only promotion smoke: `PLAYWRIGHT_BROWSERS_PATH=.cache/ms-playwright npm run smoke:promotion -- http://127.0.0.1:8080` — passed.
- Ran the staging synthetic promotion smoke: `PLAYWRIGHT_BROWSERS_PATH=.cache/ms-playwright npm run smoke:promotion -- http://127.0.0.1:8080 --synthetic` — passed and exported a synthetic backup to `test-results/` while cleaning up the browser profile; summary JSON written to `test-results/promotion-smoke-staging-synthetic.json` (safe fields only).
- Helm and Docker checks: `helm lint`/`helm template` and `docker build` could not be executed in this environment because `helm` and `docker` binary were not available, so those specific commands were not run here (blocked by missing tooling).

Notes and safety

- No server-side collection of applications, employers, contacts, compensation, notes, resumes, or browser identifiers was added; the smoke synthetic mode keeps synthetic data confined to a disposable browser profile and writes only a safe metadata summary to disk.
- Chosen resource defaults: requests `cpu: 25m`, `memory: 32Mi`; limits `cpu: 200m`, `memory: 128Mi`; rationale documented in `docs/observability.md` as Pi-friendly conservative defaults for a static asset/health service.
- All commands run and test outputs are recorded in the run transcript; `helm` and `docker` checks are marked as not-run due to environment limits and should be executed in CI or an operator environment with those tools available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52c17a80b4832fb28d8d654f9eaa6f)