### PR TITLE
Add static tracker observability smoke checks

### DIFF
--- a/charts/jobbot3000/templates/_helpers.tpl
+++ b/charts/jobbot3000/templates/_helpers.tpl
@@ -21,6 +21,8 @@ app.kubernetes.io/name: {{ include "jobbot3000.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: static-tracker
+app.kubernetes.io/part-of: jobbot3000
 {{- end -}}
 
 {{- define "jobbot3000.selectorLabels" -}}

--- a/charts/jobbot3000/templates/deployment.yaml
+++ b/charts/jobbot3000/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         {{- with .Values.podLabels }}
 {{- toYaml . | nindent 8 }}
         {{- end }}
-{{- include "jobbot3000.selectorLabels" . | nindent 8 }}
+{{- include "jobbot3000.labels" . | nindent 8 }}
       {{- with .Values.podAnnotations }}
       annotations:
 {{- toYaml . | nindent 8 }}

--- a/charts/jobbot3000/values.yaml
+++ b/charts/jobbot3000/values.yaml
@@ -39,7 +39,15 @@ ingress:
   annotations: {}
   tls: []
 
-resources: {}
+# Defaults are intentionally Pi-friendly for the static asset + health server:
+# low enough for small Sugarkube nodes, non-empty for saturation/restart analysis.
+resources:
+  requests:
+    cpu: 25m
+    memory: 32Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
 
 probes:
   readiness:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,53 @@
+# Observability contract
+
+jobbot3000 production is a static asset and health service for a browser-first tracker. Private application records remain in the user's browser-owned IndexedDB database; observability must not collect applications, employers, contacts, compensation, notes, resumes, artifact links, imported files, or browser identifiers.
+
+## Blackbox signals
+
+Use blackbox checks from outside the pod or through the deployed ingress:
+
+- `GET /` returns the static status hub HTML.
+- `GET /tracker` returns the tracker HTML.
+- `GET /healthz` returns a small `no-store` JSON response for readiness-style checks.
+- `GET /livez` returns a small `no-store` JSON response for liveness-style checks.
+- `GET /manifest.webmanifest` returns the web manifest.
+- At least one JavaScript or CSS asset referenced by deployed HTML returns successfully.
+
+The promotion smoke command is read-only by default:
+
+```sh
+npm run smoke:promotion -- https://jobbot3000.example.test
+```
+
+It writes a machine-readable summary under `test-results/` with safe fields only: route, status, duration, final URL, content type, and pass/fail. Health paths must be exact endpoint routes; an invalid health-like path must not be treated as healthy just because the SPA can render HTML.
+
+## Kubernetes resource and restart signals
+
+The Helm chart sets conservative default resources for the static Node server:
+
+- requests: `25m` CPU and `32Mi` memory;
+- limits: `200m` CPU and `128Mi` memory.
+
+These Pi-friendly defaults make CPU and memory saturation visible without reserving excessive capacity on small Sugarkube nodes. Operators should alert on pod restarts, failing readiness/liveness probes, CPU throttling, memory pressure, OOM kills, and unavailable replicas. Tune values only with measured runtime evidence or environment-specific constraints.
+
+## Server health versus IndexedDB user journeys
+
+`/healthz` and `/livez` prove that the static server can answer deterministic JSON probes. They do not prove that a specific browser profile can read or write IndexedDB, that quota is available, or that a user's local data survived browser cleanup. IndexedDB journeys are browser-local behavior and must be checked with isolated browser automation or manual verification, not server-side telemetry.
+
+## Safe staging synthetic tests
+
+Synthetic journey mode is explicit and intended only for local or staging-style targets:
+
+```sh
+npm run smoke:promotion -- https://staging-jobbot3000.example.test --mode synthetic
+```
+
+The synthetic mode must use a fresh temporary browser profile, create only clearly synthetic records, verify IndexedDB persistence across a reload, export a synthetic JSON backup, and then delete the temporary profile or otherwise clear created state. Logs, metrics, screenshots, and summaries must not include synthetic record contents. Production promotion should use the default read-only mode.
+
+## Privacy boundaries
+
+Do not add server-side collection of tracker records, browser identifiers, or backup contents. Acceptable observability fields are operational metadata such as route, HTTP status, duration, final URL, content type, probe pass/fail, Kubernetes resource usage, restart counts, and probe failures. Browser exports are generated locally and should be stored by the user in private encrypted storage.
+
+## Why custom server metrics are deferred
+
+Custom application metrics are intentionally deferred because the deployed service does not own user data or business events. Adding a metrics endpoint would create pressure to count application, employer, or browser activity server-side and could blur the privacy boundary. Until there is a measured operational need, blackbox probes plus Kubernetes resource, restart, and rollout signals provide the production-appropriate contract.

--- a/docs/privacy-and-security.md
+++ b/docs/privacy-and-security.md
@@ -30,6 +30,10 @@ IndexedDB quota is controlled by the browser and device. Low disk space, private
 
 The tracker stores artifact links/metadata, not private file bytes. Keep resumes, cover letters, transcripts, and offer documents in private storage you control. Prefer encrypted local folders or an encrypted document vault, and link to those locations only when appropriate for your threat model.
 
+## Observability privacy
+
+The observability contract is documented in [docs/observability.md](observability.md). It permits blackbox route status, Kubernetes resource, restart, and probe signals, but forbids collecting private tracker records, resumes, notes, compensation, imported files, or browser identifiers on the server.
+
 ## Static server headers
 
 `scripts/static-server.js` emits a restrictive Content Security Policy, Permissions Policy, Referrer Policy, `X-Content-Type-Options: nosniff`, and COOP headers. `/healthz` and `/livez` return JSON liveness responses without touching user data.

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -73,6 +73,10 @@ Secrets, PVCs, logs, repo fixtures, or public object storage.
 4. If data was cleared or replaced locally, restore the last known-good JSON or
    NDJSON backup through the browser UI.
 
+## Observability
+
+See [docs/observability.md](observability.md) for the production observability contract, including read-only promotion smoke checks, staging-only synthetic journeys, Kubernetes resource signals, and privacy boundaries.
+
 ## Verification checklist
 
 - `npm ci`, `npm run lint`, `npm run typecheck`, `npm run test:ci`, and

--- a/docs/staging-tracker-verification.md
+++ b/docs/staging-tracker-verification.md
@@ -2,6 +2,10 @@
 
 Use this checklist after deploying a staging image or chart update for the browser-only tracker. Use only anonymized fixtures or private local backups; never commit real backups, screenshots, application notes, company names, candidate names, private URLs, or artifact links.
 
+## Observability contract
+
+Follow [docs/observability.md](observability.md) for safe blackbox checks and staging-only synthetic journeys. Production smoke is read-only; synthetic writes must use disposable profiles and clearly synthetic records only.
+
 ## Deploy and smoke-check staging
 
 1. Deploy staging with the intended immutable image tag.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "postinstall": "node scripts/install-console-font.js",
     "build": "node scripts/build-static.js",
     "start:static": "node scripts/static-server.js",
-    "smoke:container": "bash scripts/smoke-container.sh"
+    "smoke:container": "bash scripts/smoke-container.sh",
+    "smoke:promotion": "node scripts/promotion-smoke.js"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/promotion-smoke.js
+++ b/scripts/promotion-smoke.js
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { chromium } from "@playwright/test";
+
+const args = process.argv.slice(2);
+const modeIndex = args.indexOf("--mode");
+const mode = modeIndex === -1 ? "readonly" : args[modeIndex + 1];
+const baseUrl = args.find((arg, index) => {
+  if (arg.startsWith("--")) return false;
+  return modeIndex === -1 || index !== modeIndex + 1;
+});
+if (!baseUrl || !["readonly", "synthetic"].includes(mode)) {
+  console.error(
+    "Usage: node scripts/promotion-smoke.js <base-url> [--mode readonly|synthetic]",
+  );
+  process.exit(2);
+}
+
+const startedAt = new Date().toISOString();
+const safeSummary = {
+  mode,
+  baseUrl: new URL(baseUrl).origin,
+  startedAt,
+  checks: [],
+};
+const resultsDir = path.join(process.cwd(), "test-results");
+await fs.mkdir(resultsDir, { recursive: true });
+
+function resolveUrl(route) {
+  return new URL(route, baseUrl).toString();
+}
+
+async function checkRoute(route, { expectJson = false } = {}) {
+  const url = resolveUrl(route);
+  const start = performance.now();
+  let entry;
+  try {
+    const response = await fetch(url, { redirect: "follow" });
+    const contentType = response.headers.get("content-type") ?? "";
+    if (expectJson && !contentType.includes("application/json")) {
+      throw new Error(
+        `expected application/json, got ${contentType || "missing content-type"}`,
+      );
+    }
+    entry = {
+      route,
+      status: response.status,
+      durationMs: Math.round(performance.now() - start),
+      finalUrl: response.url,
+      contentType,
+      ok: response.ok,
+    };
+  } catch (error) {
+    entry = {
+      route,
+      status: 0,
+      durationMs: Math.round(performance.now() - start),
+      finalUrl: url,
+      contentType: "",
+      ok: false,
+      error: error.message,
+    };
+  }
+  safeSummary.checks.push(entry);
+  return entry;
+}
+
+const root = await checkRoute("/");
+const tracker = await checkRoute("/tracker");
+await checkRoute("/healthz", { expectJson: true });
+await checkRoute("/livez", { expectJson: true });
+await checkRoute("/manifest.webmanifest");
+
+if (root.ok || tracker.ok) {
+  const htmlResponse = await fetch(
+    root.ok ? resolveUrl("/") : resolveUrl("/tracker"),
+  );
+  const html = await htmlResponse.text();
+  const asset = html.match(
+    /<(?:script|link)[^>]+(?:src|href)="([^"]+\.(?:js|css))"/i,
+  )?.[1];
+  if (asset) await checkRoute(asset);
+  else
+    safeSummary.checks.push({
+      route: "referenced-asset",
+      status: 0,
+      durationMs: 0,
+      finalUrl: "",
+      contentType: "",
+      ok: false,
+      error: "no JS or CSS asset reference found",
+    });
+}
+
+async function runSyntheticJourney() {
+  const userDataDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "jobbot3000-synthetic-"),
+  );
+  let context;
+  try {
+    context = await chromium.launchPersistentContext(userDataDir, {
+      acceptDownloads: true,
+    });
+    const page = await context.newPage();
+    await page.goto(resolveUrl("/tracker"));
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    const syntheticCsv = [
+      "application_id,company,role_title,status,applied_at,posting_url,application_channel,notes",
+      [
+        `synthetic_${Date.now()}`,
+        "Synthetic Observability Employer",
+        "Synthetic Journey Role",
+        "applied",
+        "2026-01-01",
+        "https://example.test/synthetic",
+        "direct",
+        "Synthetic staging journey record",
+      ].join(","),
+    ].join("\n");
+    await page.setInputFiles("[data-import-file]", {
+      name: "synthetic-staging.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(syntheticCsv),
+    });
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+    await page.getByRole("button", { name: "Apply import" }).click();
+    await page.reload();
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page
+      .getByText("Synthetic Observability Employer")
+      .waitFor({ state: "visible" });
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    const [download] = await Promise.all([
+      page.waitForEvent("download"),
+      page.locator('[data-export="json"]').first().click(),
+    ]);
+    const backupPath = path.join(
+      resultsDir,
+      `synthetic-backup-${Date.now()}.json`,
+    );
+    await download.saveAs(backupPath);
+    safeSummary.synthetic = {
+      ok: true,
+      profile: "fresh-temporary-deleted",
+      exportFormat: "json",
+      backupPath: path.relative(process.cwd(), backupPath),
+    };
+  } catch (error) {
+    safeSummary.synthetic = {
+      ok: false,
+      profile: "fresh-temporary-deleted",
+      exportFormat: "json",
+      error: error.message,
+    };
+  } finally {
+    await context?.close();
+    await fs.rm(userDataDir, { recursive: true, force: true });
+  }
+}
+
+if (mode === "synthetic") await runSyntheticJourney();
+
+safeSummary.finishedAt = new Date().toISOString();
+safeSummary.ok =
+  safeSummary.checks.every((check) => check.ok) &&
+  (mode !== "synthetic" || safeSummary.synthetic?.ok === true);
+const out = path.join(resultsDir, `promotion-smoke-${mode}.json`);
+await fs.writeFile(out, `${JSON.stringify(safeSummary, null, 2)}\n`, "utf8");
+console.log(
+  `promotion smoke ${safeSummary.ok ? "passed" : "failed"}; summary=${out}`,
+);
+process.exit(safeSummary.ok ? 0 : 1);

--- a/scripts/smoke-container.sh
+++ b/scripts/smoke-container.sh
@@ -34,3 +34,4 @@ test "${ready}" = 1
 curl -fsS "http://127.0.0.1:${port}/" >/dev/null
 curl -fsS "http://127.0.0.1:${port}/healthz" >/dev/null
 curl -fsS "http://127.0.0.1:${port}/livez" >/dev/null
+npm run smoke:promotion -- "http://127.0.0.1:${port}"

--- a/scripts/static-server.js
+++ b/scripts/static-server.js
@@ -68,6 +68,7 @@ app.use((req, res, next) => {
 const health = (_req, res) =>
   res
     .status(200)
+    .set("Cache-Control", "no-store")
     .json({ status: "ok", mode: "static", persistence: "browser-indexeddb" });
 app.get("/healthz", health);
 app.get("/livez", health);

--- a/test/helm-chart-contract.test.js
+++ b/test/helm-chart-contract.test.js
@@ -19,9 +19,24 @@ describe("Helm chart production contract", () => {
     expect(values).toContain("tag: main-latest");
     expect(values).toContain("path: /healthz");
     expect(values).toContain("path: /livez");
+    expect(values).toContain("cpu: 25m");
+    expect(values).toContain("memory: 32Mi");
+    expect(values).toContain("cpu: 200m");
+    expect(values).toContain("memory: 128Mi");
     expect(values).toContain("readOnlyRootFilesystem: true");
     expect(deployment).toContain("JOBBOT_WEB_PORT");
+    expect(deployment).toContain("resources:");
     expect(deployment).not.toContain("persistentVolumeClaim");
+  });
+
+  it("uses standard Kubernetes labels on rendered object and pod metadata", async () => {
+    const helpers = await read("charts/jobbot3000/templates/_helpers.tpl");
+    const deployment = await read(
+      "charts/jobbot3000/templates/deployment.yaml",
+    );
+    expect(helpers).toContain("app.kubernetes.io/component: static-tracker");
+    expect(helpers).toContain("app.kubernetes.io/part-of: jobbot3000");
+    expect(deployment).toContain('include "jobbot3000.labels" . | nindent 8');
   });
 
   it("does not define PVCs or user-data Secrets by default", async () => {

--- a/test/playwright/static-smoke.spec.js
+++ b/test/playwright/static-smoke.spec.js
@@ -133,6 +133,8 @@ test.describe("static tracker smoke", () => {
   }) => {
     const health = await page.request.get(`${baseUrl}/healthz`);
     expect(health.ok()).toBe(true);
+    expect(health.headers()["cache-control"]).toBe("no-store");
+    expect(health.headers()["content-type"]).toContain("application/json");
     await expect(health.json()).resolves.toEqual({
       status: "ok",
       mode: "static",
@@ -141,6 +143,13 @@ test.describe("static tracker smoke", () => {
 
     const live = await page.request.get(`${baseUrl}/livez`);
     expect(live.ok()).toBe(true);
+    expect(live.headers()["cache-control"]).toBe("no-store");
+
+    const invalidHealth = await page.request.get(`${baseUrl}/healthz/invalid`);
+    expect(invalidHealth.status()).toBe(404);
+    expect(invalidHealth.headers()["content-type"]).not.toContain(
+      "application/json",
+    );
 
     await page.goto(baseUrl);
     await expect(

--- a/test/web-deployment.test.js
+++ b/test/web-deployment.test.js
@@ -103,6 +103,9 @@ describe("web deployment artifacts", () => {
     expect(packageJson.scripts["smoke:container"]).toBe(
       "bash scripts/smoke-container.sh",
     );
+    expect(packageJson.scripts["smoke:promotion"]).toBe(
+      "node scripts/promotion-smoke.js",
+    );
 
     const staticServer = await readFile(
       path.join(repoRoot, "scripts", "static-server.js"),
@@ -123,6 +126,7 @@ describe("web deployment artifacts", () => {
     expect(staticServer).toContain(
       'res.setHeader("Cache-Control", "no-store")',
     );
+    expect(staticServer).toContain('.set("Cache-Control", "no-store")');
     expect(staticServer).not.toContain("immutable");
     expect(staticServer).toContain("Content-Security-Policy");
     expect(staticServer).not.toContain("/commands");
@@ -131,6 +135,19 @@ describe("web deployment artifacts", () => {
     expect(staticServer).not.toMatch(
       /JOBBOT_(GREENHOUSE|LEVER|SMARTRECRUITERS|WORKABLE).*TOKEN/,
     );
+
+    const promotionSmoke = await readFile(
+      path.join(repoRoot, "scripts", "promotion-smoke.js"),
+      "utf8",
+    );
+    expect(promotionSmoke).toContain("mode =");
+    expect(promotionSmoke).toContain('"readonly"');
+    expect(promotionSmoke).toContain('"synthetic"');
+    expect(promotionSmoke).toContain("test-results");
+    expect(promotionSmoke).toContain("launchPersistentContext");
+    expect(promotionSmoke).toContain("Synthetic Observability Employer");
+    expect(promotionSmoke).toContain("fresh-temporary-deleted");
+    expect(promotionSmoke).not.toMatch(/console\.log\(.*syntheticCsv/s);
   });
 
   it("documents static privacy boundaries and IndexedDB backup guidance", async () => {


### PR DESCRIPTION
### Motivation

- Provide a production-appropriate observability contract for the static, browser-first tracker that keeps private tracker data in browser-owned IndexedDB and avoids any server-side collection of user data.
- Make health endpoints deterministic and impossible to satisfy via SPA fallback so Kubernetes probes and blackbox checks cannot be fooled by the client application shell.
- Add a safe, read-only promotion smoke for production and an explicit staging-only synthetic journey that exercises IndexedDB persistence while ensuring synthetic writes are isolated and erased.

### Description

- Add a promotion smoke tool `scripts/promotion-smoke.js` and a `smoke:promotion` npm script that checks `/`, `/tracker`, `/healthz`, `/livez`, `/manifest.webmanifest`, and at least one JS/CSS asset and writes a machine-readable summary to `test-results/` with only safe fields (route, status, duration, final URL, content type, pass/fail). 
- Implement a staging-only synthetic mode in the smoke that uses a fresh Playwright persistent profile, imports a clearly synthetic CSV, verifies persistence across reload, exports a JSON backup to `test-results/`, and deletes the temporary profile without emitting synthetic record contents to logs or summaries.
- Harden server health endpoints in `scripts/static-server.js` to set `Cache-Control: no-store` and keep `/healthz` and `/livez` as small deterministic JSON endpoints that cannot be satisfied by the SPA fallback; add Playwright assertions to verify `no-store`, JSON content-type and that invalid health-like paths do not return JSON.
- Add conservative Pi-friendly Helm resource defaults in `charts/jobbot3000/values.yaml` (`requests: cpu=25m,memory=32Mi`, `limits: cpu=200m,memory=128Mi`) and add standard Kubernetes labels (`app.kubernetes.io/component: static-tracker`, `app.kubernetes.io/part-of: jobbot3000`) via the chart helper and ensure the deployment renders the label set.
- Document the contract in `docs/observability.md` and link it from `docs/production-readiness.md`, `docs/staging-tracker-verification.md`, and `docs/privacy-and-security.md` so operators and release engineers follow the privacy-preserving checks.

### Testing

- `npm run lint` — passed (ESLint run across repo): `npm run lint` ✅.
- Unit / contract tests — `npx vitest run test/web-deployment.test.js test/helm-chart-contract.test.js` — passed (both test files passed): ✅.
- Static build — `npm run build` — built `dist/` successfully: `node scripts/build-static.js` ✅.
- Playwright smoke — `npx playwright test test/playwright/static-smoke.spec.js` — initially required browser install but after `npx playwright install chromium` the test passed: ✅.
- Promotion smoke (read-only) — started local static server and ran `npm run smoke:promotion -- http://127.0.0.1:4173` and the script produced `test-results/promotion-smoke-readonly.json` and returned success: ✅.
- Promotion smoke (synthetic) — `npm run smoke:promotion -- http://127.0.0.1:4173 --mode synthetic` produced `test-results/promotion-smoke-synthetic.json`, performed an isolated synthetic write, exported a backup, and cleaned up the temporary profile: ✅.
- Helm checks — `helm lint charts/jobbot3000` (installed `helm` during the run) — lint passed and `helm template jobbot3000 charts/jobbot3000` rendered the `resources` and added labels as expected (looked for `cpu: 25m`, `memory: 32Mi`, `cpu: 200m`, `memory: 128Mi` and label keys) but note `helm` had to be installed in the environment first: ✅ after install.
- Container smoke — `docker build && npm run smoke:container` could not be run here because Docker is not available in this environment (`docker: command not found`): not run (environment limitation).

Files changed (high level): `scripts/promotion-smoke.js` (new), `scripts/static-server.js` (health no-store), `scripts/smoke-container.sh` (invoke promotion smoke), `charts/jobbot3000/values.yaml` (resources defaults), `charts/jobbot3000/templates/_helpers.tpl` and `templates/deployment.yaml` (labels applied), `docs/observability.md` (new) plus doc links updated and tests updated under `test/` to assert the new behaviors.

Notes and residual risks: Docker-based container smoke could not be executed in this environment; Helm was installed on-demand for lint/template verification; Playwright required browser install which is invoked by CI or `npx playwright install` before running the smoke; resource defaults are conservative Pi-friendly values (`25m/32Mi` requests, `200m/128Mi` limits) and should be tuned only with measured evidence.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52c185716c832f863b319c1dd67c35)