### PR TITLE
Add tracker lifecycle Diagram tab with d3-sankey diagram view

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,9 @@
+# Third-party notices
+
+## d3-sankey 0.12.3
+
+License: BSD-3-Clause
+
+Copyright 2017 Mike Bostock
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the BSD 3-Clause license conditions are met. The full license text is available in the d3-sankey package distributed from npm.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ import globals from 'globals';
 
 export default [
   {
-    ignores: ['node_modules', '.cache'],
+    ignores: ['node_modules', '.cache', 'dist'],
   },
   {
     files: ['**/*.js'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.4.1",
+        "d3-sankey": "0.12.3",
         "docx": "^9.5.1",
         "dotenv": "^16.6.1",
         "drizzle-orm": "^0.44.6",
@@ -3692,6 +3693,40 @@
         "node": ">=20"
       }
     },
+    "node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -5439,6 +5474,12 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
     },
     "node_modules/intl-messageformat": {
       "version": "10.7.16",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.4.1",
+    "d3-sankey": "0.12.3",
     "docx": "^9.5.1",
     "dotenv": "^16.6.1",
     "drizzle-orm": "^0.44.6",

--- a/src/web/tracker/index.html
+++ b/src/web/tracker/index.html
@@ -37,6 +37,10 @@
           <p data-weekly-counts class="muted">No application data yet.</p>
         </article>
       </section>
+      <section class="tracker-view" data-view="diagram" hidden>
+        <h2>Diagram</h2>
+        <div data-lifecycle-diagram></div>
+      </section>
       <section class="tracker-view" data-view="applications" hidden>
         <div class="tracker-actions">
           <h2>Applications</h2>

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -1,0 +1,461 @@
+/* global document, window, ResizeObserver */
+import { sankey, sankeyJustify, sankeyLinkHorizontal } from "d3-sankey";
+import {
+  buildLifecycleTimeline,
+  projectLifecycleAt,
+} from "./lifecycleProjection.js";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const rankFor = (id) =>
+  id.startsWith("origin:")
+    ? 0
+    : id.startsWith("endpoint:")
+      ? 6
+      : 1 +
+        [
+          "recruiter_screen",
+          "assessment_take_home",
+          "technical_interview",
+          "onsite_final_loop",
+          "offer_received",
+        ].indexOf(id.split(":")[1]);
+const label = (v) =>
+  String(v ?? "")
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+const pct = (n, d) => (d ? `${Math.round((n / d) * 100)}%` : "0%");
+const el = (name, attrs = {}, text) => {
+  const node = document.createElement(name);
+  for (const [k, v] of Object.entries(attrs))
+    if (v !== undefined) node.setAttribute(k, v);
+  if (text !== undefined) node.textContent = text;
+  return node;
+};
+const svgEl = (name, attrs = {}, text) => {
+  const node = document.createElementNS(SVG_NS, name);
+  for (const [k, v] of Object.entries(attrs))
+    if (v !== undefined) node.setAttribute(k, v);
+  if (text !== undefined) node.textContent = text;
+  return node;
+};
+const clear = (node) => {
+  node.replaceChildren();
+};
+const timeText = (bucket, projection) => {
+  if (!bucket || bucket.kind === "current") {
+    const known = projection.events
+      .map((e) => Date.parse(e.occurredAt))
+      .filter(Number.isFinite)
+      .sort((a, b) => b - a)[0];
+    const unknown = projection.events.filter((e) =>
+      ["unknown", "legacy-placeholder", "legacy_placeholder"].includes(
+        e.occurredAtPrecision,
+      ),
+    ).length;
+    const latest = known
+      ? `; latest known event ${new Date(known).toLocaleString()}`
+      : "";
+    const plural = unknown === 1 ? "" : "s";
+    return `Current — latest data in this browser${latest}; ${unknown} unknown-time event${plural}`;
+  }
+  if (bucket.kind === "unknown-date")
+    return "Unknown date — off chronological scale";
+  if (bucket.kind === "date")
+    return `${String(bucket.id).slice(0, 10)} — time not recorded`;
+  const iso = String(bucket.label ?? bucket.id).includes("T")
+    ? String(bucket.label ?? bucket.id)
+    : String(bucket.id).split("|").at(-1);
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms)
+    ? new Date(ms).toLocaleString()
+    : String(bucket.label ?? bucket.id);
+};
+const cloneForSankey = (projection) => ({
+  nodes: projection.nodes
+    .map((n) => ({ ...n, fixedRank: rankFor(n.id) }))
+    .sort((a, b) => a.fixedRank - b.fixedRank || a.id.localeCompare(b.id)),
+  links: projection.links
+    .map((l) => ({ ...l }))
+    .sort((a, b) => a.id.localeCompare(b.id)),
+});
+function renderTable(container, caption, headers, rows, onSelect) {
+  const table = el("table", { class: "tracker-table lifecycle-table" });
+  table.append(el("caption", {}, caption));
+  const thead = el("thead");
+  const tr = el("tr");
+  headers.forEach((h) => tr.append(el("th", { scope: "col" }, h)));
+  thead.append(tr);
+  table.append(thead);
+  const tbody = el("tbody");
+  rows.forEach((row) => {
+    const r = el("tr");
+    row.cells.forEach((c, i) =>
+      r.append(el(i ? "td" : "th", i ? {} : { scope: "row" }, c)),
+    );
+    const td = el("td");
+    const b = el(
+      "button",
+      { type: "button", class: "button", "data-select-id": row.id },
+      "Select",
+    );
+    b.addEventListener("click", () => onSelect(row.id));
+    td.append(b);
+    r.append(td);
+    tbody.append(r);
+  });
+  table.append(tbody);
+  container.append(table);
+}
+export function createLifecycleDiagramView(root) {
+  let selectedId = "";
+  let resizeTimer;
+  let current;
+  root.classList.add("lifecycle-diagram");
+  const onResize = () => {
+    window.clearTimeout(resizeTimer);
+    resizeTimer = window.setTimeout(() => current && draw(current), 80);
+  };
+  const ro =
+    typeof ResizeObserver === "function"
+      ? new ResizeObserver(onResize)
+      : undefined;
+  ro?.observe(root);
+  const select = (id) => {
+    selectedId = id;
+    root
+      .querySelectorAll("[data-diagram-id]")
+      .forEach((n) =>
+        n.classList.toggle("is-selected", n.dataset.diagramId === id),
+      );
+    renderDetails();
+  };
+  function renderDetails() {
+    const box = root.querySelector("[data-diagram-details]");
+    if (!box || !current) return;
+    const p = current.projection;
+    const item = [...p.nodes, ...p.links].find((x) => x.id === selectedId);
+    if (!item) {
+      box.textContent = "Select a row or diagram element for details.";
+      return;
+    }
+    const count = item.total ?? item.value;
+    const apps =
+      item.applicationIds ??
+      p.paths
+        .filter((path) => path.nodeIds.includes(item.id))
+        .map((path) => path.applicationId);
+    const observed = p.paths.filter(
+      (path) =>
+        apps.includes(path.applicationId) &&
+        !path.details.some((d) => d.code.startsWith("inferred")),
+    ).length;
+    box.replaceChildren(
+      el(
+        "h3",
+        {},
+        item.source
+          ? `${label(item.source.id ?? item.source)} to ${label(
+              item.target.id ?? item.target,
+            )}`
+          : label(item.label ?? item.id),
+      ),
+      el(
+        "p",
+        {},
+        [
+          `${count} application${count === 1 ? "" : "s"}`,
+          `(${pct(count, p.includedApplications)}).`,
+          `Observed ${observed};`,
+          `inferred ${Math.max(0, count - observed)}.`,
+          `Date range: ${p.bucket.label}.`,
+        ].join(" "),
+      ),
+      el("details", {}, ""),
+    );
+    const d = box.querySelector("details");
+    d.append(
+      el("summary", {}, "Affected applications"),
+      el("p", {}, apps.join(", ") || "None"),
+    );
+  }
+  function draw({ projection, timeline, selectedBucketId, newerAvailable }) {
+    current = { projection, timeline, selectedBucketId, newerAvailable };
+    clear(root);
+    const buckets = timeline.buckets;
+    const index = Math.max(
+      0,
+      buckets.findIndex((b) => b.id === selectedBucketId),
+    );
+    const bucket = buckets[index] ?? buckets.at(-1);
+    const controls = el("div", { class: "diagram-controls" });
+    const prev = el(
+      "button",
+      {
+        type: "button",
+        class: "button",
+        "data-diagram-prev": "",
+        disabled: index <= 0 ? "" : undefined,
+      },
+      "Previous event",
+    );
+    const rangeId = "lifecycle-bucket-range";
+    const range = el("input", {
+      id: rangeId,
+      type: "range",
+      min: "0",
+      max: String(Math.max(0, buckets.length - 1)),
+      value: String(index),
+      "aria-label": "Lifecycle event bucket",
+      "aria-valuetext": timeText(bucket, projection),
+    });
+    const next = el(
+      "button",
+      {
+        type: "button",
+        class: "button",
+        disabled: index >= buckets.length - 1 ? "" : undefined,
+      },
+      "Next event",
+    );
+    const cur = el(
+      "button",
+      {
+        type: "button",
+        class: "button",
+        disabled: selectedBucketId === "current" ? "" : undefined,
+      },
+      "Return to current",
+    );
+    controls.append(
+      prev,
+      el("label", { for: rangeId }, "Timeline"),
+      range,
+      next,
+      cur,
+      el(
+        "span",
+        { class: "chip" },
+        bucket.kind === "current" ? "Current" : "Historical",
+      ),
+      el(
+        "span",
+        {},
+        `${projection.includedApplications}/${projection.totalApplications} applications`,
+      ),
+    );
+    root.append(
+      controls,
+      el("p", {}, timeText(bucket, projection)),
+      el(
+        "p",
+        { role: "status", "aria-live": "polite", class: "muted" },
+        newerAvailable ? "Newer activity available" : "",
+      ),
+    );
+    if (projection.events.length > 1) {
+      const det = el("details");
+      det.append(
+        el(
+          "summary",
+          {},
+          `${projection.events.length} simultaneous/boundary events`,
+        ),
+        el("p", {}, projection.events.map((e) => e.id).join(", ")),
+      );
+      root.append(det);
+    }
+    const dispatch = (i) =>
+      root.dispatchEvent(
+        new CustomEvent("lifecycle-diagram-bucket", {
+          bubbles: true,
+          detail: { bucketId: buckets[i]?.id ?? "current" },
+        }),
+      );
+    prev.onclick = () => dispatch(index - 1);
+    next.onclick = () => dispatch(index + 1);
+    cur.onclick = () => dispatch(buckets.length - 1);
+    range.oninput = () => dispatch(Number(range.value));
+    if (!projection.includedApplications) {
+      root.append(
+        el(
+          "p",
+          { class: "muted", "data-diagram-empty": "" },
+          projection.totalApplications
+            ? "No applications existed at this point."
+            : "No application data yet.",
+        ),
+      );
+      return;
+    }
+    const scroll = el("div", {
+      class: "diagram-scroll",
+      tabindex: "0",
+      role: "region",
+      "aria-label": "Scrollable lifecycle diagram",
+    });
+    const svg = svgEl("svg", {
+      role: "img",
+      "aria-labelledby": "lifecycle-diagram-title lifecycle-diagram-desc",
+      width: "920",
+      height: "420",
+      viewBox: "0 0 920 420",
+    });
+    svg.append(
+      svgEl(
+        "title",
+        { id: "lifecycle-diagram-title" },
+        "Application lifecycle diagram",
+      ),
+      svgEl(
+        "desc",
+        { id: "lifecycle-diagram-desc" },
+        "Sankey diagram of application origins, milestones, and endpoints.",
+      ),
+    );
+    const graph = cloneForSankey(projection);
+    const layout = sankey()
+      .nodeId((d) => d.id)
+      .nodeAlign(sankeyJustify)
+      .nodeWidth(16)
+      .nodePadding(14)
+      .extent([
+        [12, 12],
+        [908, 360],
+      ]);
+    layout(graph);
+    graph.nodes.forEach((n) => {
+      const x = 12 + (n.fixedRank / 6) * 880;
+      n.x0 = x;
+      n.x1 = x + 16;
+    });
+    layout.update(graph);
+    const gLinks = svgEl("g", { class: "diagram-links" });
+    graph.links.forEach((l) => {
+      if (!l.value) return;
+      const pth = svgEl("path", {
+        d: sankeyLinkHorizontal()(l),
+        class: "diagram-link",
+        "data-diagram-id": l.id,
+        "stroke-width": String(Math.max(3, l.width || 1)),
+        tabindex: "-1",
+      });
+      pth.append(
+        svgEl(
+          "title",
+          {},
+          `${label(l.source.id)} to ${label(l.target.id)}: ${l.value}`,
+        ),
+      );
+      pth.addEventListener("click", () => select(l.id));
+      gLinks.append(pth);
+    });
+    const gNodes = svgEl("g", { class: "diagram-nodes" });
+    graph.nodes.forEach((n) => {
+      if (!n.value) return;
+      const h = Math.max(10, n.y1 - n.y0);
+      const r = svgEl("rect", {
+        x: String(n.x0),
+        y: String(n.y0),
+        width: String(n.x1 - n.x0),
+        height: String(h),
+        class: "diagram-node",
+        "data-diagram-id": n.id,
+      });
+      r.append(svgEl("title", {}, `${n.label}: ${n.total}`));
+      r.addEventListener("click", () => select(n.id));
+      const t = svgEl(
+        "text",
+        { x: String(n.x1 + 5), y: String(n.y0 + 12) },
+        `${n.label} (${n.total})`,
+      );
+      gNodes.append(r, t);
+    });
+    svg.append(gLinks, gNodes);
+    scroll.append(svg);
+    root.append(
+      scroll,
+      el("div", { "data-diagram-details": "", class: "card" }),
+    );
+    const sem = el("div", { class: "diagram-semantics" });
+    renderTable(
+      sem,
+      "Origins",
+      ["Origin", "Count", "Percentage", "Action"],
+      Object.entries(projection.totals.origins).map(([k, v]) => ({
+        id: `origin:${k}`,
+        cells: [label(k), String(v), pct(v, projection.includedApplications)],
+      })),
+      select,
+    );
+    renderTable(
+      sem,
+      "Endpoints",
+      ["Endpoint", "Count", "Percentage", "Action"],
+      Object.entries(projection.totals.endpoints).map(([k, v]) => ({
+        id: `endpoint:${k}`,
+        cells: [label(k), String(v), pct(v, projection.includedApplications)],
+      })),
+      select,
+    );
+    renderTable(
+      sem,
+      "Flows",
+      ["From", "To", "Applications", "Action"],
+      projection.links.map((l) => ({
+        id: l.id,
+        cells: [label(l.source), label(l.target), String(l.value)],
+      })),
+      select,
+    );
+    renderTable(
+      sem,
+      "Selected-boundary events",
+      ["Event", "Application", "Type", "Action"],
+      projection.events.map((e) => ({
+        id: "",
+        cells: [e.id, e.applicationId, label(e.eventType)],
+      })),
+      () => {},
+    );
+    sem.append(
+      el(
+        "p",
+        { class: "muted" },
+        [
+          `Warnings — inferred history: ${
+            projection.warningCounts.inferred_event ?? 0
+          };`,
+          `unknown origin/time: ${
+            (projection.warningCounts.inferred_origin ?? 0) +
+            (projection.warningCounts.invalid_timestamp ?? 0)
+          };`,
+          `status mismatch: ${projection.warningCounts.status_mismatch ?? 0};`,
+          `regression: ${projection.warningCounts.regressive_history ?? 0}.`,
+        ].join(" "),
+      ),
+    );
+    root.append(sem);
+    select(selectedId);
+  }
+  return {
+    update({
+      timeline,
+      snapshot,
+      selectedBucketId = "current",
+      newerAvailable = false,
+    }) {
+      const t = timeline ?? buildLifecycleTimeline(snapshot ?? {});
+      draw({
+        projection: projectLifecycleAt(snapshot ?? {}, selectedBucketId),
+        timeline: t,
+        selectedBucketId,
+        newerAvailable,
+      });
+    },
+    destroy() {
+      ro?.disconnect();
+      window.clearTimeout(resizeTimer);
+      clear(root);
+    },
+  };
+}

--- a/src/web/tracker/tracker.css
+++ b/src/web/tracker/tracker.css
@@ -202,3 +202,77 @@
   background: rgba(127, 29, 29, 0.35);
   color: #fecaca;
 }
+.lifecycle-diagram {
+  display: grid;
+  gap: 1rem;
+  max-width: 100%;
+}
+.diagram-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.6rem;
+}
+.diagram-controls input[type="range"] {
+  min-width: min(18rem, 100%);
+  min-height: 44px;
+}
+.diagram-scroll {
+  max-width: 100%;
+  overflow-x: auto;
+  border: 1px solid var(--card-border, #334155);
+  border-radius: 1rem;
+  padding: 0.5rem;
+}
+.diagram-scroll svg {
+  min-width: 760px;
+  max-width: none;
+  height: auto;
+}
+.diagram-link {
+  fill: none;
+  stroke: #60a5fa;
+  stroke-opacity: 0.45;
+}
+.diagram-node {
+  fill: #fbbf24;
+  stroke: #111827;
+  stroke-width: 1;
+}
+.diagram-link.is-selected,
+.diagram-node.is-selected {
+  stroke: #f8fafc;
+  stroke-opacity: 1;
+  outline: 2px solid #f8fafc;
+}
+.diagram-nodes text {
+  fill: var(--foreground, #e5e7eb);
+  font-size: 12px;
+  paint-order: stroke;
+  stroke: #0f172a;
+  stroke-width: 3px;
+}
+.diagram-semantics {
+  display: grid;
+  gap: 1rem;
+}
+.lifecycle-table caption {
+  font-weight: 700;
+  text-align: left;
+  padding: 0.5rem 0;
+}
+@media (max-width: 760px) {
+  .diagram-controls {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .diagram-controls > * {
+    width: 100%;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .lifecycle-diagram * {
+    animation: none !important;
+    transition: none !important;
+  }
+}

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -26,6 +26,8 @@ import {
 } from "./metrics.js";
 import { createIndexedDbRepository } from "../storage/indexedDbRepository.js";
 import { planLifecycleReconciliation } from "./lifecycleReconciliation.js";
+import { createLifecycleDiagramView } from "./lifecycleDiagram.js";
+import { buildLifecycleTimeline } from "./lifecycleProjection.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
 const ARRAY_STORES = [
@@ -128,6 +130,8 @@ const state = {
   current: null,
   detailSave: Promise.resolve(),
   reconciliationWarnings: [],
+  diagramBucketId: "current",
+  diagramView: null,
 };
 function weekBucket(value) {
   const d = day(value);
@@ -369,6 +373,7 @@ function route(v) {
 function renderNav() {
   const names = [
     ["Dashboard", "dashboard"],
+    ["Diagram", "diagram"],
     ["Applications", "applications"],
     ["Follow-ups", "follow-ups"],
     ["Contacts/Outreach", "contacts"],
@@ -603,9 +608,39 @@ function renderOutreach() {
       })
       .join("") || '<p class="muted">No outreach messages yet.</p>';
 }
+function renderDiagram() {
+  const root = $("[data-lifecycle-diagram]");
+  if (!root || !state.bundle) return;
+  state.diagramView ??= createLifecycleDiagramView(root);
+  const timeline = buildLifecycleTimeline(state.bundle);
+  const exists = timeline.buckets.some(
+    (bucket) => bucket.id === state.diagramBucketId,
+  );
+  if (!exists) {
+    state.diagramBucketId = "current";
+    root.dispatchEvent(
+      new CustomEvent("lifecycle-diagram-announcement", {
+        detail: {
+          message:
+            "Selected historical point is unavailable; returned to Current.",
+        },
+      }),
+    );
+  }
+  const newerAvailable =
+    state.diagramBucketId !== "current" &&
+    timeline.buckets.at(-1)?.id === "current";
+  state.diagramView.update({
+    timeline,
+    snapshot: state.bundle,
+    selectedBucketId: state.diagramBucketId,
+    newerAvailable,
+  });
+}
 function renderAll() {
   renderDashboard();
   renderList();
+  renderDiagram();
   renderFollowups();
   renderOutreach();
 }
@@ -1432,6 +1467,13 @@ function renderBuildMetadata() {
 function init() {
   renderBuildMetadata();
   renderNav();
+  $(`[data-lifecycle-diagram]`)?.addEventListener(
+    "lifecycle-diagram-bucket",
+    (event) => {
+      state.diagramBucketId = event.detail?.bucketId ?? "current";
+      renderDiagram();
+    },
+  );
   $('[data-filter="status"]').innerHTML += STATUSES.map(
     (s) => `<option>${s}</option>`,
   ).join("");

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -132,6 +132,22 @@ test.describe("browser application tracker", () => {
       .click();
     await expect(page.getByText("No applications yet")).toBeVisible();
   });
+
+  test("renders lifecycle diagram smoke coverage", async ({ page }) => {
+    await importRegressionBundle(page);
+
+    await page.getByRole("button", { name: "Diagram" }).click();
+
+    await expect(
+      page.locator("[data-lifecycle-diagram] svg[role='img']"),
+    ).toBeVisible();
+    await expect(page.getByRole("table", { name: "Origins" })).toBeVisible();
+    await expect(page.getByRole("table", { name: "Endpoints" })).toBeVisible();
+    await expect(page.locator("[data-lifecycle-diagram]")).toContainText(
+      "15/15 applications",
+    );
+  });
+
   test("previews compact CSV regression fixture without phantom interviews", async ({
     page,
   }) => {

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -1,0 +1,168 @@
+/* global document */
+// @vitest-environment jsdom
+import { fireEvent, getByRole, getByText, within } from "@testing-library/dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createLifecycleDiagramView } from "../src/web/tracker/lifecycleDiagram.js";
+import {
+  buildLifecycleTimeline,
+  projectLifecycleAt,
+} from "../src/web/tracker/lifecycleProjection.js";
+
+const bundle = (applications = [], lifecycleEvents = []) => ({
+  applications,
+  lifecycleEvents,
+});
+const app = (id, overrides = {}) => ({
+  id,
+  company: `Company ${id}`,
+  role: "Engineer",
+  status: "applied",
+  appliedAt: "2026-01-01",
+  ...overrides,
+});
+const event = (id, applicationId, eventType, occurredAt, overrides = {}) => ({
+  id,
+  applicationId,
+  eventType,
+  occurredAt,
+  source: "manual",
+  ...overrides,
+});
+
+describe("lifecycle diagram view", () => {
+  let root;
+  beforeEach(() => {
+    root = document.createElement("section");
+    document.body.replaceChildren(root);
+  });
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it("renders current by default with accessible SVG and semantic totals", () => {
+    const data = bundle(
+      [app("a1"), app("a2", { status: "offer" })],
+      [
+        event("e1", "a1", "application_submitted", "2026-01-01T10:00:00.000Z"),
+        event("e2", "a2", "referral", "2026-01-01T10:00:00.000Z"),
+        event("e3", "a2", "offer_received", "2026-01-03T10:00:00.000Z"),
+      ],
+    );
+    createLifecycleDiagramView(root).update({ snapshot: data });
+    expect(getByText(root, "Current")).toBeTruthy();
+    expect(root.querySelector("svg[role='img'] title")?.textContent).toContain(
+      "Application lifecycle diagram",
+    );
+    expect(root.querySelectorAll("[data-diagram-id]").length).toBeGreaterThan(
+      0,
+    );
+    const origins = getByRole(root, "table", { name: "Origins" });
+    expect(within(origins).getByText("Application Submitted")).toBeTruthy();
+    expect(
+      within(getByRole(root, "table", { name: "Endpoints" })).getByText(
+        "Offer Negotiating",
+      ),
+    ).toBeTruthy();
+    expect(root.textContent).toContain("2/2 applications");
+  });
+
+  it("supports empty, unknown-only, timestamp, and simultaneous-event states", () => {
+    const view = createLifecycleDiagramView(root);
+    view.update({ snapshot: bundle() });
+    expect(root.querySelector("[data-diagram-empty]")?.textContent).toContain(
+      "No application data",
+    );
+    const data = bundle(
+      [app("a1")],
+      [
+        event("u1", "a1", "application_submitted", "", {
+          occurredAtPrecision: "unknown",
+        }),
+        event("u2", "a1", "candidate_outreach", "", {
+          occurredAtPrecision: "unknown",
+        }),
+      ],
+    );
+    view.update({ snapshot: data, selectedBucketId: "unknown-date" });
+    expect(root.textContent).toContain(
+      "Unknown date — off chronological scale",
+    );
+    expect(root.textContent).toContain("2 simultaneous/boundary events");
+    expect(
+      root.querySelector("input[type='range']")?.getAttribute("aria-valuetext"),
+    ).toContain("Unknown date");
+  });
+
+  it("synchronizes controls and disabled states without persisting selection itself", () => {
+    const data = bundle(
+      [app("a1")],
+      [event("e1", "a1", "application_submitted", "2026-01-02")],
+    );
+    const timeline = buildLifecycleTimeline(data);
+    const seen = [];
+    root.addEventListener("lifecycle-diagram-bucket", (e) =>
+      seen.push(e.detail.bucketId),
+    );
+    createLifecycleDiagramView(root).update({
+      snapshot: data,
+      timeline,
+      selectedBucketId: "current",
+    });
+    expect(getByRole(root, "button", { name: "Next event" }).disabled).toBe(
+      true,
+    );
+    fireEvent.click(getByRole(root, "button", { name: "Previous event" }));
+    expect(seen.at(-1)).toBe(timeline.buckets.at(-2).id);
+    fireEvent.input(root.querySelector("input[type='range']"), {
+      target: { value: "0" },
+    });
+    expect(seen.at(-1)).toBe("unknown-date");
+  });
+
+  it("selects node/link rows and leaves P4 projection immutable", () => {
+    const data = bundle(
+      [app("a1")],
+      [event("e1", "a1", "application_submitted", "2026-01-01T10:00:00Z")],
+    );
+    const projection = projectLifecycleAt(data);
+    expect(Object.isFrozen(projection.nodes[0])).toBe(true);
+    createLifecycleDiagramView(root).update({ snapshot: data });
+    fireEvent.click(
+      within(getByRole(root, "table", { name: "Origins" })).getByRole(
+        "button",
+        { name: "Select" },
+      ),
+    );
+    expect(root.querySelector("[data-diagram-details]")?.textContent).toContain(
+      "1 application",
+    );
+    expect(projection.nodes.every((n) => n.x0 === undefined)).toBe(true);
+  });
+
+  it("registers one resize observer and removes it on destroy", () => {
+    const disconnect = vi.fn();
+    const observe = vi.fn();
+    vi.stubGlobal(
+      "ResizeObserver",
+      vi.fn(() => ({ observe, disconnect })),
+    );
+    const view = createLifecycleDiagramView(root);
+    view.update({ snapshot: bundle([app("a1")]) });
+    view.update({ snapshot: bundle([app("a1")]) });
+    expect(observe).toHaveBeenCalledTimes(1);
+    view.destroy();
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders malicious-looking text inertly and uses no external references", () => {
+    createLifecycleDiagramView(root).update({
+      snapshot: bundle([app("<img src=x onerror=alert(1)>")]),
+    });
+    expect(root.querySelector("img")).toBeNull();
+    expect([
+      ...root.querySelectorAll("script, foreignObject, image, use"),
+    ]).toHaveLength(0);
+    expect(root.innerHTML).not.toContain("onerror");
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a dedicated Diagram tab that renders P3 lifecycle timeline + P4 projection as an accessible sankey-style lifecycle diagram and semantic tables for parity with the design contract.
- Use a small, explicitly-versioned layout dependency (`d3-sankey@0.12.3`) bundled into the existing build and captured with a BSD-3-Clause notice.

### Description
- Add `src/web/tracker/lifecycleDiagram.js` implementing `createLifecycleDiagramView(root)` which draws a D3-based sankey layout from the P4 projection (cloned before layout), exposes `update({ timeline, snapshot, selectedBucketId, newerAvailable })` and `destroy()`, registers a single ResizeObserver, and renders accessible SVG plus semantic tables and controls.
- Add `test/web-tracker-lifecycle-diagram.test.js` with focused Vitest coverage for default/current behavior, empty/unknown/simultaneous states, control synchronization, selection/details, ResizeObserver lifecycle, and safety of text rendering.
- Wire the Diagram tab into the tracker: insert a hidden `data-view=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52f4d0af18832fa4eaf7eabec1dd93)