### PR TITLE
Add Diagram tab: lifecycle Sankey diagram (d3-sankey@0.12.3)

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,9 @@
+# Third-party notices
+
+## d3-sankey 0.12.3
+
+License: BSD-3-Clause
+
+Copyright 2017 Mike Bostock
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the conditions of the BSD 3-Clause License are met. See the package distribution for the complete license text.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.4.1",
+        "d3-sankey": "0.12.3",
         "docx": "^9.5.1",
         "dotenv": "^16.6.1",
         "drizzle-orm": "^0.44.6",
@@ -3692,6 +3693,40 @@
         "node": ">=20"
       }
     },
+    "node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -5439,6 +5474,12 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
     },
     "node_modules/intl-messageformat": {
       "version": "10.7.16",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.4.1",
+    "d3-sankey": "0.12.3",
     "docx": "^9.5.1",
     "dotenv": "^16.6.1",
     "drizzle-orm": "^0.44.6",

--- a/src/web/tracker/index.html
+++ b/src/web/tracker/index.html
@@ -37,6 +37,14 @@
           <p data-weekly-counts class="muted">No application data yet.</p>
         </article>
       </section>
+
+      <section class="tracker-view" data-view="diagram" hidden>
+        <h2>Diagram</h2>
+        <p class="muted">
+          Lifecycle history is diagrammed from local tracker data only.
+        </p>
+        <div data-lifecycle-diagram></div>
+      </section>
       <section class="tracker-view" data-view="applications" hidden>
         <div class="tracker-actions">
           <h2>Applications</h2>

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -1,0 +1,479 @@
+/* global document, ResizeObserver */
+/* eslint-disable max-len */
+import { sankey, sankeyJustify, sankeyLinkHorizontal } from "d3-sankey";
+import { LIFECYCLE_DIAGRAM_TAXONOMY } from "./lifecycleProjection.js";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const COLUMNS = { origin: 0, milestone: 1, endpoint: 6 };
+const codeCompare = (a, b) => String(a).localeCompare(String(b));
+const percent = (value, total) =>
+  total ? `${Math.round((value / total) * 100)}%` : "0%";
+const el = (name, attrs = {}, text) => {
+  const node = document.createElement(name);
+  for (const [key, value] of Object.entries(attrs))
+    if (value !== undefined) node.setAttribute(key, value);
+  if (text !== undefined) node.textContent = text;
+  return node;
+};
+const svgEl = (name, attrs = {}, text) => {
+  const node = document.createElementNS(SVG_NS, name);
+  for (const [key, value] of Object.entries(attrs))
+    if (value !== undefined) node.setAttribute(key, value);
+  if (text !== undefined) node.textContent = text;
+  return node;
+};
+const taxonomy = new Map([
+  ...LIFECYCLE_DIAGRAM_TAXONOMY.origins.map((x) => [
+    x.nodeId,
+    { ...x, type: "origin", column: 0 },
+  ]),
+  ...LIFECYCLE_DIAGRAM_TAXONOMY.milestones.map((x) => [
+    x.nodeId,
+    { ...x, type: "milestone", column: x.rank + 1 },
+  ]),
+  ...LIFECYCLE_DIAGRAM_TAXONOMY.endpoints.map((x) => [
+    x.nodeId,
+    { ...x, type: "endpoint", column: 6 },
+  ]),
+]);
+const fmtDate = (value) => {
+  if (!value) return "Unknown";
+  const d = new Date(value);
+  return Number.isNaN(d.getTime())
+    ? String(value).slice(0, 10)
+    : d.toLocaleString();
+};
+const ariaText = (bucket) => {
+  if (!bucket || bucket.id === "current")
+    return "Current, latest data in this browser";
+  if (bucket.id === "unknown-date")
+    return "Unknown date, off chronological scale";
+  return bucket.kind === "date"
+    ? `${String(bucket.label).slice(0, 10)}, time not recorded`
+    : fmtDate(bucket.label);
+};
+const cloneProjection = (snapshot) => ({
+  ...snapshot,
+  nodes: (snapshot?.nodes ?? []).map((n) => ({ ...n })),
+  links: (snapshot?.links ?? []).map((l) => ({
+    ...l,
+    applicationIds: [...(l.applicationIds ?? [])],
+  })),
+  paths: (snapshot?.paths ?? []).map((p) => ({
+    ...p,
+    milestones: [...p.milestones],
+    nodeIds: [...p.nodeIds],
+  })),
+});
+
+export function createLifecycleDiagramView(root, options = {}) {
+  const onSelectBucket = options.onSelectBucket ?? (() => {});
+  let selectedId = "current";
+  let selectedElementId = "";
+  let projection = undefined;
+  let ro;
+  let liveTimer;
+
+  root.textContent = "";
+  const controls = el("div", { class: "diagram-controls" });
+  const prev = el(
+    "button",
+    { type: "button", class: "button" },
+    "Previous event",
+  );
+  const label = el("label", {}, "Timeline position");
+  const range = el("input", { type: "range", min: "0", value: "0" });
+  label.append(range);
+  const next = el("button", { type: "button", class: "button" }, "Next event");
+  const current = el(
+    "button",
+    { type: "button", class: "button" },
+    "Return to current",
+  );
+  const badge = el(
+    "span",
+    { class: "pill", "data-diagram-badge": "" },
+    "Current",
+  );
+  controls.append(prev, label, next, current, badge);
+  const timestamp = el("p", { class: "muted", "data-diagram-timestamp": "" });
+  const counts = el("p", { class: "muted", "data-diagram-counts": "" });
+  const simultaneous = el("details", { "data-diagram-simultaneous": "" });
+  const live = el("p", {
+    class: "sr-only",
+    role: "status",
+    "aria-live": "polite",
+  });
+  const scroller = el("div", {
+    class: "diagram-scroll",
+    tabindex: "0",
+    role: "region",
+    "aria-label": "Scrollable lifecycle diagram",
+  });
+  const details = el("div", { class: "card", "data-diagram-details": "" });
+  const tables = el("div", { class: "diagram-tables" });
+  root.append(
+    controls,
+    timestamp,
+    counts,
+    simultaneous,
+    live,
+    scroller,
+    details,
+    tables,
+  );
+
+  const announce = (message) => {
+    clearTimeout(liveTimer);
+    liveTimer = setTimeout(() => {
+      live.textContent = message;
+    }, 120);
+  };
+  const bucketIndex = (timeline) =>
+    Math.max(
+      0,
+      (timeline?.buckets ?? []).findIndex((b) => b.id === selectedId),
+    );
+  const bucketAt = (timeline, index) =>
+    timeline.buckets[Math.max(0, Math.min(timeline.buckets.length - 1, index))];
+  const selectIndex = (timeline, index) => {
+    const b = bucketAt(timeline, index);
+    if (b) onSelectBucket(b.id);
+  };
+  prev.addEventListener("click", () =>
+    selectIndex(lastTimeline, bucketIndex(lastTimeline) - 1),
+  );
+  next.addEventListener("click", () =>
+    selectIndex(lastTimeline, bucketIndex(lastTimeline) + 1),
+  );
+  current.addEventListener("click", () => onSelectBucket("current"));
+  range.addEventListener("input", () =>
+    selectIndex(lastTimeline, Number(range.value)),
+  );
+  let lastTimeline = { buckets: [] };
+
+  const renderSvg = () => {
+    scroller.textContent = "";
+    const snap = cloneProjection(projection);
+    const nodes = snap.nodes
+      .filter((n) => n.total > 0)
+      .sort(
+        (a, b) =>
+          (taxonomy.get(a.id)?.column ?? 0) -
+            (taxonomy.get(b.id)?.column ?? 0) || codeCompare(a.id, b.id),
+      );
+    const links = snap.links
+      .filter((l) => l.value > 0)
+      .sort((a, b) => codeCompare(a.id, b.id));
+    if (!nodes.length) {
+      scroller.append(
+        el(
+          "p",
+          { class: "muted" },
+          "No lifecycle paths to diagram for this bucket.",
+        ),
+      );
+      return;
+    }
+    const width = Math.max(720, root.clientWidth || 720),
+      height = Math.max(360, nodes.length * 38);
+    const graph = {
+      nodes: nodes.map((n) => ({
+        ...n,
+        column:
+          taxonomy.get(n.id)?.column ?? COLUMNS[taxonomy.get(n.id)?.type] ?? 0,
+      })),
+      links: links.map((l) => ({ ...l })),
+    };
+    const s = sankey()
+      .nodeId((d) => d.id)
+      .nodeAlign(sankeyJustify)
+      .nodeWidth(16)
+      .nodePadding(14)
+      .extent([
+        [8, 8],
+        [width - 180, height - 24],
+      ]);
+    s(graph);
+    for (const n of graph.nodes) {
+      const c = taxonomy.get(n.id)?.column ?? n.column;
+      n.x0 = 8 + ((width - 220) * c) / 6;
+      n.x1 = n.x0 + 16;
+    }
+    s.update(graph);
+    const svg = svgEl("svg", {
+      role: "img",
+      width,
+      height,
+      viewBox: `0 0 ${width} ${height}`,
+      "aria-labelledby": "lifecycle-diagram-title lifecycle-diagram-desc",
+    });
+    svg.append(
+      svgEl(
+        "title",
+        { id: "lifecycle-diagram-title" },
+        "Lifecycle Sankey diagram",
+      ),
+    );
+    svg.append(
+      svgEl(
+        "desc",
+        { id: "lifecycle-diagram-desc" },
+        "Application counts flow from origin through milestones to endpoints. Equivalent tables follow.",
+      ),
+    );
+    for (const link of graph.links) {
+      if (![link.y0, link.y1, link.width].every(Number.isFinite)) continue;
+      const path = svgEl("path", {
+        d: sankeyLinkHorizontal()(link),
+        class: `diagram-link ${selectedElementId === link.id ? "is-selected" : ""}`,
+        "data-diagram-id": link.id,
+        stroke: "currentColor",
+        "stroke-width": Math.max(4, link.width),
+        fill: "none",
+      });
+      path.append(
+        svgEl(
+          "title",
+          {},
+          `${link.source.label} to ${link.target.label}: ${link.value} applications`,
+        ),
+      );
+      path.addEventListener("click", () => {
+        selectedElementId = link.id;
+        renderSelection(link);
+        renderSvg();
+      });
+      svg.append(path);
+    }
+    for (const node of graph.nodes) {
+      if (![node.x0, node.x1, node.y0, node.y1].every(Number.isFinite))
+        continue;
+      const g = svgEl("g", {
+        class: selectedElementId === node.id ? "is-selected" : "",
+        "data-diagram-id": node.id,
+      });
+      const rect = svgEl("rect", {
+        x: node.x0,
+        y: node.y0,
+        width: Math.max(16, node.x1 - node.x0),
+        height: Math.max(10, node.y1 - node.y0),
+        rx: "3",
+      });
+      rect.append(
+        svgEl("title", {}, `${node.label}: ${node.total} applications`),
+      );
+      rect.addEventListener("click", () => {
+        selectedElementId = node.id;
+        renderSelection(node);
+        renderSvg();
+      });
+      g.append(
+        rect,
+        svgEl(
+          "text",
+          {
+            x: node.x1 + 6,
+            y: Math.max(14, (node.y0 + node.y1) / 2),
+            "dominant-baseline": "middle",
+          },
+          `${node.label} (${node.total})`,
+        ),
+      );
+      svg.append(g);
+    }
+    scroller.append(svg);
+  };
+  const table = (caption, headers, rows) => {
+    const t = el("table", { class: "tracker-table" });
+    t.append(el("caption", {}, caption));
+    const thead = el("thead"),
+      tr = el("tr");
+    headers.forEach((h) => tr.append(el("th", { scope: "col" }, h)));
+    thead.append(tr);
+    t.append(thead);
+    const tbody = el("tbody");
+    rows.forEach((r) => {
+      const row = el("tr");
+      r.forEach((c, i) =>
+        row.append(el(i ? "td" : "th", i ? {} : { scope: "row" }, c)),
+      );
+      tbody.append(row);
+    });
+    t.append(tbody);
+    return t;
+  };
+  const renderSelection = (item) => {
+    const total = projection?.includedApplications ?? 0,
+      value = item.value ?? item.total ?? 0;
+    const apps =
+      item.applicationIds ??
+      projection.paths
+        .filter((p) => p.nodeIds.includes(item.id))
+        .map((p) => p.applicationId);
+    details.textContent = "";
+    details.append(
+      el(
+        "h3",
+        {},
+        item.source
+          ? `${item.source.label} → ${item.target.label}`
+          : item.label,
+      ),
+    );
+    details.append(
+      el(
+        "p",
+        {},
+        `${value} applications (${percent(value, total)}). Observed/inferred details are reflected in warning counts below. Date range: ${ariaText(projection.bucket)}.`,
+      ),
+    );
+    const disclosure = el("details");
+    disclosure.append(
+      el("summary", {}, `Affected applications (${apps.length})`),
+      el("p", {}, apps.join(", ") || "None"),
+    );
+    details.append(disclosure);
+  };
+  const renderTables = () => {
+    tables.textContent = "";
+    const total = projection.includedApplications;
+    const rowsFor = (obj) =>
+      Object.entries(obj ?? {}).map(([k, v]) => [
+        taxonomy.get(`${k.includes(":") ? k : "origin:" + k}`)?.label ??
+          taxonomy.get(`endpoint:${k}`)?.label ??
+          k,
+        String(v),
+        percent(v, total),
+      ]);
+    tables.append(
+      table(
+        "Origins",
+        ["Origin", "Count", "Percentage"],
+        rowsFor(projection.totals.origins),
+      ),
+    );
+    tables.append(
+      table(
+        "Endpoints",
+        ["Endpoint", "Count", "Percentage"],
+        Object.entries(projection.totals.endpoints ?? {}).map(([k, v]) => [
+          taxonomy.get(`endpoint:${k}`)?.label ?? k,
+          String(v),
+          percent(v, total),
+        ]),
+      ),
+    );
+    tables.append(
+      table(
+        "Transitions",
+        ["From", "To", "Application count"],
+        projection.links.map((l) => [
+          taxonomy.get(l.source)?.label ?? l.source,
+          taxonomy.get(l.target)?.label ?? l.target,
+          String(l.value),
+        ]),
+      ),
+    );
+    tables.append(
+      table(
+        "Selected-boundary events",
+        ["Event", "Application", "Type"],
+        (projection.events ?? []).map((e) => [
+          e.id,
+          e.applicationId,
+          e.eventType,
+        ]),
+      ),
+    );
+    tables.append(
+      el(
+        "p",
+        { class: "muted" },
+        `Warnings — inferred history: ${projection.warningCounts.inferred_event ?? 0}, unknown origin/time: ${(projection.warningCounts.inferred_origin ?? 0) + (projection.warningCounts.invalid_timestamp ?? 0)}, status mismatch: ${projection.warningCounts.status_mismatch ?? 0}, regression: ${projection.warningCounts.regressive_history ?? 0}.`,
+      ),
+    );
+  };
+  if (typeof ResizeObserver !== "undefined") {
+    ro = new ResizeObserver(() => {
+      clearTimeout(liveTimer);
+      liveTimer = setTimeout(renderSvg, 100);
+    });
+    ro.observe(root);
+  }
+  return {
+    update({
+      timeline,
+      snapshot,
+      selectedBucketId = "current",
+      newerAvailable = false,
+    }) {
+      lastTimeline = timeline;
+      selectedId = selectedBucketId;
+      projection = snapshot;
+      const idx = bucketIndex(timeline),
+        max = Math.max(0, timeline.buckets.length - 1),
+        bucket = timeline.buckets[idx] ?? timeline.buckets[max];
+      range.max = String(max);
+      range.value = String(idx);
+      range.disabled = max === 0;
+      range.setAttribute("aria-valuetext", ariaText(bucket, timeline));
+      prev.disabled = idx <= 0;
+      next.disabled = idx >= max;
+      current.disabled = selectedId === "current";
+      badge.textContent =
+        selectedId === "current"
+          ? "Current"
+          : `Historical${newerAvailable ? " — Newer activity available" : ""}`;
+      timestamp.textContent = "";
+      const knownBuckets = timeline.buckets.filter(
+        (candidate) =>
+          !["current", "unknown-date"].includes(candidate.id) &&
+          candidate.eventIds?.length,
+      );
+      const latestKnown = knownBuckets.at(-1);
+      const unknownCount =
+        timeline.buckets.find((candidate) => candidate.id === "unknown-date")
+          ?.eventIds?.length ?? 0;
+      const timestampText =
+        bucket?.id === "current"
+          ? `Current — latest data in this browser. Latest known event time: ${latestKnown ? ariaText(latestKnown) : "none"}. Unknown-time events: ${unknownCount}.`
+          : ariaText(bucket);
+      timestamp.append(
+        el(
+          "time",
+          {
+            datetime:
+              bucket?.id === "current"
+                ? new Date().toISOString()
+                : String(bucket?.cutoff ?? bucket?.id ?? ""),
+          },
+          timestampText,
+        ),
+      );
+      simultaneous.textContent = "";
+      const simultaneousCount = bucket?.eventIds?.length ?? 0;
+      if (simultaneousCount > 1) {
+        simultaneous.append(
+          el("summary", {}, `Simultaneous events (${simultaneousCount})`),
+          el("p", {}, bucket.eventIds.join(", ")),
+        );
+      }
+      counts.textContent = `${snapshot.includedApplications} of ${snapshot.totalApplications} applications included`;
+      announce(`${badge.textContent}. ${counts.textContent}.`);
+      renderSvg();
+      renderTables();
+      renderSelection({
+        label: "Diagram summary",
+        total: snapshot.includedApplications,
+        id: "summary",
+        applicationIds: snapshot.paths.map((p) => p.applicationId),
+      });
+    },
+    destroy() {
+      ro?.disconnect();
+      clearTimeout(liveTimer);
+      root.textContent = "";
+    },
+  };
+}

--- a/src/web/tracker/tracker.css
+++ b/src/web/tracker/tracker.css
@@ -202,3 +202,75 @@
   background: rgba(127, 29, 29, 0.35);
   color: #fecaca;
 }
+
+.diagram-controls {
+  align-items: end;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-block: 1rem;
+}
+.diagram-controls label {
+  display: grid;
+  gap: 0.25rem;
+  min-width: min(18rem, 100%);
+}
+.diagram-controls input[type="range"] {
+  min-height: 44px;
+}
+.diagram-scroll {
+  border: 1px solid var(--border, #334155);
+  border-radius: 0.75rem;
+  margin-block: 1rem;
+  max-width: 100%;
+  overflow-x: auto;
+  padding: 0.75rem;
+}
+.diagram-scroll svg {
+  min-width: 720px;
+  max-width: none;
+}
+.diagram-scroll rect {
+  fill: var(--accent, #38bdf8);
+  stroke: CanvasText;
+  stroke-width: 1px;
+}
+.diagram-scroll text {
+  fill: currentColor;
+  font-size: 0.8rem;
+  paint-order: stroke;
+  stroke: var(--background, #0f172a);
+  stroke-width: 3px;
+}
+.diagram-link {
+  opacity: 0.45;
+}
+.diagram-link.is-selected,
+.diagram-scroll g.is-selected rect {
+  opacity: 1;
+  stroke: #fbbf24;
+  stroke-width: 3px;
+}
+.diagram-tables {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(min(22rem, 100%), 1fr));
+}
+.sr-only {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}
+@media (max-width: 640px) {
+  .diagram-controls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .diagram-controls .button {
+    min-height: 44px;
+  }
+}

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -26,6 +26,11 @@ import {
 } from "./metrics.js";
 import { createIndexedDbRepository } from "../storage/indexedDbRepository.js";
 import { planLifecycleReconciliation } from "./lifecycleReconciliation.js";
+import {
+  buildLifecycleTimeline,
+  projectLifecycleAt,
+} from "./lifecycleProjection.js";
+import { createLifecycleDiagramView } from "./lifecycleDiagram.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
 const ARRAY_STORES = [
@@ -128,6 +133,8 @@ const state = {
   current: null,
   detailSave: Promise.resolve(),
   reconciliationWarnings: [],
+  diagramBucketId: "current",
+  diagramView: null,
 };
 function weekBucket(value) {
   const d = day(value);
@@ -369,6 +376,7 @@ function route(v) {
 function renderNav() {
   const names = [
     ["Dashboard", "dashboard"],
+    ["Diagram", "diagram"],
     ["Applications", "applications"],
     ["Follow-ups", "follow-ups"],
     ["Contacts/Outreach", "contacts"],
@@ -603,8 +611,41 @@ function renderOutreach() {
       })
       .join("") || '<p class="muted">No outreach messages yet.</p>';
 }
+function renderDiagram() {
+  const root = $("[data-lifecycle-diagram]");
+  if (!root || !state.bundle) return;
+  state.diagramView ??= createLifecycleDiagramView(root, {
+    onSelectBucket: (bucketId) => {
+      state.diagramBucketId = bucketId;
+      renderDiagram();
+    },
+  });
+  const timeline = buildLifecycleTimeline(state.bundle);
+  const hasSelected = timeline.buckets.some(
+    (bucket) => bucket.id === state.diagramBucketId,
+  );
+  let selectedBucketId = hasSelected ? state.diagramBucketId : "current";
+  let newerAvailable = false;
+  if (!hasSelected && state.diagramBucketId !== "current") {
+    selectedBucketId = "current";
+    state.diagramBucketId = "current";
+  } else if (selectedBucketId !== "current") {
+    newerAvailable =
+      timeline.buckets.at(-1)?.eventIds?.join("|") !==
+      timeline.buckets
+        .find((bucket) => bucket.id === selectedBucketId)
+        ?.eventIds?.join("|");
+  }
+  state.diagramView.update({
+    timeline,
+    snapshot: projectLifecycleAt(state.bundle, selectedBucketId),
+    selectedBucketId,
+    newerAvailable,
+  });
+}
 function renderAll() {
   renderDashboard();
+  renderDiagram();
   renderList();
   renderFollowups();
   renderOutreach();

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -132,6 +132,27 @@ test.describe("browser application tracker", () => {
       .click();
     await expect(page.getByText("No applications yet")).toBeVisible();
   });
+
+  test("shows diagram tab between dashboard and applications", async ({
+    page,
+  }) => {
+    const navButtons = page.locator(".tracker-nav button");
+    await expect(navButtons).toHaveText([
+      "Dashboard",
+      "Diagram",
+      "Applications",
+      "Follow-ups",
+      "Contacts/Outreach",
+      "Import/Export",
+      "Settings",
+    ]);
+    await page.getByRole("button", { name: "Diagram", exact: true }).click();
+    await expect(page.locator('[data-view="diagram"]')).toBeVisible();
+    await expect(page.locator("[data-lifecycle-diagram]")).toContainText(
+      "Current",
+    );
+    await expect(page.locator('[data-view="applications"]')).toBeHidden();
+  });
   test("previews compact CSV regression fixture without phantom interviews", async ({
     page,
   }) => {

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -1,0 +1,151 @@
+/* global document */
+/* eslint-disable max-len */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, getByRole } from "@testing-library/dom";
+import { JSDOM } from "jsdom";
+import { createLifecycleDiagramView } from "../src/web/tracker/lifecycleDiagram.js";
+import {
+  buildLifecycleTimeline,
+  projectLifecycleAt,
+} from "../src/web/tracker/lifecycleProjection.js";
+
+const bundle = {
+  applications: [
+    {
+      id: "a1",
+      company: "<img src=x onerror=alert(1)>",
+      role: "Eng",
+      status: "applied",
+      origin: "application_submitted",
+    },
+    {
+      id: "a2",
+      company: "Beta",
+      role: "Eng",
+      status: "rejected",
+      origin: "referral",
+    },
+  ],
+  lifecycleEvents: [
+    {
+      id: "e1",
+      applicationId: "a1",
+      eventType: "application_submitted",
+      occurredAt: "2026-01-01T10:00:00Z",
+    },
+    {
+      id: "e2",
+      applicationId: "a1",
+      eventType: "assessment_take_home",
+      occurredAt: "2026-01-02",
+      occurredAtPrecision: "date",
+    },
+    {
+      id: "e3",
+      applicationId: "a2",
+      eventType: "referral",
+      occurredAtPrecision: "unknown",
+    },
+    {
+      id: "e4",
+      applicationId: "a2",
+      eventType: "employer_rejected",
+      occurredAt: "2026-01-03T10:00:00Z",
+    },
+  ],
+};
+
+const mount = (data = bundle, bucket = "current") => {
+  const dom = new JSDOM(`<div id="root"></div>`, { pretendToBeVisual: true });
+  global.document = dom.window.document;
+  global.window = dom.window;
+  global.ResizeObserver = class {
+    observe() {}
+    disconnect() {}
+  };
+  const root = document.querySelector("#root");
+  const selected = [];
+  const view = createLifecycleDiagramView(root, {
+    onSelectBucket: (id) => selected.push(id),
+  });
+  view.update({
+    timeline: buildLifecycleTimeline(data),
+    snapshot: projectLifecycleAt(data, bucket),
+    selectedBucketId: bucket,
+    newerAvailable: bucket !== "current",
+  });
+  return { dom, root, view, selected };
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete global.document;
+  delete global.window;
+  delete global.ResizeObserver;
+});
+
+describe("lifecycle diagram view", () => {
+  it("renders current by default with accessible svg, controls, and semantic totals", () => {
+    const { root } = mount();
+    expect(
+      getByRole(root, "img", { name: /lifecycle sankey diagram/i }),
+    ).toBeTruthy();
+    expect(getByRole(root, "slider").getAttribute("aria-valuetext")).toContain(
+      "Current",
+    );
+    expect(root.textContent).toContain("2 of 2 applications included");
+    expect(getByRole(root, "table", { name: "Origins" }).textContent).toContain(
+      "50%",
+    );
+    expect(
+      getByRole(root, "table", { name: "Endpoints" }).textContent,
+    ).toContain("50%");
+  });
+
+  it("supports historical bucket controls, date timestamp modes, and disabled states", () => {
+    const timeline = buildLifecycleTimeline(bundle);
+    const dateBucket = timeline.buckets.find((b) => b.kind === "date").id;
+    const { root, selected } = mount(bundle, dateBucket);
+    expect(root.textContent).toContain("Historical — Newer activity available");
+    expect(getByRole(root, "slider").getAttribute("aria-valuetext")).toContain(
+      "time not recorded",
+    );
+    fireEvent.click(getByRole(root, "button", { name: "Next event" }));
+    expect(selected.at(-1)).toBeTruthy();
+    fireEvent.click(getByRole(root, "button", { name: "Return to current" }));
+    expect(selected.at(-1)).toBe("current");
+  });
+
+  it("renders unknown-only and empty states safely without mutating projection", () => {
+    const snapshot = projectLifecycleAt(bundle, "unknown-date");
+    const before = JSON.stringify(snapshot);
+    const { root } = mount(bundle, "unknown-date");
+    expect(getByRole(root, "slider").getAttribute("aria-valuetext")).toContain(
+      "Unknown date",
+    );
+    expect(JSON.stringify(snapshot)).toBe(before);
+    expect(root.innerHTML).not.toContain("onerror");
+    const empty = mount({ applications: [], lifecycleEvents: [] }).root;
+    expect(empty.textContent).toContain("No lifecycle paths");
+  });
+
+  it("selection rows and svg clicks drive one details region without listener multiplication", () => {
+    const { root, view, dom } = mount();
+    const addSpy = vi.spyOn(
+      dom.window.EventTarget.prototype,
+      "addEventListener",
+    );
+    const initial = addSpy.mock.calls.length;
+    view.update({
+      timeline: buildLifecycleTimeline(bundle),
+      snapshot: projectLifecycleAt(bundle),
+      selectedBucketId: "current",
+    });
+    expect(addSpy.mock.calls.length - initial).toBeLessThan(20);
+    const link = root.querySelector("path[data-diagram-id]");
+    fireEvent.click(link);
+    expect(root.querySelector("[data-diagram-details]").textContent).toContain(
+      "applications",
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a Diagram view that visualizes P3 lifecycle history using the canonical P4 projection so users can explore current and historical lifecycle buckets with an accessible Sankey-style diagram. 
- Keep all data-local and projection-first: the diagram must clone P4 projection objects (d3 mutates layout objects), render with safe DOM/SVG APIs, and expose semantic table equivalents for accessibility and testing. 

### Description
- Added a new hidden tracker view and mount point in `src/web/tracker/index.html` for `data-view="diagram"` and a `[data-lifecycle-diagram]` container. 
- Implemented `createLifecycleDiagramView(root, options)` in `src/web/tracker/lifecycleDiagram.js` that uses named imports from `d3-sankey` for layout, clones projection data, fixes column x-coordinates, produces accessible SVG (`role="img"`, `<title>`, `<desc>`), renders controls (previous/next/range/current, badge, timestamp, simultaneous-event disclosure), and creates semantic tables and a single details region. 
- Wired the view into `src/web/tracker/tracker.js` with `renderDiagram()` and navigation placement (Diagram inserted between Dashboard and Applications), preserved selected bucket across tab navigation, and implemented fallback to Current when a selected bucket is missing. 
- Added responsive and a11y-focused styles in `src/web/tracker/tracker.css`, a focused Vitest unit test file `test/web-tracker-lifecycle-diagram.test.js`, and a Playwright smoke test that asserts nav order and Diagram visibility in `test/playwright/browser-tracker.spec.js`. 
- Installed exactly `d3-sankey@0.12.3` (named imports only), updated `package.json`/`package-lock.json`, and added `THIRD_PARTY_NOTICES.md` with the BSD-3-Clause notice for d3-sankey. 

### Testing
- Installed the dependency with `npm install d3-sankey@0.12.3` (success). 
- Ran focused unit tests with `npx vitest run test/web-tracker-lifecycle-projection.test.js test/web-tracker-lifecycle-diagram.test.js` and both test files passed (32 tests total, all passed). 
- Ran Playwright smoke tests for the Diagram tab with `npx playwright test test/playwright/browser-tracker.spec.js --grep "diagram tab"` and the focused check passed, then ran the full Playwright tracker suite `npx playwright test test/playwright/browser-tracker.spec.js` which passed (27 tests). 
- Built the static assets with `npm run build` and inspected the bundle for external references using `rg` (local bundling of `d3-sankey` observed in `dist/assets/tracker.js` and no CDN/runtime fetches). 
- Lint and formatting checks: `npm run lint` and `npx prettier --check` were run; lint passed for staged changes and Prettier checks passed for the touched files (repo-wide Prettier baseline warnings exist but were not introduced by this change). 
- Typecheck succeeded with `npm run typecheck`. 
- CI-style test run `npm run test:ci` was executed; the majority of tests passed but one existing/unrelated test failed: `test/web-security-alerts.test.js` asserted a length of 2 alert files but found 1 (this failure is not caused by the Diagram changes). 

If you want I can split follow-ups (smaller a11y refinements, keyboard focus tuning, or semantic table improvements) into separate PRs; the Diagram implementation and tests above intentionally avoid mutating P4 projection objects and bundle `d3-sankey` locally with a proper third-party notice.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52f4abe07c832f8aa8684689a2863a)