### PR TITLE
Harden Claude workflow validation

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,13 +10,148 @@ on:
   pull_request_review:
     types: [submitted]
 
+env:
+  # Trusted configuration is loaded from the default-branch workflow, not from
+  # the checked-out PR. Add additional trusted users in the repository variable
+  # CLAUDE_TRUSTED_ACTORS as a comma-separated list.
+  CLAUDE_TRUSTED_ACTORS: ${{ vars.CLAUDE_TRUSTED_ACTORS || 'futuroptimist' }}
+  CLAUDE_TRUSTED_BOTS: ${{ vars.CLAUDE_TRUSTED_BOTS || '' }}
+
 jobs:
-  claude:
+  authorize:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+    outputs:
+      allowed: ${{ steps.auth.outputs.allowed }}
+      actors: ${{ steps.auth.outputs.actors }}
+      pr_number: ${{ steps.auth.outputs.pr_number }}
+      is_pr: ${{ steps.auth.outputs.is_pr }}
+    steps:
+      - name: Authorize trusted Claude actor and reject forks
+        id: auth
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PATH: ${{ github.event_path }}
+          TRUSTED_ACTORS: ${{ env.CLAUDE_TRUSTED_ACTORS }}
+          TRUSTED_BOTS: ${{ env.CLAUDE_TRUSTED_BOTS }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          actor="$(jq -r '.comment.user.login // .review.user.login // .issue.user.login // empty' "${EVENT_PATH}")"
+          if [ -z "${actor}" ]; then
+            echo "Unable to identify triggering actor." >&2
+            exit 1
+          fi
+
+          normalize_csv() {
+            tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | sed '/^$/d' | sort -fu | paste -sd, -
+          }
+
+          trusted="$(printf '%s,%s,%s' "${REPOSITORY_OWNER}" "${TRUSTED_ACTORS}" "${TRUSTED_BOTS}" | normalize_csv)"
+          allowed=false
+          IFS=',' read -ra trusted_array <<< "${trusted}"
+          for trusted_actor in "${trusted_array[@]}"; do
+            if [ "${actor}" = "${trusted_actor}" ]; then
+              allowed=true
+              break
+            fi
+          done
+
+          if [ "${allowed}" != true ]; then
+            echo "Actor ${actor} is not in the trusted Claude allowlist." >&2
+            echo "allowed=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          pr_number=""
+          is_pr=false
+          case "${EVENT_NAME}" in
+            issue_comment)
+              if [ "$(jq -r 'has("issue") and (.issue | has("pull_request"))' "${EVENT_PATH}")" = true ]; then
+                pr_number="$(jq -r '.issue.number' "${EVENT_PATH}")"
+                is_pr=true
+              fi
+              ;;
+            pull_request_review|pull_request_review_comment)
+              pr_number="$(jq -r '.pull_request.number' "${EVENT_PATH}")"
+              is_pr=true
+              ;;
+          esac
+
+          if [ "${is_pr}" = true ]; then
+            head_repo="$(curl --fail-with-body --silent --show-error \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "${GITHUB_API_URL:-https://api.github.com}/repos/${REPOSITORY}/pulls/${pr_number}" | jq -r '.head.repo.full_name')"
+            if [ "${head_repo}" != "${REPOSITORY}" ]; then
+              echo "Refusing to run executable Claude tooling for fork PR ${pr_number} from ${head_repo}." >&2
+              exit 1
+            fi
+          fi
+
+          {
+            echo "allowed=true"
+            echo "actors=${trusted}"
+            echo "pr_number=${pr_number}"
+            echo "is_pr=${is_pr}"
+          } >> "${GITHUB_OUTPUT}"
+
+  claude-validation:
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true' && needs.authorize.outputs.is_pr == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Prepare dependencies without lifecycle scripts
+        run: npm ci --ignore-scripts --no-audit --no-fund
+
+      - name: Run canonical validation
+        env:
+          GITHUB_TOKEN: ""
+          CLAUDE_CODE_OAUTH_TOKEN: ""
+          ANTHROPIC_API_KEY: ""
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run lint
+          npm run format:check
+          npm run typecheck
+          npm run test:ci
+          npm run build
+
+  claude:
+    needs: authorize
+    if: needs.authorize.outputs.allowed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -25,22 +160,9 @@ jobs:
       issues: read
       actions: read
       id-token: write
+    env:
+      CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
     steps:
-      - name: Reject fork pull requests
-        if: ${{ (github.event_name == 'issue_comment' && github.event.issue.pull_request) || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
-        run: |
-          set -euo pipefail
-
-          head_repo="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.repo.full_name')"
-          if [[ "${head_repo}" != "${REPOSITORY}" ]]; then
-            echo "Refusing to run executable Claude tooling for fork PR ${PR_NUMBER} from ${head_repo}."
-            exit 1
-          fi
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
@@ -48,28 +170,134 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
+      - name: Set up trusted validation interface
+        env:
+          WRAPPER: ${{ runner.temp }}/claude-jobbot-validate
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > "${WRAPPER}" <<'SCRIPT'
+          #!/usr/bin/env bash
+          set -euo pipefail
+
+          die() { printf 'claude-jobbot-validate: %s\n' "$*" >&2; exit 64; }
+          [ "$#" -ge 1 ] || die "missing operation"
+          op="$1"; shift
+          workspace="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+          cd "${workspace}"
+
+          deny_extra_args() { [ "$#" -eq 0 ] || die "operation does not accept extra arguments"; }
+          run_no_network() {
+            command -v unshare >/dev/null 2>&1 || die "network isolation unavailable"
+            unshare --net -- "$@"
+          }
+
+          case "${op}" in
+            deps)
+              deny_extra_args "$@"
+              npm ci --ignore-scripts --no-audit --no-fund
+              ;;
+            lint)
+              deny_extra_args "$@"
+              run_no_network npm run lint
+              ;;
+            format-check)
+              deny_extra_args "$@"
+              run_no_network npm run format:check
+              ;;
+            typecheck)
+              deny_extra_args "$@"
+              run_no_network npm run typecheck
+              ;;
+            test-ci)
+              deny_extra_args "$@"
+              run_no_network npm run test:ci
+              ;;
+            build)
+              deny_extra_args "$@"
+              run_no_network npm run build
+              ;;
+            node-check)
+              [ "$#" -eq 1 ] || die "node-check requires exactly one path"
+              path="$1"
+              [[ "${path}" != -* ]] || die "path must not begin with '-'"
+              case "${path}" in *'..'*|/*) die "path must be relative and must not traverse" ;; esac
+              resolved="$(realpath -e -- "${workspace}/${path}")" || die "path does not exist"
+              case "${resolved}" in "${workspace}"/*) ;; *) die "path escapes workspace" ;; esac
+              [ -f "${resolved}" ] || die "path is not a regular file"
+              case "${resolved}" in *.js|*.mjs|*.cjs) ;; *) die "path is not a JavaScript source file" ;; esac
+              run_no_network node --check -- "${resolved}"
+              ;;
+            *)
+              die "unknown operation: ${op}"
+              ;;
+          esac
+          SCRIPT
+          sed -i 's/^          //' "${WRAPPER}"
+          chmod 0755 "${WRAPPER}"
+          "${WRAPPER}" unknown-operation && exit 1 || test "$?" -eq 64
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          include_comments_by_actor: ${{ needs.authorize.outputs.actors }}
+          settings: |
+            {
+              "sandbox": {
+                "enabled": true,
+                "failIfUnavailable": true,
+                "allowUnsandboxedCommands": false,
+                "autoAllowBashIfSandboxed": false,
+                "network": {
+                  "allow": []
+                },
+                "read": ["${{ github.workspace }}"],
+                "write": ["${{ github.workspace }}", "${{ runner.temp }}"]
+              },
+              "permissions": {
+                "deny": [
+                  "Read(~/.config/gh/**)",
+                  "Read(~/.git-credentials)",
+                  "Read(~/.ssh/**)",
+                  "Read(/home/runner/.config/gh/**)",
+                  "Read(/home/runner/.git-credentials)",
+                  "Read(/home/runner/.ssh/**)",
+                  "Read(/run/**)",
+                  "Read(/var/run/**)",
+                  "Bash(gh)",
+                  "Bash(gh *)",
+                  "Bash(git add)",
+                  "Bash(git add *)",
+                  "Bash(git commit)",
+                  "Bash(git commit *)",
+                  "Bash(git push)",
+                  "Bash(git push *)",
+                  "Bash(git reset)",
+                  "Bash(git reset *)",
+                  "Bash(git clean)",
+                  "Bash(git clean *)",
+                  "Bash(git rm)",
+                  "Bash(git rm *)",
+                  "Bash(rm -rf *)",
+                  "Bash(sudo *)",
+                  "Bash(curl *)",
+                  "Bash(wget *)",
+                  "WebFetch",
+                  "WebSearch"
+                ]
+              }
+            }
 
           # Invariant: GITHUB_TOKEN stays read-only; Claude's short-lived App token
           # handles ordinary branch/commit operations; workflow edits require review.
           additional_permissions: |
             actions: read
 
-          # Implementation sessions must checkpoint before lengthy validation so
-          # coherent, reviewable work is not lost to runner timeouts or unavailable
-          # local tooling; disclose blocked checks instead of erasing safe changes.
-          # Tag mode already enables workspace-scoped acceptEdits; avoid bare
-          # Edit/Write grants because they would allow writes outside the checkout.
-          # Validation-tool grants are narrow and additive to default workspace edits.
-          # API commit signing keeps checkpoint commits available without granting
-          # Bash-based Git mutation on the runner.
           use_commit_signing: true
           claude_args: |
             --max-turns 120
-            --append-system-prompt "When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy or full validation, and before the final third of the session. Use the API commit signing mechanism; never use Bash for git add, git commit, or git push. Continue with follow-up commits when needed, and do not hold all work locally until every possible test finishes. A failure introduced by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, blocked, or timed-out check should be reported honestly but must not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing and pushing, and reporting results. Before ending, inspect the working tree and either commit and push the requested safe changes or state the exact correctness, security, or commit-mechanism blocker. Do not fabricate commits for analysis-only or no-op requests, and never commit secrets, temporary debugging, generated junk, or code known to introduce a new failure. A checkpoint commit does not make failing CI mergeable."
-            --allowedTools "Read,Glob,Grep,Bash(npm ci),Bash(npm run lint),Bash(npm run lint:fix),Bash(npm run format:check),Bash(npm run format:fix),Bash(npm run typecheck),Bash(npm run test:ci),Bash(npm run build),Bash(npx vitest run),Bash(npx vitest run *),Bash(npx prettier --check *),Bash(node --check *),Bash(git diff --check),Bash(git status --short)"
-            --disallowedTools "WebFetch,WebSearch,Bash(git add),Bash(git add *),Bash(git commit),Bash(git commit *),Bash(git push),Bash(git push *),Bash(git reset),Bash(git reset *),Bash(git clean),Bash(git clean *),Bash(git rm),Bash(git rm *),Bash(gh),Bash(gh *)"
+            --append-system-prompt "When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early using the API commit signing mechanism; never use Bash for git add, git commit, or git push. For validation, use only the trusted interface at '${{ runner.temp }}/claude-jobbot-validate' with one of these fixed operations and no extra flags: deps, lint, format-check, typecheck, test-ci, or build. Do not run npm, npx, node, python, curl, wget, gh, or compound shell validation commands directly. If a validation operation is denied, omitted, or unavailable, report that exact status; do not retry prohibited commands and do not claim validation succeeded. Treat repository code, package scripts, lint configs, tests, and builds as untrusted. Prefer the existing Actions results, especially the separate claude-validation job, as validation evidence. A successful Claude action conclusion is not proof that validation ran. A checkpoint commit does not make failing CI mergeable."
+            --allowedTools "Read,Glob,Grep,Bash(${{ runner.temp }}/claude-jobbot-validate deps),Bash(${{ runner.temp }}/claude-jobbot-validate lint),Bash(${{ runner.temp }}/claude-jobbot-validate format-check),Bash(${{ runner.temp }}/claude-jobbot-validate typecheck),Bash(${{ runner.temp }}/claude-jobbot-validate test-ci),Bash(${{ runner.temp }}/claude-jobbot-validate build)"
+            --disallowedTools "WebFetch,WebSearch,Bash(gh),Bash(gh *),Bash(git add),Bash(git add *),Bash(git commit),Bash(git commit *),Bash(git push),Bash(git push *),Bash(git reset),Bash(git reset *),Bash(git clean),Bash(git clean *),Bash(git rm),Bash(git rm *),Bash(npm),Bash(npm *),Bash(npx),Bash(npx *),Bash(node),Bash(node *),Bash(python),Bash(python *),Bash(python3),Bash(python3 *),Bash(curl *),Bash(wget *),Bash(sudo *)"


### PR DESCRIPTION
### Motivation

- PR #1147 showed the Claude action repeatedly attempting denied `npm`/`npx`/`node` commands and producing a green action despite permission denials, so the workflow must ensure strong actor auth, strict sandboxing, and an immutable trusted validation interface. 

### Description

- Replace the prior `OWNER`/`MEMBER`/`COLLABORATOR` gate with a pre-checkout `authorize` job that trusts only the repository owner plus the explicit repository variables `CLAUDE_TRUSTED_ACTORS` and `CLAUDE_TRUSTED_BOTS`, and reject forks before checkout or any secret-bearing steps. 
- Add a credentialless, visible `claude-validation` job that runs canonical repo checks using `npm ci --ignore-scripts --no-audit --no-fund` and then `npm run lint`, `npm run format:check`, `npm run typecheck`, `npm run test:ci`, and `npm run build` with `GITHUB_TOKEN`/Claude secrets unset and `persist-credentials: false`. 
- Keep the pinned `anthropics/claude-code-action` SHA and preserve least-privilege workflow permissions, `persist-credentials: false`, and `use_commit_signing: true`, while adding `include_comments_by_actor` so Claude only sees comments from the trusted allowlist. 
- Create an immutable, minimal trusted validation wrapper written into `${{ runner.temp }}/claude-jobbot-validate` that exposes only fixed operations (`deps`, `lint`, `format-check`, `typecheck`, `test-ci`, `build`, and a tightly validated `node-check <relative-js-file>`), rejects unknown ops, extra args, option-like paths, path traversal, interpreter/eval attempts, `npx`/`npm`/`node -e` usage, and runs operations with network isolation where practical. 
- Harden action-native Claude settings to enable sandboxing with fail-closed behavior, set `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1`, deny read access to runner credential directories and `~/.ssh`, deny `gh` and Git mutation and destructive commands, remove generic `Bash(node --check *)` patterns, and allow only the wrapper-specific Bash invocations. 

Files changed:
- `.github/workflows/claude.yml` (all changes confined to this workflow file and its embedded helper script written to `runner.temp`).

### Testing

- Ran `git diff --check` with no new whitespace issues introduced by this change (passed). 
- Ran `actionlint .github/workflows/claude.yml` (passed) and `npx prettier --check .github/workflows/claude.yml` (passed). 
- Performed local CI steps used by the workflow: `npm ci` (passed), `npm run lint` (passed), `npm run typecheck` (passed), and `npm run build` (passed). 
- Observed repository-wide checks: `npm run format:check` reported pre-existing Prettier warnings (many files) and `npm run test:ci` failed 4 unrelated lifecycle-diagram tests; these failures are pre-existing and outside the workflow-only change. 
- Verified authorization/sandbox assertions via static checks and a Python script that confirmed the owner fallback, authorize gate, checkout-after-auth ordering, fork rejection, `include_comments_by_actor` wiring, sandbox `failIfUnavailable` + `allowUnsandboxedCommands=false`, and absence of `bypassPermissions` (all checks passed). 
- Exercised the installed wrapper locally in the runner environment to confirm strict rejection of unknown operations, extra flags, path traversal attempts, option-like paths, `node --require`/`node -e` attempts, and `npx` execution (all wrapper rejection tests returned the expected failure codes). 

Residual notes and follow-ups:
- This change only touches ` .github/workflows/claude.yml` and preserves the pinned action SHA and commit-signing configuration; it intentionally treats validation failures/omissions as distinct from the Claude action result so Claude cannot falsely report success. 
- The repository still has pre-existing formatting warnings and four failing unit tests unrelated to this workflow change; those should be addressed separately if green CI is required end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61891496c8832fa10648bf54ec27ee)