### PR TITLE
Harden Claude workflow commit guidance

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -59,6 +59,15 @@ jobs:
           additional_permissions: |
             actions: read
 
+          # Implementation sessions should checkpoint coherent work before lengthy
+          # validation so environmental failures or timeouts do not erase safe changes.
+          # Validation-tool grants are narrow and additive; they do not permit broad
+          # package-manager, shell, network, publication, or mutation commands.
+          # Bash Git mutation is denied so Claude uses the action-native signed commit
+          # and push path; unavailable local checks should be disclosed, not used to
+          # abandon otherwise coherent work.
           claude_args: >-
-            --allowedTools "Bash(npm ci),Bash(npm run lint),Bash(npm run lint:fix),Bash(npm run format:check),Bash(npm run format:fix),Bash(npm run typecheck),Bash(npm run test:ci),Bash(npm run build),Bash(npx vitest run:*)"
-            --disallowedTools "Bash(git push:*),Bash(git reset --hard:*),Bash(git clean:*)"
+            --max-turns 120
+            --append-system-prompt "When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy or full validation, and before the final third of the session. Use the action-native signed commit and push mechanism; never use Bash for git add, git commit, or git push. Continue with follow-up commits when needed, and do not hold all work locally until every possible test finishes. A failure introduced by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, blocked, or timed-out check should be reported honestly but must not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing and pushing, and reporting results. Before ending, inspect the working tree and either commit and push the requested safe changes or state the exact correctness, security, or commit-mechanism blocker. Do not fabricate commits for analysis-only or no-op requests, and never commit secrets, temporary debugging, generated junk, or code known to introduce a new failure. A checkpoint commit does not make failing CI mergeable."
+            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(npm ci),Bash(npm run lint:*),Bash(npm run lint:fix:*),Bash(npm run format:check:*),Bash(npm run format:fix:*),Bash(npm run typecheck:*),Bash(npm run test:ci:*),Bash(npm run build:*),Bash(npx vitest run:*),Bash(npx prettier --check:*),Bash(node --check:*),Bash(git diff --check),Bash(git status --short)"
+            --disallowedTools "WebFetch,WebSearch,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git reset:*),Bash(git clean:*),Bash(git rm:*),Bash(gh api:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr merge:*),Bash(gh pr close:*),Bash(gh workflow:*),Bash(gh repo:*)"


### PR DESCRIPTION
### Motivation

- Implementation-oriented `@claude` sessions should prioritize making early, reviewable checkpoint commits so coherent work is not lost to long-running or unavailable local validation.  
- The workflow must make allowed file-editing tools and validation commands explicit and narrowly additive to avoid accidental broad shell or network access.  
- Defensive denials for web access, Bash-based Git mutation, and direct `gh` mutation paths are required while preserving the action-native signed commit mechanism and existing security boundaries.

### Description

- Add `--max-turns 120` and a single, safely quoted `--append-system-prompt` that requires early checkpoint commits for implementation requests unless a concrete correctness, security, or commit-mechanism blocker exists.  
- Make file-editing tools explicit and additive by adding `Read`, `Edit`, `Write`, `Glob`, and `Grep` to `--allowedTools`.  
- Correct the Claude action Bash permission patterns to auto-approve the repository's intended validation commands (narrow `npm` script patterns, focused `npx vitest run ...`, and targeted checks like `npx prettier --check`, `node --check`, `git diff --check`, and `git status --short`) without permitting broad `Bash(*)` or `Bash(npm:*)` patterns.  
- Strengthen `--disallowedTools` to deny `WebFetch`, `WebSearch`, Bash-based `git add`/`git commit`/`git push`, destructive Git Bash operations, and direct `gh` mutation/escape paths, and add concise workflow comments explaining the rationale and timing for checkpointing.

### Testing

- Parsed the updated YAML and ran a shlex split on `claude_args` to verify exactly one `--append-system-prompt`, presence of `--max-turns 120`, the additive allowed tools, the defensive denied tools, and absence of dangerous permission-bypass flags (PASS).  
- Effective parsed `claude_args` (array):
```
["--max-turns","120","--append-system-prompt","When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy or full validation, and before the final third of the session. Use the action-native signed commit and push mechanism; never use Bash for git add, git commit, or git push. Continue with follow-up commits when needed, and do not hold all work locally until every possible test finishes. A failure introduced by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, blocked, or timed-out check should be reported honestly but must not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing and pushing, and reporting results. Before ending, inspect the working tree and either commit and push the requested safe changes or state the exact correctness, security, or commit-mechanism blocker. Do not fabricate commits for analysis-only or no-op requests, and never commit secrets, temporary debugging, generated junk, or code known to introduce a new failure. A checkpoint commit does not make failing CI mergeable.","--allowedTools","Read,Edit,Write,Glob,Grep,Bash(npm ci),Bash(npm run lint:*),Bash(npm run lint:fix:*),Bash(npm run format:check:*),Bash(npm run format:fix:*),Bash(npm run typecheck:*),Bash(npm run test:ci:*),Bash(npm run build:*),Bash(npx vitest run:*),Bash(npx prettier --check:*),Bash(node --check:*),Bash(git diff --check),Bash(git status --short)","--disallowedTools","WebFetch,WebSearch,Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(git reset:*),Bash(git clean:*),Bash(git rm:*),Bash(gh api:*),Bash(gh pr create:*),Bash(gh pr edit:*),Bash(gh pr merge:*),Bash(gh pr close:*),Bash(gh workflow:*),Bash(gh repo:*)"]
```
- Ran the repository tests that touch workflow files: `npx vitest run test/web-deployment.test.js test/web-build-metadata.test.js` (13 tests total) and they all passed (PASS).  
- `git diff --check` passed and the repo pre-commit tasks executed during commit (prettier check and `npm run typecheck`) (PASS).  
- `actionlint .github/workflows/claude.yml` was not executed because `actionlint` is not installed in this environment (UNAVAILABLE).  

Residual notes: remote push was not attempted in this environment due to absent credentials, and no workflow triggers, permission scopes, fork protections, timeout, pinned action SHA, or action-native commit mechanism were changed. The diff is minimal and focused on `.github/workflows/claude.yml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6150debe70832f8948a389e190fb5f)