### PR TITLE
Harden Claude workflow commit policy

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -59,6 +59,15 @@ jobs:
           additional_permissions: |
             actions: read
 
+          # Implementation sessions checkpoint before long validation so reviewable,
+          # coherent work is not lost to runner timeouts or unavailable npm tooling.
+          # Validation-tool grants are narrow and additive: file tools are explicit,
+          # and only repository-standard npm/Vitest/prettier/node/git status checks run.
+          # Direct Bash git mutation is denied; keep using the action-native signed
+          # branch/commit/push path instead of shelling out to git add/commit/push.
+          # Disclose unavailable local verification honestly, but do not erase safe work.
           claude_args: >-
-            --allowedTools "Bash(npm ci),Bash(npm run lint),Bash(npm run lint:fix),Bash(npm run format:check),Bash(npm run format:fix),Bash(npm run typecheck),Bash(npm run test:ci),Bash(npm run build),Bash(npx vitest run:*)"
-            --disallowedTools "Bash(git push:*),Bash(git reset --hard:*),Bash(git clean:*)"
+            --max-turns 120
+            --append-system-prompt "When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy or full validation, and before the final third of the session. Use the action-native signed commit and push mechanism; never use Bash for git add, git commit, or git push. Continue with follow-up commits when needed, and do not hold all work locally until every possible test finishes. A failure introduced by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, blocked, or timed-out check should be reported honestly but must not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing and pushing, and reporting results. Before ending, inspect the working tree and either commit and push the requested safe changes or state the exact correctness, security, or commit-mechanism blocker. Do not fabricate commits for analysis-only or no-op requests, and never commit secrets, temporary debugging, generated junk, or code known to introduce a new failure. A checkpoint commit does not make failing CI mergeable."
+            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(npm ci),Bash(npm run lint),Bash(npm run lint:fix),Bash(npm run format:check),Bash(npm run format:fix),Bash(npm run typecheck),Bash(npm run test:ci),Bash(npm run build),Bash(npx vitest run *),Bash(npx prettier --check *),Bash(node --check *),Bash(git diff --check),Bash(git status --short)"
+            --disallowedTools "WebFetch,WebSearch,Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git reset *),Bash(git clean *),Bash(git rm *),Bash(gh *)"


### PR DESCRIPTION
### Motivation
- Ensure implementation-oriented `@claude` sessions prioritize making early, signed, pushed checkpoint commits when changes are requested while preserving existing workflow security boundaries.
- Import the relevant commit-guidance and narrow tool-policy improvements from the referenced behavior so sessions do not hoard work locally or rely on unsafe shell pushes.
- Make allowed file-editing tools explicit and correct the validation-tool permission patterns so intended commands are auto-approved and web/direct-git mutation paths remain denied.

### Description
- Update `.github/workflows/claude.yml` to add `--max-turns 120` and a single safely quoted `--append-system-prompt` that requires early reviewable checkpoint commits using the action-native signed commit/push path and reserves the final turns for finalization.
- Make file-editing tools explicit and additive with `--allowedTools` including `Read`, `Edit`, `Write`, `Glob`, and `Grep`, and retain focused npm/Vitest/Prettier/Node/git checks in the allowed list.
- Strengthen `--disallowedTools` to defensively deny `WebFetch`, `WebSearch`, Bash-based `git add/commit/push` and destructive Git commands, and direct `gh` mutation paths while keeping the action-native commit mechanism usable.
- Preserve all existing invariants: triggers and author-association checks, fork rejection, pinned Claude action SHA, 45-minute timeout, `persist-credentials: false`, read-only `GITHUB_TOKEN` permissions, `additional_permissions`, and the action-native branch/commit mechanism.

### Testing
- Parsed `.github/workflows/claude.yml` as YAML successfully with `node` and verified the `claude_args` tokenization via `shlex.split` returned exactly one `--append-system-prompt` and `--max-turns 120`.
- Verified allowed/disallowed tool lists and absence of dangerous permission-bypass flags using a scripted `shlex` verification, and the effective parsed `claude_args` is:

```json
[
  "--max-turns",
  "120",
  "--append-system-prompt",
  "When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy or full validation, and before the final third of the session. Use the action-native signed commit and push mechanism; never use Bash for git add, git commit, or git push. Continue with follow-up commits when needed, and do not hold all work locally until every possible test finishes. A failure introduced by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, blocked, or timed-out check should be reported honestly but must not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing and pushing, and reporting results. Before ending, inspect the working tree and either commit and push the requested safe changes or state the exact correctness, security, or commit-mechanism blocker. Do not fabricate commits for analysis-only or no-op requests, and never commit secrets, temporary debugging, generated junk, or code known to introduce a new failure. A checkpoint commit does not make failing CI mergeable.",
  "--allowedTools",
  "Read,Edit,Write,Glob,Grep,Bash(npm ci),Bash(npm run lint),Bash(npm run lint:fix),Bash(npm run format:check),Bash(npm run format:fix),Bash(npm run typecheck),Bash(npm run test:ci),Bash(npm run build),Bash(npx vitest run *),Bash(npx prettier --check *),Bash(node --check *),Bash(git diff --check),Bash(git status --short)",
  "--disallowedTools",
  "WebFetch,WebSearch,Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git reset *),Bash(git clean *),Bash(git rm *),Bash(gh *)"
]
```
- Ran `git diff --check` (PASS) and `npx prettier --check .github/workflows/claude.yml` (PASS for the YAML); `npm run format:check` reported pre-existing formatting warnings across unrelated files (WARN), and `actionlint` was unavailable in the environment (WARN).
- Committed the change locally with pre-commit hooks (which ran `prettier --check` and `npm run typecheck`) but `git push -u origin work` failed because the checkout has no configured `origin` remote (WARN).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6150ce5c30832fac0cb17245e81f18)