### PR TITLE
Isolate lifecycle layout solver baseline state

### DIFF
--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -267,6 +267,43 @@ destabilizes the DFS — e.g. by diffing `assignMonotoneIntervals`'s per-rank do
 where availability collapses — rather than iterating on the ordering logic itself again, which is
 what this and prior sessions already tried repeatedly without success.
 
+## Verified base-layout/solver coupling root cause (2026-07-24)
+
+The safe foundation for the deferred rankOrder-aware base-layout work is to treat a base D3-Sankey
+pass and every transition-lane attempt as geometry-isolated phases. The latest investigation found a
+concrete stale-state defect in that boundary: `layoutLifecycleRoutingGraph` captured its link
+baseline before the D3-Sankey pass, so a clean candidate retry could restore `link.y0`/`link.y1` to
+pre-layout values instead of the base-layout coordinates that the lane solver's domains were derived
+from. A previously materialized graph passed back through `options.routingGraph` masked this by
+already having finite coordinates, while a fresh graph could make candidate attempts depend on
+closures and geometry from the wrong phase. The fix is intentionally narrow: keep the user-visible
+layout behavior unchanged, but capture the reusable baseline from an already-materialized graph when
+one is supplied and otherwise capture it immediately after the base Sankey layout/update pass.
+
+A rankOrder-directed second base-layout pass must preserve these invariants before it is safe to ship:
+
+- Re-run D3-Sankey from a clean graph state; do not reuse link coordinates, visible-node lists, label
+  boxes, hit boxes, lane obstacles, legal interval closures, domain caches, candidate caches, handle
+  budgets, or diagnostics from the prior pass.
+- Capture baseline link coordinates only after the base pass whose node positions define the domains
+  for the following lane attempt, unless the caller deliberately supplies an already-materialized
+  routing graph whose finite link coordinates are the baseline being protected.
+- Rebuild `rankRefinementInfo` per attempt; it is not a stable input to D3 until a lane attempt has
+  produced it, and any second pass that consumes it must re-solve lanes against the new real-node
+  geometry.
+- Keep real nodes in the routing-anchor monotone assignment as fixed singleton-domain entries. This
+  existing coordination is part of the current correctness envelope; removing or duplicating it would
+  change the real-node/routing-node invariant rather than isolating the base-layout coupling.
+- Preserve deterministic diagnostics for every rejected attempt: the first rejected phase and reason,
+  per-rank branch order, real/routing-node positions, legal interval/domain sizes, centered-assignment
+  feasibility, and deterministic state counts must all be derived from the same geometry snapshot.
+
+With those invariants, the known `tracker-lifecycle-diagram-routing-v2.json` fixture remains a
+zero-fatal-finding route-audit case, while `tracker-lifecycle-diagram-v2.json` still identifies the
+first failing invariant as deterministic handle-state exhaustion rather than a route-audit success or
+an unbounded search. That distinction is important: this step does not ship barycenter ordering or a
+rankOrder-driven heuristic; it only makes the phase boundary safe enough to investigate one later.
+
 ## Separately: the deterministic-budget fix
 
 Unrelated to the ordering-systems problem above (shipped first, in an earlier commit on this same

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -614,7 +614,7 @@ export function layoutLifecycleRoutingGraph(
   options = {},
 ) {
   const graph = options.routingGraph ?? buildLifecycleRoutingGraph(projection);
-  const baselineLinks = new Map(
+  const preLayoutBaselineLinks = new Map(
     graph.links.map((link) => [
       link.id,
       {
@@ -623,6 +623,12 @@ export function layoutLifecycleRoutingGraph(
         transitionLaneY: link.transitionLaneY,
       },
     ]),
+  );
+  const hasReusableLinkBaseline = [...preLayoutBaselineLinks.values()].every(
+    (link) =>
+      Number.isFinite(link.y0) &&
+      Number.isFinite(link.y1) &&
+      Number.isFinite(link.transitionLaneY),
   );
   const dimensions = calculateLifecycleDiagramLayout(
     projection,
@@ -657,6 +663,20 @@ export function layoutLifecycleRoutingGraph(
     }
   }
   layout.update(graph);
+
+  const sankeyBaselineLinks = new Map(
+    graph.links.map((link) => [
+      link.id,
+      {
+        y0: link.y0,
+        y1: link.y1,
+        transitionLaneY: link.transitionLaneY,
+      },
+    ]),
+  );
+  const baselineLinks = hasReusableLinkBaseline
+    ? preLayoutBaselineLinks
+    : sankeyBaselineLinks;
 
   const orderedBranches = [...graph.branches].sort(compareBranches);
   const branchById = new Map(
@@ -2467,6 +2487,86 @@ export function layoutLifecycleRoutingGraph(
   // passes — independent of machine speed — instead of retrying expensive
   // work indefinitely.
   const handleBudget = { statesVisited: 0, stateLimit: 32768 };
+  const rankDiagnostics = [];
+  const snapshotRankDiagnostics = (
+    rankRefinementInfo,
+    firstRejected = null,
+  ) => {
+    if (!options.__collectRankDiagnostics) return;
+    const nodeById = new Map(graph.nodes.map((node) => [node.id, node]));
+    const linkById = new Map(graph.links.map((link) => [link.id, link]));
+    rankDiagnostics.length = 0;
+    for (const [rank, info] of [...rankRefinementInfo.entries()].sort(
+      ([left], [right]) => left - right,
+    )) {
+      const branchOrder = info.rankOrder.map((item) => item.branchId);
+      const routingNodeIds = graph.nodes
+        .filter((node) => node.routing && node.rank === rank)
+        .sort((left, right) => compareLifecycleIds(left.id, right.id))
+        .map((node) => node.id);
+      rankDiagnostics.push(
+        Object.freeze({
+          rank,
+          branchOrder: Object.freeze(branchOrder),
+          positions: Object.freeze(
+            [...info.rankOrder].map((item, index) => {
+              const link = linkById.get(item.id);
+              return Object.freeze({
+                branchId: item.branchId,
+                linkId: item.id,
+                laneY: info.cen[index] ?? null,
+                sourceY: link?.y0 ?? null,
+                targetY: link?.y1 ?? null,
+              });
+            }),
+          ),
+          realNodePositions: Object.freeze(
+            graph.nodes
+              .filter((node) => !node.routing && node.rank === rank)
+              .sort((left, right) => nodeSort(left, right))
+              .map((node) =>
+                Object.freeze({
+                  id: node.id,
+                  y0: node.y0,
+                  y1: node.y1,
+                  centerY: (node.y0 + node.y1) / 2,
+                }),
+              ),
+          ),
+          routingNodePositions: Object.freeze(
+            routingNodeIds.map((id) => {
+              const node = nodeById.get(id);
+              const incoming = incomingByNode.get(node)?.[0];
+              const outgoing = outgoingByNode.get(node)?.[0];
+              return Object.freeze({
+                id,
+                branchId: node.branchId,
+                y: incoming?.y1 ?? outgoing?.y0 ?? null,
+              });
+            }),
+          ),
+          domainSizes: Object.freeze(
+            info.rankOrder.map((item) =>
+              Object.freeze({
+                linkId: item.id,
+                branchId: item.branchId,
+                intervals: item.intervals.length,
+                legalValues: item.intervals.reduce(
+                  (sum, [start, end]) =>
+                    sum + Math.max(0, Math.floor((end - start) * 1000) + 1),
+                  0,
+                ),
+              }),
+            ),
+          ),
+          centeredAssignmentFeasible: info.cen.length === info.rankOrder.length,
+          firstRejected,
+          statesVisited: transitionLaneSolverStats.statesVisited,
+          handleStatesVisited: handleBudget.statesVisited,
+        }),
+      );
+    }
+  };
   // See createLaneGeometryFailureCache() above for why a typed cache (rather
   // than a plain membership Set) is required: on a cache hit the callback
   // must still restore lastRoutingAnchorFailure/lastHandleFailure to
@@ -2522,7 +2622,9 @@ export function layoutLifecycleRoutingGraph(
       return false;
     }
     try {
+      snapshotRankDiagnostics(rankRefinementInfo);
       materializeLaneAssignments(globalAssignments, rankRefinementInfo);
+      snapshotRankDiagnostics(rankRefinementInfo);
     } catch (error) {
       if (error.cause?.type === "lifecycle-routing-anchor-allocation") {
         // Recoverable, candidate-specific failure: retain the evidence for
@@ -2532,6 +2634,11 @@ export function layoutLifecycleRoutingGraph(
         // let the search continue with another candidate.
         lastRoutingAnchorFailure = error;
         lastHandleFailure = null;
+        snapshotRankDiagnostics(rankRefinementInfo, {
+          phase: "routing-anchor",
+          reason: error.cause?.reason ?? "unknown",
+          rank: error.cause?.rank ?? null,
+        });
         geometryFailureCache.recordRoutingAnchorFailure(
           geometrySignature,
           error,
@@ -2610,6 +2717,11 @@ export function layoutLifecycleRoutingGraph(
         routeFindings: routeAudit.fatalFindings,
       };
       lastHandleFailure = routeFailure;
+      snapshotRankDiagnostics(rankRefinementInfo, {
+        phase: "route-audit",
+        reason: routeFailure.reason,
+        branchIds: blockedBranchIds,
+      });
       geometryFailureCache.recordHandleFailure(geometrySignature, routeFailure);
       return false;
     }
@@ -2620,6 +2732,10 @@ export function layoutLifecycleRoutingGraph(
       throwHandleStateLimitExceeded();
     }
     lastHandleFailure = handleCheck;
+    snapshotRankDiagnostics(rankRefinementInfo, {
+      phase: "handle",
+      reason: handleCheck.reason ?? "unknown",
+    });
     geometryFailureCache.recordHandleFailure(geometrySignature, handleCheck);
     return false;
   };
@@ -2675,6 +2791,9 @@ export function layoutLifecycleRoutingGraph(
   graph.transitionLaneSolverStats = Object.freeze({
     ...transitionLaneSolverStats,
   });
+  if (options.__collectRankDiagnostics) {
+    graph.__rankDiagnostics = Object.freeze([...rankDiagnostics]);
+  }
   return { graph, dimensions };
 }
 

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -2265,5 +2265,79 @@ describe("lifecycle diagram render-only routing layout", () => {
       layoutLifecycleRoutingGraph(denseBranchProjection(), 1850),
     ).toThrow(deterministicFailure);
     expect(Date.now() - start).toBeLessThan(90000);
+  }, 90000);
+});
+
+describe("rank-order layout coupling diagnostics", () => {
+  const rankDiagnosticSignature = (value) =>
+    value.map((rank) => ({
+      rank: rank.rank,
+      branchOrder: rank.branchOrder,
+      realNodePositions: rank.realNodePositions.map((node) => [
+        node.id,
+        Number(node.centerY.toFixed(3)),
+      ]),
+      routingNodePositions: rank.routingNodePositions.map((node) => [
+        node.id,
+        node.y === null ? null : Number(node.y.toFixed(3)),
+      ]),
+      domainSizes: rank.domainSizes.map((domain) => [
+        domain.linkId,
+        domain.intervals,
+        domain.legalValues,
+      ]),
+      centeredAssignmentFeasible: rank.centeredAssignmentFeasible,
+      firstRejected: rank.firstRejected,
+      statesVisited: rank.statesVisited,
+      handleStatesVisited: rank.handleStatesVisited,
+    }));
+
+  it("records deterministic per-rank coupling diagnostics for the routing fixture", () => {
+    const { graph, dimensions } = layoutLifecycleRoutingGraph(
+      projection(),
+      1850,
+      {
+        __collectRankDiagnostics: true,
+      },
+    );
+    const baseProjection = projection();
+    const shuffledProjection = {
+      ...baseProjection,
+      nodes: [...baseProjection.nodes].reverse(),
+      links: [...baseProjection.links].reverse(),
+      paths: [...baseProjection.paths].reverse(),
+    };
+    const { graph: shuffledGraph } = layoutLifecycleRoutingGraph(
+      shuffledProjection,
+      1850,
+      { __collectRankDiagnostics: true },
+    );
+
+    expect(graph.__rankDiagnostics.length).toBeGreaterThan(0);
+    expect(rankDiagnosticSignature(graph.__rankDiagnostics)).toEqual(
+      rankDiagnosticSignature(shuffledGraph.__rankDiagnostics),
+    );
+    expect(
+      graph.__rankDiagnostics.every((rank) =>
+        rank.positions.every(
+          (position) =>
+            Number.isFinite(position.sourceY) &&
+            Number.isFinite(position.targetY) &&
+            Number.isFinite(position.laneY),
+        ),
+      ),
+    ).toBe(true);
+    expect(
+      auditLifecycleRouteGeometry({ graph, dimensions, handles: [] })
+        .fatalFindings,
+    ).toEqual([]);
   });
+
+  it("identifies the dense fixture's first invariant as handle state exhaustion", () => {
+    expect(() =>
+      layoutLifecycleRoutingGraph(projectLifecycleAt(denseFixture), 1850, {
+        __collectRankDiagnostics: true,
+      }),
+    ).toThrow(/Lifecycle handle search exceeded 32768 states/u);
+  }, 90000);
 });


### PR DESCRIPTION
### Motivation
- Prevent stale geometry from leaking across a base D3-Sankey pass and subsequent transition-lane attempts so retries always start from a clean, geometry-consistent state.
- Provide a deterministic, test-only diagnostic seam to reason about per-rank ordering/geometry and to make regression tests reproducible under shuffled input.
- Document the verified root cause that previously made a second base-layout pass unsafe and enumerate invariants a safe second pass must preserve.

### Description
- Capture a reusable baseline of link coordinates from a caller-provided, already-materialized routing graph, otherwise record the baseline immediately after the Sankey `layout.update(graph)` pass so candidate materialization always restores the correct phase geometry (`src/web/tracker/lifecycleDiagramLayout.js`).
- Add a test-only diagnostics seam behind `options.__collectRankDiagnostics` that snapshots per-rank `rankOrder`, link/source/target/lane positions, real/routing node positions, per-link domain sizes, centered-assignment feasibility, first rejected phase, and deterministic state counters (`snapshotRankDiagnostics` and `graph.__rankDiagnostics`).
- Ensure `materializeLaneAssignments` and the candidate callback restore the appropriate baseline before each candidate so every attempt reconstructs geometry-dependent state rather than reusing stale closures or coordinates.
- Add deterministic regression tests that (a) assert diagnostics are stable under reversed/shuffled projection input and produce zero fatal route-audit findings for the routing fixture, and (b) assert the dense fixture still exhausts the deterministic handle-state budget as its first failing invariant, without increasing solver budgets or unskipping existing tests (`test/web-tracker-lifecycle-diagram-layout.test.js`).
- Update the design doc with the verified root cause and exact invariants required before pursuing a rankOrder-driven re-run of the base Sankey pass (`docs/design/lifecycle-diagram-layout-algorithm.md`).

### Testing
- `npm test -- --run test/web-tracker-lifecycle-diagram-layout.test.js` — passed (targeted test file completed: 55 tests passed, 3 skipped in the final run).
- `npm run lint` — passed (no new ESLint failures in touched files).
- `npm run typecheck` — passed (`tsc -p tsconfig.json` completed successfully).
- `npx prettier --check src/web/tracker/lifecycleDiagramLayout.js test/web-tracker-lifecycle-diagram-layout.test.js docs/design/lifecycle-diagram-layout-algorithm.md` — passed for the changed files; note that `npm run format:check` reported pre-existing formatting drift across many unrelated files (pre-existing, not introduced by this change).
- `git diff --check` — passed (no whitespace or diff check errors introduced by these edits).

Residual risks / follow-ups: real-node vs routing-node coordination remains a structural follow-up (deferred); the diagnostic seam and documented invariants make it safe to explore a rankOrder-aware second Sankey pass in a subsequent change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62fe58c4cc832f93cf0b6bba8e0c61)