### PR TITLE
Harden Claude validation workflow and add trusted validation wrapper

### DIFF
--- a/.github/claude-code-settings.json
+++ b/.github/claude-code-settings.json
@@ -1,0 +1,102 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Glob",
+      "Grep",
+      "Bash(/tmp/jobbot-claude-validate prepare)",
+      "Bash(/tmp/jobbot-claude-validate lint)",
+      "Bash(/tmp/jobbot-claude-validate format-check)",
+      "Bash(/tmp/jobbot-claude-validate typecheck)",
+      "Bash(/tmp/jobbot-claude-validate test-ci)",
+      "Bash(/tmp/jobbot-claude-validate build)",
+      "Bash(/tmp/jobbot-claude-validate node-check *)",
+      "Bash(git diff --check)",
+      "Bash(git status --short)"
+    ],
+    "deny": [
+      "WebFetch",
+      "WebSearch",
+      "Bash(gh)",
+      "Bash(gh *)",
+      "Bash(git add)",
+      "Bash(git add *)",
+      "Bash(git commit)",
+      "Bash(git commit *)",
+      "Bash(git push)",
+      "Bash(git push *)",
+      "Bash(git reset)",
+      "Bash(git reset *)",
+      "Bash(git clean)",
+      "Bash(git clean *)",
+      "Bash(git rm)",
+      "Bash(git rm *)",
+      "Bash(rm -rf *)",
+      "Bash(sudo *)",
+      "Bash(curl *)",
+      "Bash(wget *)",
+      "Bash(npm *)",
+      "Bash(npx *)",
+      "Bash(node *)",
+      "Bash(python *)",
+      "Bash(python3 *)"
+    ]
+  },
+  "sandbox": {
+    "enabled": true,
+    "failIfUnavailable": true,
+    "allowUnsandboxedCommands": false,
+    "autoAllowBashIfSandboxed": false,
+    "filesystem": {
+      "denyRead": [
+        "~/",
+        "/home/runner/.config/gh",
+        "/home/runner/.docker",
+        "/home/runner/.git-credentials",
+        "/home/runner/.netrc",
+        "/home/runner/.ssh",
+        "/home/runner/.npmrc",
+        "/home/runner/work/_temp/_github_home",
+        "/home/runner/work/_temp/_runner_file_commands"
+      ],
+      "allowRead": ["."],
+      "denyWrite": [
+        "/home/runner/.config/gh",
+        "/home/runner/.docker",
+        "/home/runner/.git-credentials",
+        "/home/runner/.netrc",
+        "/home/runner/.ssh",
+        "/home/runner/.npmrc",
+        "/home/runner/work/_temp/_github_home",
+        "/home/runner/work/_temp/_runner_file_commands"
+      ]
+    },
+    "network": {
+      "allowedDomains": [],
+      "deniedDomains": ["*"]
+    },
+    "credentials": {
+      "files": [
+        { "path": "~/.config/gh", "mode": "deny" },
+        { "path": "~/.docker", "mode": "deny" },
+        { "path": "~/.git-credentials", "mode": "deny" },
+        { "path": "~/.netrc", "mode": "deny" },
+        { "path": "~/.ssh", "mode": "deny" },
+        { "path": "~/.npmrc", "mode": "deny" },
+        { "path": "/home/runner/work/_temp/_github_home", "mode": "deny" },
+        {
+          "path": "/home/runner/work/_temp/_runner_file_commands",
+          "mode": "deny"
+        }
+      ],
+      "envVars": [
+        { "name": "ACTIONS_ID_TOKEN_REQUEST_TOKEN", "mode": "deny" },
+        { "name": "ANTHROPIC_API_KEY", "mode": "deny" },
+        { "name": "CLAUDE_CODE_OAUTH_TOKEN", "mode": "deny" },
+        { "name": "GH_TOKEN", "mode": "deny" },
+        { "name": "GITHUB_TOKEN", "mode": "deny" },
+        { "name": "NPM_TOKEN", "mode": "deny" }
+      ]
+    }
+  }
+}

--- a/.github/scripts/jobbot-claude-validate.sh
+++ b/.github/scripts/jobbot-claude-validate.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage: jobbot-claude-validate.sh <operation> [source-file]
+
+Operations:
+  prepare        npm ci --ignore-scripts --no-audit --no-fund
+  lint           npm run lint
+  format-check   npm run format:check
+  typecheck      npm run typecheck
+  test-ci        npm run test:ci
+  build          npm run build
+  node-check     node --check -- <regular repository source file>
+USAGE
+}
+
+if [ "$#" -lt 1 ]; then
+  usage
+  exit 64
+fi
+
+workspace="${GITHUB_WORKSPACE:-}"
+if [ -z "${workspace}" ]; then
+  echo "GITHUB_WORKSPACE is required." >&2
+  exit 70
+fi
+
+workspace="$(realpath "$workspace")"
+cd "$workspace"
+
+operation="$1"
+shift
+
+reject_extra_args() {
+  if [ "$#" -ne 0 ]; then
+    echo "Operation '${operation}' does not accept additional arguments." >&2
+    exit 64
+  fi
+}
+
+case "$operation" in
+  prepare)
+    reject_extra_args "$@"
+    exec npm ci --ignore-scripts --no-audit --no-fund
+    ;;
+  lint)
+    reject_extra_args "$@"
+    exec npm run lint
+    ;;
+  format-check)
+    reject_extra_args "$@"
+    exec npm run format:check
+    ;;
+  typecheck)
+    reject_extra_args "$@"
+    exec npm run typecheck
+    ;;
+  test-ci)
+    reject_extra_args "$@"
+    exec npm run test:ci
+    ;;
+  build)
+    reject_extra_args "$@"
+    exec npm run build
+    ;;
+  node-check)
+    if [ "$#" -ne 1 ]; then
+      echo "Operation 'node-check' requires exactly one source file path." >&2
+      exit 64
+    fi
+    candidate="$1"
+    if [[ "$candidate" == -* ]]; then
+      echo "Source file path must not begin with '-'." >&2
+      exit 64
+    fi
+    resolved="$(realpath -m -- "$candidate")"
+    case "$resolved" in
+      "$workspace"/*) ;;
+      *)
+        echo "Source file must resolve beneath GITHUB_WORKSPACE." >&2
+        exit 64
+        ;;
+    esac
+    if [ ! -f "$resolved" ]; then
+      echo "Source file must be a regular file." >&2
+      exit 66
+    fi
+    case "$resolved" in
+      *.js|*.mjs|*.cjs) ;;
+      *)
+        echo "Source file must be a JavaScript source file (*.js, *.mjs, or *.cjs)." >&2
+        exit 64
+        ;;
+    esac
+    exec node --check -- "$resolved"
+    ;;
+  *)
+    echo "Unknown validation operation: ${operation}" >&2
+    usage
+    exit 64
+    ;;
+esac

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.review.author_association)) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:
@@ -26,6 +26,30 @@ jobs:
       actions: read
       id-token: write
     steps:
+      - name: Authorize trusted Claude actor
+        env:
+          ACTOR: ${{ github.actor }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          TRUSTED_ACTORS: ${{ vars.CLAUDE_TRUSTED_ACTORS }}
+        run: |
+          set -euo pipefail
+
+          if [ "${ACTOR}" = "${REPOSITORY_OWNER}" ]; then
+            exit 0
+          fi
+
+          IFS=',' read -r -a trusted <<< "${TRUSTED_ACTORS:-}"
+          for login in "${trusted[@]}"; do
+            login="${login//[[:space:]]/}"
+            if [ -n "${login}" ] && [ "${ACTOR}" = "${login}" ]; then
+              exit 0
+            fi
+          done
+
+          echo "Refusing to run privileged Claude workflow for untrusted actor ${ACTOR}." >&2
+          echo "Configure trusted actors in the CLAUDE_TRUSTED_ACTORS repository variable." >&2
+          exit 1
+
       - name: Reject fork pull requests
         if: ${{ (github.event_name == 'issue_comment' && github.event.issue.pull_request) || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review' }}
         env:
@@ -48,11 +72,22 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
+      - name: Install trusted Claude validation wrapper
+        run: |
+          set -euo pipefail
+          install -m 0755 .github/scripts/jobbot-claude-validate.sh /tmp/jobbot-claude-validate
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608 # v1
+        env:
+          CLAUDE_CODE_SUBPROCESS_ENV_SCRUB: "1"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          include_comments_by_actor: ${{ github.repository_owner }}${{ vars.CLAUDE_TRUSTED_ACTORS != '' && format(',{0}', vars.CLAUDE_TRUSTED_ACTORS) || '' }},github-actions[bot],claude[bot]
+          display_report: "false"
+          show_full_output: "false"
+          settings: .github/claude-code-settings.json
 
           # Invariant: GITHUB_TOKEN stays read-only; Claude's short-lived App token
           # handles ordinary branch/commit operations; workflow edits require review.
@@ -70,6 +105,91 @@ jobs:
           use_commit_signing: true
           claude_args: |
             --max-turns 120
-            --append-system-prompt "When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy or full validation, and before the final third of the session. Use the API commit signing mechanism; never use Bash for git add, git commit, or git push. Continue with follow-up commits when needed, and do not hold all work locally until every possible test finishes. A failure introduced by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, blocked, or timed-out check should be reported honestly but must not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing and pushing, and reporting results. Before ending, inspect the working tree and either commit and push the requested safe changes or state the exact correctness, security, or commit-mechanism blocker. Do not fabricate commits for analysis-only or no-op requests, and never commit secrets, temporary debugging, generated junk, or code known to introduce a new failure. A checkpoint commit does not make failing CI mergeable."
-            --allowedTools "Read,Glob,Grep,Bash(npm ci),Bash(npm run lint),Bash(npm run lint:fix),Bash(npm run format:check),Bash(npm run format:fix),Bash(npm run typecheck),Bash(npm run test:ci),Bash(npm run build),Bash(npx vitest run),Bash(npx vitest run *),Bash(npx prettier --check *),Bash(node --check *),Bash(git diff --check),Bash(git status --short)"
-            --disallowedTools "WebFetch,WebSearch,Bash(git add),Bash(git add *),Bash(git commit),Bash(git commit *),Bash(git push),Bash(git push *),Bash(git reset),Bash(git reset *),Bash(git clean),Bash(git clean *),Bash(git rm),Bash(git rm *),Bash(gh),Bash(gh *)"
+            --append-system-prompt "Use only existing Actions results and the trusted validation wrapper for local validation. The only validation commands you may ask Bash to run are: /tmp/jobbot-claude-validate prepare, /tmp/jobbot-claude-validate lint, /tmp/jobbot-claude-validate format-check, /tmp/jobbot-claude-validate typecheck, /tmp/jobbot-claude-validate test-ci, /tmp/jobbot-claude-validate build, /tmp/jobbot-claude-validate node-check <repo-js-file>, git diff --check, and git status --short. Do not retry prohibited npm, npx, node, python, curl, wget, gh, or git mutation commands. If a validation command is denied, skipped, blocked, or unavailable, say so explicitly and do not claim validation succeeded. A successful Claude action result is not proof that validation ran; report the specific validation operations and outcomes. When the triggering request asks for repository changes, producing a remote commit is a required deliverable unless a concrete correctness or security blocker prevents it. Make and push the first coherent, reviewable checkpoint commit early: after focused validation or syntax checks, before lengthy or full validation, and before the final third of the session. Use the API commit signing mechanism; never use Bash for git add, git commit, or git push. Continue with follow-up commits when needed, and do not hold all work locally until every possible test finishes. A failure introduced by the new code must be fixed before finalizing. A pre-existing, environmental, unavailable, blocked, or timed-out check should be reported honestly but must not cause otherwise coherent and safe requested changes to disappear. Reserve the final ten turns for reviewing the diff, checking status, running the narrowest remaining verification, committing and pushing, and reporting results. Before ending, inspect the working tree and either commit and push the requested safe changes or state the exact correctness, security, or commit-mechanism blocker. Do not fabricate commits for analysis-only or no-op requests, and never commit secrets, temporary debugging, generated junk, or code known to introduce a new failure. A checkpoint commit does not make failing CI mergeable."
+            --allowedTools "Read,Glob,Grep,Bash(/tmp/jobbot-claude-validate prepare),Bash(/tmp/jobbot-claude-validate lint),Bash(/tmp/jobbot-claude-validate format-check),Bash(/tmp/jobbot-claude-validate typecheck),Bash(/tmp/jobbot-claude-validate test-ci),Bash(/tmp/jobbot-claude-validate build),Bash(/tmp/jobbot-claude-validate node-check *),Bash(git diff --check),Bash(git status --short)"
+            --disallowedTools "WebFetch,WebSearch,Bash(gh),Bash(gh *),Bash(git add),Bash(git add *),Bash(git commit),Bash(git commit *),Bash(git push),Bash(git push *),Bash(git reset),Bash(git reset *),Bash(git clean),Bash(git clean *),Bash(git rm),Bash(git rm *),Bash(rm -rf *),Bash(sudo *),Bash(curl *),Bash(wget *),Bash(npm *),Bash(npx *),Bash(node *),Bash(python *),Bash(python3 *)"
+
+  claude-validation:
+    name: Claude validation interface
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+    steps:
+      - name: Authorize trusted validation actor
+        env:
+          ACTOR: ${{ github.actor }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          TRUSTED_ACTORS: ${{ vars.CLAUDE_TRUSTED_ACTORS }}
+        run: |
+          set -euo pipefail
+          if [ "${ACTOR}" = "${REPOSITORY_OWNER}" ]; then exit 0; fi
+          IFS=',' read -r -a trusted <<< "${TRUSTED_ACTORS:-}"
+          for login in "${trusted[@]}"; do
+            login="${login//[[:space:]]/}"
+            if [ -n "${login}" ] && [ "${ACTOR}" = "${login}" ]; then exit 0; fi
+          done
+          echo "Skipping validation for untrusted actor ${ACTOR}." >&2
+          exit 1
+
+      - name: Resolve pull request head
+        id: pr
+        if: ${{ (github.event_name == 'issue_comment' && github.event.issue.pull_request) || github.event_name == 'pull_request_review_comment' || github.event_name == 'pull_request_review' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          pr_json="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}")"
+          head_repo="$(jq -r '.head.repo.full_name' <<< "${pr_json}")"
+          if [ "${head_repo}" != "${REPOSITORY}" ]; then
+            echo "Refusing validation for fork PR ${PR_NUMBER} from ${head_repo}." >&2
+            exit 1
+          fi
+          jq -r '.head.sha | "sha=\(.)"' <<< "${pr_json}" >> "${GITHUB_OUTPUT}"
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Set up Node 20
+        uses: actions/setup-node@v5
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies without lifecycle scripts
+        run: .github/scripts/jobbot-claude-validate.sh prepare
+
+      - name: Block outbound network for repository validation
+        run: |
+          set -euo pipefail
+          sudo iptables -P OUTPUT DROP
+          sudo iptables -A OUTPUT -o lo -j ACCEPT
+          sudo ip6tables -P OUTPUT DROP
+          sudo ip6tables -A OUTPUT -o lo -j ACCEPT
+
+      - name: Lint
+        run: .github/scripts/jobbot-claude-validate.sh lint
+
+      - name: Format check
+        run: .github/scripts/jobbot-claude-validate.sh format-check
+
+      - name: Typecheck
+        run: .github/scripts/jobbot-claude-validate.sh typecheck
+
+      - name: Test
+        run: .github/scripts/jobbot-claude-validate.sh test-ci
+
+      - name: Build
+        run: .github/scripts/jobbot-claude-validate.sh build

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "build": "node scripts/build-static.js",
     "start:static": "node scripts/static-server.js",
     "smoke:container": "bash scripts/smoke-container.sh",
-    "smoke:promotion": "node scripts/promotion-smoke.js"
+    "smoke:promotion": "node scripts/promotion-smoke.js",
+    "test:claude-workflow-security": "vitest run test/claude-workflow-security.test.js"
   },
   "engines": {
     "node": ">=20"

--- a/test/claude-workflow-security.test.js
+++ b/test/claude-workflow-security.test.js
@@ -1,0 +1,246 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { cp, mkdir, readFile, symlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml } from "yaml";
+
+const repoRoot = path.resolve(import.meta.dirname, "..");
+const workflowPath = path.join(repoRoot, ".github/workflows/claude.yml");
+const settingsPath = path.join(repoRoot, ".github/claude-code-settings.json");
+const wrapperPath = path.join(
+  repoRoot,
+  ".github/scripts/jobbot-claude-validate.sh",
+);
+
+async function readWorkflow() {
+  return parseYaml(await readFile(workflowPath, "utf8"));
+}
+
+function runWrapper(args, workspace) {
+  return spawnSync(wrapperPath, args, {
+    cwd: workspace,
+    env: {
+      ...process.env,
+      GITHUB_WORKSPACE: workspace,
+      PATH: process.env.PATH,
+    },
+    encoding: "utf8",
+  });
+}
+
+describe("Claude workflow hardening", () => {
+  it("uses explicit trusted actors before checkout or secret-bearing Claude steps", async () => {
+    const workflowText = await readFile(workflowPath, "utf8");
+    const workflow = await readWorkflow();
+    const steps = workflow.jobs.claude.steps;
+
+    expect(workflowText).toContain("vars.CLAUDE_TRUSTED_ACTORS");
+    expect(workflowText).toContain("github.repository_owner");
+    expect(workflowText).not.toContain('"OWNER", "MEMBER", "COLLABORATOR"');
+    expect(steps[0].name).toBe("Authorize trusted Claude actor");
+    expect(
+      steps.findIndex((step) => step.name === "Checkout repository"),
+    ).toBeGreaterThan(0);
+    expect(
+      steps.findIndex((step) => step.name === "Run Claude Code"),
+    ).toBeGreaterThan(
+      steps.findIndex((step) => step.name === "Reject fork pull requests"),
+    );
+    expect(workflowText).toContain("include_comments_by_actor:");
+    expect(workflowText).toContain("github-actions[bot],claude[bot]");
+  });
+
+  it("keeps privileged Claude permissions narrow and sensitive output disabled", async () => {
+    const workflow = await readWorkflow();
+    const job = workflow.jobs.claude;
+    const runClaude = job.steps.find((step) => step.name === "Run Claude Code");
+
+    expect(job.permissions).toMatchObject({
+      contents: "read",
+      "pull-requests": "read",
+      issues: "read",
+      actions: "read",
+      "id-token": "write",
+    });
+    expect(runClaude.uses).toBe(
+      "anthropics/claude-code-action@fa7e2f0a29a126f0b81cdcf360561b36e44cf608",
+    );
+    expect(runClaude.with.use_commit_signing).toBe(true);
+    expect(runClaude.with.display_report).toBe("false");
+    expect(runClaude.with.show_full_output).toBe("false");
+  });
+
+  it("allows only the trusted validation wrapper and denies generic interpreters", async () => {
+    const workflowText = await readFile(workflowPath, "utf8");
+    const settings = JSON.parse(await readFile(settingsPath, "utf8"));
+    const allowed = settings.permissions.allow.join("\n");
+    const denied = `${workflowText}\n${settings.permissions.deny.join("\n")}`;
+
+    for (const op of [
+      "prepare",
+      "lint",
+      "format-check",
+      "typecheck",
+      "test-ci",
+      "build",
+    ]) {
+      expect(allowed).toContain(`Bash(/tmp/jobbot-claude-validate ${op})`);
+    }
+    expect(allowed).toContain("Bash(/tmp/jobbot-claude-validate node-check *)");
+    for (const forbidden of [
+      "Bash(npm ci)",
+      "Bash(npm run lint)",
+      "Bash(npx vitest run",
+      "Bash(node --check *)",
+      "Bash(node -e",
+      "--dangerously-skip-permissions",
+      "bypassPermissions",
+      "Bash(curl *)",
+      "Bash(wget *)",
+    ]) {
+      expect(allowed).not.toContain(forbidden);
+    }
+    for (const deniedTool of [
+      "Bash(npm *)",
+      "Bash(npx *)",
+      "Bash(node *)",
+      "WebFetch",
+      "WebSearch",
+    ]) {
+      expect(denied).toContain(deniedTool);
+    }
+  });
+
+  it("configures strict sandboxing and credential containment", async () => {
+    const settings = JSON.parse(await readFile(settingsPath, "utf8"));
+    expect(settings.sandbox).toMatchObject({
+      enabled: true,
+      failIfUnavailable: true,
+      allowUnsandboxedCommands: false,
+      autoAllowBashIfSandboxed: false,
+    });
+    expect(settings.sandbox.network.allowedDomains).toEqual([]);
+    expect(settings.sandbox.network.deniedDomains).toEqual(["*"]);
+    expect(settings.sandbox.filesystem.denyRead).toEqual(
+      expect.arrayContaining([
+        "~/",
+        "/home/runner/.ssh",
+        "/home/runner/work/_temp/_github_home",
+      ]),
+    );
+    expect(settings.sandbox.credentials.envVars).toEqual(
+      expect.arrayContaining([
+        { name: "GITHUB_TOKEN", mode: "deny" },
+        { name: "CLAUDE_CODE_OAUTH_TOKEN", mode: "deny" },
+        { name: "ACTIONS_ID_TOKEN_REQUEST_TOKEN", mode: "deny" },
+      ]),
+    );
+  });
+});
+
+describe("trusted Claude validation wrapper", () => {
+  async function fixtureWorkspace() {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "jobbot-claude-wrapper-"));
+    await writeFile(
+      path.join(dir, "package.json"),
+      JSON.stringify({ scripts: {} }),
+    );
+    await mkdir(path.join(dir, "src"));
+    await writeFile(path.join(dir, "src/ok.js"), "const ok = true;\n");
+    await writeFile(path.join(dir, "src/not-js.txt"), "text\n");
+    return dir;
+  }
+
+  it("rejects unsafe operations and arguments", async () => {
+    const workspace = await fixtureWorkspace();
+    try {
+      for (const args of [
+        ["unknown"],
+        ["lint", "--", "--fix"],
+        ["lint;echo pwned"],
+        ["node-check", "../outside.js"],
+        ["node-check", "-e"],
+        ["node-check", "--require"],
+        ["node-check", "src/not-js.txt"],
+        ["npx", "vitest", "run"],
+      ]) {
+        const result = runWrapper(args, workspace);
+        expect(result.status).not.toBe(0);
+      }
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("uses node --check with an option terminator for repository JS files", async () => {
+    const workspace = await fixtureWorkspace();
+    try {
+      const nodePath = path.join(workspace, "node");
+      writeFileSync(
+        nodePath,
+        '#!/usr/bin/env bash\nprintf "%s\\n" "$@" > node-argv.txt\n',
+        { mode: 0o755 },
+      );
+      const result = spawnSync(wrapperPath, ["node-check", "src/ok.js"], {
+        cwd: workspace,
+        env: {
+          ...process.env,
+          GITHUB_WORKSPACE: workspace,
+          PATH: `${workspace}:${process.env.PATH}`,
+        },
+        encoding: "utf8",
+      });
+      expect(result.status).toBe(0);
+      const argv = execFileSync(
+        "cat",
+        [path.join(workspace, "node-argv.txt")],
+        {
+          encoding: "utf8",
+        },
+      )
+        .trimEnd()
+        .split("\n");
+      expect(argv.slice(0, 2)).toEqual(["--check", "--"]);
+      expect(argv[2]).toBe(path.join(workspace, "src/ok.js"));
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects symlinks that resolve outside the workspace", async () => {
+    const workspace = await fixtureWorkspace();
+    const outside = path.join(os.tmpdir(), `outside-${process.pid}.js`);
+    try {
+      await writeFile(outside, "const outside = true;\n");
+      await symlink(outside, path.join(workspace, "src/link.js"));
+      const result = runWrapper(["node-check", "src/link.js"], workspace);
+      expect(result.status).not.toBe(0);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+      rmSync(outside, { force: true });
+    }
+  });
+
+  it("keeps the workflow copyable to immutable runner temp storage", async () => {
+    const workspace = await fixtureWorkspace();
+    try {
+      await mkdir(path.join(workspace, ".github/scripts"), { recursive: true });
+      await cp(
+        wrapperPath,
+        path.join(workspace, ".github/scripts/jobbot-claude-validate.sh"),
+      );
+      const result = spawnSync("install", [
+        "-m",
+        "0755",
+        path.join(workspace, ".github/scripts/jobbot-claude-validate.sh"),
+        path.join(workspace, "jobbot-claude-validate"),
+      ]);
+      expect(result.status).toBe(0);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent repeated Claude tool failures and accidental privilege escalation while preserving strong prompt-injection containment and the pinned Claude action SHA. 
- Ensure only the repository owner and an explicit allowlist of trusted GitHub logins can reach secret-bearing Claude steps or checkout. 
- Replace fragile, pattern-based allowed shell commands with a minimal, immutable trusted validation interface that exposes only fixed repo operations. 
- Enforce sandboxed Claude execution, deny runner credentials and outbound network to PR-controlled scripts, and avoid false-green validation results.

### Description

- Replace role-based gating (OWNER/MEMBER/COLLABORATOR) with an explicit repository-owner plus `CLAUDE_TRUSTED_ACTORS` check that runs before checkout or OAuth-bearing Claude steps in `.github/workflows/claude.yml` and keep fork rejection, pinned action SHA, least-privilege permissions, `persist-credentials: false`, and commit-signing invariant. 
- Limit Claude comment context with `include_comments_by_actor` to the owner, configured trusted actors, and necessary bot accounts, and suppress full/public Claude outputs (`display_report: false`, `show_full_output: false`) while enabling `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB=1`. 
- Add a minimal immutable validation wrapper script `.github/scripts/jobbot-claude-validate.sh` installed to `/tmp/jobbot-claude-validate` that exposes only fixed operations (`prepare`, `lint`, `format-check`, `typecheck`, `test-ci`, `build`, `node-check <repo-js-file>`) and rejects extra args, shell metacharacters, path traversal, option-like paths, non-JS files, and arbitrary `npx`/`node -e` usage. 
- Add a Claude settings file `.github/claude-code-settings.json` that requires the action sandbox, fails closed if unavailable, disables unsandboxed fallbacks, explicitly denies web tools and generic interpreters, denies access to common credential files and runner token env vars, and denies outbound network for sandboxed Bash. 
- Add a separate `claude-validation` job in `.github/workflows/claude.yml` that runs credentialless repository validation (checkout with `persist-credentials: false`, `npm ci --ignore-scripts --no-audit --no-fund`, then lint/format/typecheck/test/build) inside demonstrably network-blocked containment and surfaces those results independently of the Claude action result. 
- Add focused regression tests `test/claude-workflow-security.test.js` exercising trusted-actor gating, comment filtering, the settings deny/allow lists, sandbox config, wrapper rejection cases, and correct `node --check -- <file>` invocation, and expose a helper script entry `test:claude-workflow-security` in `package.json` for running them. 

Files changed (high level): `.github/workflows/claude.yml`, `.github/claude-code-settings.json` (new), `.github/scripts/jobbot-claude-validate.sh` (new), `test/claude-workflow-security.test.js` (new), and `package.json` (test script). 

### Testing

- Ran `git diff --check` which reported no problems for the changed files (OK). 
- Confirmed YAML validity with `node -e

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61890cac80832f854cb8d2c5709fa7)