### PR TITLE
Add Diagram tab with accessible lifecycle Sankey and tables (d3-sankey@0.12.3)

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,9 @@
+# Third-party notices
+
+## d3-sankey 0.12.3
+
+License: BSD-3-Clause
+
+Copyright 2019 Mike Bostock
+
+This project bundles d3-sankey through the existing local build pipeline. See the package distribution for the complete BSD-3-Clause license text.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.4.1",
+        "d3-sankey": "0.12.3",
         "docx": "^9.5.1",
         "dotenv": "^16.6.1",
         "drizzle-orm": "^0.44.6",
@@ -3692,6 +3693,40 @@
         "node": ">=20"
       }
     },
+    "node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
@@ -5439,6 +5474,12 @@
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
+    },
+    "node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
     },
     "node_modules/intl-messageformat": {
       "version": "10.7.16",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.4.1",
+    "d3-sankey": "0.12.3",
     "docx": "^9.5.1",
     "dotenv": "^16.6.1",
     "drizzle-orm": "^0.44.6",

--- a/src/web/tracker/index.html
+++ b/src/web/tracker/index.html
@@ -37,6 +37,12 @@
           <p data-weekly-counts class="muted">No application data yet.</p>
         </article>
       </section>
+      <section class="tracker-view" data-view="diagram" hidden>
+        <h2>Diagram</h2>
+        <article class="card" data-lifecycle-diagram>
+          <p class="muted">Loading lifecycle diagram…</p>
+        </article>
+      </section>
       <section class="tracker-view" data-view="applications" hidden>
         <div class="tracker-actions">
           <h2>Applications</h2>

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -1,0 +1,420 @@
+/* global document, window, ResizeObserver */
+import { sankey, sankeyLinkHorizontal } from "d3-sankey";
+import { LIFECYCLE_DIAGRAM_TAXONOMY } from "./lifecycleProjection.js";
+
+const NS = "http://www.w3.org/2000/svg";
+const columns = new Map([
+  ...LIFECYCLE_DIAGRAM_TAXONOMY.origins.map((n) => [n.nodeId, 0]),
+  ...LIFECYCLE_DIAGRAM_TAXONOMY.milestones.map((n, i) => [n.nodeId, i + 1]),
+  ...LIFECYCLE_DIAGRAM_TAXONOMY.endpoints.map((n) => [n.nodeId, 6]),
+]);
+const fmt = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "full",
+  timeStyle: "long",
+});
+const pct = (n, d) => (d ? `${Math.round((n / d) * 100)}%` : "0%");
+const el = (tag, attrs = {}, text) => {
+  const node = document.createElement(tag);
+  for (const [k, v] of Object.entries(attrs))
+    if (v !== undefined) node.setAttribute(k, String(v));
+  if (text !== undefined) node.textContent = text;
+  return node;
+};
+const svgEl = (tag, attrs = {}) => {
+  const node = document.createElementNS(NS, tag);
+  for (const [k, v] of Object.entries(attrs)) node.setAttribute(k, String(v));
+  return node;
+};
+const labelFor = (id) =>
+  [
+    ...LIFECYCLE_DIAGRAM_TAXONOMY.origins,
+    ...LIFECYCLE_DIAGRAM_TAXONOMY.milestones,
+    ...LIFECYCLE_DIAGRAM_TAXONOMY.endpoints,
+  ].find((x) => x.nodeId === id)?.label ?? id;
+const bucketText = (bucket, projection) => {
+  if (!bucket || bucket.id === "current") {
+    const known = (projection?.events ?? []).filter(
+      (e) => e.occurredAt && e.occurredAtPrecision !== "unknown",
+    );
+    const latest = known
+      .map((e) => Date.parse(e.occurredAt))
+      .filter(Number.isFinite)
+      .sort((a, b) => b - a)[0];
+    const suffix = latest
+      ? `, latest known event time ${fmt.format(new Date(latest))}`
+      : "";
+    const unknownCount = projection?.warningCounts?.invalid_timestamp ?? 0;
+    return `Current — latest data in this browser${suffix}; unknown-time count ${unknownCount}`;
+  }
+  if (bucket.kind === "unknown-date")
+    return "Unknown date — off chronological scale";
+  if (bucket.kind === "date") return `${bucket.label}`;
+  const iso = String(bucket.label ?? bucket.id)
+    .split("|")
+    .pop();
+  const ms = Date.parse(iso);
+  return Number.isFinite(ms)
+    ? fmt.format(new Date(ms))
+    : String(bucket.label ?? bucket.id);
+};
+
+export function createLifecycleDiagramView(root, options = {}) {
+  let selectedId = "current",
+    selectedDatum,
+    last,
+    ro,
+    timer;
+  root.classList.add("lifecycle-diagram");
+  const controls = el("div", { class: "diagram-controls" });
+  const prev = el(
+    "button",
+    { type: "button", class: "button", "data-diagram-prev": "" },
+    "Previous event",
+  );
+  const rangeLabel = el(
+    "label",
+    { class: "diagram-range-label" },
+    "Lifecycle scrubber",
+  );
+  const range = el("input", {
+    type: "range",
+    min: "0",
+    value: "0",
+    "aria-label": "Lifecycle event bucket",
+  });
+  rangeLabel.append(range);
+  const next = el(
+    "button",
+    { type: "button", class: "button", "data-diagram-next": "" },
+    "Next event",
+  );
+  const current = el(
+    "button",
+    { type: "button", class: "button", "data-diagram-current": "" },
+    "Return to current",
+  );
+  const badge = el("span", { class: "chip", "data-diagram-badge": "" });
+  const count = el("span", { class: "chip", "data-diagram-count": "" });
+  controls.append(prev, rangeLabel, next, current, badge, count);
+  const time = el("p", { class: "muted", "data-diagram-time": "" });
+  const live = el("p", {
+    class: "muted",
+    "aria-live": "polite",
+    "data-diagram-live": "",
+  });
+  const disclosure = el("details", { "data-diagram-simultaneous": "" });
+  disclosure.append(
+    el("summary", {}, "Simultaneous events"),
+    el("p", { class: "muted" }),
+  );
+  const scroller = el("div", {
+    class: "diagram-scroll",
+    tabindex: "0",
+    role: "region",
+    "aria-label": "Scrollable lifecycle diagram",
+  });
+  const details = el("section", {
+    class: "card",
+    "data-diagram-selection": "",
+  });
+  const tables = el("div", { class: "diagram-tables" });
+  root.replaceChildren(
+    controls,
+    time,
+    live,
+    disclosure,
+    scroller,
+    details,
+    tables,
+  );
+  const choose = (id) => options.onSelectBucket?.(id);
+  prev.addEventListener("click", () => {
+    if (last)
+      choose(last.timeline.buckets[Math.max(0, range.valueAsNumber - 1)]?.id);
+  });
+  next.addEventListener("click", () => {
+    if (last)
+      choose(
+        last.timeline.buckets[
+          Math.min(last.timeline.buckets.length - 1, range.valueAsNumber + 1)
+        ]?.id,
+      );
+  });
+  current.addEventListener("click", () => choose("current"));
+  range.addEventListener("input", () => {
+    if (last) choose(last.timeline.buckets[range.valueAsNumber]?.id);
+  });
+  const resize = () => {
+    clearTimeout(timer);
+    timer = setTimeout(() => last && draw(last), 80);
+  };
+  if (typeof ResizeObserver !== "undefined") {
+    ro = new ResizeObserver(resize);
+    ro.observe(root);
+  } else window.addEventListener("resize", resize);
+
+  function draw(payload) {
+    last = payload;
+    const { timeline, snapshot, selectedBucketId, newerAvailable } = payload;
+    const buckets = timeline?.buckets ?? [];
+    const index = Math.max(
+      0,
+      buckets.findIndex((b) => b.id === selectedBucketId),
+    );
+    const bucket = buckets[index] ?? { id: "current", label: "Current" };
+    range.max = String(Math.max(0, buckets.length - 1));
+    range.value = String(index);
+    range.disabled = buckets.length <= 1;
+    prev.disabled = index <= 0;
+    next.disabled = index >= buckets.length - 1;
+    current.disabled = bucket.id === "current";
+    range.setAttribute("aria-valuetext", bucketText(bucket, snapshot));
+    badge.textContent =
+      bucket.id === "current"
+        ? "Current"
+        : newerAvailable
+          ? "Historical · Newer activity available"
+          : "Historical";
+    const includedCount = snapshot.includedApplications ?? 0;
+    const totalCount = snapshot.totalApplications ?? 0;
+    count.textContent = `${includedCount}/${totalCount} applications`;
+    const dt =
+      bucket.id === "current"
+        ? new Date().toISOString()
+        : (bucket.cutoff?.split("|").pop() ?? "");
+    time.replaceChildren(
+      el("time", dt ? { datetime: dt } : {}, bucketText(bucket, snapshot)),
+    );
+    clearTimeout(timer);
+    timer = setTimeout(() => {
+      const visibleTime = bucketText(bucket, snapshot);
+      live.textContent = `${badge.textContent}: ${count.textContent}. ${visibleTime}`;
+    }, 120);
+    disclosure.hidden = (snapshot.events ?? []).length <= 1;
+    disclosure.querySelector("p").textContent =
+      `${(snapshot.events ?? []).length} boundary events share this selection.`;
+    renderSvg(snapshot);
+    renderTables(snapshot);
+    renderSelection();
+  }
+  function renderSvg(snapshot) {
+    scroller.replaceChildren();
+    if (!snapshot.totalApplications) {
+      scroller.append(
+        el("p", { class: "muted" }, "No diagram applications yet."),
+      );
+      return;
+    }
+    if (!snapshot.nodes?.length) {
+      scroller.append(
+        el(
+          "p",
+          { class: "muted" },
+          "No lifecycle diagram data for this bucket.",
+        ),
+      );
+      return;
+    }
+    const width = Math.max(760, root.clientWidth || 760),
+      height = Math.max(320, snapshot.nodes.length * 34);
+    const nodes = snapshot.nodes.map((n) => ({ ...n, value: n.total }));
+    const links = snapshot.links.map((l) => ({ ...l }));
+    const graph = sankey()
+      .nodeId((d) => d.id)
+      .nodeWidth(16)
+      .nodePadding(14)
+      .extent([
+        [16, 28],
+        [width - 24, height - 24],
+      ])({ nodes, links });
+    for (const n of graph.nodes) {
+      const x = 16 + (columns.get(n.id) ?? 0) * ((width - 56) / 6);
+      n.x0 = x;
+      n.x1 = x + 16;
+    }
+    sankey()
+      .nodeId((d) => d.id)
+      .update(graph);
+    const svg = svgEl("svg", {
+      role: "img",
+      width,
+      height,
+      viewBox: `0 0 ${width} ${height}`,
+      "aria-labelledby": "lifecycle-diagram-title lifecycle-diagram-desc",
+    });
+    const title = svgEl("title", { id: "lifecycle-diagram-title" });
+    title.textContent = "Application lifecycle Sankey diagram";
+    const desc = svgEl("desc", { id: "lifecycle-diagram-desc" });
+    desc.textContent =
+      "Application counts flow from origins through milestones to endpoints. " +
+      "Equivalent data tables follow.";
+    svg.append(title, desc);
+    for (const l of graph.links
+      .filter((x) => x.value > 0)
+      .sort((a, b) => String(a.id).localeCompare(String(b.id)))) {
+      const path = svgEl("path", {
+        d: sankeyLinkHorizontal()(l),
+        class: `diagram-link${selectedId === l.id ? " is-selected" : ""}`,
+        stroke: "#38bdf8",
+        "stroke-width": Math.max(3, l.width),
+        fill: "none",
+        "data-id": l.id,
+      });
+      const pathTitle = svgEl("title");
+      pathTitle.textContent = `${labelFor(l.source.id)} to ${labelFor(
+        l.target.id,
+      )}: ${l.value} applications`;
+      path.append(pathTitle);
+      path.addEventListener("click", () => {
+        selectedId = l.id;
+        selectedDatum = l;
+        draw(last);
+      });
+      svg.append(path);
+    }
+    for (const n of graph.nodes
+      .filter((x) => x.value > 0)
+      .sort(
+        (a, b) =>
+          columns.get(a.id) - columns.get(b.id) ||
+          String(a.id).localeCompare(String(b.id)),
+      )) {
+      const g = svgEl("g", {
+        class: selectedId === n.id ? "is-selected" : "",
+        "data-id": n.id,
+      });
+      const rect = svgEl("rect", {
+        x: n.x0,
+        y: n.y0,
+        width: n.x1 - n.x0,
+        height: Math.max(8, n.y1 - n.y0),
+        fill: "#fbbf24",
+        stroke: selectedId === n.id ? "#fff" : "#111827",
+      });
+      rect.addEventListener("click", () => {
+        selectedId = n.id;
+        selectedDatum = n;
+        draw(last);
+      });
+      g.append(
+        rect,
+        svgEl("text", {
+          x: n.x1 + 6,
+          y: Math.max(12, n.y0 + 14),
+          fill: "currentColor",
+        }),
+      );
+      g.querySelector("text").textContent =
+        `${n.label} (${n.total ?? n.value})`;
+      const nodeTitle = svgEl("title");
+      nodeTitle.textContent = `${n.label}: ${n.total ?? n.value} applications`;
+      g.append(nodeTitle);
+      svg.append(g);
+    }
+    scroller.append(svg);
+  }
+  function row(cells, header = false) {
+    const tr = el("tr");
+    for (const c of cells)
+      tr.append(el(header ? "th" : "td", header ? { scope: "col" } : {}, c));
+    return tr;
+  }
+  function table(caption, heads, rows) {
+    const t = el("table", { class: "tracker-table" });
+    t.append(el("caption", {}, caption));
+    const thead = el("thead");
+    thead.append(row(heads, true));
+    const tbody = el("tbody");
+    rows.forEach((r) => tbody.append(row(r)));
+    t.append(thead, tbody);
+    return t;
+  }
+  function renderTables(s) {
+    const originRows = Object.entries(s.totals?.origins ?? {}).map(([k, v]) => [
+      labelFor(`origin:${k}`),
+      String(v),
+      pct(v, s.includedApplications),
+    ]);
+    const endpointRows = Object.entries(s.totals?.endpoints ?? {}).map(
+      ([k, v]) => [
+        labelFor(`endpoint:${k}`),
+        String(v),
+        pct(v, s.includedApplications),
+      ],
+    );
+    const boundaryRows = (s.links ?? []).map((l) => [
+      labelFor(l.source),
+      labelFor(l.target),
+      String(l.value),
+    ]);
+    const eventRows = (s.events ?? []).map((event) => [
+      event.id,
+      event.applicationId,
+      event.eventType,
+    ]);
+    tables.replaceChildren(
+      el("h3", {}, "Semantic lifecycle data"),
+      table("Origins", ["Origin", "Count", "Percentage"], originRows),
+      table("Endpoints", ["Endpoint", "Count", "Percentage"], endpointRows),
+      table("Boundaries", ["From", "To", "Application count"], boundaryRows),
+      table(
+        "Selected-boundary events",
+        ["Event", "Application", "Type"],
+        eventRows,
+      ),
+    );
+    tables.append(el("p", { class: "muted" }, warningText(s)));
+    tables.querySelectorAll("tbody tr").forEach((tr) => {
+      const b = el("button", { type: "button", class: "button" }, "Select");
+      b.addEventListener("click", () => {
+        selectedId = tr.textContent;
+        selectedDatum = { id: selectedId, value: 0 };
+        renderSelection();
+      });
+      tr.append(el("td"));
+      tr.lastChild.append(b);
+    });
+  }
+  function warningText(s) {
+    const inferred = s.warningCounts?.inferred_event ?? 0;
+    const unknown =
+      (s.warningCounts?.inferred_origin ?? 0) +
+      (s.warningCounts?.invalid_timestamp ?? 0);
+    const mismatch = s.warningCounts?.status_mismatch ?? 0;
+    const regression = s.warningCounts?.regressive_history ?? 0;
+    return (
+      `Warnings: inferred history ${inferred}; unknown origin/time ${unknown}; ` +
+      `status mismatch ${mismatch}; regression ${regression}.`
+    );
+  }
+  function renderSelection() {
+    details.replaceChildren(
+      el("h3", {}, "Selection details"),
+      el(
+        "p",
+        {},
+        selectedDatum
+          ? selectionText()
+          : "Select a node, ribbon, or table row for drilldown.",
+      ),
+    );
+  }
+  function selectionText() {
+    const value = selectedDatum.value ?? selectedDatum.total ?? 0;
+    const total = last?.snapshot?.includedApplications ?? 0;
+    return (
+      `${selectedId}: ${value} applications (${pct(value, total)}). ` +
+      "Observed and inferred counts reflect lifecycle warning tables. " +
+      "Date range: current bucket."
+    );
+  }
+  return {
+    update: draw,
+    destroy() {
+      ro?.disconnect();
+      window.removeEventListener("resize", resize);
+      clearTimeout(timer);
+      root.replaceChildren();
+    },
+  };
+}

--- a/src/web/tracker/tracker.css
+++ b/src/web/tracker/tracker.css
@@ -202,3 +202,75 @@
   background: rgba(127, 29, 29, 0.35);
   color: #fecaca;
 }
+.lifecycle-diagram {
+  display: grid;
+  gap: 1rem;
+}
+.diagram-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: end;
+}
+.diagram-range-label {
+  display: grid;
+  gap: 0.25rem;
+  min-width: min(100%, 18rem);
+}
+.diagram-range-label input {
+  min-height: 44px;
+}
+.diagram-scroll {
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  border: 1px solid var(--card-border, #334155);
+  border-radius: 0.75rem;
+  padding: 0.5rem;
+}
+.diagram-scroll svg {
+  display: block;
+  min-width: 760px;
+  color: var(--foreground, #e5e7eb);
+}
+.diagram-link {
+  opacity: 0.72;
+  cursor: pointer;
+}
+.diagram-link:hover,
+.diagram-link.is-selected,
+.lifecycle-diagram .is-selected .diagram-link {
+  opacity: 1;
+  stroke: #fbbf24;
+}
+.lifecycle-diagram rect {
+  cursor: pointer;
+}
+.lifecycle-diagram .is-selected rect {
+  stroke-width: 3px;
+}
+.diagram-tables {
+  display: grid;
+  gap: 1rem;
+}
+.diagram-tables .tracker-table {
+  min-width: 32rem;
+}
+.diagram-tables caption {
+  text-align: left;
+  font-weight: 700;
+  padding: 0.5rem 0;
+}
+@media (max-width: 760px) {
+  .diagram-controls,
+  .diagram-controls .button,
+  .diagram-range-label {
+    width: 100%;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .diagram-link,
+  .lifecycle-diagram rect {
+    transition: none;
+  }
+}

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -26,6 +26,11 @@ import {
 } from "./metrics.js";
 import { createIndexedDbRepository } from "../storage/indexedDbRepository.js";
 import { planLifecycleReconciliation } from "./lifecycleReconciliation.js";
+import {
+  buildLifecycleTimeline,
+  projectLifecycleAt,
+} from "./lifecycleProjection.js";
+import { createLifecycleDiagramView } from "./lifecycleDiagram.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
 const ARRAY_STORES = [
@@ -128,6 +133,8 @@ const state = {
   current: null,
   detailSave: Promise.resolve(),
   reconciliationWarnings: [],
+  diagramBucketId: "current",
+  diagramView: null,
 };
 function weekBucket(value) {
   const d = day(value);
@@ -369,6 +376,7 @@ function route(v) {
 function renderNav() {
   const names = [
     ["Dashboard", "dashboard"],
+    ["Diagram", "diagram"],
     ["Applications", "applications"],
     ["Follow-ups", "follow-ups"],
     ["Contacts/Outreach", "contacts"],
@@ -605,10 +613,40 @@ function renderOutreach() {
 }
 function renderAll() {
   renderDashboard();
+  renderDiagram();
   renderList();
   renderFollowups();
   renderOutreach();
 }
+function renderDiagram() {
+  const root = $("[data-lifecycle-diagram]");
+  if (!root || !state.bundle) return;
+  if (!state.diagramView)
+    state.diagramView = createLifecycleDiagramView(root, {
+      onSelectBucket: (bucketId) => {
+        state.diagramBucketId = bucketId || "current";
+        renderDiagram();
+      },
+    });
+  const timeline = buildLifecycleTimeline(state.bundle);
+  const ids = new Set(timeline.buckets.map((bucket) => bucket.id));
+  let selectedBucketId = state.diagramBucketId || "current";
+  if (!ids.has(selectedBucketId)) {
+    selectedBucketId = "current";
+    state.diagramBucketId = "current";
+  }
+  const newerAvailable =
+    selectedBucketId !== "current" &&
+    timeline.buckets.findIndex((bucket) => bucket.id === selectedBucketId) <
+      timeline.buckets.length - 1;
+  state.diagramView.update({
+    timeline,
+    snapshot: projectLifecycleAt(state.bundle, selectedBucketId),
+    selectedBucketId,
+    newerAvailable,
+  });
+}
+
 function sortedLifecycleEvents(appId, options = {}) {
   return [...state.bundle.lifecycleEvents]
     .filter(

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -132,6 +132,33 @@ test.describe("browser application tracker", () => {
       .click();
     await expect(page.getByText("No applications yet")).toBeVisible();
   });
+
+  test("shows Diagram tab between Dashboard and Applications", async ({
+    page,
+  }) => {
+    const navNames = await page
+      .locator(".tracker-nav button")
+      .allTextContents();
+    expect(navNames.slice(0, 3)).toEqual([
+      "Dashboard",
+      "Diagram",
+      "Applications",
+    ]);
+    await importRegressionBundle(page);
+    await page.getByRole("button", { name: "Diagram" }).click();
+    await expect(page.locator('[data-view="diagram"]')).toBeVisible();
+    await expect(
+      page.locator('[data-lifecycle-diagram] svg[role="img"]'),
+    ).toBeVisible();
+    await expect(page.locator("[data-diagram-badge]")).toContainText("Current");
+    await expect(
+      page.locator("[data-lifecycle-diagram] table caption").first(),
+    ).toContainText("Origins");
+    await expect(
+      page.locator("[data-lifecycle-diagram] foreignObject"),
+    ).toHaveCount(0);
+  });
+
   test("previews compact CSV regression fixture without phantom interviews", async ({
     page,
   }) => {

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -1,0 +1,148 @@
+/* global document */
+import { JSDOM } from "jsdom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createLifecycleDiagramView } from "../src/web/tracker/lifecycleDiagram.js";
+import {
+  buildLifecycleTimeline,
+  projectLifecycleAt,
+} from "../src/web/tracker/lifecycleProjection.js";
+
+const app = (id, extra = {}) => ({
+  id,
+  company: `<img src=x onerror=alert(1)> ${id}`,
+  role: "Engineer",
+  status: "applied",
+  origin: "application_submitted",
+  appliedAt: "2026-01-01",
+  ...extra,
+});
+const ev = (id, applicationId, eventType, occurredAt, extra = {}) => ({
+  id,
+  applicationId,
+  eventType,
+  occurredAt,
+  occurredAtPrecision: occurredAt?.includes?.("T") ? "instant" : "date",
+  inferred: false,
+  createdAt: occurredAt,
+  ...extra,
+});
+const bundle = {
+  applications: [
+    app("a1"),
+    app("a2", { origin: "referral" }),
+    app("a3", { status: "rejected" }),
+  ],
+  lifecycleEvents: [
+    ev("e1", "a1", "application_submitted", "2026-01-01"),
+    ev("e2", "a1", "recruiter_screen", "2026-01-02T10:00:00Z"),
+    ev("e3", "a2", "referral", "2026-01-02T10:00:00Z"),
+    ev("e4", "a3", "employer_rejected", "", {
+      occurredAtPrecision: "unknown",
+      inferred: true,
+    }),
+  ],
+};
+
+function setup(input = bundle, selectedBucketId = "current") {
+  const dom = new JSDOM("<!doctype html><div data-lifecycle-diagram></div>", {
+    pretendToBeVisual: true,
+  });
+  global.document = dom.window.document;
+  global.window = dom.window;
+  global.ResizeObserver = class {
+    observe() {}
+    disconnect() {}
+  };
+  const root = document.querySelector("[data-lifecycle-diagram]");
+  Object.defineProperty(root, "clientWidth", {
+    value: 900,
+    configurable: true,
+  });
+  const onSelectBucket = vi.fn();
+  const view = createLifecycleDiagramView(root, { onSelectBucket });
+  const timeline = buildLifecycleTimeline(input);
+  const snapshot = projectLifecycleAt(input, selectedBucketId);
+  view.update({
+    timeline,
+    snapshot,
+    selectedBucketId,
+    newerAvailable: selectedBucketId !== "current",
+  });
+  return { dom, root, view, onSelectBucket, timeline, snapshot, input };
+}
+
+afterEach(() => {
+  delete global.document;
+  delete global.window;
+  delete global.ResizeObserver;
+});
+
+describe("lifecycle diagram view", () => {
+  it("renders current by default with accessible SVG and tables", () => {
+    const { root, snapshot } = setup();
+    expect(root.querySelector("[data-diagram-badge]").textContent).toBe(
+      "Current",
+    );
+    expect(root.querySelector('svg[role="img"] title').textContent).toContain(
+      "Application lifecycle",
+    );
+    expect(root.querySelector("svg desc").textContent).toContain(
+      "Equivalent data tables",
+    );
+    expect(
+      root.querySelector('input[type="range"]').getAttribute("aria-valuetext"),
+    ).toContain("Current");
+    expect(
+      [...root.querySelectorAll("path")].every(
+        (path) => !path.getAttribute("d").includes("NaN"),
+      ),
+    ).toBe(true);
+    const originTotal = [...root.querySelectorAll("table")][0].textContent;
+    const endpointTotal = [...root.querySelectorAll("table")][1].textContent;
+    expect(originTotal).toContain(String(snapshot.includedApplications));
+    expect(endpointTotal).toContain(String(snapshot.includedApplications));
+  });
+
+  it("supports unknown, date, instant, simultaneous, and scrubber synchronization", () => {
+    const { root, timeline, onSelectBucket } = setup(bundle, "unknown-date");
+    expect(root.querySelector("[data-diagram-time]").textContent).toContain(
+      "Unknown date",
+    );
+    const instant = timeline.buckets.find((b) => b.kind === "instant");
+    const view = createLifecycleDiagramView(root, { onSelectBucket });
+    view.update({
+      timeline,
+      snapshot: projectLifecycleAt(bundle, instant.id),
+      selectedBucketId: instant.id,
+      newerAvailable: true,
+    });
+    expect(root.querySelector("[data-diagram-badge]").textContent).toContain(
+      "Newer activity available",
+    );
+    expect(root.querySelector("[data-diagram-simultaneous]").hidden).toBe(
+      false,
+    );
+    root.querySelector("[data-diagram-next]").click();
+    expect(onSelectBucket).toHaveBeenCalled();
+  });
+
+  it("keeps malicious text inert, preserves P4 input, and destroys observers", () => {
+    const before = structuredClone(bundle);
+    const { root, view } = setup();
+    expect(bundle).toEqual(before);
+    expect(root.innerHTML).not.toContain("onerror=alert");
+    expect(root.textContent).toContain("Warnings:");
+    view.destroy();
+    expect(root.textContent).toBe("");
+  });
+
+  it("renders empty state and no external references", () => {
+    const { root } = setup({ applications: [], lifecycleEvents: [] });
+    expect(root.textContent).toContain("No diagram applications yet");
+    expect(
+      root.querySelectorAll(
+        'script,link,foreignObject,[href^="http"],[src^="http"]',
+      ).length,
+    ).toBe(0);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a browser-local Diagram view that visualizes P3 timeline and P4 projection as an accessible Sankey diagram and semantic tables without changing persistence, projection semantics, or server behavior.

### Description
- Installed `d3-sankey@0.12.3` (exact) and added a BSD-3-Clause notice in `THIRD_PARTY_NOTICES.md`.
- New view module `createLifecycleDiagramView(root, options)` in `src/web/tracker/lifecycleDiagram.js` that renders an accessible SVG Sankey (using named `d3-sankey` imports), scrubber controls, Current/Historical badge, timestamp display, live region, simultaneous-event disclosure, and semantic tables; it clones P4 snapshot data and cleans up listeners/ResizeObserver on `destroy()`.
- Wired Diagram into navigation by inserting a hidden `data-view="diagram"` section in `src/web/tracker/index.html` and registering the tab between Dashboard and Applications in `src/web/tracker/tracker.js`; added `renderDiagram()` and in-memory selected-bucket preservation and fallback-to-Current logic.
- Added responsive and accessible styling in `src/web/tracker/tracker.css` including mobile stacking, 44px targets, local horizontal scrolling, and reduced-motion respect.
- Tests: added `test/web-tracker-lifecycle-diagram.test.js` (Vitest unit tests) and extended Playwright smoke in `test/playwright/browser-tracker.spec.js` to cover Diagram tab nav and basic rendering.

### Testing
- Installed dependency: `npm install --save-exact d3-sankey@0.12.3` (succeeded).
- Unit tests: `npx vitest run test/web-tracker-lifecycle-projection.test.js test/web-tracker-lifecycle-diagram.test.js` — passed (all diagram + projection tests succeeded).
- Playwright smoke: `npx playwright test test/playwright/browser-tracker.spec.js` — passed (diagram tab smoke assertions passed in CI environment after installing Playwright browsers during run).
- Build and checks: `npm run build` — built `dist/` and confirmed `d3-sankey` bundled into `dist/assets/tracker.js`; `npm run lint` and `npm run typecheck` — passed; `npm run test:ci` — passed.
- Formatting: `npm run format:check` reported pre-existing repo-wide formatting warnings outside touched files; staged files passed Prettier during commit.

All changes are limited to tracker UI, tests, package manifest and third-party notice; no server, schema, migration, or persistence behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52f5264374832f948125aa837954eb)