### PR TITLE
Harden Claude workflow checkpoint and tool policy

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -59,6 +59,13 @@ jobs:
           additional_permissions: |
             actions: read
 
+          # Implementation sessions should checkpoint coherent work before lengthy
+          # validation so environmental or timed-out checks do not erase safe changes.
+          # File-editing tools and validation commands are narrow, additive grants.
+          # Bash Git mutation is denied; the action-native signed commit path remains
+          # available for branch updates while workflow edits still require review.
           claude_args: >-
-            --allowedTools "Bash(npm ci),Bash(npm run lint),Bash(npm run lint:fix),Bash(npm run format:check),Bash(npm run format:fix),Bash(npm run typecheck),Bash(npm run test:ci),Bash(npm run build),Bash(npx vitest run:*)"
-            --disallowedTools "Bash(git push:*),Bash(git reset --hard:*),Bash(git clean:*)"
+            --max-turns 120
+            --append-system-prompt 'When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy or full validation, and before the final third of the session. Use the action-native signed commit and push mechanism; never use Bash for git add, git commit, or git push. Continue with follow-up commits when needed, and do not hold all work locally until every possible test finishes. A failure introduced by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, blocked, or timed-out check should be reported honestly but must not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing and pushing, and reporting results. Before ending, inspect the working tree and either commit and push the requested safe changes or state the exact correctness, security, or commit-mechanism blocker. Do not fabricate commits for analysis-only or no-op requests, and never commit secrets, temporary debugging, generated junk, or code known to introduce a new failure. A checkpoint commit does not make failing CI mergeable.'
+            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(npm ci),Bash(npm run lint *),Bash(npm run lint:fix *),Bash(npm run format:check *),Bash(npm run format:fix *),Bash(npm run typecheck *),Bash(npm run test:ci *),Bash(npm run build *),Bash(npx vitest run *),Bash(npx prettier --check *),Bash(node --check *),Bash(git diff --check),Bash(git status --short)"
+            --disallowedTools "WebFetch,WebSearch,Bash(git add *),Bash(git commit *),Bash(git push *),Bash(git reset *),Bash(git clean *),Bash(git rm *),Bash(gh pr merge *),Bash(gh pr edit *),Bash(gh pr close *),Bash(gh pr ready *),Bash(gh issue edit *),Bash(gh issue close *),Bash(gh api *),Bash(gh workflow *),Bash(gh run *),Bash(gh auth *),Bash(gh secret *),Bash(gh variable *),Bash(gh release *),Bash(gh repo *)"


### PR DESCRIPTION
### Motivation

- Implementation-oriented `@claude` sessions should produce early, reviewable checkpoint commits using the action-native signed commit path rather than holding all changes locally until lengthy validation completes.  
- Make file-editing tools explicit and additive so allowed mutations are clearly scoped and auditable.  
- Defensively deny web access, broad Bash mutation, and destructive Git paths while preserving the action-native commit mechanism and existing workflow security boundaries.

### Description

- Added `--max-turns 120` and a single safely quoted `--append-system-prompt` that requires early checkpoint commits for repository-change requests unless a concrete correctness/security/commit-mechanism blocker prevents it.  
- Made `--allowedTools` explicit and additive by adding `Read`, `Edit`, `Write`, `Glob`, and `Grep`, and by replacing brittle patterns with narrow `Bash(...)` permission patterns for the intended validation commands (the repo `npm` scripts, focused `npx vitest run ...`, `npx prettier --check ...`, `node --check ...`, `git diff --check`, and `git status --short`).  
- Strengthened `--disallowedTools` to include `WebFetch`, `WebSearch`, Bash-based `git add/commit/push`, destructive Git operations (`git reset`, `git clean`, `git rm`), and direct `gh` mutation/escape paths while leaving the action-native commit/push mechanism available.  
- Added concise inline workflow comments explaining early checkpointing, narrow/additive validation grants, rationale for denying Bash Git mutation, and that unavailable local verification should be disclosed and not erase coherent work; preserved pinned action SHA, `persist-credentials: false`, read-only `GITHUB_TOKEN` permissions, `additional_permissions`, timeout, and triggers.

### Testing

- Parsed `.github/workflows/claude.yml` as YAML and extracted `claude_args`, then parsed it with `shlex.split` and verified exactly one `--append-system-prompt`, presence of `--max-turns 120`, the explicit allowed-file tools (`Read,Edit,Write,Glob,Grep`), the intended narrow `Bash(...)` validation commands, the strengthened denied tools (`WebFetch,WebSearch` and the listed Bash Git/`gh` mutation patterns), and absence of dangerous permission-bypass flags; this check succeeded.  
- Ran `npx vitest run test/pre-commit-hooks.test.js` and it passed.  
- Ran `git diff --check` and it reported no problems; committing the change exercised pre-commit which ran `prettier --check` for the workflow and `npm run typecheck` and succeeded.  
- Reported unavailable checks: `actionlint .github/workflows/claude.yml` is not installed in this environment, and `git push` failed due to lack of non-interactive GitHub HTTPS credentials (authentication is expected to be performed by maintainers from CI or a local environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6150ed8edc832fa852b9d8223b1677)