### PR TITLE
Make lifecycle Sankey height density-aware

### DIFF
--- a/docs/design/application-lifecycle-diagram-validation.md
+++ b/docs/design/application-lifecycle-diagram-validation.md
@@ -19,6 +19,9 @@ P6 hardens the P1-P5 Application Lifecycle Diagram for production readiness: bou
 | Selection not color-only and table buttons expose state                                          | `aria-pressed` and detail text assertions in Vitest and Playwright                                                                   |
 | Keyboard-accessible semantic controls                                                            | Semantic table button tests in Vitest and Playwright                                                                                 |
 | Pointer/touch SVG selection                                                                      | SVG node/link click and mobile tap coverage in Playwright; transparent hit-region tests in Vitest                                    |
+| Density-aware SVG height uses busiest active aggregate rank, not app/event volume                | `calculateLifecycleDiagramLayout` Vitest cases for 1/3/5/10/11 nodes, invalid widths, shuffled nodes, zero totals, and frozen inputs |
+| 44px D3 node padding prevents rank crowding and hit-region overlap                               | Vitest SVG geometry assertions plus desktop and 375×812 Playwright DOM/SVG geometry checks                                           |
+| Fixed taxonomy bounds height and DOM even for 1,000 applications                                 | `test/web-tracker-lifecycle-diagram-performance.test.js` compares small and 1,000-application bundles with unchanged density         |
 | Bounded DOM and complete reachability                                                            | 50-row event/application pagination in Vitest performance coverage                                                                   |
 | Accessibility                                                                                    | axe-core injected from local dependency in `test/playwright/lifecycle-diagram.spec.js`                                               |
 | Reduced motion                                                                                   | CSS media query and Vitest reduced-motion rendering assertion                                                                        |
@@ -37,9 +40,13 @@ The focused Playwright spec injects the installed `axe-core` source locally and 
 
 The fixture and tests use synthetic data only. Hostile strings containing script, SVG markup, event-handler attributes, quotes, and `javascript:`-style content are asserted to remain inert text. Diagram interactions are read-only: no POST, PUT, PATCH, or DELETE request is produced, no cross-origin runtime request is allowed, no application data is placed in URLs/cookies/telemetry, and `d3-sankey` is loaded only through the local bundle.
 
+## Density-aware spacing validation
+
+P6-F2 maps the spacing contract to three layers of automated coverage. `test/web-tracker-lifecycle-diagram.test.js` validates the pure helper formula, width fallback, order independence, non-busiest-rank stability, exact `perNodeVerticalBudget + nodePadding` growth, zero-total exclusion, frozen-projection purity, sparse `360px` rendering, dense fixture `900px` rendering, SVG/viewBox height agreement, 44px adjacent-node spacing, non-overlapping transparent node hit rectangles, in-bounds top/bottom geometry, and selection rerender height preservation. `test/web-tracker-lifecycle-diagram-performance.test.js` proves that height depends on bounded aggregate taxonomy density rather than application volume. `test/playwright/lifecycle-diagram.spec.js` exercises the same DOM/SVG geometry in desktop and real `375×812` touch contexts, including page-level horizontal overflow, diagram-local mobile scrolling, unclipped labels, touch node/flow selection, semantic-table keyboard parity, axe, and console/page-error checks.
+
 ## Large-data and DOM-clutter limits
 
-`test/web-tracker-lifecycle-diagram-performance.test.js` creates 1,000 synthetic applications with eight effective lifecycle events each. After one warm-up render, the measured render must complete within 5,000 ms. The test asserts at most 21 aggregate SVG nodes, no per-application/company nodes, at most 50 rendered event rows, at most 50 rendered affected application IDs, complete pagination reachability, no projection mutation, and no `NaN`/`Infinity` SVG geometry.
+`test/web-tracker-lifecycle-diagram-performance.test.js` creates 1,000 synthetic applications with eight effective lifecycle events each. After one warm-up render, the measured render must complete within 5,000 ms. The test asserts density-equivalent small and 1,000-application bundles have the same calculated height, at most 21 aggregate SVG nodes, no per-application/company nodes, at most 50 rendered event rows, at most 50 rendered affected application IDs, complete pagination reachability, no projection mutation, and no `NaN`/`Infinity` SVG geometry.
 
 ## Static build and container checks
 

--- a/docs/design/application-lifecycle-diagram.md
+++ b/docs/design/application-lifecycle-diagram.md
@@ -232,6 +232,38 @@ Origin inference is allowed only from explicit structured evidence and exact all
 
 Migration adds one deterministic inferred `migration_status_snapshot` only when the current status is otherwise unrepresented. Before falling back to `status_changed`, migration must preserve known legacy interview, assessment, and employer-response milestones by applying the canonical event-type allowlist in this contract. It must never manufacture intermediate stages. Re-running migration or reconciliation must not create duplicates.
 
+## Density-aware SVG layout
+
+The SVG canvas height is derived from active aggregate-node density in the busiest Sankey rank. A fixed minimum-height floor is allowed, but fixed final desktop, mobile, fixture-specific, or viewport-specific heights are prohibited. Application count and lifecycle-event count do not directly affect height; only aggregate nodes with numeric `total > 0` participate in sizing, so zero-count taxonomy rows do not enlarge the SVG.
+
+The renderer uses these normative constants:
+
+| Constant                      |   Value |
+| ----------------------------- | ------: |
+| Minimum SVG width             | `760px` |
+| Minimum SVG height            | `360px` |
+| Top internal layout margin    |  `32px` |
+| Bottom internal layout margin |  `32px` |
+| D3 node padding               |  `44px` |
+| Per-node vertical budget      |  `36px` |
+| D3 node width                 |  `18px` |
+
+For a projection and available container width, the layout helper sanitizes width to a finite positive integer, falls back to `760px`, and returns `max(760, sanitizedWidth)`. It groups active aggregate nodes by their fixed `nodeRank(node.id)`, uses the largest active count in any rank as `densestColumnCount`, and floors that count at `1` when there are no active nodes. The height formula is:
+
+```text
+densityHeight =
+  topMargin +
+  bottomMargin +
+  densestColumnCount * perNodeVerticalBudget +
+  max(0, densestColumnCount - 1) * nodePadding
+
+height = max(minimumSvgHeight, ceil(densityHeight))
+```
+
+Examples: one or three active nodes in the busiest rank use the `360px` minimum; five produce `420px`; ten produce `820px`; eleven produce `900px`. The D3 extent is `[16, topMargin]` to `[width - 24, height - bottomMargin]`, while existing seven-rank horizontal placement and taxonomy ordering remain unchanged. The `44px` node padding is required to prevent visible-node, label, and touch-hit-region crowding.
+
+Mobile keeps the `760px` minimum SVG width inside the labeled diagram-local horizontal scroller and uses normal page-level vertical scrolling for taller dense diagrams. The page itself must not gain horizontal overflow, and the diagram must not add a fixed CSS height, maximum height, scale transform, viewport-height shrink, or diagram-local vertical scrollbar.
+
 ## UI and accessibility
 
 The Diagram tab must provide:

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -3,6 +3,17 @@ import { sankey, sankeyLinkHorizontal } from "d3-sankey";
 import { LIFECYCLE_DIAGRAM_TAXONOMY } from "./lifecycleProjection.js";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
+const MINIMUM_SVG_WIDTH = 760;
+const MINIMUM_SVG_HEIGHT = 360;
+const TOP_LAYOUT_MARGIN = 32;
+const BOTTOM_LAYOUT_MARGIN = 32;
+const SANKEY_NODE_PADDING = 44;
+const PER_NODE_VERTICAL_BUDGET = 36;
+const SANKEY_NODE_WIDTH = 18;
+const LEFT_LAYOUT_MARGIN = 16;
+const RIGHT_LAYOUT_MARGIN = 24;
+const HORIZONTAL_RANK_SPAN = 64;
+const RANK_INTERVALS = 6;
 const RANKS = { origin: 0, milestone: 1, endpoint: 6 };
 const MILESTONE_RANKS = new Map(
   LIFECYCLE_DIAGRAM_TAXONOMY.milestones.map((item, index) => [
@@ -70,6 +81,34 @@ const nodeRank = (id) => {
 };
 const nodeSort = (a, b) =>
   nodeRank(a.id) - nodeRank(b.id) || compare(a.id, b.id);
+
+export function calculateLifecycleDiagramLayout(projection, availableWidth) {
+  const integerWidth = Math.floor(Number(availableWidth));
+  const sanitizedWidth =
+    Number.isFinite(integerWidth) && integerWidth > 0
+      ? integerWidth
+      : MINIMUM_SVG_WIDTH;
+  const rankCounts = new Map();
+  for (const node of projection?.nodes ?? []) {
+    if (Number(node.total) > 0) {
+      const rank = nodeRank(String(node.id ?? ""));
+      rankCounts.set(rank, (rankCounts.get(rank) ?? 0) + 1);
+    }
+  }
+  const densestColumnCount = Math.max(1, ...rankCounts.values());
+  const densityHeight =
+    TOP_LAYOUT_MARGIN +
+    BOTTOM_LAYOUT_MARGIN +
+    densestColumnCount * PER_NODE_VERTICAL_BUDGET +
+    Math.max(0, densestColumnCount - 1) * SANKEY_NODE_PADDING;
+  return {
+    width: Math.max(MINIMUM_SVG_WIDTH, sanitizedWidth),
+    height: Math.max(MINIMUM_SVG_HEIGHT, Math.ceil(densityHeight)),
+    nodePadding: SANKEY_NODE_PADDING,
+    topMargin: TOP_LAYOUT_MARGIN,
+    bottomMargin: BOTTOM_LAYOUT_MARGIN,
+  };
+}
 const bucketValueText = (bucket) => {
   if (!bucket) return "Current — latest data in this browser";
   if (bucket.kind === "current") return "Current — latest data in this browser";
@@ -446,17 +485,17 @@ export function createLifecycleDiagramView(root, options = {}) {
       );
       return;
     }
-    const width = Math.max(760, root.clientWidth || 760),
-      height = Math.max(260, 70 + projection.nodes.length * 34);
+    const { width, height, nodePadding, topMargin, bottomMargin } =
+      calculateLifecycleDiagramLayout(projection, root.clientWidth);
     const graph = cloneProjectionForSankey(projection);
     const layout = sankey()
       .nodeId((d) => d.id)
-      .nodeWidth(18)
-      .nodePadding(16)
+      .nodeWidth(SANKEY_NODE_WIDTH)
+      .nodePadding(nodePadding)
       .nodeSort(nodeSort)
       .extent([
-        [16, 20],
-        [width - 24, height - 30],
+        [LEFT_LAYOUT_MARGIN, topMargin],
+        [width - RIGHT_LAYOUT_MARGIN, height - bottomMargin],
       ]);
     try {
       layout(graph);
@@ -469,11 +508,11 @@ export function createLifecycleDiagramView(root, options = {}) {
       );
       return;
     }
-    const columnWidth = (width - 64) / 6;
+    const columnWidth = (width - HORIZONTAL_RANK_SPAN) / RANK_INTERVALS;
     for (const node of graph.nodes) {
-      const fixedX = 16 + node.rank * columnWidth;
+      const fixedX = LEFT_LAYOUT_MARGIN + node.rank * columnWidth;
       node.x0 = fixedX;
-      node.x1 = fixedX + 18;
+      node.x1 = fixedX + SANKEY_NODE_WIDTH;
     }
     layout.update(graph);
     const finiteNode = (node) =>
@@ -532,7 +571,7 @@ export function createLifecycleDiagramView(root, options = {}) {
       const hitPath = svgEl("path", {
         d: pathData,
         stroke: "transparent",
-        "stroke-width": Math.max(44, link.width || 1),
+        "stroke-width": Math.max(SANKEY_NODE_PADDING, link.width || 1),
         "data-diagram-link-hit": link.id,
         "aria-hidden": "true",
       });
@@ -576,10 +615,10 @@ export function createLifecycleDiagramView(root, options = {}) {
           applicationIds: node.applicationIds,
         });
       const hitRect = svgEl("rect", {
-        x: node.x0 - Math.max(0, 44 - (node.x1 - node.x0)) / 2,
-        y: node.y0 - Math.max(0, 44 - (node.y1 - node.y0)) / 2,
-        width: Math.max(44, node.x1 - node.x0),
-        height: Math.max(44, node.y1 - node.y0),
+        x: node.x0 - Math.max(0, nodePadding - (node.x1 - node.x0)) / 2,
+        y: node.y0,
+        width: Math.max(nodePadding, node.x1 - node.x0),
+        height: Math.max(nodePadding, node.y1 - node.y0),
         fill: "transparent",
         "aria-hidden": "true",
         "data-diagram-node-hit": node.id,

--- a/test/playwright/lifecycle-diagram.spec.js
+++ b/test/playwright/lifecycle-diagram.spec.js
@@ -181,6 +181,72 @@ async function assertVisibleControlsLargeEnough(page) {
   }
 }
 
+async function assertDensityAwareGeometry(page, expectedHeight = 820) {
+  const geometry = await page.locator("svg[role='img']").evaluate((svg) => {
+    const height = Number(svg.getAttribute("height"));
+    const viewBoxHeight = Number(svg.getAttribute("viewBox")?.split(/\s+/u)[3]);
+    const byRank = new Map();
+    for (const group of svg.querySelectorAll("[data-diagram-node]")) {
+      const rect = group.querySelector("rect:not([data-diagram-node-hit])");
+      const hit = group.querySelector("[data-diagram-node-hit]");
+      const text = group.querySelector("text");
+      const x = Math.round(Number(rect.getAttribute("x")));
+      const item = {
+        rect: {
+          y0: Number(rect.getAttribute("y")),
+          y1:
+            Number(rect.getAttribute("y")) +
+            Number(rect.getAttribute("height")),
+        },
+        hit: {
+          y0: Number(hit.getAttribute("y")),
+          y1:
+            Number(hit.getAttribute("y")) + Number(hit.getAttribute("height")),
+        },
+        label: (() => {
+          const box = text.getBBox();
+          return { y0: box.y, y1: box.y + box.height };
+        })(),
+      };
+      if (!byRank.has(x)) byRank.set(x, []);
+      byRank.get(x).push(item);
+    }
+    return { height, viewBoxHeight, ranks: [...byRank.values()] };
+  });
+  expect(geometry.height).toBe(expectedHeight);
+  expect(geometry.viewBoxHeight).toBe(expectedHeight);
+  for (const rank of geometry.ranks) {
+    rank.sort((a, b) => a.rect.y0 - b.rect.y0);
+    for (const item of rank) {
+      expect(item.rect.y0).toBeGreaterThanOrEqual(0);
+      expect(item.rect.y1).toBeLessThanOrEqual(geometry.height);
+      expect(item.hit.y0).toBeGreaterThanOrEqual(0);
+      expect(item.hit.y1).toBeLessThanOrEqual(geometry.height);
+      expect(item.label.y0).toBeGreaterThanOrEqual(0);
+      expect(item.label.y1).toBeLessThanOrEqual(geometry.height);
+    }
+    for (let index = 1; index < rank.length; index += 1) {
+      expect(
+        rank[index].rect.y0 - rank[index - 1].rect.y1,
+      ).toBeGreaterThanOrEqual(43.5);
+      expect(rank[index].hit.y0).toBeGreaterThanOrEqual(
+        rank[index - 1].hit.y1 - 0.5,
+      );
+      expect(rank[index].label.y0).toBeGreaterThanOrEqual(
+        rank[index - 1].label.y1 - 0.5,
+      );
+    }
+  }
+  const scrollBottom = await page.locator(".diagram-scroll").evaluate((el) => {
+    const scroll = el.getBoundingClientRect();
+    const svg = el.querySelector("svg").getBoundingClientRect();
+    return { scrollBottom: scroll.bottom, svgBottom: svg.bottom };
+  });
+  expect(scrollBottom.svgBottom).toBeLessThanOrEqual(
+    scrollBottom.scrollBottom + 0.5,
+  );
+}
+
 async function runAxe(page) {
   await page.addScriptTag({ content: axe.source });
   const results = await page.evaluate(
@@ -433,6 +499,8 @@ test.describe("Application Lifecycle Diagram", () => {
       EXPECTED_CURRENT.included,
     );
 
+    await assertDensityAwareGeometry(page);
+
     const nodeGroup = page
       .locator("[data-diagram-node='origin:application_submitted']")
       .first();
@@ -568,6 +636,7 @@ test.describe("Application Lifecycle Diagram", () => {
         EXPECTED_CURRENT.included,
       );
       await assertNoPageOverflow(page);
+      await assertDensityAwareGeometry(page);
       const scroll = page.locator(".diagram-scroll");
       expect(
         await scroll.evaluate((el) => el.scrollWidth > el.clientWidth),

--- a/test/web-tracker-lifecycle-diagram-performance.test.js
+++ b/test/web-tracker-lifecycle-diagram-performance.test.js
@@ -2,7 +2,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { JSDOM } from "jsdom";
 
-import { createLifecycleDiagramView } from "../src/web/tracker/lifecycleDiagram.js";
+import {
+  calculateLifecycleDiagramLayout,
+  createLifecycleDiagramView,
+} from "../src/web/tracker/lifecycleDiagram.js";
 import {
   buildLifecycleTimeline,
   projectLifecycleAt,
@@ -97,6 +100,11 @@ describe("lifecycle diagram large-data rendering", () => {
     const bundle = largeBundle();
     const timeline = buildLifecycleTimeline(bundle);
     const snapshot = projectLifecycleAt(bundle, "current");
+    const smallSnapshot = projectLifecycleAt(largeBundle(10), "current");
+    expect(calculateLifecycleDiagramLayout(snapshot, 1200).height).toBe(420);
+    expect(calculateLifecycleDiagramLayout(snapshot, 1200).height).toBe(
+      calculateLifecycleDiagramLayout(smallSnapshot, 1200).height,
+    );
     const serialized = JSON.stringify(snapshot);
     Object.freeze(snapshot);
 
@@ -158,7 +166,13 @@ describe("lifecycle diagram large-data rendering", () => {
       firstRange,
     );
     expect(JSON.stringify(snapshot)).toBe(serialized);
+    expect(Number(root.querySelector("svg").getAttribute("height"))).toBe(420);
     for (const element of root.querySelectorAll("path"))
       expect(element.getAttribute("d") ?? "").not.toMatch(/NaN|Infinity/u);
+    for (const element of root.querySelectorAll("rect,text"))
+      for (const attr of ["x", "y", "width", "height"]) {
+        const value = element.getAttribute(attr);
+        if (value !== null) expect(value).not.toMatch(/NaN|Infinity/u);
+      }
   });
 });

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -2,7 +2,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { JSDOM } from "jsdom";
 
-import { createLifecycleDiagramView } from "../src/web/tracker/lifecycleDiagram.js";
+import {
+  calculateLifecycleDiagramLayout,
+  createLifecycleDiagramView,
+} from "../src/web/tracker/lifecycleDiagram.js";
 import {
   buildLifecycleTimeline,
   LIFECYCLE_DIAGRAM_TAXONOMY,
@@ -37,6 +40,62 @@ const bundle = (applications = [], lifecycleEvents = []) => ({
   applications,
   lifecycleEvents,
 });
+
+const node = (id, total = 1) => ({ id, label: id, total, applicationIds: [] });
+const projectionWithCounts = ({
+  origins = 1,
+  milestones = 1,
+  endpoints = 1,
+} = {}) => ({
+  nodes: [
+    ...Array.from({ length: origins }, (_, index) =>
+      node(
+        `origin:${LIFECYCLE_DIAGRAM_TAXONOMY.origins[index]?.id ?? `extra_${index}`}`,
+      ),
+    ),
+    ...Array.from({ length: milestones }, (_, index) =>
+      node(
+        `milestone:${
+          LIFECYCLE_DIAGRAM_TAXONOMY.milestones[index]?.id ?? `extra_${index}`
+        }`,
+      ),
+    ),
+    ...Array.from({ length: endpoints }, (_, index) =>
+      node(
+        `endpoint:${
+          LIFECYCLE_DIAGRAM_TAXONOMY.endpoints[index]?.id ?? `extra_${index}`
+        }`,
+      ),
+    ),
+  ],
+  links: [],
+});
+const deepFreeze = (value) => {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const child of Object.values(value)) deepFreeze(child);
+  }
+  return value;
+};
+const svgHeight = (root) =>
+  Number(root.querySelector("svg").getAttribute("height"));
+const visibleNodeBoxesByRank = (root) => {
+  const ranks = new Map();
+  for (const group of root.querySelectorAll("[data-diagram-node]")) {
+    const rect = group.querySelector("rect:not([data-diagram-node-hit])");
+    const x = Number(rect.getAttribute("x"));
+    const box = {
+      y0: Number(rect.getAttribute("y")),
+      y1: Number(rect.getAttribute("y")) + Number(rect.getAttribute("height")),
+    };
+    const key = String(Math.round(x));
+    if (!ranks.has(key)) ranks.set(key, []);
+    ranks.get(key).push(box);
+  }
+  for (const boxes of ranks.values()) boxes.sort((a, b) => a.y0 - b.y0);
+  return ranks;
+};
+
 const EXPECTED_FIXTURE_TAXONOMY_TOTALS = {
   endpoints: {
     awaiting_response: 2,
@@ -88,6 +147,116 @@ function render(b, selectedBucketId = "current", onBucketChange = vi.fn()) {
   });
   return { root, view, timeline, snapshot, onBucketChange };
 }
+
+describe("lifecycle diagram density-aware layout", () => {
+  it.each([
+    [1, 360],
+    [3, 360],
+    [5, 420],
+    [10, 820],
+    [11, 900],
+  ])(
+    "calculates contractual height for %i active nodes in the busiest rank",
+    (count, height) => {
+      expect(
+        calculateLifecycleDiagramLayout(
+          projectionWithCounts({ endpoints: count }),
+          760,
+        ),
+      ).toMatchObject({
+        width: 760,
+        height,
+        nodePadding: 44,
+        topMargin: 32,
+        bottomMargin: 32,
+      });
+    },
+  );
+
+  it.each([undefined, 0, -1, NaN, Infinity])(
+    "falls invalid width %s back to 760",
+    (width) => {
+      expect(
+        calculateLifecycleDiagramLayout(projectionWithCounts(), width).width,
+      ).toBe(760);
+    },
+  );
+
+  it("preserves wider desktop widths and is stable across node order", () => {
+    const projection = projectionWithCounts({
+      origins: 3,
+      milestones: 4,
+      endpoints: 5,
+    });
+    const shuffled = { ...projection, nodes: [...projection.nodes].reverse() };
+    expect(calculateLifecycleDiagramLayout(projection, 1200)).toEqual(
+      calculateLifecycleDiagramLayout(shuffled, 1200),
+    );
+    expect(calculateLifecycleDiagramLayout(projection, 1200).width).toBe(1200);
+  });
+
+  it("only grows when the busiest rank grows and ignores zero-total nodes", () => {
+    const base = projectionWithCounts({
+      origins: 2,
+      milestones: 3,
+      endpoints: 5,
+    });
+    const same = {
+      ...base,
+      nodes: [...base.nodes, node("origin:extra", 1), node("endpoint:zero", 0)],
+    };
+    const larger = {
+      ...base,
+      nodes: [...base.nodes, node("endpoint:extra", 1)],
+    };
+    expect(calculateLifecycleDiagramLayout(same, 760).height).toBe(
+      calculateLifecycleDiagramLayout(base, 760).height,
+    );
+    expect(calculateLifecycleDiagramLayout(larger, 760).height).toBe(
+      calculateLifecycleDiagramLayout(base, 760).height + 36 + 44,
+    );
+  });
+
+  it("does not mutate a deeply frozen projection", () => {
+    const projection = deepFreeze(
+      projectionWithCounts({ origins: 2, endpoints: 5 }),
+    );
+    const before = JSON.stringify(projection);
+    expect(calculateLifecycleDiagramLayout(projection, 760).height).toBe(420);
+    expect(JSON.stringify(projection)).toBe(before);
+  });
+
+  it("renders sparse and dense SVGs with calculated height and safe spacing", async () => {
+    const sparse = render(
+      bundle([app("a")], [ev("o", "a", "application_submitted", "2026-01-01")]),
+    );
+    expect(svgHeight(sparse.root)).toBe(360);
+    const fixture = await import(
+      "./fixtures/tracker-lifecycle-diagram-v2.json",
+      { with: { type: "json" } }
+    );
+    const dense = render(fixture.default);
+    const svg = dense.root.querySelector("svg");
+    expect(svgHeight(dense.root)).toBe(900);
+    expect(svg.getAttribute("viewBox")).toBe("0 0 760 900");
+    for (const boxes of visibleNodeBoxesByRank(dense.root).values()) {
+      for (let index = 1; index < boxes.length; index += 1)
+        expect(boxes[index].y0 - boxes[index - 1].y1).toBeGreaterThanOrEqual(
+          43.5,
+        );
+    }
+    for (const group of dense.root.querySelectorAll("[data-diagram-node]")) {
+      const hit = group.querySelector("[data-diagram-node-hit]");
+      const y = Number(hit.getAttribute("y"));
+      expect(y).toBeGreaterThanOrEqual(0);
+      expect(y + Number(hit.getAttribute("height"))).toBeLessThanOrEqual(900);
+    }
+    dense.root
+      .querySelector("[data-diagram-node-hit]")
+      .dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    expect(svgHeight(dense.root)).toBe(900);
+  });
+});
 
 describe("lifecycle diagram view", () => {
   beforeEach(() => vi.useRealTimers());


### PR DESCRIPTION
### Motivation
- Replace the previous coarse, node-count-derived canvas sizing (`Math.max(260, 70 + projection.nodes.length * 34)`) and small Sankey padding with a deterministic, density-aware layout so dense diagrams grow vertically to avoid overlapping node rectangles, labels, and 44px hit targets.
- Make the layout deterministic, pure, and testable so height depends only on aggregate-node density in the busiest fixed Sankey rank and not on application/event volume, DOM measurements, or viewport heuristics.

### Description
- Add named layout constants and an exported pure helper `calculateLifecycleDiagramLayout(projection, availableWidth)` that sanitizes width, counts only `node.total > 0` nodes by `nodeRank`, derives `densestColumnCount`, and returns the `width`, `height`, `nodePadding`, `topMargin`, and `bottomMargin` using the exact contractual formula and constants (`760`, `360`, `32`, `32`, `44`, `36`, `18`).
- Integrate the helper into `renderSvg`: consume returned `width/height/nodePadding/topMargin/bottomMargin` for `sankey().nodePadding(...)`, `sankey().extent(...)`, SVG `viewBox`, and SVG `width`/`height`, preserve existing horizontal rank placement and `nodeWidth`, and continue to clone the projection before calling `d3-sankey`.
- Adjust transparent hit rectangles and link hit paths to use the `nodePadding` budget and ensure hit regions remain non-overlapping and in-bounds while leaving node/link semantics unchanged.
- Extend unit, performance, and Playwright tests and update docs: add focused Vitest cases for the helper (1/3/5/10/11 busiest-rank counts, invalid widths, order-independence, zero-total exclusion, frozen-projection purity, exact growth delta), performance assertions that height is bounded by taxonomy density, Playwright DOM/SVG geometry assertions for desktop and real `375×812` touch contexts, and document the constants and formula in `docs/design/application-lifecycle-diagram.md` and the validation mapping in `docs/design/application-lifecycle-diagram-validation.md`.

### Testing
- Ran `npm ci`, `npm run prepare:test`, `npm run lint`, `npm run typecheck`, `npm run build`, and the full `npm run test:ci` suite; all completed successfully in this environment and the bundle produced a successful build output.
- Ran focused unit and perf tests with `npx vitest run test/web-tracker-lifecycle-projection.test.js test/web-tracker-lifecycle-diagram.test.js test/web-tracker-lifecycle-diagram-performance.test.js`, which passed (all Vitest cases passed); Playwright tests `npx playwright test test/playwright/lifecycle-diagram.spec.js test/playwright/static-smoke.spec.js` initially revealed a geometry expectation mismatch that was corrected and the Playwright suite passed thereafter.
- Verified `npx prettier --check` for all changed files passed and `npx prettier --check` repository-wide reports known pre-existing drift (262 files) unrelated to these changes; secret scan and binary-file audit against the merge base both passed locally.
- Note: GitHub Actions visual-review artifacts (diagram PNGs), GHCR image build/smoke, and final CI run results are expected to be confirmed on the PR; local runs confirmed the same behavioral and geometry assertions exercised by the CI/visual-review workflows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a55ea90fb70832fa0ba8b9903734341)