### PR TITLE
Isolate lifecycle layout base pass coupling

### DIFF
--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -344,3 +344,35 @@ without external requests"`
    overlapping render. There is no automated end-to-end test asserting "the diagram is visually
    readable" beyond `auditLifecycleRouteGeometry`'s structural checks — worth considering as a
    follow-up if visual regressions become a recurring concern.
+
+## Verified base-layout/solver coupling root cause
+
+The follow-up base-layout investigation isolated the previous deterministic budget exhaustion to the
+fact that a second D3 pass is not a pure topological reorder. Re-running Sankey with a different
+`nodeSort` changes the real nodes' concrete `y0`/`y1` geometry. The transition-lane solver then
+rebuilds legal intervals, centered assignments, routing-node anchors, handle candidates, and route
+audit inputs from those new real-node positions. In other words, the solver budget was exhausted
+because the second pass changed the geometry-dependent domains the solver was searching, not because
+the candidate rank order was merely shuffled.
+
+A test-only diagnostic pass now reproduces this without changing production layout behavior. On
+`tracker-lifecycle-diagram-routing-v2.json`, the existing base layout's first route-audit rejection is
+at transition rank 2, while a rank-local reversed base Sankey order moves the first rejection to rank 0. On `tracker-lifecycle-diagram-v2.json`, both the existing and reversed base layouts reject first at
+rank 0, but with different real-node positions. These deterministic differences persist even when the
+fixture's nodes, links, and paths are reversed before graph construction, which confirms that the
+observable difference comes from the requested base-layout order rather than incidental input order.
+
+Safe rankOrder-aware second-pass work must preserve these invariants:
+
+1. Each attempt must start from a fresh base Sankey geometry for its own node/link order.
+2. Baseline link coordinates, visible nodes, label boxes, renderer hit boxes, lane obstacles, legal
+   intervals, lane-domain caches, handle-candidate caches, shared budgets, and diagnostics must be
+   rebuilt for that attempt only.
+3. No closure derived from a prior D3 pass may be reused by a later pass; this includes obstacle
+   predicates, lane-domain caches, routing-anchor domains, and handle/audit inputs.
+4. Real nodes at a rank must remain coordinated with routing nodes through the existing fixed
+   singleton-domain entries in `materializeLaneAssignments`; do not duplicate or remove that behavior
+   unless a replacement proves the same real-vs-routing ordering constraint.
+5. A second pass must be accepted only if the full route audit and handle placement pass with the
+   existing budgets and auditing rules. Budget increases, relaxed route auditing, and skipped-test
+   changes would hide the same coupling instead of fixing it.

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -633,13 +633,19 @@ export function layoutLifecycleRoutingGraph(
     (left, right) => left - right,
   );
   const layerByRank = new Map(rankLayers.map((rank, index) => [rank, index]));
+  const allowTestLayoutOverrides =
+    process.env.NODE_ENV === "test" || process.env.VITEST === "true";
   const layout = sankey()
     .nodeId((d) => d.id)
     .nodeAlign((node) => layerByRank.get(node.rank) ?? 0)
     .nodeWidth(SANKEY_NODE_WIDTH)
     .nodePadding(ROUTED_NODE_PADDING)
-    .nodeSort(nodeSort)
-    .linkSort(linkSort)
+    .nodeSort(
+      allowTestLayoutOverrides ? (options.testNodeSort ?? nodeSort) : nodeSort,
+    )
+    .linkSort(
+      allowTestLayoutOverrides ? (options.testLinkSort ?? linkSort) : linkSort,
+    )
     .extent([
       [LAYOUT_LEFT_MARGIN, LAYOUT_TOP_MARGIN],
       [
@@ -2676,6 +2682,101 @@ export function layoutLifecycleRoutingGraph(
     ...transitionLaneSolverStats,
   });
   return { graph, dimensions };
+}
+
+export function diagnoseLifecycleLayoutForTest(
+  projection,
+  availableWidth,
+  options = {},
+) {
+  if (process.env.NODE_ENV !== "test" && process.env.VITEST !== "true") {
+    throw new Error("Lifecycle layout diagnostics are only available in tests");
+  }
+  const result = {
+    ok: false,
+    firstRejectedPhase: null,
+    structuredReason: null,
+    states: null,
+    ranks: [],
+  };
+  try {
+    const { graph, dimensions } = layoutLifecycleRoutingGraph(
+      projection,
+      availableWidth,
+      {
+        ...options,
+        transitionLanePhaseOnly: true,
+      },
+    );
+    const audit = auditLifecycleRouteGeometry({
+      graph,
+      dimensions,
+      handles: [],
+    });
+    result.ok = audit.fatalFindings.length === 0;
+    result.firstRejectedPhase = audit.fatalFindings.length
+      ? "route-audit"
+      : null;
+    result.structuredReason = audit.fatalFindings[0] ?? null;
+    result.states = graph.transitionLaneSolverStats;
+    const linksByRank = new Map();
+    for (const link of graph.links) {
+      const rank = link.source?.rank;
+      if (!linksByRank.has(rank)) linksByRank.set(rank, []);
+      linksByRank.get(rank).push(link);
+    }
+    const ranks = [...linksByRank.keys()].sort((a, b) => a - b);
+    result.ranks = ranks.map((rank) => {
+      const links = [...(linksByRank.get(rank) ?? [])].sort(
+        (a, b) =>
+          a.transitionLaneY - b.transitionLaneY ||
+          compareLifecycleIds(a.branchId, b.branchId) ||
+          compareLifecycleIds(a.id, b.id),
+      );
+      const nodes = graph.nodes
+        .filter((node) => node.rank === rank)
+        .sort(
+          (a, b) =>
+            (a.y0 + a.y1) / 2 - (b.y0 + b.y1) / 2 ||
+            compareLifecycleIds(a.id, b.id),
+        )
+        .map((node) => ({
+          id: node.id,
+          branchId: node.branchId ?? null,
+          routing: node.routing === true,
+          y0: node.y0,
+          y1: node.y1,
+        }));
+      return {
+        rank,
+        branchOrder: links.map((link) => link.branchId),
+        linkOrder: links.map((link) => link.id),
+        nodePositions: nodes,
+        lanePositions: links.map((link) => ({
+          id: link.id,
+          branchId: link.branchId,
+          sourceY: link.y0,
+          targetY: link.y1,
+          laneY: link.transitionLaneY,
+          domainSize: Number.isFinite(link.transitionLaneY) ? 1 : 0,
+          centeredFeasible: Number.isFinite(link.transitionLaneY),
+        })),
+      };
+    });
+  } catch (error) {
+    result.firstRejectedPhase =
+      error.cause?.reason === "state-limit" ? "state-limit" : "layout";
+    result.structuredReason = error.cause ?? { message: error.message };
+    result.states = error.cause
+      ? {
+          statesVisited: error.cause.statesVisited ?? null,
+          stateLimit: error.cause.stateLimit ?? null,
+          backtracks: error.cause.backtracks ?? null,
+          memoizedFailures: error.cause.memoizedFailures ?? null,
+        }
+      : null;
+  }
+  return JSON.parse(JSON.stringify(result));
 }
 
 const point = (x, y) => `${Number(x).toFixed(3)},${Number(y).toFixed(3)}`;

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -34,6 +34,7 @@ import {
   compareLifecycleIds,
   createLaneGeometryFailureCache,
   cubicTransitionPoint,
+  diagnoseLifecycleLayoutForTest,
   endpointColor,
   layoutLifecycleRoutingGraph,
   labelBoxForNode,
@@ -668,6 +669,52 @@ describe("transition lane solver", () => {
         transitionLanePhaseOnly: true,
       }).graph,
     ).toBeTruthy();
+  });
+
+  it("diagnoses rank-order-directed base-layout passes deterministically", () => {
+    const reverseWithinRank = (left, right) =>
+      left.rank === right.rank ? -nodeSort(left, right) : nodeSort(left, right);
+    const shuffledProjection = {
+      ...projection(),
+      nodes: [...projection().nodes].reverse(),
+      links: [...projection().links].reverse(),
+      paths: [...projection().paths].reverse(),
+    };
+    const base = diagnoseLifecycleLayoutForTest(projection(), 1850);
+    const shuffled = diagnoseLifecycleLayoutForTest(shuffledProjection, 1850);
+    const reversed = diagnoseLifecycleLayoutForTest(projection(), 1850, {
+      testNodeSort: reverseWithinRank,
+    });
+
+    expect(JSON.stringify(shuffled)).toBe(JSON.stringify(base));
+    expect(base.firstRejectedPhase).toBe("route-audit");
+    expect(base.structuredReason.transitionRank).toBe(2);
+    expect(reversed.firstRejectedPhase).toBe("route-audit");
+    expect(reversed.structuredReason.transitionRank).toBe(0);
+    expect(reversed.ranks[1].nodePositions.map((node) => node.id)).not.toEqual(
+      base.ranks[1].nodePositions.map((node) => node.id),
+    );
+    expect(reversed.states.statesVisited).toBeGreaterThan(0);
+  });
+
+  it("diagnoses dense fixture base-layout coupling without raising budgets", () => {
+    const reverseWithinRank = (left, right) =>
+      left.rank === right.rank ? -nodeSort(left, right) : nodeSort(left, right);
+    const denseProjection = projectLifecycleAt(denseFixture);
+    const base = diagnoseLifecycleLayoutForTest(denseProjection, 1850);
+    const reversed = diagnoseLifecycleLayoutForTest(denseProjection, 1850, {
+      testNodeSort: reverseWithinRank,
+    });
+
+    expect(base.firstRejectedPhase).toBe("route-audit");
+    expect(base.structuredReason.transitionRank).toBe(0);
+    expect(reversed.firstRejectedPhase).toBe("route-audit");
+    expect(reversed.structuredReason.transitionRank).toBe(0);
+    expect(reversed.ranks[0].nodePositions.map((node) => node.id)).not.toEqual(
+      base.ranks[0].nodePositions.map((node) => node.id),
+    );
+    expect(base.states.stateLimit).toBe(200000);
+    expect(reversed.states.stateLimit).toBe(200000);
   });
 
   it("assigns spacing-legal lanes for 55-branch multi-source dense graph", () => {


### PR DESCRIPTION
### Motivation
- Create a safe, behavior-preserving foundation for future rankOrder-aware second-pass work by isolating why re-running the D3/Sankey base layout changed solver feasibility and exhausted deterministic budgets.
- Provide a deterministic, test-only diagnostic seam so tests can reproduce rank-local base-layout differences without changing production layout behavior.

### Description
- Add test-only Sankey sort overrides (guarded by test env) so `layoutLifecycleRoutingGraph` can be rerun with `options.testNodeSort` / `options.testLinkSort` during tests without affecting production behavior (`src/web/tracker/lifecycleDiagramLayout.js`).
- Introduce `diagnoseLifecycleLayoutForTest(projection, availableWidth, options)` which runs a lane-phase layout (test-only), runs the route audit, and returns deterministic per-rank summaries, solver state counts, and the first rejected phase/reason for deterministic test assertions (`src/web/tracker/lifecycleDiagramLayout.js`).
- Add focused regression tests that exercise the routing-v2 and lifecycle-v2 fixtures, verify shuffled-input determinism, run a rankOrder-directed second base-layout pass in tests, and assert the first rejected transition rank and solver budgets remain unchanged (`test/web-tracker-lifecycle-diagram-layout.test.js`).
- Document the verified root cause and the exact invariants a safe second pass must preserve in the layout design doc (`docs/design/lifecycle-diagram-layout-algorithm.md`).

### Testing
- Ran the focused diagnostic tests with `npm test -- --run test/web-tracker-lifecycle-diagram-layout.test.js -t "diagnoses"` which passed (diagnostic assertions for routing and dense fixtures succeeded).
- Ran the full focused file with `npm test -- --run test/web-tracker-lifecycle-diagram-layout.test.js`; the file mostly passed, but one long, pre-existing dense multi-rank fan-in test exceeded Vitest's default 30s per-test timeout in this environment and timed out (observed and left unchanged because it exercises a legitimately infeasible, bounded search and is pre-documented in the repo as expensive); behavior and deterministic failure modes were validated during development runs.
- Lint/typecheck/format checks: `npm run lint` passed, `npm run typecheck` passed, and `npx prettier --check src/web/tracker/lifecycleDiagramLayout.js test/web-tracker-lifecycle-diagram-layout.test.js docs/design/lifecycle-diagram-layout-algorithm.md` passed for the changed files; `npm run format:check` reported pre-existing repo-wide formatting warnings outside the scoped files (not changed in this PR).
- Verified production routing fixture still has zero fatal route-audit findings by running the real layout and `auditLifecycleRouteGeometry` for `tracker-lifecycle-diagram-routing-v2.json` (result `0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62fe4d8480832f90e90784dad89958)