### PR TITLE
Add static tracker observability smoke checks

### DIFF
--- a/charts/jobbot3000/templates/deployment.yaml
+++ b/charts/jobbot3000/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         {{- with .Values.podLabels }}
 {{- toYaml . | nindent 8 }}
         {{- end }}
-{{- include "jobbot3000.selectorLabels" . | nindent 8 }}
+{{- include "jobbot3000.labels" . | nindent 8 }}
       {{- with .Values.podAnnotations }}
       annotations:
 {{- toYaml . | nindent 8 }}

--- a/charts/jobbot3000/values.yaml
+++ b/charts/jobbot3000/values.yaml
@@ -39,7 +39,13 @@ ingress:
   annotations: {}
   tls: []
 
-resources: {}
+resources:
+  requests:
+    cpu: 25m
+    memory: 32Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
 
 probes:
   readiness:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,59 @@
+# Static tracker observability contract
+
+jobbot3000 production is a static asset and health service. Private tracker state stays in the user's browser-owned IndexedDB database; observability must prove the deployment can serve the app without collecting applications, employers, contacts, compensation, notes, resumes, browser identifiers, or backup contents.
+
+## Blackbox signals
+
+Monitor the deployment from outside the pod with read-only probes:
+
+- `/` returns the static landing page.
+- `/tracker` returns the browser tracker shell.
+- `/healthz` returns small `no-store` JSON for readiness.
+- `/livez` returns small `no-store` JSON for liveness.
+- `/manifest.webmanifest` returns the web manifest.
+- At least one JavaScript or CSS asset referenced by deployed HTML returns successfully.
+
+Health endpoints are exact routes and must not be satisfied by the SPA or 404 fallback. Treat any invalid health subpath such as `/healthz/invalid` as a failure if it returns health JSON or a 2xx status.
+
+Run the read-only smoke with:
+
+```sh
+npm run smoke:promotion -- https://jobbot3000.example.test
+```
+
+The command writes a safe machine-readable summary under `test-results/` containing only route, status, duration, final URL, content type, and pass/fail metadata.
+
+## Kubernetes resource and restart signals
+
+The Helm chart sets conservative Pi-friendly defaults so schedulers and dashboards can reason about saturation:
+
+- requests: `25m` CPU and `32Mi` memory;
+- limits: `200m` CPU and `128Mi` memory.
+
+Watch Kubernetes-native signals rather than private app data: pod readiness, liveness failures, restart counts, CPU throttling, memory working set, OOM kills, deployment rollout status, image pull failures, and ingress/load-balancer 4xx/5xx rates.
+
+## Server health versus IndexedDB user journeys
+
+`/healthz` and `/livez` prove only that the static server process can answer deterministic JSON without touching user data. They do not prove that a user's browser can create, persist, export, or restore IndexedDB records.
+
+IndexedDB journeys are browser-local and profile-specific. A server-side metric cannot see them without violating the browser-first architecture, so journey checks must run in a controlled browser profile with synthetic data only.
+
+## Safe staging synthetic tests
+
+Synthetic journey mode is for local or staging-style targets only:
+
+```sh
+npm run smoke:synthetic -- https://staging-jobbot3000.example.test
+```
+
+This mode uses a fresh browser profile, creates clearly synthetic records, verifies persistence across reload, exports a synthetic JSON backup, and deletes the browser profile afterward. Logs, JSON summaries, metrics, and screenshots must never include synthetic record contents; only safe route/status/timing metadata is emitted.
+
+Do not run synthetic mode against a real user's production browser profile. Production promotion smoke remains read-only.
+
+## Privacy boundaries
+
+Do not add telemetry, server logs, metrics labels, traces, screenshots, support bundles, Helm values, ConfigMaps, Secrets, or persistent volumes containing applications, employers, contacts, compensation, notes, resumes, artifact links, browser identifiers, or backup contents. Expected production traffic is static navigation/assets, manifest requests, and health checks.
+
+## Why custom server metrics are deferred
+
+Custom metrics are intentionally deferred because the current production server has no private state and only serves static files plus health JSON. Kubernetes, ingress, container runtime, and blackbox probes already cover the useful server-side failure modes. Adding application-specific server metrics now would create privacy and maintenance risk without improving visibility into browser-owned IndexedDB journeys.

--- a/docs/privacy-and-security.md
+++ b/docs/privacy-and-security.md
@@ -2,6 +2,8 @@
 
 The production tracker is a static, browser-only application. The container or server serves HTML, CSS, JavaScript, the web manifest, and health endpoints; private tracker records are stored in the user's browser IndexedDB database named `jobbot3000`.
 
+See [Static tracker observability contract](observability.md) for blackbox smoke checks, resource signals, synthetic staging journeys, and telemetry privacy boundaries.
+
 ## What stays in IndexedDB
 
 The browser tracker stores applications, contacts, outreach messages, lifecycle events, interviews, offers, artifact links, reminders, and tracker settings in IndexedDB. Imported CSV contents are parsed in the browser and written directly to IndexedDB only after the user chooses **Apply import**.

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -4,6 +4,8 @@ jobbot3000 production mode is a static, browser-local application tracker. The
 container serves HTML, CSS, JavaScript, the web manifest, and health endpoints on
 port `8080`; tracker records are stored only in the user's browser IndexedDB.
 
+See [Static tracker observability contract](observability.md) for blackbox smoke checks, resource signals, synthetic staging journeys, and telemetry privacy boundaries.
+
 ## Architecture summary
 
 - Public deployment surface: `/`, `/tracker`, `/healthz`, `/livez`, and static

--- a/docs/staging-tracker-verification.md
+++ b/docs/staging-tracker-verification.md
@@ -2,6 +2,8 @@
 
 Use this checklist after deploying a staging image or chart update for the browser-only tracker. Use only anonymized fixtures or private local backups; never commit real backups, screenshots, application notes, company names, candidate names, private URLs, or artifact links.
 
+See [Static tracker observability contract](observability.md) for blackbox smoke checks, resource signals, synthetic staging journeys, and telemetry privacy boundaries.
+
 ## Deploy and smoke-check staging
 
 1. Deploy staging with the intended immutable image tag.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "postinstall": "node scripts/install-console-font.js",
     "build": "node scripts/build-static.js",
     "start:static": "node scripts/static-server.js",
-    "smoke:container": "bash scripts/smoke-container.sh"
+    "smoke:container": "bash scripts/smoke-container.sh",
+    "smoke:promotion": "node scripts/promotion-smoke.js",
+    "smoke:synthetic": "node scripts/promotion-smoke.js --synthetic"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/promotion-smoke.js
+++ b/scripts/promotion-smoke.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { chromium } from "@playwright/test";
+
+const args = process.argv.slice(2);
+const baseUrlArg = args.find((arg) => !arg.startsWith("--"));
+const synthetic = args.includes("--synthetic");
+const baseUrl = new URL(
+  baseUrlArg ?? process.env.JOBBOT_SMOKE_BASE_URL ?? "http://127.0.0.1:8080",
+);
+const startedAt = Date.now();
+const results = [];
+
+function routeUrl(route) {
+  return new URL(route, baseUrl).toString();
+}
+async function check(route, expectJson = false) {
+  const start = Date.now();
+  let entry = {
+    route,
+    status: 0,
+    durationMs: 0,
+    finalUrl: routeUrl(route),
+    contentType: "",
+    ok: false,
+  };
+  try {
+    const response = await fetch(routeUrl(route), { redirect: "follow" });
+    const text = await response.text();
+    entry = {
+      route,
+      status: response.status,
+      durationMs: Date.now() - start,
+      finalUrl: response.url,
+      contentType: response.headers.get("content-type") ?? "",
+      ok: response.ok,
+    };
+    if (expectJson) {
+      const json = JSON.parse(text);
+      entry.ok =
+        entry.ok &&
+        entry.contentType.includes("application/json") &&
+        json.status === "ok" &&
+        json.persistence === "browser-indexeddb";
+    }
+  } catch (error) {
+    entry.durationMs = Date.now() - start;
+    entry.error = error.name;
+  }
+  results.push(entry);
+  return entry;
+}
+
+await fs.mkdir("test-results", { recursive: true });
+await check("/");
+const rootHtml = await (await fetch(routeUrl("/"))).text();
+await check("/tracker");
+await check("/healthz", true);
+await check("/livez", true);
+await check("/manifest.webmanifest");
+const invalid = await check("/healthz/invalid");
+invalid.ok =
+  invalid.status === 404 && !invalid.contentType.includes("application/json");
+const assetMatch = rootHtml.match(/(?:href|src)=["']([^"']+\.(?:js|css))["']/i);
+if (assetMatch) await check(assetMatch[1]);
+else {
+  results.push({
+    route: "referenced-asset",
+    status: 0,
+    durationMs: 0,
+    finalUrl: "",
+    contentType: "",
+    ok: false,
+    error: "missing_asset_reference",
+  });
+}
+
+if (synthetic) {
+  const userDataDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "jobbot3000-synthetic-"),
+  );
+  const route = "/tracker#synthetic-journey";
+  const start = Date.now();
+  let ok = false;
+  try {
+    const context = await chromium.launchPersistentContext(userDataDir, {
+      headless: true,
+      acceptDownloads: true,
+    });
+    const page = await context.newPage();
+    await page.goto(routeUrl("/tracker"));
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "New application" }).click();
+    await page.locator('input[name="company"]').fill("Synthetic Smoke Company");
+    await page.locator('input[name="role"]').fill("Synthetic Smoke Role");
+    await page
+      .locator('textarea[name="notes"]')
+      .fill("Synthetic staging smoke only");
+    await page.getByRole("button", { name: "Save application" }).click();
+    await page.reload();
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    const persisted = await page
+      .getByText("Synthetic Smoke Company")
+      .isVisible();
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Backup now JSON" }).first().click();
+    const download = await downloadPromise;
+    const backupPath = path.join(
+      "test-results",
+      `synthetic-backup-${Date.now()}.json`,
+    );
+    await download.saveAs(backupPath);
+    ok = persisted;
+    await context.close();
+  } finally {
+    await fs.rm(userDataDir, { recursive: true, force: true });
+  }
+  results.push({
+    route,
+    status: ok ? 200 : 500,
+    durationMs: Date.now() - start,
+    finalUrl: routeUrl("/tracker"),
+    contentType: "text/html",
+    ok,
+  });
+}
+
+const summary = {
+  baseUrl: baseUrl.toString(),
+  mode: synthetic ? "staging-synthetic" : "production-read-only",
+  startedAt: new Date(startedAt).toISOString(),
+  durationMs: Date.now() - startedAt,
+  checks: results,
+  ok: results.every((r) => r.ok),
+};
+const summaryPath = path.join(
+  "test-results",
+  `promotion-smoke-${synthetic ? "synthetic" : "readonly"}.json`,
+);
+await fs.writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+console.log(`promotion smoke summary: ${summaryPath}`);
+if (!summary.ok) process.exit(1);

--- a/scripts/static-server.js
+++ b/scripts/static-server.js
@@ -65,10 +65,12 @@ app.use((req, res, next) => {
   next();
 });
 
-const health = (_req, res) =>
+const health = (_req, res) => {
+  res.setHeader("Cache-Control", "no-store");
   res
     .status(200)
     .json({ status: "ok", mode: "static", persistence: "browser-indexeddb" });
+};
 app.get("/healthz", health);
 app.get("/livez", health);
 app.get("/health", health);

--- a/test/helm-chart-contract.test.js
+++ b/test/helm-chart-contract.test.js
@@ -20,6 +20,11 @@ describe("Helm chart production contract", () => {
     expect(values).toContain("path: /healthz");
     expect(values).toContain("path: /livez");
     expect(values).toContain("readOnlyRootFilesystem: true");
+    expect(values).toContain("cpu: 25m");
+    expect(values).toContain("memory: 32Mi");
+    expect(values).toContain("cpu: 200m");
+    expect(values).toContain("memory: 128Mi");
+    expect(deployment).toContain('include "jobbot3000.labels"');
     expect(deployment).toContain("JOBBOT_WEB_PORT");
     expect(deployment).not.toContain("persistentVolumeClaim");
   });

--- a/test/web-deployment.test.js
+++ b/test/web-deployment.test.js
@@ -103,6 +103,12 @@ describe("web deployment artifacts", () => {
     expect(packageJson.scripts["smoke:container"]).toBe(
       "bash scripts/smoke-container.sh",
     );
+    expect(packageJson.scripts["smoke:promotion"]).toBe(
+      "node scripts/promotion-smoke.js",
+    );
+    expect(packageJson.scripts["smoke:synthetic"]).toBe(
+      "node scripts/promotion-smoke.js --synthetic",
+    );
 
     const staticServer = await readFile(
       path.join(repoRoot, "scripts", "static-server.js"),


### PR DESCRIPTION
### Motivation
- Provide a production-appropriate observability contract for the browser-first static tracker while preserving the privacy boundary that all user tracker data remains in browser-owned IndexedDB.
- Ensure promotion checks are read-only by default and add a staging-only synthetic journey mode that can verify browser persistence without emitting private record contents.
- Make the Helm chart render conservative Pi-friendly resource requests/limits so cluster schedulers and dashboards can perform saturation analysis.

### Description
- Added a promotion smoke utility `scripts/promotion-smoke.js` and two npm scripts `smoke:promotion` (read-only) and `smoke:synthetic` (staging-only) that check `/`, `/tracker`, `/healthz`, `/livez`, `/manifest.webmanifest`, at least one referenced JS/CSS asset, and ensure invalid health subpaths cannot be satisfied by the SPA fallback; the tool writes a machine-readable summary to `test-results/` with only safe fields. (new: `scripts/promotion-smoke.js`, `package.json` updates)
- Tightened health endpoint behavior and caching by setting `Cache-Control: no-store` on `/healthz` and `/livez` and kept the static SPA fallback/404 behaviour intact. (`scripts/static-server.js`)
- Added conservative Helm resource defaults in `charts/jobbot3000/values.yaml` with requests `cpu: 25m`, `memory: 32Mi` and limits `cpu: 200m`, `memory: 128Mi`, and ensured pod templates include standard chart labels via existing helper conventions so labels render in the Deployment template. (`charts/jobbot3000/values.yaml`, `charts/jobbot3000/templates/deployment.yaml`)
- Documented the observability contract in `docs/observability.md` and added links to it from `docs/production-readiness.md`, `docs/staging-tracker-verification.md`, and `docs/privacy-and-security.md` describing blackbox signals, k8s signals, server health vs. IndexedDB journeys, safe staging synthetic tests, privacy boundaries, and rationale for deferring server-side custom metrics.
- Updated unit/contract tests to expect the new smoke scripts and Helm values so the repo contract validates the additions. (`test/web-deployment.test.js`, `test/helm-chart-contract.test.js`)

### Testing
- `npm run lint` — passed.
- `npm run test:ci` — passed.
- `npx playwright install chromium` — run successfully to provide browsers for Playwright.
- `npx playwright test test/playwright/static-smoke.spec.js test/playwright/browser-tracker.spec.js` — passed after installing Chromium.
- Local promotion smoke against a running static server: built static files and launched `scripts/static-server.js`, then ran `npm run smoke:promotion -- http://127.0.0.1:8099` and `npm run smoke:synthetic -- http://127.0.0.1:8099`; both wrote safe summaries to `test-results/` (files like `promotion-smoke-readonly.json` and `promotion-smoke-synthetic.json`) and completed successfully.
- `helm lint` / `helm template` — not run here because `helm` is not installed in this environment (`helm: command not found`).
- Repo hygiene checks `git diff --check` and `git diff | ./scripts/scan-secrets.py` — passed.

Files changed (high level): `scripts/promotion-smoke.js`, `scripts/static-server.js`, `package.json`, `charts/jobbot3000/values.yaml`, `charts/jobbot3000/templates/deployment.yaml`, `docs/observability.md`, updates to `docs/production-readiness.md`, `docs/staging-tracker-verification.md`, `docs/privacy-and-security.md`, and small test updates under `test/` to validate the contract.

Notes and residual risks
- Synthetic mode uses a fresh browser profile, creates only synthetic records, verifies persistence and exports a JSON backup, then removes the profile; the script is implemented to avoid emitting any synthetic record contents into logs or the summary file, but reviewers should confirm the environment running synthetic mode has no shared browser profile or external backup sinks.
- Helm checks should be run in CI or a developer environment with `helm` installed to validate rendered templates end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52c1805418832f9798bfa0b2c8bd03)