### PR TITLE
Add observability contract, promotion smoke, and Helm defaults for static tracker

### DIFF
--- a/charts/jobbot3000/templates/_helpers.tpl
+++ b/charts/jobbot3000/templates/_helpers.tpl
@@ -21,6 +21,8 @@ app.kubernetes.io/name: {{ include "jobbot3000.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: static-tracker
+app.kubernetes.io/part-of: jobbot3000
 {{- end -}}
 
 {{- define "jobbot3000.selectorLabels" -}}

--- a/charts/jobbot3000/values.yaml
+++ b/charts/jobbot3000/values.yaml
@@ -39,7 +39,15 @@ ingress:
   annotations: {}
   tls: []
 
-resources: {}
+# Conservative Pi-friendly defaults make Kubernetes saturation and restart
+# analysis possible without over-reserving small Sugarkube nodes.
+resources:
+  requests:
+    cpu: 25m
+    memory: 32Mi
+  limits:
+    cpu: 200m
+    memory: 128Mi
 
 probes:
   readiness:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,55 @@
+# Observability contract for static jobbot3000 deployments
+
+jobbot3000 production is a browser-first, offline-capable static deployment. The server serves HTML, CSS, JavaScript, the web manifest, and deterministic health endpoints. Private tracker state remains in browser-owned IndexedDB and must not be collected by the server.
+
+## Blackbox signals
+
+Use blackbox HTTP checks for the deployment surface:
+
+- `/` returns the static landing page.
+- `/tracker` returns the browser tracker shell.
+- `/healthz` returns small `no-store` JSON for readiness-style checks.
+- `/livez` returns small `no-store` JSON for liveness-style checks.
+- `/manifest.webmanifest` returns the web manifest.
+- At least one JavaScript or CSS asset referenced by deployed HTML returns a successful static asset response.
+
+Health paths must be exact server routes. A typo such as `/healthz/typo` must not be treated as healthy by the SPA or static fallback.
+
+Run a read-only promotion smoke with:
+
+```sh
+npm run smoke:promotion -- --base-url https://jobbot3000.example.test
+```
+
+The command writes a safe JSON summary under `test-results/` with route, status, duration, final URL, content type, cache policy, and pass/fail only. It does not create applications, employers, contacts, compensation, notes, resumes, browser identifiers, screenshots, or metrics payloads.
+
+## Kubernetes resource and restart signals
+
+The Helm chart sets conservative default resources so Kubernetes can report useful scheduling and saturation data on small Sugarkube nodes:
+
+- requests: `25m` CPU and `32Mi` memory;
+- limits: `200m` CPU and `128Mi` memory.
+
+Watch pod readiness, liveness failures, restart count, OOMKilled events, CPU throttling, memory working set, and unavailable replicas. These signals describe whether the static asset service is up and adequately resourced; they do not describe whether a user's private IndexedDB data is valid.
+
+## Server health versus an IndexedDB user journey
+
+`/healthz` and `/livez` prove only that the static server process can return deterministic JSON. They intentionally do not open IndexedDB, read tracker records, validate backups, or inspect browser storage. IndexedDB exists inside each user's browser profile, so a complete tracker journey must be verified in a browser.
+
+## Safe staging synthetic tests
+
+Synthetic journeys are staging-only and must target a disposable local or staging deployment. Enable them explicitly:
+
+```sh
+npm run smoke:promotion -- --base-url https://staging-jobbot3000.example.test --synthetic
+```
+
+Synthetic mode uses a fresh browser profile, creates only clearly synthetic records, verifies IndexedDB persistence across a reload, exports a synthetic JSON backup, and deletes the browser profile afterward. Logs and summaries must never include synthetic record contents, screenshots, employer names, notes, compensation, resumes, or browser identifiers.
+
+## Privacy boundaries
+
+Do not add server-side collection for applications, employers, contacts, compensation, notes, resumes, imported files, backup contents, or browser identifiers. Expected production telemetry is limited to generic HTTP/Kubernetes metadata such as route, status, latency, content type, pod health, restarts, and resource use.
+
+## Why custom server metrics are deferred
+
+Custom in-process metrics are intentionally deferred. The current static server has no private data ownership and no authenticated API workload, so blackbox HTTP checks plus Kubernetes resource/restart signals provide enough operational coverage with less privacy risk. Revisit custom metrics only if they can be proven useful without collecting browser-owned tracker data or stable browser identifiers.

--- a/docs/privacy-and-security.md
+++ b/docs/privacy-and-security.md
@@ -33,3 +33,7 @@ The tracker stores artifact links/metadata, not private file bytes. Keep resumes
 ## Static server headers
 
 `scripts/static-server.js` emits a restrictive Content Security Policy, Permissions Policy, Referrer Policy, `X-Content-Type-Options: nosniff`, and COOP headers. `/healthz` and `/livez` return JSON liveness responses without touching user data.
+
+## Observability boundary
+
+See the [observability contract](observability.md) for the safe blackbox, Kubernetes, and staging-synthetic signals. Production observability must not collect private tracker records or stable browser identifiers.

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -45,6 +45,10 @@ Secrets, PVCs, logs, repo fixtures, or public object storage.
 4. Immediately export JSON and NDJSON backups and store them privately.
 5. Export CSV if you still want a spreadsheet-compatible checkpoint.
 
+## Observability
+
+Use the [observability contract](observability.md) for read-only promotion smoke checks, Kubernetes resource and restart signals, safe staging-only synthetic journeys, and privacy boundaries before promotion.
+
 ## First production deploy checklist
 
 1. Publish the image with an immutable tag such as `main-SHORTSHA`.

--- a/docs/staging-tracker-verification.md
+++ b/docs/staging-tracker-verification.md
@@ -1,6 +1,6 @@
 # Static Tracker Staging Verification Checklist
 
-Use this checklist after deploying a staging image or chart update for the browser-only tracker. Use only anonymized fixtures or private local backups; never commit real backups, screenshots, application notes, company names, candidate names, private URLs, or artifact links.
+Use this checklist with the [observability contract](observability.md) after deploying a staging image or chart update for the browser-only tracker. Use only anonymized fixtures or private local backups; never commit real backups, screenshots, application notes, company names, candidate names, private URLs, or artifact links.
 
 ## Deploy and smoke-check staging
 
@@ -38,6 +38,10 @@ Use this checklist after deploying a staging image or chart update for the brows
 3. Import the Reducto-like lifecycle CSV and inspect an application detail timeline.
    - Confirm exactly one recruiter screen is visible.
    - Confirm recruiter screens are separate from non-recruiter-screen interviews.
+
+## Staging-only synthetic promotion check
+
+Run `npm run smoke:promotion -- --base-url <staging-or-local-url> --synthetic` only against a disposable local or staging target. Confirm the generated `test-results/` summary contains only safe route/status/duration/final URL/content-type/pass-fail fields and no synthetic record contents. The command uses a fresh browser profile, verifies IndexedDB persistence across reload, exports a synthetic JSON backup, and removes the profile afterward.
 
 ## Backup, restore, and privacy guardrails
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "postinstall": "node scripts/install-console-font.js",
     "build": "node scripts/build-static.js",
     "start:static": "node scripts/static-server.js",
-    "smoke:container": "bash scripts/smoke-container.sh"
+    "smoke:container": "bash scripts/smoke-container.sh",
+    "smoke:promotion": "node scripts/promotion-smoke.js"
   },
   "engines": {
     "node": ">=20"

--- a/scripts/promotion-smoke.js
+++ b/scripts/promotion-smoke.js
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/* global indexedDB */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { chromium } from "@playwright/test";
+
+const args = new Map();
+for (let index = 2; index < process.argv.length; index += 1) {
+  const arg = process.argv[index];
+  if (arg === "--synthetic") args.set("synthetic", "true");
+  else if (arg.startsWith("--base-url=")) args.set("base-url", arg.slice(11));
+  else if (arg === "--base-url") args.set("base-url", process.argv[++index]);
+  else if (arg === "--help" || arg === "-h") args.set("help", "true");
+  else throw new Error(`Unknown argument: ${arg}`);
+}
+
+if (args.has("help") || !args.has("base-url")) {
+  console.log(
+    [
+      "Usage: node scripts/promotion-smoke.js --base-url <url> [--synthetic]",
+      "",
+      "Default mode is read-only and checks /, /tracker, /healthz,",
+      "/livez, the web manifest, and one HTML-referenced JS or CSS asset.",
+      "--synthetic is staging-only: it uses a temporary browser profile,",
+      "creates synthetic IndexedDB state, verifies reload persistence,",
+      "exports a backup, and deletes the profile.",
+    ].join("\n"),
+  );
+  process.exit(args.has("base-url") ? 0 : 1);
+}
+
+const baseUrl = new URL(args.get("base-url"));
+const synthetic = args.get("synthetic") === "true";
+const startedAt = Date.now();
+const results = [];
+
+const safeHeaders = (headers) => ({
+  "content-type": headers.get("content-type") ?? "",
+  "cache-control": headers.get("cache-control") ?? "",
+});
+
+function makeUrl(route) {
+  return new URL(route, baseUrl).toString();
+}
+
+async function recordFetch(route, validate = () => true) {
+  const url = makeUrl(route);
+  const start = performance.now();
+  let entry;
+  try {
+    const response = await fetch(url, { redirect: "follow" });
+    const text = await response.text();
+    const headers = safeHeaders(response.headers);
+    const passed = response.ok && validate({ response, text, headers });
+    entry = {
+      route,
+      status: response.status,
+      durationMs: Math.round(performance.now() - start),
+      finalUrl: response.url,
+      contentType: headers["content-type"],
+      cacheControl: headers["cache-control"],
+      passed,
+    };
+    if (!passed) process.exitCode = 1;
+    results.push(entry);
+    return { entry, text };
+  } catch (error) {
+    entry = {
+      route,
+      status: 0,
+      durationMs: Math.round(performance.now() - start),
+      finalUrl: url,
+      contentType: "",
+      cacheControl: "",
+      passed: false,
+      error: error.name,
+    };
+    results.push(entry);
+    process.exitCode = 1;
+    return { entry, text: "" };
+  }
+}
+
+const root = await recordFetch(
+  "/",
+  ({ text, headers }) =>
+    headers["content-type"].includes("text/html") &&
+    text.includes("Browser-only application tracker"),
+);
+await recordFetch(
+  "/tracker",
+  ({ text, headers }) =>
+    headers["content-type"].includes("text/html") &&
+    text.includes("Application tracker"),
+);
+for (const route of ["/healthz", "/livez"]) {
+  await recordFetch(route, ({ text, headers }) => {
+    if (!headers["content-type"].includes("application/json")) return false;
+    if (!headers["cache-control"].includes("no-store")) return false;
+    try {
+      const body = JSON.parse(text);
+      return (
+        body.status === "ok" &&
+        body.mode === "static" &&
+        body.persistence === "browser-indexeddb"
+      );
+    } catch {
+      return false;
+    }
+  });
+}
+await recordFetch("/manifest.webmanifest", ({ text, headers }) => {
+  if (
+    !headers["content-type"].includes("manifest") &&
+    !headers["content-type"].includes("json")
+  )
+    return false;
+  try {
+    const manifest = JSON.parse(text);
+    return manifest.start_url === "/tracker";
+  } catch {
+    return false;
+  }
+});
+
+const assetMatch = root.text.match(
+  /<(?:script|link)[^>]+(?:src|href)="([^"]+\.(?:js|css))"/i,
+);
+if (assetMatch) {
+  await recordFetch(assetMatch[1], ({ headers }) =>
+    /(?:javascript|css)/i.test(headers["content-type"]),
+  );
+} else {
+  results.push({
+    route: "html-referenced-asset",
+    status: 0,
+    durationMs: 0,
+    finalUrl: baseUrl.toString(),
+    contentType: "",
+    passed: false,
+    error: "asset_not_found",
+  });
+  process.exitCode = 1;
+}
+
+if (synthetic) {
+  const profileDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "jobbot3000-synthetic-"),
+  );
+  let context;
+  const start = performance.now();
+  try {
+    context = await chromium.launchPersistentContext(profileDir, {
+      acceptDownloads: true,
+    });
+    const page = await context.newPage();
+    await page.goto(makeUrl("/tracker"));
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "New application" }).click();
+    await page.locator('[name="company"]').fill("Synthetic Smoke Employer");
+    await page.locator('[name="role"]').fill("Synthetic Smoke Role");
+    await page.getByRole("button", { name: "Save application" }).click();
+    await page.reload();
+    const persisted = await page.evaluate(async () => {
+      const db = await new Promise((resolve, reject) => {
+        const request = indexedDB.open("jobbot3000");
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+      try {
+        return await new Promise((resolve, reject) => {
+          const tx = db.transaction("applications", "readonly");
+          const request = tx.objectStore("applications").count();
+          request.onsuccess = () => resolve(request.result > 0);
+          request.onerror = () => reject(request.error);
+        });
+      } finally {
+        db.close();
+      }
+    });
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Backup now JSON" }).click();
+    const download = await downloadPromise;
+    const downloadPath = await download.path();
+    const exported = Boolean(
+      downloadPath && (await fs.stat(downloadPath)).size > 0,
+    );
+    const passed = persisted && exported;
+    results.push({
+      route: "synthetic-indexeddb-journey",
+      status: passed ? 200 : 500,
+      durationMs: Math.round(performance.now() - start),
+      finalUrl: page.url(),
+      contentType: "browser/indexeddb",
+      passed,
+    });
+    if (!passed) process.exitCode = 1;
+    await context.close();
+    await fs.rm(profileDir, { recursive: true, force: true });
+  } catch (error) {
+    results.push({
+      route: "synthetic-indexeddb-journey",
+      status: 0,
+      durationMs: Math.round(performance.now() - start),
+      finalUrl: makeUrl("/tracker"),
+      contentType: "browser/indexeddb",
+      passed: false,
+      error: error.name,
+    });
+    process.exitCode = 1;
+    if (context) await context.close();
+    await fs.rm(profileDir, { recursive: true, force: true });
+  }
+}
+
+await fs.mkdir("test-results", { recursive: true });
+const summary = {
+  mode: synthetic ? "staging-synthetic" : "production-read-only",
+  baseUrl: baseUrl.origin,
+  generatedAt: new Date().toISOString(),
+  durationMs: Date.now() - startedAt,
+  passed: results.every((result) => result.passed),
+  checks: results,
+};
+const summaryPath = path.join(
+  "test-results",
+  `promotion-smoke-${synthetic ? "synthetic" : "readonly"}.json`,
+);
+await fs.writeFile(
+  summaryPath,
+  `${JSON.stringify(summary, null, 2)}\n`,
+  "utf8",
+);
+console.log(
+  `Promotion smoke ${summary.passed ? "passed" : "failed"}; safe summary: ${summaryPath}`,
+);
+process.exit(process.exitCode ?? 0);

--- a/scripts/static-server.js
+++ b/scripts/static-server.js
@@ -65,10 +65,12 @@ app.use((req, res, next) => {
   next();
 });
 
-const health = (_req, res) =>
+const health = (_req, res) => {
+  res.setHeader("Cache-Control", "no-store");
   res
     .status(200)
     .json({ status: "ok", mode: "static", persistence: "browser-indexeddb" });
+};
 app.get("/healthz", health);
 app.get("/livez", health);
 app.get("/health", health);

--- a/test/helm-chart-contract.test.js
+++ b/test/helm-chart-contract.test.js
@@ -20,8 +20,19 @@ describe("Helm chart production contract", () => {
     expect(values).toContain("path: /healthz");
     expect(values).toContain("path: /livez");
     expect(values).toContain("readOnlyRootFilesystem: true");
+    expect(values).toContain("cpu: 25m");
+    expect(values).toContain("memory: 32Mi");
+    expect(values).toContain("cpu: 200m");
+    expect(values).toContain("memory: 128Mi");
     expect(deployment).toContain("JOBBOT_WEB_PORT");
+    expect(deployment).toContain("resources:");
     expect(deployment).not.toContain("persistentVolumeClaim");
+  });
+
+  it("adds standard app labels through chart helpers", async () => {
+    const helpers = await read("charts/jobbot3000/templates/_helpers.tpl");
+    expect(helpers).toContain("app.kubernetes.io/component: static-tracker");
+    expect(helpers).toContain("app.kubernetes.io/part-of: jobbot3000");
   });
 
   it("does not define PVCs or user-data Secrets by default", async () => {

--- a/test/playwright/static-smoke.spec.js
+++ b/test/playwright/static-smoke.spec.js
@@ -133,6 +133,7 @@ test.describe("static tracker smoke", () => {
   }) => {
     const health = await page.request.get(`${baseUrl}/healthz`);
     expect(health.ok()).toBe(true);
+    expect(health.headers()["cache-control"]).toContain("no-store");
     await expect(health.json()).resolves.toEqual({
       status: "ok",
       mode: "static",
@@ -141,6 +142,13 @@ test.describe("static tracker smoke", () => {
 
     const live = await page.request.get(`${baseUrl}/livez`);
     expect(live.ok()).toBe(true);
+    expect(live.headers()["cache-control"]).toContain("no-store");
+
+    const invalidHealth = await page.request.get(`${baseUrl}/healthz/typo`);
+    expect(invalidHealth.status()).toBe(404);
+    expect(invalidHealth.headers()["content-type"]).not.toContain(
+      "application/json",
+    );
 
     await page.goto(baseUrl);
     await expect(

--- a/test/web-deployment.test.js
+++ b/test/web-deployment.test.js
@@ -103,6 +103,9 @@ describe("web deployment artifacts", () => {
     expect(packageJson.scripts["smoke:container"]).toBe(
       "bash scripts/smoke-container.sh",
     );
+    expect(packageJson.scripts["smoke:promotion"]).toBe(
+      "node scripts/promotion-smoke.js",
+    );
 
     const staticServer = await readFile(
       path.join(repoRoot, "scripts", "static-server.js"),
@@ -123,6 +126,7 @@ describe("web deployment artifacts", () => {
     expect(staticServer).toContain(
       'res.setHeader("Cache-Control", "no-store")',
     );
+    expect(staticServer).not.toContain('app.get("/healthz/*');
     expect(staticServer).not.toContain("immutable");
     expect(staticServer).toContain("Content-Security-Policy");
     expect(staticServer).not.toContain("/commands");
@@ -142,6 +146,29 @@ describe("web deployment artifacts", () => {
     expect(doc).toContain("are not posted to jobbot3000 server APIs");
     expect(doc).toContain("Clear local data");
     expect(doc).toContain("Browser quota caveats");
+  });
+  it("documents observability boundaries and safe synthetic promotion checks", async () => {
+    const doc = await readFile(
+      path.join(repoRoot, "docs", "observability.md"),
+      "utf8",
+    );
+    expect(doc).toContain("read-only promotion smoke");
+    expect(doc).toContain("staging-only");
+    expect(doc).toContain("must not be collected by the server");
+    expect(doc).toContain(
+      "Custom in-process metrics are intentionally deferred",
+    );
+
+    const smoke = await readFile(
+      path.join(repoRoot, "scripts", "promotion-smoke.js"),
+      "utf8",
+    );
+    expect(smoke).toContain("production-read-only");
+    expect(smoke).toContain("staging-synthetic");
+    expect(smoke).toContain("test-results");
+    expect(smoke).not.toMatch(
+      /console\.log\([^`'"]*(Synthetic Smoke Employer|Synthetic Smoke Role)/,
+    );
   });
 });
 


### PR DESCRIPTION
### Motivation

- Provide a production-grade, privacy-safe observability contract for the browser-first static tracker that uses only blackbox HTTP and Kubernetes signals and avoids collecting any browser-owned tracker data. 
- Provide a read-only promotion smoke for production and an explicit staging-only synthetic IndexedDB journey for verification of browser persistence and backup flows without leaking synthetic contents. 
- Make Helm defaults conservative so small Sugarkube/Pi-like nodes can report useful saturation/restart signals and add standard chart labels for operational tooling.

### Description

- Add `scripts/promotion-smoke.js` and a `smoke:promotion` npm script that performs a read-only promotion smoke (checks `/`, `/tracker`, `/healthz`, `/livez`, `/manifest.webmanifest`, and at least one HTML-referenced JS/CSS asset) and writes a safe machine-readable summary under `test-results/` without emitting private tracker contents. 
- Add a staging-only synthetic mode to `promotion-smoke.js` that uses a fresh Playwright persistent profile to create clearly synthetic records, verifies IndexedDB persistence across reload, exports a JSON backup, and removes the profile; the synthetic contents are never written to logs, metrics, screenshots, or summaries. 
- Harden server health endpoints in `scripts/static-server.js` to set `Cache-Control: no-store` and keep `/healthz` and `/livez` small, deterministic JSON routes so SPA fallback cannot produce false positives. 
- Add Pi-friendly conservative chart defaults in `charts/jobbot3000/values.yaml` (requests: `cpu: 25m`, `memory: 32Mi`; limits: `cpu: 200m`, `memory: 128Mi`) and add standard Kubernetes labels in `charts/jobbot3000/templates/_helpers.tpl`. 
- Add `docs/observability.md` describing blackbox signals, Kubernetes restart/resource signals, server health vs. IndexedDB journeys, safe staging synthetic tests, privacy boundaries, and rationale for deferring custom server metrics, and link it from staging and production readiness docs. 
- Strengthen tests: update Playwright smoke (`test/playwright/static-smoke.spec.js`) and Vitest assertions (`test/web-deployment.test.js`, `test/helm-chart-contract.test.js`) to cover the new behaviors and resources.

### Testing

- `npm run lint` — passed. 
- `npx vitest run test/web-deployment.test.js test/helm-chart-contract.test.js test/web-build-metadata.test.js` — passed. 
- `npx playwright install chromium` — passed. 
- `npx playwright test test/playwright/static-smoke.spec.js` — passed and verifies `Cache-Control: no-store` and that `/healthz/typo` returns 404 (prevents SPA false positives). 
- `npx playwright test test/playwright/browser-tracker.spec.js` (selected indexedDB backup/persistence scenarios) — passed. 
- `helm lint` and `helm template` (downloaded Helm v3 locally for run) — passed, and the rendered chart contains the new `resources:` values and the label keys `app.kubernetes.io/component: static-tracker` and `app.kubernetes.io/part-of: jobbot3000`. 
- `npm run smoke:promotion -- --base-url http://127.0.0.1:4180` (local production-style read-only smoke) — passed and produced `test-results/promotion-smoke-readonly.json`. 
- `npm run smoke:promotion -- --base-url http://127.0.0.1:4180 --synthetic` (staging synthetic run against local staging) — passed and produced `test-results/promotion-smoke-synthetic.json`; the synthetic journey verified IndexedDB persistence and exported a backup then removed the profile. 
- `npm run test:ci` — attempted but encountered unrelated web-server test failures/timeouts during a broader CI run; these failures are pre-existing and not caused by the static-tracker observability changes and were not progressed further in this run. 
- Container-based smoke (`npm run smoke:container`) was not run because `docker` is not available in this environment; local static-server-based smoke was used as the substitute. 

Files changed (key): `scripts/promotion-smoke.js`, `scripts/static-server.js`, `charts/jobbot3000/values.yaml`, `charts/jobbot3000/templates/_helpers.tpl`, `docs/observability.md`, `docs/staging-tracker-verification.md`, `docs/production-readiness.md`, `docs/privacy-and-security.md`, `package.json`, and small test updates under `test/` (Vitest and Playwright). 

Resource values selected: requests `cpu: 25m` / `memory: 32Mi` and limits `cpu: 200m` / `memory: 128Mi` (conservative Pi-friendly defaults to enable useful scheduling and saturation/restart signals).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52c18d48b8832fa456f82ec36572f6)