### PR TITLE
Implement bounded rank-aware two-pass lifecycle layout

### DIFF
--- a/docs/design/lifecycle-diagram-handle-search-seeding-plan.md
+++ b/docs/design/lifecycle-diagram-handle-search-seeding-plan.md
@@ -1,0 +1,291 @@
+# Plan: seed the final pass's lane search with discovery's proven assignment
+
+## Status
+
+Not implemented. This document records root-cause findings from a debugging session
+on PR #1164 (`codex/implement-rankorder-aware-base-layout`) and a scoped plan for the
+remaining fix, for whoever picks this up next (a future session, or another engineer).
+
+Two real, independent, low-risk bugs found during that session are already fixed and
+merged into the branch (see "What's already fixed" below). This document is about the
+_third_, deeper issue that remains: `layoutLifecycleRoutingGraph`'s production entry
+point still throws `Lifecycle handle search exceeded 32768 states` for the dense
+production fixture `test/fixtures/tracker-lifecycle-diagram-v2.json`, but now misses
+the budget by roughly 1% (~32900-33150 states used against a 32768 limit) instead of
+failing immediately with four permanently-blocked branches. This is close enough that
+naive parameter tuning (candidate-sample density, port-spacing constants) reliably
+lands within a few hundred states of success but never reliably crosses the line, and
+several tuning attempts materially regressed either correctness (see "Dead ends" for
+the `authoritativeNodePositions`/topological-order regression) or wall-clock latency
+(one configuration pushed the full test suite from ~26s to over 800s). The fix
+documented here is architectural, not a constant tweak.
+
+## Background: what the two-pass design is and why it exists
+
+`layoutLifecycleRoutingGraph` (the production entry point) runs
+`layoutLifecycleRoutingGraphPass` (the actual layout engine — D3-Sankey plus a
+custom deterministic transition-lane solver, `src/web/tracker/lifecycleDiagramLayout.js`)
+exactly twice:
+
+1. **Discovery pass** (`options.discoveryPhase = true`, wired up around line 3219):
+   runs the full pass on a _fresh_ graph clone with D3's own default `nodeSort`/
+   `linkSort` (no order constraints). Its `candidateCallback` (~line 2811) returns
+   `true` on the very first lane-legal candidate it evaluates — it does **not** check
+   handle placement or the route-crossing audit before accepting. It captures that
+   candidate's per-rank branch order (`rankRefinementInfo`) via `discoverySink`, then
+   discards all its own geometry.
+2. **Final pass**: rebuilds a second fresh graph clone, this time passing
+   `authoritativeBranchOrderByRank`/`authoritativeNodeOrderByRank` (derived from
+   discovery's captured order via `deriveAuthoritativeLayoutOrders`, ~line 3072) into
+   D3's `nodeSort`/`linkSort`. It then runs the _entire_ transition-lane solver again,
+   from scratch, with full handle-placement and route-crossing-audit validation. If
+   its own final rank order disagrees with what discovery found, it throws a typed
+   `order-disagreement` error (~line 3250).
+
+**Why two passes at all**: `nodeSort`/`linkSort` (D3's own comparators, taxonomy- and
+median-endpoint-based) and the transition-lane solver's own crossing-avoidance
+backtracking are two _independent_ decision processes over the same graph. Run only
+one of them and you can get a rendered node/link array order that disagrees with the
+solver's own geometric decisions — the exact bug this PR's motivation describes
+("Prevent inconsistent per-rank ordering between D3-Sankey and the deterministic
+transition-lane solver"). The two-pass split exists specifically to force D3's sort to
+agree with whatever order the solver already decided, and the `order-disagreement`
+check is a correctness guard confirming that alignment actually held.
+
+## The problem: discovery's cheap success doesn't prove final's hard problem is solved
+
+Discovery's `candidateCallback` short-circuits before ever calling
+`tryAssignBranchHandles` or `auditLifecycleRouteGeometry` — it only proves _lane_
+legality (a much weaker, essentially-always-immediately-satisfiable property), not
+_handle_ feasibility. For sparse fixtures this doesn't matter, because the first
+lane-legal candidate is essentially always handle-feasible too. For the dense
+production fixture, it isn't: the first candidate discovery accepts is frequently one
+where several branches can't get a legal handle placement at all.
+
+So the final pass, constrained to replay discovery's order, is not "verifying a proven
+solution" — it is independently solving the much harder handle-feasible-_and_-order-
+matching problem for the first time, alone, with its own fresh 32768-state budget.
+Confirmed directly in this session:
+
+- Making discovery _also_ require full handle+audit validation (removing its
+  early-return in `candidateCallback`) does make the _discovered_ order actually
+  handle-feasible — but discovery then does the same expensive search final was doing,
+  so both passes are now expensive. One configuration of this pushed the whole
+  `test/web-tracker-lifecycle-diagram-layout.test.js` + `test/web-tracker-lifecycle-diagram.test.js`
+  suite from ~26s to **811s**, because several already-slow deliberately-infeasible
+  torture fixtures (`transitionDensityProjection`, `denseBranchProjection`) now pay
+  the escalating-candidate-search cost twice, once per pass, and repeatedly per
+  rejected backtracking candidate. Not viable as-is.
+- Seeding final's D3 layout with discovery's _exact_ resulting real-node Y positions
+  (`authoritativeNodePositions`, applied right after `layout.update(graph)`) had
+  **zero measurable effect** on states-visited. This confirms D3's layout is already
+  fully deterministic given the same order constraint — position mismatches are not
+  the divergence source.
+- Seeding with discovery's exact _link_ dock positions too
+  (`authoritativeLinkDockPositions`, matched by `link.id`) had a small, real, but
+  insufficient effect (~33145 → ~32903 states in one configuration) — real signal, not
+  enough alone to close the gap by itself, and this option was reverted (see "Dead
+  ends") because it's redundant with the seeding approach below and added surface
+  area for no committed benefit.
+
+The conclusion: final's _own_ `solveTransitionLanes` search (branch-order backtracking
+wrapping per-rank coordinate backtracking, ~line 1335, roughly 1,000 lines) explores
+a **different sequence of candidates** than discovery's search did, even given
+identical input geometry and the same authoritative order constraint fed to D3. The
+order constraint only affects D3's `nodeSort`/`linkSort` — it is never threaded into
+`solveTransitionLanes`'s own candidate-generation/MRV heuristics, so nothing forces
+final's solver to try discovery's exact winning candidate first (or at all, before
+exhausting budget on others).
+
+## The proposed fix: seed the search, don't just constrain D3's rendering sort
+
+Rather than have `deriveAuthoritativeLayoutOrders` produce an _order_ for D3 to match
+(current design), capture discovery's actual winning **assignment** — the raw
+`globalAssignments` map (`linkId -> chosen lane Y`) and `rankRefinementInfo` that its
+successful `candidateCallback(globalAssignments, rankRefinementInfo)` invocation
+received — and let the final pass replay that assignment directly instead of
+re-deriving it via a second independent search.
+
+This preserves the two-pass architecture's actual safety property (a _pristine_
+final pass, fresh graph clone, fresh obstacles/domains/caches/budgets, full
+handle+audit validation actually run) while eliminating the wasted, unguided
+re-search. If discovery is required to fully validate (handle+audit) before
+accepting — which it must be, to guarantee the seed is worth anything — its own
+search is the _only_ expensive step; final becomes a cheap, deterministic replay-and-
+verify.
+
+### Concrete steps
+
+1. **Discovery does full validation.** Move discovery's `discoverySink` call from the
+   current early-return point in `candidateCallback` (~line 2814) to the success path
+   after the route-crossing audit passes (`routeAudit.fatalFindings.length === 0`,
+   ~line 2930), matching what this session's "discovery requires audit" experiment
+   already did. Capture both `rankRefinementInfo` _and_ `globalAssignments` in the
+   sink (currently only `rankRefinementInfo` is captured).
+
+2. **Add a seed path to `layoutLifecycleRoutingGraphPass`.** New options:
+   `options.seedAssignment` (the raw `globalAssignments` Map) and
+   `options.seedRankRefinementInfo`. When both are present, skip the
+   `solveTransitionLanes(graph.links, { candidateCallback })` call (~line 2995)
+   entirely and instead call `candidateCallback(seedAssignment, seedRankRefinementInfo)`
+   directly, exactly once:
+   - If it returns `true`: the graph is already materialized (candidateCallback
+     mutates it in place on success, same as today) — proceed exactly as the current
+     post-search code does (~line 3036 onward: set `graph.transitionLaneRankOrder`,
+     freeze `transitionLaneSolverStats`, return `{ graph, dimensions }`).
+   - If it returns `false`, or throws: this means D3's authoritative-order-constrained
+     layout produced geometry that the seed assignment doesn't actually satisfy —
+     which determinism says should never happen, but must **not** be silently papered
+     over. Throw a clear, distinctly-typed error (e.g.
+     `lifecycle-authoritative-rank-order` / `seed-replay-failed`) rather than falling
+     back to a full search — a silent fallback would hide a real bug in this
+     mechanism and defeat the entire point of the change. Route this into the
+     existing `order-disagreement` diagnostic in `layoutLifecycleRoutingGraph`
+     (~line 3250) if it's the same underlying failure mode, or as a clearly distinct
+     sibling failure otherwise.
+
+3. **`transitionLaneSolverStats.components` needs a value even when the search is
+   skipped.** `laneResult.componentMembers.size` (~line 3037) currently comes from
+   `solveTransitionLanes`'s own union-find over branch/rank adjacency (~line 1670),
+   computed structurally _before_ any backtracking search runs — it's a pure function
+   of graph structure (which branches share which ranks), not a search _decision_, so
+   it is identical between discovery and final for the same graph. Two options,
+   in order of preference:
+   - Preferred: factor the union-find/component-partition step out of
+     `solveTransitionLanes` into its own small function callable independently, and
+     call it directly in the seed path (cheap, no behavior risk, keeps `components`
+     meaningfully "freshly computed" for the final pass rather than reused from
+     discovery).
+   - Fallback: capture `componentMembers.size` from discovery's own successful
+     `solveTransitionLanes` result and pass it through as
+     `options.seedComponentCount`, used directly in the seed path. Simpler, but reuses
+     a discovery-pass-computed number for final's stats, which is a slightly weaker
+     "freshly proven" story than the current design's phrasing implies.
+
+4. **Wire the wrapper (`layoutLifecycleRoutingGraph`, ~line 3200).** Capture
+   `globalAssignments` from discovery's sink alongside the existing
+   `discoveredRankOrder`. Pass `seedAssignment`/`seedRankRefinementInfo` (and whichever
+   `components` mechanism was chosen in step 3) into the final
+   `layoutLifecycleRoutingGraphPass` call (~line 3243), alongside the existing
+   `authoritativeBranchOrderByRank`/`authoritativeNodeOrderByRank` (still needed, since
+   D3's `nodeSort`/`linkSort` still must agree with the replayed geometry for
+   rendering consistency — this part of the current design is correct and should stay).
+
+5. **Keep the existing `order-disagreement` check** (~line 3250) as-is. It remains a
+   valid, cheap safety net: even with a seeded replay, confirm the _materialized_
+   `graph.transitionLaneRankOrder` still matches what discovery reported before
+   returning to the caller.
+
+### Why this should actually close the gap
+
+With this change, the _only_ expensive, exhaustive search happens once (discovery).
+Final's own cost becomes: one D3 layout pass (cheap, deterministic) + one
+`candidateCallback` invocation (one `tryAssignBranchHandles` call + one
+`auditLifecycleRouteGeometry` call — the same fixed cost every candidate already pays,
+just paid once instead of dozens of times). The 32768-state final-pass budget, which
+is currently being exhausted by dozens of full search attempts, is reduced to a
+handful of states for the single replay-and-verify. This should give the production
+fixture comfortable headroom rather than the ~1% miss it currently has, without
+touching the protected `32,768`/`200,000` state limits or `HANDLE_ROUTE_EDGE_COST_DIVISOR`
+themselves.
+
+## Risks and what to verify carefully
+
+- **`solveTransitionLanes` is large and intricate** (~1,000 lines: branch-order
+  backtracking wrapping per-component coordinate backtracking, `MRV` variable
+  selection, `failedStates`/`geometryFailureCache` memoization, routing-anchor
+  monotone assignment). This plan avoids touching its internals — the seed path is
+  designed to bypass the whole function, not modify it — but double-check nothing
+  downstream of `solveTransitionLanes` in `layoutLifecycleRoutingGraphPass` implicitly
+  depends on side effects only `solveTransitionLanes` itself sets (skim for module-
+  level `let`s mutated only inside it before committing to the bypass).
+- **`geometryFailureCache`** is populated during the search to memoize rejected
+  geometries within _that pass_. The seed path never calls it (only ever evaluates one
+  candidate), which is fine functionally, but confirm no other code assumes the cache
+  is non-empty or reads from it after a successful pass.
+- **Test fallout, likely large.** `testOnlyDiagnoseLifecycleLayoutAttempt` and several
+  tests that call `layoutLifecycleRoutingGraph` without `transitionLanePhaseOnly` (i.e.
+  exercising the real two-pass wrapper) may assert on `layoutAttempts[1].statesVisited`,
+  `candidateEvaluations`, or similar being "large" or otherwise search-shaped; these
+  will need updating to reflect the new cheap-replay final pass. Search the test file
+  for `layoutAttemptCount`, `layoutAttempts`, `candidateEvaluations` before starting.
+- **Latency tests must be re-checked**, not assumed fixed. The torture fixtures
+  (`transitionDensityProjection`, `denseBranchProjection`) still need discovery to run
+  its _own_ full validated search once — with the smaller `HANDLE_FALLBACK_CANDIDATE_T_VALUES`
+  grid already landed on this branch (10 points, `docs` comment in
+  `lifecycleDiagramLayout.js` above the constant explains the sizing), this was ~7s
+  locally for the worst case; re-measure once discovery is doing full validation
+  again, since that's the change that previously pushed timing from ~17s to unsafe
+  territory in one earlier attempt this session.
+- **Run the full test suite at each step**, not just at the end — this exact area bit
+  us three times in one session (a "authoritative node order disagrees" regression
+  from running port-spacing during discovery; an 811s latency regression from
+  discovery-does-full-validation; a stale test comment/assertion mismatch after
+  reverting an escalation threshold). Small, frequent test runs would have caught each
+  faster than the large batched runs this session sometimes used.
+- **`npm run lint`, `npm run typecheck`, `npm run format:check`, `git diff --check`,
+  `git diff | ./scripts/scan-secrets.py`** — the existing required checks for this PR.
+
+## Dead ends already explored (don't retry these first)
+
+- **Tuning `MINIMUM_PORT_SPACING`, `HANDLE_FALLBACK_CANDIDATE_T_VALUES` size/step, or
+  `HANDLE_FALLBACK_CORRIDOR_HALF_WIDTH` alone.** Swept roughly a dozen combinations;
+  states-visited hovers in the 32,780-33,250 range regardless, never reliably crossing
+  under 32,768. The bottleneck is architectural (see above), not sampling density.
+- **Tripling `PER_LANE_VERTICAL_BUDGET`** (giving the whole canvas much more height) as
+  a blunt test — does not fix the dense fixture; it just moves which branches are
+  blocked, because D3-sankey's `ky` (value-to-pixel) scale is computed as the _minimum_
+  across all rank-columns (`min(columns, c => (y1 - y0 - (c.length-1)*py) / sum(c, value))`
+  in `d3-sankey/src/sankey.js`), so uniformly scaling doesn't fix _local_ dock adjacency
+  for specific low-value converging links — see `MINIMUM_PORT_SPACING` and
+  `enforceMinimumPortSpacing`/`enforceLinkDockSpacing` in `lifecycleDiagramLayout.js`
+  for the fix that actually targets this instead.
+- **`authoritativeNodePositions`** (seed D3's real-node Y positions from discovery's
+  graph directly) — implemented and measured zero effect (see above); reverted.
+- **`authoritativeLinkDockPositions`** (seed individual link dock Y positions from
+  discovery) — implemented, had a small real effect (~250 states) but not remotely
+  enough alone, and combined with running `enforceMinimumPortSpacing`/
+  `enforceLinkDockSpacing` unconditionally (including during discovery) caused a
+  concrete regression: "Lifecycle authoritative node order disagrees at rank 2" on the
+  small, previously-always-passing routing fixture, because shifting link dock
+  positions _before_ `solveTransitionLanes` runs changes which order the solver finds,
+  not just fixes geometry. Root-caused and fixed by gating both port-spacing functions
+  behind `!options.discoveryPhase && !options.transitionLanePhaseOnly` (already landed
+  on this branch) — but the `authoritativeLinkDockPositions` seeding itself was
+  reverted since the seeding-the-actual-search approach in this document supersedes it
+  cleanly (no need to separately reconcile two different "make final reuse discovery's
+  work" mechanisms).
+- **Running `enforceMinimumPortSpacing`/`enforceLinkDockSpacing` during discovery or
+  the `transitionLanePhaseOnly` diagnostic mode.** Confirmed to corrupt discovery's own
+  order-derivation (topological-sort failure) and to blow up
+  `transitionLanePhaseOnly`'s own lane-search state budget (a _different_, 200,000-
+  state budget than the handle budget, hit directly by
+  `"paginates 60 applications into 120 lane-only display branches deterministically"`).
+  Both are test-only/discovery-only code paths that don't need correct final geometry,
+  so gating this port-spacing work out of them was the right fix, already landed.
+
+## What's already fixed on this branch (context, not part of this plan)
+
+Two independent, verified, low-risk fixes are already committed and pushed to
+`codex/implement-rankorder-aware-base-layout`:
+
+1. **Sparse handle-candidate sampling** — `tryAssignBranchHandles` only ever sampled 3
+   fixed `t` values per route segment. Added an escalating fallback (denser grid, then
+   a narrower handle-only corridor buffer) that only engages when the primary 3 find
+   nothing, so it can't change behavior for fixtures that already worked. See
+   `HANDLE_CANDIDATE_T_VALUES`/`HANDLE_FALLBACK_CANDIDATE_T_VALUES`/
+   `HANDLE_FALLBACK_CORRIDOR_HALF_WIDTH` in `lifecycleDiagramLayout.js`.
+2. **Zero minimum port spacing** — D3-sankey docks a node's incident links purely
+   proportional to link value, with no minimum gap; for a node where several
+   low-value branches converge, adjacent docks can land only a few pixels apart, far
+   short of the clearance a `BRANCH_HANDLE_RADIUS` handle needs. Added
+   `MINIMUM_PORT_SPACING`, `enforceMinimumPortSpacing` (grows/compacts node boxes
+   once after D3's layout), and `enforceLinkDockSpacing` (re-applies minimum spacing
+   after each candidate's lane-coordinate blend, which can otherwise pull docks back
+   together) — both gated out of the discovery and `transitionLanePhaseOnly` paths
+   per the "dead ends" note above.
+
+Together these took the production fixture from failing immediately (4 permanently
+handle-blocked branches, no amount of budget would help) to failing at ~99% of the
+state budget. Full test suite is green (86 passed, 4 pre-existing skips, unchanged)
+at a runtime comparable to the pre-session baseline (~23s vs. ~26s).

--- a/docs/design/lifecycle-diagram-handle-search-seeding-plan.md
+++ b/docs/design/lifecycle-diagram-handle-search-seeding-plan.md
@@ -270,11 +270,11 @@ Two independent, verified, low-risk fixes are already committed and pushed to
 `codex/implement-rankorder-aware-base-layout`:
 
 1. **Sparse handle-candidate sampling** — `tryAssignBranchHandles` only ever sampled 3
-   fixed `t` values per route segment. Added an escalating fallback (denser grid, then
-   a narrower handle-only corridor buffer) that only engages when the primary 3 find
-   nothing, so it can't change behavior for fixtures that already worked. See
-   `HANDLE_CANDIDATE_T_VALUES`/`HANDLE_FALLBACK_CANDIDATE_T_VALUES`/
-   `HANDLE_FALLBACK_CORRIDOR_HALF_WIDTH` in `lifecycleDiagramLayout.js`.
+   fixed `t` values per route segment. Added a denser fallback grid that only engages
+   when the primary 3 find nothing and remains within the standard rank corridor, so
+   it can't change behavior for fixtures that already worked. See
+   `HANDLE_CANDIDATE_T_VALUES`/`HANDLE_FALLBACK_CANDIDATE_T_VALUES` in
+   `lifecycleDiagramLayout.js`.
 2. **Zero minimum port spacing** — D3-sankey docks a node's incident links purely
    proportional to link value, with no minimum gap; for a node where several
    low-value branches converge, adjacent docks can land only a few pixels apart, far

--- a/docs/design/lifecycle-diagram-handle-search-seeding-plan.md
+++ b/docs/design/lifecycle-diagram-handle-search-seeding-plan.md
@@ -6,10 +6,13 @@ Implemented. This document originally recorded root-cause findings and a propose
 from a debugging session on PR #1164 (`codex/implement-rankorder-aware-base-layout`). A
 later session implemented that plan (with two additions the original plan didn't
 anticipate — see "Surprises found during implementation" below), landed active
-regression tests for it, and re-verified the production-fixture claim in the original
+regression tests for it, and found the production-fixture claim in the original
 "Status" section below turned out to be wrong in an important way: see "Correction:
 `tracker-lifecycle-diagram-v2.json` is not a close miss" before relying on anything in
-this document's original motivating framing.
+this document's original motivating framing. A follow-up review then found that
+removing `enforceLinkDockSpacing` (see "Surprises" below) had left `MINIMUM_PORT_SPACING`
+as an unenforced, partial feature; it and `enforceMinimumPortSpacing` were removed
+entirely — see "Correction: the port-spacing feature was incomplete, not just deferred".
 
 ## What was actually landed
 
@@ -136,8 +139,8 @@ _after_ the solver's chosen `globalAssignments` — which meant `geometryFailure
 signature-based memoization (keyed on pre-redistribution `globalAssignments`) missed
 whenever different raw solver decisions collapsed to the same post-redistribution
 geometry, wasting large amounts of search budget. Removed entirely (function and call
-site); `enforceMinimumPortSpacing` (the one-time post-D3-layout node growth/compaction
-from the same earlier session) is unaffected and still runs.
+site). See "Correction: the port-spacing feature was incomplete, not just deferred"
+below for a fifth issue this removal exposed.
 
 ## Correction: `tracker-lifecycle-diagram-v2.json` is not a close miss
 
@@ -176,6 +179,33 @@ underlying handle-clearance-feasibility gap for this fixture predates it, is
 independently confirmed by three separate investigations now, and is out of scope for a
 search/plumbing fix. It remains exactly what the existing skip comments already say it
 is: a tracked follow-up requiring new placement geometry logic, not touched by this work.
+
+## Correction: the port-spacing feature was incomplete, not just deferred
+
+Removing `enforceLinkDockSpacing` (see "Surprises" above) left `MINIMUM_PORT_SPACING`/
+`enforceMinimumPortSpacing` (the one-time post-D3-layout node growth from the same
+earlier session) as a partial, internally contradictory feature: it still grew a real
+node's box and reserved canvas height on the assumption that its incident docks would
+end up at least `MINIMUM_PORT_SPACING` apart, but with `enforceLinkDockSpacing` gone,
+nothing actually redistributed those docks within the grown box — D3's original
+value-proportional positions were left untouched. A follow-up review caught this
+(adjacent same-side dock gaps as low as ~9px measured on the routing fixture despite the
+advertised 60px minimum) before merge.
+
+Confirmed the routing fixture's seeded-replay regressions do not depend on port spacing
+at all — disabling it locally left every test passing, and the seeded search actually
+converges noticeably faster without the extra box growth to route around (the four
+`describe("seeded-replay production layout (routing fixture)")` tests dropped from
+~15s to ~140ms with it disabled; the whole file's runtime roughly halved). So
+`MINIMUM_PORT_SPACING`, `enforceMinimumPortSpacing`, and the height reservation that
+existed to accommodate it (`nodeMinHeight`/`portSpacingHeight` inside
+`calculateLifecycleDiagramLayout`) were removed entirely rather than completed, per the
+smaller, safer cut for this reduced-scope PR. Re-adding real minimum port spacing (as a
+complete, correctly-enforced invariant covering discovery, seeded replay, and
+cache-signature correctness) is deferred alongside the dense-fixture
+constructive-placement work — see the parent reviewer thread for the two options
+considered (complete removal vs. a fully-enforced invariant) and why removal was judged
+the safer cut here.
 
 ---
 
@@ -265,15 +295,14 @@ required beyond what was originally planned.
   landed").
 - **Running `enforceMinimumPortSpacing` during the `transitionLanePhaseOnly` diagnostic
   mode** — confirmed to blow up that mode's own 200,000-state lane-search budget on a
-  paginated dense fixture. `enforceMinimumPortSpacing` now runs whenever
-  `!options.transitionLanePhaseOnly` (including during discovery, which needs it to
-  successfully materialize and check handles now that discovery does full validation) —
-  `enforceLinkDockSpacing` was removed entirely (see "Surprises" above), so its own gating
-  is moot.
+  paginated dense fixture. Moot now: `enforceMinimumPortSpacing` and
+  `MINIMUM_PORT_SPACING` were removed entirely in the same pass that removed
+  `enforceLinkDockSpacing` (see "Correction" above) — the leftover, unenforced box-growth
+  they left behind was itself the bug a later review caught.
 
 ## What's already fixed on this branch (context, not part of this document's own work)
 
-Two independent, verified, low-risk fixes landed before the seeded-replay work above:
+One independent, verified, low-risk fix landed before the seeded-replay work above:
 
 1. **Sparse handle-candidate sampling** — `tryAssignBranchHandles` only ever sampled 3
    fixed `t` values per route segment. Added a denser fallback grid that only engages
@@ -281,9 +310,12 @@ Two independent, verified, low-risk fixes landed before the seeded-replay work a
    it can't change behavior for fixtures that already worked. See
    `HANDLE_CANDIDATE_T_VALUES`/`HANDLE_FALLBACK_CANDIDATE_T_VALUES` in
    `lifecycleDiagramLayout.js`.
-2. **Zero minimum port spacing** — D3-sankey docks a node's incident links purely
-   proportional to link value, with no minimum gap; for a node where several
-   low-value branches converge, adjacent docks can land only a few pixels apart, far
-   short of the clearance a `BRANCH_HANDLE_RADIUS` handle needs. Added
-   `MINIMUM_PORT_SPACING` and `enforceMinimumPortSpacing` (grows/compacts node boxes
-   once after D3's layout).
+
+A second fix from the same earlier session — `MINIMUM_PORT_SPACING` and
+`enforceMinimumPortSpacing`, growing a real node's box once after D3's layout so its
+incident docks would have room to be spread apart — did not survive to this document's
+final state. It depended on `enforceLinkDockSpacing` (a different, per-candidate
+mechanism) to actually redistribute docks within the grown box; once that was removed
+(see "Correction" above), the box growth alone no longer enforced any real spacing
+invariant, so both were removed together rather than left as a partial, misleading
+feature. See "Correction" for the full removal rationale.

--- a/docs/design/lifecycle-diagram-handle-search-seeding-plan.md
+++ b/docs/design/lifecycle-diagram-handle-search-seeding-plan.md
@@ -1,273 +1,279 @@
-# Plan: seed the final pass's lane search with discovery's proven assignment
+# Implemented: seeding the final pass's lane search with discovery's proven assignment
 
 ## Status
 
-Not implemented. This document records root-cause findings from a debugging session
-on PR #1164 (`codex/implement-rankorder-aware-base-layout`) and a scoped plan for the
-remaining fix, for whoever picks this up next (a future session, or another engineer).
+Implemented. This document originally recorded root-cause findings and a proposed plan
+from a debugging session on PR #1164 (`codex/implement-rankorder-aware-base-layout`). A
+later session implemented that plan (with two additions the original plan didn't
+anticipate — see "Surprises found during implementation" below), landed active
+regression tests for it, and re-verified the production-fixture claim in the original
+"Status" section below turned out to be wrong in an important way: see "Correction:
+`tracker-lifecycle-diagram-v2.json` is not a close miss" before relying on anything in
+this document's original motivating framing.
 
-Two real, independent, low-risk bugs found during that session are already fixed and
-merged into the branch (see "What's already fixed" below). This document is about the
-_third_, deeper issue that remains: `layoutLifecycleRoutingGraph`'s production entry
-point still throws `Lifecycle handle search exceeded 32768 states` for the dense
-production fixture `test/fixtures/tracker-lifecycle-diagram-v2.json`, but now misses
-the budget by roughly 1% (~32900-33150 states used against a 32768 limit) instead of
-failing immediately with four permanently-blocked branches. This is close enough that
-naive parameter tuning (candidate-sample density, port-spacing constants) reliably
-lands within a few hundred states of success but never reliably crosses the line, and
-several tuning attempts materially regressed either correctness (see "Dead ends" for
-the `authoritativeNodePositions`/topological-order regression) or wall-clock latency
-(one configuration pushed the full test suite from ~26s to over 800s). The fix
-documented here is architectural, not a constant tweak.
+## What was actually landed
 
-## Background: what the two-pass design is and why it exists
+`layoutLifecycleRoutingGraph` still runs `layoutLifecycleRoutingGraphPass` exactly
+twice, but the two passes now have a real producer/consumer relationship instead of
+each independently solving the same problem:
+
+1. **Discovery now requires full validation to publish a result.** Its
+   `candidateCallback` no longer returns `true` on the first lane-legal candidate — it
+   runs the same materialization, `tryAssignBranchHandles`, and
+   `auditLifecycleRouteGeometry` checks the final pass runs, and only calls
+   `options.discoverySink` once a candidate clears all three with zero fatal audit
+   findings. The sink now receives three things (previously one): `rankRefinementInfo`,
+   `globalAssignments`, and the accepted `handleCheck.handles`.
+2. **The wrapper (`layoutLifecycleRoutingGraph`) captures four things from discovery as
+   an immutable seed**, all keyed by stable branch/link IDs (never array position, so
+   normal and reversed input seed and replay identically):
+   - `discoveredRankOrder` / `discoveredAssignments` — the per-rank branch order and
+     lane-Y assignments discovery's `candidateCallback` was invoked with.
+   - `discoveredHandles` — the branch handle positions discovery's `tryAssignBranchHandles`
+     accepted, frozen as a `Map<branchId, handle>`.
+   - `discoveredLinkDocks` — every link's final `y0`/`y1`, frozen as a
+     `Map<linkId, {y0, y1}>`.
+   - `discoveredNodeOrderByRank` — each rank's node order, derived **directly from
+     discovery's own graph nodes' Y positions** (sorted, ID-tiebroken), not via
+     `deriveAuthoritativeLayoutOrders`'s topological merge. See "Surprises" below for why
+     this had to be separate from `orders.branchOrderByRank` (which is still derived the
+     normal way and still used for `authoritativeBranchOrderByRank`).
+3. **The final pass takes four new options** — `seedAssignments`, `seedRankOrderByRank`,
+   `seedHandles`, `seedLinkDocks` — threaded through from the wrapper alongside the
+   existing `authoritativeBranchOrderByRank` / `authoritativeNodeOrderByRank` (which
+   still drive D3's `nodeSort`/`linkSort`, so rendering stays consistent with the
+   geometry about to be replayed).
+4. **`solveTransitionLanes` (`solveGlobal`), when given a seed, skips its own search
+   entirely.** Instead of `solveFromComponent(0)`, it:
+   - Validates the seed's link-ID coverage exactly matches the fresh graph's link IDs.
+   - For each rank, reconstructs `rankOrder` from `seedRankOrderByRank` filtered against
+     the fresh graph's own `variablesByRank` (never trusts discovery's own variable
+     objects — everything is rebuilt from the pristine final graph, per the reviewer
+     requirement this was built against), validates it against
+     `authoritativeBranchOrderByRank`, builds `cen` from `seedAssignments` (validating
+     every value is finite, within the fresh graph's own legal intervals, and
+     monotonically spaced), and charges `recordSolverState` once per validated value —
+     real state cost, not free, so `statesVisited` still reflects genuine work done.
+   - Calls `candidateCallback(globalAssignments, rankRefinementInfo)` **exactly once**.
+   - On any validation failure or a `false`/throwing callback result, throws a typed
+     `{ type: "lifecycle-authoritative-rank-order", reason: "seed-replay-failed" }`
+     error — never silently falls back to a fresh search. A silent fallback would hide a
+     real bug in the mechanism and reintroduce the unbounded search cost this change
+     exists to remove.
+5. **`tryAssignBranchHandles` takes a `seedHandles` option.** When present, instead of
+   generating and backtracking over candidate sets, it validates each seeded handle
+   directly against the fresh pass's own fixed geometry and route edges (same checks
+   every ordinary candidate must pass) and returns immediately — `ok: true` if every
+   branch's seeded handle clears and no two overlap, `ok: false` (with the normal
+   `blockedBranchIds`/`reason` shape) otherwise. See "Surprises" for why this is needed
+   even after lane geometry is seeded.
+6. **`materializeLaneAssignments` takes a `seedLinkDocks` option.** When present, after
+   the existing routing-continuity invariant check, every link's `y0`/`y1` is overwritten
+   directly from the seed instead of being left to the routing-node monotone-assignment
+   DP's own (re-)computation. See "Surprises" for why.
+7. **`layoutAttemptCount` remains exactly 2**, and each attempt's stats remain
+   independently frozen and phase-labelled (`discovery` then `final`) under the unchanged
+   200,000 / 32,768 limits — unchanged from before this work, just now genuinely cheap
+   for final in the case that matters (final's own `statesVisited`/`handleStatesVisited`
+   for the seeded replay is a handful of states: one materialization, one handle check,
+   one audit, instead of a from-scratch search).
+
+New active (non-skipped) regression coverage lives in
+`test/web-tracker-lifecycle-diagram-layout.test.js`, `describe("seeded-replay production
+layout (routing fixture)")`: both normal and reversed `tracker-lifecycle-diagram-routing-v2.json`
+input succeed in exactly two bounded passes, with one finite valid handle per branch,
+zero fatal `auditLifecycleRouteGeometry` findings, and — checked separately — identical
+`transitionLaneRankOrder` plus stable-ID-normalized equivalent lane geometry and solver
+stats between the normal and reversed runs.
+
+## Surprises found during implementation (not anticipated by the original plan below)
+
+The original plan (preserved below for the reasoning trail) anticipated seeding
+`globalAssignments`/`rankRefinementInfo` would be sufficient — "the graph is already
+materialized... proceed exactly as the current post-search code does." Two more
+independent non-determinism sources had to be found and closed before the routing
+fixture's seeded replay reliably passed its own audit:
+
+1. **Handle placement is not a pure function of lane geometry.** `tryAssignBranchHandles`'
+   multi-branch backtracking (`solveHandleCandidateSets`) can have more than one legal
+   global assignment for identical lane geometry, and which one it finds depends on the
+   shared search budget's accumulated state — discovery has already spent many states on
+   earlier rejected candidates before its own success; a fresh final-pass search over the
+   exact same geometry starts near zero and can land on a _different_, still individually
+   legal, handle. Confirmed directly: a fresh handle search over discovery's exact seeded
+   lane values picked a different handle for a multi-segment branch than discovery's own
+   run had, and the fresh pick failed the route-crossing audit discovery's own pick had
+   already cleared. Closed by seeding handle positions (`seedHandles`) and validating each
+   one directly against final's own fresh route edges and fixed geometry, rather than
+   re-searching for one (item 5 above).
+2. **Routing-node anchor Y positions are their own monotone-assignment DP**
+   (`assignMonotone`, inside `materializeLaneAssignments`), seeded from but not equal to
+   the `transitionLaneY` values the outer search produces — distinct legal anchor
+   positions can score identically in that DP, so it is not provably deterministic across
+   otherwise-identical passes. Confirmed directly: a fresh replay of discovery's exact
+   seeded lane values still produced a routing anchor a few hundredths of a pixel off from
+   discovery's own, which was enough to fail the route-crossing audit discovery's own
+   geometry had already cleared. Closed by seeding link dock positions (`seedLinkDocks`)
+   and reproducing them exactly instead of trusting a second DP solve to land on the same
+   one (item 6 above).
+3. **Node order needed a different derivation for the seeded final pass than
+   `authoritativeBranchOrderByRank` uses.** `deriveAuthoritativeLayoutOrders`'s
+   `nodeOrderByRank` is a topological merge of each node's incoming/outgoing branch
+   positions — a different algorithm than discovery's own D3 `nodeSort`, and the two can
+   legitimately disagree for the same graph. Feeding the merge-derived order into the
+   seeded final pass produced `seed-value-illegal` rejections at rank 0 for the routing
+   fixture, because the merge's node ordering didn't match the order the seeded branch
+   positions actually needed. Fixed by deriving `authoritativeNodeOrderByRank` for the
+   seeded final pass directly from discovery's own graph nodes' Y positions (sorted,
+   ID-tiebroken) instead — `orders.branchOrderByRank` (used for
+   `authoritativeBranchOrderByRank`) is unaffected, since it's a direct 1:1 mapping from
+   rank order and doesn't have this divergence.
+
+A fourth, adjacent issue was found and fixed independently of the seeding work:
+`enforceLinkDockSpacing` (a per-candidate dock-redistribution step from an earlier
+session, applied after each candidate's lane-coordinate blend) mutates `link.y0`/`y1`
+_after_ the solver's chosen `globalAssignments` — which meant `geometryFailureCache`'s
+signature-based memoization (keyed on pre-redistribution `globalAssignments`) missed
+whenever different raw solver decisions collapsed to the same post-redistribution
+geometry, wasting large amounts of search budget. Removed entirely (function and call
+site); `enforceMinimumPortSpacing` (the one-time post-D3-layout node growth/compaction
+from the same earlier session) is unaffected and still runs.
+
+## Correction: `tracker-lifecycle-diagram-v2.json` is not a close miss
+
+The original "Status" section below (preserved for its diagnostic value) characterized
+the production dense fixture as landing "close enough" to the 32,768 handle-state
+budget — roughly 1% over — that the problem looked like wasted search effort rather than
+genuine infeasibility, and framed this seeding work as the fix that should "give the
+production fixture comfortable headroom."
+
+That turned out not to be the right diagnosis for this specific fixture. With this
+seeding mechanism fully implemented and the routing fixture's regression passing
+reliably, `tracker-lifecycle-diagram-v2.json` **still** throws `Lifecycle handle search
+exceeded 32768 states` — now failing during discovery's own one-time combined
+lane+handle search, before there is ever a seed to replay. Raising the handle-state
+budget to 2,000,000 in a local, uncommitted diagnostic run (not shipped; the 32,768
+constant was restored immediately after) still failed after 100+ seconds of search.
+Direct instrumentation of `tryAssignBranchHandles`'s per-branch candidate generation
+showed the same ~3 branches (`branch:link:origin:other_unknown->milestone:recruiter_screen:endpoint:interviewing`,
+`branch:link:origin:candidate_outreach->milestone:assessment_take_home:endpoint:assessment_in_progress`,
+`branch:link:origin:referral->milestone:recruiter_screen:endpoint:offer_negotiating`, plus
+a fourth that varies) rejected with `reason: "no-candidates"` — zero legal handle
+positions at all, independent of lane assignment — across every one of the 98 distinct
+lane-order candidates evaluated before hitting the ordinary 32,768 budget.
+
+This is not new: it is the same class of gap two existing `it.skip` tests in
+`test/web-tracker-lifecycle-diagram-layout.test.js` already document for this exact
+fixture and for `denseBranchProjection()` — "no handle-clearance-feasible lane
+arrangement... confirmed by direct instrumentation, the set of blocked branches is
+identical across hundreds of distinct coordinate assignments" — and it matches
+`docs/design/lifecycle-diagram-layout-algorithm.md`'s own "Outstanding follow-up work"
+item 1, which already named the real fix as making the base D3-Sankey layout
+`rankOrder`-aware (or a constructive/greedy handle-placement strategy), not a search or
+plumbing change. This session's seeded-replay work eliminates the wasted, redundant
+_second_ search final used to run — a real and verified improvement, landed — but the
+underlying handle-clearance-feasibility gap for this fixture predates it, is
+independently confirmed by three separate investigations now, and is out of scope for a
+search/plumbing fix. It remains exactly what the existing skip comments already say it
+is: a tracked follow-up requiring new placement geometry logic, not touched by this work.
+
+---
+
+## Original plan (preserved for its reasoning trail; see corrections above)
+
+The sections below are the original pre-implementation plan and are kept for context —
+several details (state variable names, line numbers, the production-fixture framing)
+have drifted from what actually shipped; see "What was actually landed" above for the
+authoritative description.
+
+### Background: what the two-pass design is and why it exists
 
 `layoutLifecycleRoutingGraph` (the production entry point) runs
 `layoutLifecycleRoutingGraphPass` (the actual layout engine — D3-Sankey plus a
 custom deterministic transition-lane solver, `src/web/tracker/lifecycleDiagramLayout.js`)
 exactly twice:
 
-1. **Discovery pass** (`options.discoveryPhase = true`, wired up around line 3219):
-   runs the full pass on a _fresh_ graph clone with D3's own default `nodeSort`/
-   `linkSort` (no order constraints). Its `candidateCallback` (~line 2811) returns
-   `true` on the very first lane-legal candidate it evaluates — it does **not** check
-   handle placement or the route-crossing audit before accepting. It captures that
-   candidate's per-rank branch order (`rankRefinementInfo`) via `discoverySink`, then
-   discards all its own geometry.
+1. **Discovery pass** (`options.discoveryPhase = true`): runs the full pass on a
+   _fresh_ graph clone with D3's own default `nodeSort`/`linkSort` (no order
+   constraints). Its `candidateCallback` used to return `true` on the very first
+   lane-legal candidate it evaluated, without checking handle placement or the
+   route-crossing audit. It captured that candidate's per-rank branch order
+   (`rankRefinementInfo`) via `discoverySink`, then discarded all its own geometry.
 2. **Final pass**: rebuilds a second fresh graph clone, this time passing
    `authoritativeBranchOrderByRank`/`authoritativeNodeOrderByRank` (derived from
-   discovery's captured order via `deriveAuthoritativeLayoutOrders`, ~line 3072) into
-   D3's `nodeSort`/`linkSort`. It then runs the _entire_ transition-lane solver again,
-   from scratch, with full handle-placement and route-crossing-audit validation. If
-   its own final rank order disagrees with what discovery found, it throws a typed
-   `order-disagreement` error (~line 3250).
+   discovery's captured order via `deriveAuthoritativeLayoutOrders`) into D3's
+   `nodeSort`/`linkSort`. It then ran the _entire_ transition-lane solver again, from
+   scratch, with full handle-placement and route-crossing-audit validation. If its own
+   final rank order disagreed with what discovery found, it threw a typed
+   `order-disagreement` error.
 
 **Why two passes at all**: `nodeSort`/`linkSort` (D3's own comparators, taxonomy- and
 median-endpoint-based) and the transition-lane solver's own crossing-avoidance
 backtracking are two _independent_ decision processes over the same graph. Run only
 one of them and you can get a rendered node/link array order that disagrees with the
-solver's own geometric decisions — the exact bug this PR's motivation describes
-("Prevent inconsistent per-rank ordering between D3-Sankey and the deterministic
-transition-lane solver"). The two-pass split exists specifically to force D3's sort to
-agree with whatever order the solver already decided, and the `order-disagreement`
-check is a correctness guard confirming that alignment actually held.
+solver's own geometric decisions. The two-pass split exists specifically to force D3's
+sort to agree with whatever order the solver already decided, and the
+`order-disagreement` check is a correctness guard confirming that alignment actually
+held.
 
-## The problem: discovery's cheap success doesn't prove final's hard problem is solved
+### The problem: discovery's cheap success doesn't prove final's hard problem is solved
 
-Discovery's `candidateCallback` short-circuits before ever calling
-`tryAssignBranchHandles` or `auditLifecycleRouteGeometry` — it only proves _lane_
+Discovery's `candidateCallback` used to short-circuit before ever calling
+`tryAssignBranchHandles` or `auditLifecycleRouteGeometry` — it only proved _lane_
 legality (a much weaker, essentially-always-immediately-satisfiable property), not
-_handle_ feasibility. For sparse fixtures this doesn't matter, because the first
-lane-legal candidate is essentially always handle-feasible too. For the dense
-production fixture, it isn't: the first candidate discovery accepts is frequently one
-where several branches can't get a legal handle placement at all.
+_handle_ feasibility. For sparse fixtures this didn't matter, because the first
+lane-legal candidate was essentially always handle-feasible too. For denser fixtures, it
+wasn't: the first candidate discovery accepted was frequently one where several branches
+couldn't get a legal handle placement at all.
 
-So the final pass, constrained to replay discovery's order, is not "verifying a proven
-solution" — it is independently solving the much harder handle-feasible-_and_-order-
+So the final pass, constrained to replay discovery's order, was not "verifying a proven
+solution" — it was independently solving the much harder handle-feasible-_and_-order-
 matching problem for the first time, alone, with its own fresh 32768-state budget.
-Confirmed directly in this session:
 
-- Making discovery _also_ require full handle+audit validation (removing its
-  early-return in `candidateCallback`) does make the _discovered_ order actually
-  handle-feasible — but discovery then does the same expensive search final was doing,
-  so both passes are now expensive. One configuration of this pushed the whole
-  `test/web-tracker-lifecycle-diagram-layout.test.js` + `test/web-tracker-lifecycle-diagram.test.js`
-  suite from ~26s to **811s**, because several already-slow deliberately-infeasible
-  torture fixtures (`transitionDensityProjection`, `denseBranchProjection`) now pay
-  the escalating-candidate-search cost twice, once per pass, and repeatedly per
-  rejected backtracking candidate. Not viable as-is.
-- Seeding final's D3 layout with discovery's _exact_ resulting real-node Y positions
-  (`authoritativeNodePositions`, applied right after `layout.update(graph)`) had
-  **zero measurable effect** on states-visited. This confirms D3's layout is already
-  fully deterministic given the same order constraint — position mismatches are not
-  the divergence source.
-- Seeding with discovery's exact _link_ dock positions too
-  (`authoritativeLinkDockPositions`, matched by `link.id`) had a small, real, but
-  insufficient effect (~33145 → ~32903 states in one configuration) — real signal, not
-  enough alone to close the gap by itself, and this option was reverted (see "Dead
-  ends") because it's redundant with the seeding approach below and added surface
-  area for no committed benefit.
+### The fix that was implemented: seed the search, don't just constrain D3's rendering sort
 
-The conclusion: final's _own_ `solveTransitionLanes` search (branch-order backtracking
-wrapping per-rank coordinate backtracking, ~line 1335, roughly 1,000 lines) explores
-a **different sequence of candidates** than discovery's search did, even given
-identical input geometry and the same authoritative order constraint fed to D3. The
-order constraint only affects D3's `nodeSort`/`linkSort` — it is never threaded into
-`solveTransitionLanes`'s own candidate-generation/MRV heuristics, so nothing forces
-final's solver to try discovery's exact winning candidate first (or at all, before
-exhausting budget on others).
-
-## The proposed fix: seed the search, don't just constrain D3's rendering sort
-
-Rather than have `deriveAuthoritativeLayoutOrders` produce an _order_ for D3 to match
-(current design), capture discovery's actual winning **assignment** — the raw
-`globalAssignments` map (`linkId -> chosen lane Y`) and `rankRefinementInfo` that its
-successful `candidateCallback(globalAssignments, rankRefinementInfo)` invocation
-received — and let the final pass replay that assignment directly instead of
-re-deriving it via a second independent search.
-
-This preserves the two-pass architecture's actual safety property (a _pristine_
-final pass, fresh graph clone, fresh obstacles/domains/caches/budgets, full
-handle+audit validation actually run) while eliminating the wasted, unguided
-re-search. If discovery is required to fully validate (handle+audit) before
-accepting — which it must be, to guarantee the seed is worth anything — its own
-search is the _only_ expensive step; final becomes a cheap, deterministic replay-and-
-verify.
-
-### Concrete steps
-
-1. **Discovery does full validation.** Move discovery's `discoverySink` call from the
-   current early-return point in `candidateCallback` (~line 2814) to the success path
-   after the route-crossing audit passes (`routeAudit.fatalFindings.length === 0`,
-   ~line 2930), matching what this session's "discovery requires audit" experiment
-   already did. Capture both `rankRefinementInfo` _and_ `globalAssignments` in the
-   sink (currently only `rankRefinementInfo` is captured).
-
-2. **Add a seed path to `layoutLifecycleRoutingGraphPass`.** New options:
-   `options.seedAssignment` (the raw `globalAssignments` Map) and
-   `options.seedRankRefinementInfo`. When both are present, skip the
-   `solveTransitionLanes(graph.links, { candidateCallback })` call (~line 2995)
-   entirely and instead call `candidateCallback(seedAssignment, seedRankRefinementInfo)`
-   directly, exactly once:
-   - If it returns `true`: the graph is already materialized (candidateCallback
-     mutates it in place on success, same as today) — proceed exactly as the current
-     post-search code does (~line 3036 onward: set `graph.transitionLaneRankOrder`,
-     freeze `transitionLaneSolverStats`, return `{ graph, dimensions }`).
-   - If it returns `false`, or throws: this means D3's authoritative-order-constrained
-     layout produced geometry that the seed assignment doesn't actually satisfy —
-     which determinism says should never happen, but must **not** be silently papered
-     over. Throw a clear, distinctly-typed error (e.g.
-     `lifecycle-authoritative-rank-order` / `seed-replay-failed`) rather than falling
-     back to a full search — a silent fallback would hide a real bug in this
-     mechanism and defeat the entire point of the change. Route this into the
-     existing `order-disagreement` diagnostic in `layoutLifecycleRoutingGraph`
-     (~line 3250) if it's the same underlying failure mode, or as a clearly distinct
-     sibling failure otherwise.
-
-3. **`transitionLaneSolverStats.components` needs a value even when the search is
-   skipped.** `laneResult.componentMembers.size` (~line 3037) currently comes from
-   `solveTransitionLanes`'s own union-find over branch/rank adjacency (~line 1670),
-   computed structurally _before_ any backtracking search runs — it's a pure function
-   of graph structure (which branches share which ranks), not a search _decision_, so
-   it is identical between discovery and final for the same graph. Two options,
-   in order of preference:
-   - Preferred: factor the union-find/component-partition step out of
-     `solveTransitionLanes` into its own small function callable independently, and
-     call it directly in the seed path (cheap, no behavior risk, keeps `components`
-     meaningfully "freshly computed" for the final pass rather than reused from
-     discovery).
-   - Fallback: capture `componentMembers.size` from discovery's own successful
-     `solveTransitionLanes` result and pass it through as
-     `options.seedComponentCount`, used directly in the seed path. Simpler, but reuses
-     a discovery-pass-computed number for final's stats, which is a slightly weaker
-     "freshly proven" story than the current design's phrasing implies.
-
-4. **Wire the wrapper (`layoutLifecycleRoutingGraph`, ~line 3200).** Capture
-   `globalAssignments` from discovery's sink alongside the existing
-   `discoveredRankOrder`. Pass `seedAssignment`/`seedRankRefinementInfo` (and whichever
-   `components` mechanism was chosen in step 3) into the final
-   `layoutLifecycleRoutingGraphPass` call (~line 3243), alongside the existing
-   `authoritativeBranchOrderByRank`/`authoritativeNodeOrderByRank` (still needed, since
-   D3's `nodeSort`/`linkSort` still must agree with the replayed geometry for
-   rendering consistency — this part of the current design is correct and should stay).
-
-5. **Keep the existing `order-disagreement` check** (~line 3250) as-is. It remains a
-   valid, cheap safety net: even with a seeded replay, confirm the _materialized_
-   `graph.transitionLaneRankOrder` still matches what discovery reported before
-   returning to the caller.
-
-### Why this should actually close the gap
-
-With this change, the _only_ expensive, exhaustive search happens once (discovery).
-Final's own cost becomes: one D3 layout pass (cheap, deterministic) + one
-`candidateCallback` invocation (one `tryAssignBranchHandles` call + one
-`auditLifecycleRouteGeometry` call — the same fixed cost every candidate already pays,
-just paid once instead of dozens of times). The 32768-state final-pass budget, which
-is currently being exhausted by dozens of full search attempts, is reduced to a
-handful of states for the single replay-and-verify. This should give the production
-fixture comfortable headroom rather than the ~1% miss it currently has, without
-touching the protected `32,768`/`200,000` state limits or `HANDLE_ROUTE_EDGE_COST_DIVISOR`
-themselves.
-
-## Risks and what to verify carefully
-
-- **`solveTransitionLanes` is large and intricate** (~1,000 lines: branch-order
-  backtracking wrapping per-component coordinate backtracking, `MRV` variable
-  selection, `failedStates`/`geometryFailureCache` memoization, routing-anchor
-  monotone assignment). This plan avoids touching its internals — the seed path is
-  designed to bypass the whole function, not modify it — but double-check nothing
-  downstream of `solveTransitionLanes` in `layoutLifecycleRoutingGraphPass` implicitly
-  depends on side effects only `solveTransitionLanes` itself sets (skim for module-
-  level `let`s mutated only inside it before committing to the bypass).
-- **`geometryFailureCache`** is populated during the search to memoize rejected
-  geometries within _that pass_. The seed path never calls it (only ever evaluates one
-  candidate), which is fine functionally, but confirm no other code assumes the cache
-  is non-empty or reads from it after a successful pass.
-- **Test fallout, likely large.** `testOnlyDiagnoseLifecycleLayoutAttempt` and several
-  tests that call `layoutLifecycleRoutingGraph` without `transitionLanePhaseOnly` (i.e.
-  exercising the real two-pass wrapper) may assert on `layoutAttempts[1].statesVisited`,
-  `candidateEvaluations`, or similar being "large" or otherwise search-shaped; these
-  will need updating to reflect the new cheap-replay final pass. Search the test file
-  for `layoutAttemptCount`, `layoutAttempts`, `candidateEvaluations` before starting.
-- **Latency tests must be re-checked**, not assumed fixed. The torture fixtures
-  (`transitionDensityProjection`, `denseBranchProjection`) still need discovery to run
-  its _own_ full validated search once — with the smaller `HANDLE_FALLBACK_CANDIDATE_T_VALUES`
-  grid already landed on this branch (10 points, `docs` comment in
-  `lifecycleDiagramLayout.js` above the constant explains the sizing), this was ~7s
-  locally for the worst case; re-measure once discovery is doing full validation
-  again, since that's the change that previously pushed timing from ~17s to unsafe
-  territory in one earlier attempt this session.
-- **Run the full test suite at each step**, not just at the end — this exact area bit
-  us three times in one session (a "authoritative node order disagrees" regression
-  from running port-spacing during discovery; an 811s latency regression from
-  discovery-does-full-validation; a stale test comment/assertion mismatch after
-  reverting an escalation threshold). Small, frequent test runs would have caught each
-  faster than the large batched runs this session sometimes used.
-- **`npm run lint`, `npm run typecheck`, `npm run format:check`, `git diff --check`,
-  `git diff | ./scripts/scan-secrets.py`** — the existing required checks for this PR.
+Rather than have `deriveAuthoritativeLayoutOrders` produce only an _order_ for D3 to
+match, discovery's actual winning **assignment** — the raw `globalAssignments` map
+(`linkId -> chosen lane Y`) and `rankRefinementInfo` that its successful
+`candidateCallback(globalAssignments, rankRefinementInfo)` invocation received — is
+captured and the final pass replays that assignment directly instead of re-deriving it
+via a second independent search. See "What was actually landed" above for the complete,
+accurate description including the two additional seed types (handles, link docks) this
+required beyond what was originally planned.
 
 ## Dead ends already explored (don't retry these first)
 
 - **Tuning `MINIMUM_PORT_SPACING`, `HANDLE_FALLBACK_CANDIDATE_T_VALUES` size/step, or
   `HANDLE_FALLBACK_CORRIDOR_HALF_WIDTH` alone.** Swept roughly a dozen combinations;
-  states-visited hovers in the 32,780-33,250 range regardless, never reliably crossing
-  under 32,768. The bottleneck is architectural (see above), not sampling density.
+  states-visited hovered in the 32,780-33,250 range regardless, never reliably crossing
+  under 32,768. The bottleneck was architectural, not sampling density — and even the
+  architectural fix (seeded replay) doesn't close it for
+  `tracker-lifecycle-diagram-v2.json`; see "Correction" above.
 - **Tripling `PER_LANE_VERTICAL_BUDGET`** (giving the whole canvas much more height) as
   a blunt test — does not fix the dense fixture; it just moves which branches are
   blocked, because D3-sankey's `ky` (value-to-pixel) scale is computed as the _minimum_
-  across all rank-columns (`min(columns, c => (y1 - y0 - (c.length-1)*py) / sum(c, value))`
-  in `d3-sankey/src/sankey.js`), so uniformly scaling doesn't fix _local_ dock adjacency
-  for specific low-value converging links — see `MINIMUM_PORT_SPACING` and
-  `enforceMinimumPortSpacing`/`enforceLinkDockSpacing` in `lifecycleDiagramLayout.js`
-  for the fix that actually targets this instead.
+  across all rank-columns, so uniformly scaling doesn't fix _local_ dock adjacency for
+  specific low-value converging links.
 - **`authoritativeNodePositions`** (seed D3's real-node Y positions from discovery's
-  graph directly) — implemented and measured zero effect (see above); reverted.
+  graph directly) — implemented and measured zero effect; reverted.
 - **`authoritativeLinkDockPositions`** (seed individual link dock Y positions from
-  discovery) — implemented, had a small real effect (~250 states) but not remotely
-  enough alone, and combined with running `enforceMinimumPortSpacing`/
-  `enforceLinkDockSpacing` unconditionally (including during discovery) caused a
-  concrete regression: "Lifecycle authoritative node order disagrees at rank 2" on the
-  small, previously-always-passing routing fixture, because shifting link dock
-  positions _before_ `solveTransitionLanes` runs changes which order the solver finds,
-  not just fixes geometry. Root-caused and fixed by gating both port-spacing functions
-  behind `!options.discoveryPhase && !options.transitionLanePhaseOnly` (already landed
-  on this branch) — but the `authoritativeLinkDockPositions` seeding itself was
-  reverted since the seeding-the-actual-search approach in this document supersedes it
-  cleanly (no need to separately reconcile two different "make final reuse discovery's
-  work" mechanisms).
-- **Running `enforceMinimumPortSpacing`/`enforceLinkDockSpacing` during discovery or
-  the `transitionLanePhaseOnly` diagnostic mode.** Confirmed to corrupt discovery's own
-  order-derivation (topological-sort failure) and to blow up
-  `transitionLanePhaseOnly`'s own lane-search state budget (a _different_, 200,000-
-  state budget than the handle budget, hit directly by
-  `"paginates 60 applications into 120 lane-only display branches deterministically"`).
-  Both are test-only/discovery-only code paths that don't need correct final geometry,
-  so gating this port-spacing work out of them was the right fix, already landed.
+  discovery, as a standalone mechanism separate from the full seeded-replay approach) —
+  implemented, had a small real effect but not remotely enough alone, and combined with
+  running `enforceMinimumPortSpacing`/`enforceLinkDockSpacing` unconditionally caused a
+  concrete regression on the routing fixture. Superseded by the `seedLinkDocks` mechanism
+  that shipped as part of the full seeded-replay work (item 6 in "What was actually
+  landed").
+- **Running `enforceMinimumPortSpacing` during the `transitionLanePhaseOnly` diagnostic
+  mode** — confirmed to blow up that mode's own 200,000-state lane-search budget on a
+  paginated dense fixture. `enforceMinimumPortSpacing` now runs whenever
+  `!options.transitionLanePhaseOnly` (including during discovery, which needs it to
+  successfully materialize and check handles now that discovery does full validation) —
+  `enforceLinkDockSpacing` was removed entirely (see "Surprises" above), so its own gating
+  is moot.
 
-## What's already fixed on this branch (context, not part of this plan)
+## What's already fixed on this branch (context, not part of this document's own work)
 
-Two independent, verified, low-risk fixes are already committed and pushed to
-`codex/implement-rankorder-aware-base-layout`:
+Two independent, verified, low-risk fixes landed before the seeded-replay work above:
 
 1. **Sparse handle-candidate sampling** — `tryAssignBranchHandles` only ever sampled 3
    fixed `t` values per route segment. Added a denser fallback grid that only engages
@@ -279,13 +285,5 @@ Two independent, verified, low-risk fixes are already committed and pushed to
    proportional to link value, with no minimum gap; for a node where several
    low-value branches converge, adjacent docks can land only a few pixels apart, far
    short of the clearance a `BRANCH_HANDLE_RADIUS` handle needs. Added
-   `MINIMUM_PORT_SPACING`, `enforceMinimumPortSpacing` (grows/compacts node boxes
-   once after D3's layout), and `enforceLinkDockSpacing` (re-applies minimum spacing
-   after each candidate's lane-coordinate blend, which can otherwise pull docks back
-   together) — both gated out of the discovery and `transitionLanePhaseOnly` paths
-   per the "dead ends" note above.
-
-Together these took the production fixture from failing immediately (4 permanently
-handle-blocked branches, no amount of budget would help) to failing at ~99% of the
-state budget. Full test suite is green (86 passed, 4 pre-existing skips, unchanged)
-at a runtime comparable to the pre-session baseline (~23s vs. ~26s).
+   `MINIMUM_PORT_SPACING` and `enforceMinimumPortSpacing` (grows/compacts node boxes
+   once after D3's layout).

--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -343,7 +343,15 @@ skip states and test names can drift. `grep -rn "it\.skip(\|test\.skip(" test/` 
    read both before starting a third. The barycenter attempt's unsolved mystery (node-position
    changes destabilizing the deadline-based DFS in an unexplained way) is the most likely blocker
    and should be root-caused first — see that section's closing paragraph for where to start
-   looking.
+   looking. Re-confirmed independently by a later session that built the seeded-replay pipeline
+   above: even with final's redundant search eliminated, discovery's own one-time combined
+   lane+handle search for `tracker-lifecycle-diagram-v2.json` never finds a working assignment —
+   raising the handle-search budget from 32,768 to 2,000,000 states (diagnostic only, not shipped)
+   still failed after 100+ seconds, and the same ~3 branches were blocked (`reason: "no-candidates"`)
+   across every one of the 98 distinct lane-order candidates tried before hitting the normal
+   budget. This rules out "the search just needs to be more efficient" and confirms the gap really
+   is what this section already says: a constructive/greedy placement strategy, not a search
+   or plumbing fix.
 2. **4 unit tests remain `it.skip`ed**, all for the same reason (a genuinely infeasible
    crossing-free arrangement in the current domain, not a bug this document's fixes address):
    - `test/web-tracker-lifecycle-diagram-layout.test.js`: `"shares a single handle budget across
@@ -380,26 +388,76 @@ without external requests"`
 
 ## Bounded authoritative-order pipeline
 
-The production layout now uses exactly two fresh layout attempts. The first is a
-rank-order discovery phase: it runs the deterministic transition-lane solver and
-captures its per-transition-rank branch order, but its partially materialized
-geometry is always discarded. The second rebuilds the routing graph from the
-projection, reruns D3-Sankey with link and combined real/routing-node comparators
-derived from that order, and then performs the complete lane, handle, and route
-audit pipeline with new obstacles, domains, caches, baselines, and budgets.
+The production layout uses exactly two fresh layout attempts. The first is a rank-order
+discovery phase: it runs the deterministic transition-lane solver on a pristine graph
+clone with no order constraints, but — unlike an earlier version of this mechanism — it
+does not stop at the first lane-legal candidate. It runs the same materialization,
+handle-placement, and route-crossing-audit checks the final pass runs, and only
+publishes a result once a candidate clears all three with zero fatal audit findings.
+That candidate's authoritative per-rank branch order, lane assignments, node order (by
+real Y position within each rank), branch handle positions, and per-link dock (`y0`/`y1`)
+positions are all captured as an immutable seed, keyed by stable branch/link IDs — never
+by array position, since normal and reversed input must seed and replay identically.
 
-Origin and endpoint ranks retain their taxonomy anchoring. At intermediate
-ranks, routing nodes retain both their incoming and outgoing branch positions,
-and real nodes retain every ordered incident branch. Incoming and outgoing
-positions remain separate rank/side contexts: the combined order is a stable
-topological merge of those contextual requirements, not a comparison of bare
-integers from different rank-local orders. Conflicting requirements produce a
-typed order-disagreement failure. Routing-anchor materialization consumes that
-same combined order rather than re-sorting fixed and movable entries by ideal Y.
+The second pass rebuilds the routing graph from the projection from scratch, reruns
+D3-Sankey with comparators derived from the seed's order (so rendering stays consistent
+with the geometry it's about to replay), and reconstructs every obstacle, legal
+interval, domain, cache, and budget fresh — exactly as it always did. But instead of
+re-running the transition-lane solver's own backtracking search a second time, it
+validates the seed against this fresh graph (exact ID coverage, finite values, legal
+intervals, monotone spacing, agreement with the freshly-derived authoritative order) and
+invokes the candidate-acceptance callback exactly once with the seed's own values. If
+that single validated replay is rejected — which determinism says should never happen —
+the pass throws a typed `lifecycle-authoritative-rank-order` / `seed-replay-failed`
+error rather than silently falling back to a fresh search; a silent fallback would hide
+a real bug in the mechanism and reintroduce the unbounded final-pass search cost this
+change exists to remove.
 
-The final graph exposes frozen, explicitly phase-labelled `layoutAttempts`
-statistics (`discovery` followed by `final`) and `layoutAttemptCount: 2`. Each attempt retains its independent
-transition and handle state counts and the unchanged 200,000/32,768 limits. A
-final solver order that differs from discovery is rejected with the typed
-`lifecycle-authoritative-rank-order` / `order-disagreement` failure; there is no
-convergence retry or wall-clock deadline.
+This closes two determinism gaps discovered while building it, both handled by seeding
+values the fresh final pass would otherwise have to re-derive on its own:
+
+- **Handle placement is not a pure function of lane geometry.** `tryAssignBranchHandles`'
+  multi-branch backtracking can have more than one legal global assignment for identical
+  lane geometry, and which one it lands on depends on the shared search budget's
+  accumulated state — a fresh pass starting near zero can pick a different (still
+  individually legal) handle than a pass that arrived at the same geometry after already
+  spending states on rejected candidates. Confirmed directly: replaying discovery's exact
+  lane values into a fresh handle search sometimes picked a different, still-legal handle
+  that failed the stricter route-crossing audit discovery's own pick had already cleared.
+  Fixed by seeding handle positions too and verifying each one directly against the final
+  pass's own fresh route edges and fixed geometry, instead of re-searching for one.
+- **Routing-node anchor Y positions are their own monotone-assignment DP**, seeded from
+  but not equal to the lane assignments above — distinct legal anchor positions can score
+  identically in that DP, so it is not provably deterministic across otherwise-identical
+  passes. Confirmed directly: a fresh replay of discovery's exact seeded lane values still
+  produced a routing anchor a few hundredths of a pixel off from discovery's own, enough
+  to fail the route-crossing audit discovery's own geometry had already cleared. Fixed by
+  reproducing discovery's own final link dock (`y0`/`y1`) positions exactly when the
+  caller supplies them, instead of trusting a second DP solve to land on the same one.
+
+Origin and endpoint ranks retain their taxonomy anchoring. At intermediate ranks, routing
+nodes retain both their incoming and outgoing branch positions, and real nodes retain
+every ordered incident branch. Incoming and outgoing positions remain separate rank/side
+contexts: the combined order used to drive D3's comparators is a stable topological merge
+of those contextual requirements, not a comparison of bare integers from different
+rank-local orders — except for node order specifically, which the final pass derives
+directly from discovery's own real Y positions per rank rather than through that
+topological merge, since the two can legitimately disagree (the merge and D3's own
+`nodeSort` are different heuristics over the same graph) and only discovery's own order is
+guaranteed to reproduce discovery's own already-validated geometry.
+
+The final graph exposes frozen, explicitly phase-labelled `layoutAttempts` statistics
+(`discovery` followed by `final`) and `layoutAttemptCount: 2`. Each attempt retains its
+independent transition and handle state counts and the unchanged 200,000/32,768 limits.
+Because the final pass replays rather than re-searches, its own state counts are now a
+handful of states (materialize + one handle check + one audit) rather than a search that
+could itself approach either budget. A final solver order that differs from discovery is
+still rejected with the typed `lifecycle-authoritative-rank-order` / `order-disagreement`
+failure; there is no convergence retry or wall-clock deadline.
+
+This mechanism does not change whether a fixture's geometry is handle-feasible in the
+first place — see [Outstanding follow-up work](#outstanding-follow-up-work-as-of-this-writing)
+item 1 below for that gap and why `tracker-lifecycle-diagram-v2.json` specifically is
+still infeasible even under this pipeline. It only removes the wasted, unguided
+second search final used to run against a problem discovery had already spent its own
+budget solving (or, for that fixture, failing to solve — see below).

--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -377,3 +377,26 @@ without external requests"`
    overlapping render. There is no automated end-to-end test asserting "the diagram is visually
    readable" beyond `auditLifecycleRouteGeometry`'s structural checks — worth considering as a
    follow-up if visual regressions become a recurring concern.
+
+## Bounded authoritative-order pipeline
+
+The production layout now uses exactly two fresh layout attempts. The first is a
+rank-order discovery phase: it runs the deterministic transition-lane solver and
+captures its per-transition-rank branch order, but its partially materialized
+geometry is always discarded. The second rebuilds the routing graph from the
+projection, reruns D3-Sankey with link and combined real/routing-node comparators
+derived from that order, and then performs the complete lane, handle, and route
+audit pipeline with new obstacles, domains, caches, baselines, and budgets.
+
+Origin and endpoint ranks retain their taxonomy anchoring. At intermediate
+ranks, routing nodes use their branch position and real nodes use the ordered
+positions of all incident branches, followed by stable node-kind, taxonomy, and
+ID tie-breaks. Routing-anchor materialization consumes that same combined order
+rather than re-sorting fixed and movable entries by ideal Y.
+
+The final graph exposes frozen `layoutAttempts` statistics (discovery followed
+by final) and `layoutAttemptCount: 2`. Each attempt retains its independent
+transition and handle state counts and the unchanged 200,000/32,768 limits. A
+final solver order that differs from discovery is rejected with the typed
+`lifecycle-authoritative-rank-order` / `order-disagreement` failure; there is no
+convergence retry or wall-clock deadline.

--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -389,13 +389,16 @@ derived from that order, and then performs the complete lane, handle, and route
 audit pipeline with new obstacles, domains, caches, baselines, and budgets.
 
 Origin and endpoint ranks retain their taxonomy anchoring. At intermediate
-ranks, routing nodes use their branch position and real nodes use the ordered
-positions of all incident branches, followed by stable node-kind, taxonomy, and
-ID tie-breaks. Routing-anchor materialization consumes that same combined order
-rather than re-sorting fixed and movable entries by ideal Y.
+ranks, routing nodes retain both their incoming and outgoing branch positions,
+and real nodes retain every ordered incident branch. Incoming and outgoing
+positions remain separate rank/side contexts: the combined order is a stable
+topological merge of those contextual requirements, not a comparison of bare
+integers from different rank-local orders. Conflicting requirements produce a
+typed order-disagreement failure. Routing-anchor materialization consumes that
+same combined order rather than re-sorting fixed and movable entries by ideal Y.
 
-The final graph exposes frozen `layoutAttempts` statistics (discovery followed
-by final) and `layoutAttemptCount: 2`. Each attempt retains its independent
+The final graph exposes frozen, explicitly phase-labelled `layoutAttempts`
+statistics (`discovery` followed by `final`) and `layoutAttemptCount: 2`. Each attempt retains its independent
 transition and handle state counts and the unchanged 200,000/32,768 limits. A
 final solver order that differs from discovery is rejected with the typed
 `lifecycle-authoritative-rank-order` / `order-disagreement` failure; there is no

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -30,17 +30,6 @@ export const renderedBranchStrokeWidth = () => 3;
 export const selectedEnvelopeRadius = (segment) =>
   (renderedBranchStrokeWidth(segment?.width) + 12) / 2;
 
-// Minimum vertical separation to reserve between adjacent link docks at the
-// same real node. D3-sankey sizes a node's incident link docks purely
-// proportional to each link's value, with no minimum gap -- for a node
-// where several low-value branches converge, that can place docks only a
-// few pixels apart, far short of what a BRANCH_HANDLE_RADIUS handle needs
-// to clear its neighbor's rendered route envelope. Matches the lane-spacing
-// margin already used elsewhere (BRANCH_HANDLE_RADIUS*2 plus the rendered
-// route envelope) for the same clearance reason.
-export const MINIMUM_PORT_SPACING =
-  BRANCH_HANDLE_RADIUS * 2 + selectedEnvelopeRadius({ width: 1 }) * 2 + 1;
-
 export const rendererHitBoxForNode = (node) => {
   const size = BRANCH_HANDLE_RADIUS * 2;
   const nodeWidth = node.x1 - node.x0;
@@ -542,12 +531,9 @@ export function calculateLifecycleDiagramLayout(
       : MINIMUM_SVG_WIDTH;
   const graph = routingGraph ?? buildLifecycleRoutingGraph(projection);
   const rankCounts = new Map();
-  const nodesByRank = new Map();
   for (const node of graph.nodes ?? []) {
     if (node.routing || Number(node.total) > 0 || Number(node.value) > 0) {
       rankCounts.set(node.rank, (rankCounts.get(node.rank) ?? 0) + 1);
-      if (!nodesByRank.has(node.rank)) nodesByRank.set(node.rank, []);
-      nodesByRank.get(node.rank).push(node);
     }
   }
   const rankByNodeId = new Map(
@@ -573,18 +559,6 @@ export function calculateLifecycleDiagramLayout(
     return rank;
   };
   const transitionCounts = new Map();
-  // Real (non-routing) nodes with more than one incident link on a side
-  // need at least MINIMUM_PORT_SPACING between each adjacent dock -- D3's
-  // own value-proportional sizing doesn't guarantee that (see
-  // MINIMUM_PORT_SPACING). Tally per-node incident counts alongside the
-  // existing transition-count pass so the reserved height below can fit
-  // them once enforceMinimumPortSpacing grows those nodes after layout.
-  const incidentLinkCounts = new Map();
-  const bumpIncident = (nodeId, side) => {
-    if (!incidentLinkCounts.has(nodeId))
-      incidentLinkCounts.set(nodeId, { incoming: 0, outgoing: 0 });
-    incidentLinkCounts.get(nodeId)[side] += 1;
-  };
   for (const link of graph.links ?? []) {
     const sourceRank = resolveLinkEndpointRank(link, "source");
     const targetRank = resolveLinkEndpointRank(link, "target");
@@ -608,41 +582,17 @@ export function calculateLifecycleDiagramLayout(
     }
     for (let rank = sourceRank; rank < targetRank; rank += 1)
       transitionCounts.set(rank, (transitionCounts.get(rank) ?? 0) + 1);
-    bumpIncident(linkEndpointId(link, "source"), "outgoing");
-    bumpIncident(linkEndpointId(link, "target"), "incoming");
   }
   const densestRoutedRank = Math.max(
     1,
     ...rankCounts.values(),
     ...transitionCounts.values(),
   );
-  const nodeMinHeight = (node) => {
-    if (node.routing) return PER_LANE_VERTICAL_BUDGET;
-    const counts = incidentLinkCounts.get(node.id) ?? {
-      incoming: 0,
-      outgoing: 0,
-    };
-    const maxSide = Math.max(counts.incoming, counts.outgoing, 1);
-    return Math.max(
-      PER_LANE_VERTICAL_BUDGET,
-      (maxSide - 1) * MINIMUM_PORT_SPACING,
-    );
-  };
-  let portSpacingHeight = 0;
-  for (const nodes of nodesByRank.values()) {
-    const total =
-      nodes.reduce((sum, node) => sum + nodeMinHeight(node), 0) +
-      Math.max(0, nodes.length - 1) * ROUTED_NODE_PADDING;
-    portSpacingHeight = Math.max(portSpacingHeight, total);
-  }
   const densityHeight =
     LAYOUT_TOP_MARGIN +
     LAYOUT_BOTTOM_MARGIN +
-    Math.max(
-      densestRoutedRank * PER_LANE_VERTICAL_BUDGET +
-        Math.max(0, densestRoutedRank - 1) * ROUTED_NODE_PADDING,
-      portSpacingHeight,
-    );
+    densestRoutedRank * PER_LANE_VERTICAL_BUDGET +
+    Math.max(0, densestRoutedRank - 1) * ROUTED_NODE_PADDING;
   return {
     width: Math.max(MINIMUM_SVG_WIDTH, sanitizedWidth),
     height: Math.max(MINIMUM_SVG_HEIGHT, Math.ceil(densityHeight)),
@@ -691,88 +641,6 @@ export function createLaneGeometryFailureCache() {
   };
 }
 
-// D3-sankey docks a node's incident links purely proportional to link value,
-// with no minimum gap between adjacent docks. For a real node where several
-// low-value branches converge (e.g. several origins funnelling into one
-// milestone), that can place adjacent docks only a few pixels apart --
-// nowhere near enough for a BRANCH_HANDLE_RADIUS handle to clear its
-// neighbor's rendered route envelope, regardless of how much headroom the
-// overall canvas has (confirmed directly: even a much taller canvas doesn't
-// fix this, since D3's value-proportional scale is shared globally across
-// every rank, not adjustable per node).
-//
-// This runs once, right after D3's own layout, as a bounded, deterministic
-// post-process: for every real (non-routing) node, redistribute its
-// incident docks on each side (incoming/outgoing) so adjacent ones are at
-// least MINIMUM_PORT_SPACING apart, growing the node's own box downward
-// first if its natural D3 height is too small to fit them. Routing nodes
-// are skipped -- by construction they always have exactly one link per
-// side, so there is no adjacent-dock gap to enforce. A single compaction
-// pass per rank then pushes any node (real or routing) down just enough to
-// clear a grown predecessor, translating that node's own incident dock
-// positions by the same shift so link geometry stays consistent with its
-// endpoints. calculateLifecycleDiagramLayout already reserves enough total
-// height for the worst-case rank to make growth here rare; the returned
-// overflow (usually 0) covers the remaining edge case where a rank's value
-// distribution is skewed enough that D3 gave most of that reserved height
-// to one large-value node, leaving too little slack for the others --
-// growing the canvas by exactly that amount only adds trailing whitespace,
-// it never rescales or invalidates any node/link position already placed.
-const requiredPortSpan = (incidentCount) =>
-  Math.max(0, incidentCount - 1) * MINIMUM_PORT_SPACING;
-
-// Node boxes are set once by D3 and never touched again outside this
-// function. Grow each real node's box just enough to let its most crowded
-// side fit minimum-spaced docks, then compact same-rank neighbors (real or
-// routing) downward to clear any growth, shifting each moved node's own
-// incident dock positions along with it so link geometry stays consistent
-// with its endpoints.
-const enforceMinimumPortSpacing = (graph, dimensions) => {
-  const nodesByRank = new Map();
-  for (const node of graph.nodes) {
-    if (!(node.routing || Number(node.total) > 0)) continue;
-    if (!nodesByRank.has(node.rank)) nodesByRank.set(node.rank, []);
-    nodesByRank.get(node.rank).push(node);
-  }
-  let maxOverflow = 0;
-  for (const nodes of nodesByRank.values()) {
-    nodes.sort((left, right) => left.y0 - right.y0);
-    for (const node of nodes) {
-      if (node.routing) continue;
-      const incomingCount = graph.links.filter(
-        (link) => link.target === node,
-      ).length;
-      const outgoingCount = graph.links.filter(
-        (link) => link.source === node,
-      ).length;
-      const span = Math.max(
-        requiredPortSpan(incomingCount),
-        requiredPortSpan(outgoingCount),
-      );
-      if (node.y1 - node.y0 < span) node.y1 = node.y0 + span;
-    }
-    for (let index = 1; index < nodes.length; index += 1) {
-      const previous = nodes[index - 1];
-      const node = nodes[index];
-      const minY0 = previous.y1 + ROUTED_NODE_PADDING;
-      if (node.y0 >= minY0) continue;
-      const shift = minY0 - node.y0;
-      node.y0 += shift;
-      node.y1 += shift;
-      for (const link of graph.links) {
-        if (link.source === node) link.y0 += shift;
-        if (link.target === node) link.y1 += shift;
-      }
-    }
-    const last = nodes.at(-1);
-    if (last) {
-      const overflow = last.y1 - (dimensions.height - LAYOUT_BOTTOM_MARGIN);
-      if (overflow > maxOverflow) maxOverflow = overflow;
-    }
-  }
-  return maxOverflow > 0 ? Math.ceil(maxOverflow) : 0;
-};
-
 function layoutLifecycleRoutingGraphPass(
   projection,
   availableWidth,
@@ -796,7 +664,7 @@ function layoutLifecycleRoutingGraphPass(
       },
     ]),
   );
-  let dimensions = calculateLifecycleDiagramLayout(
+  const dimensions = calculateLifecycleDiagramLayout(
     projection,
     availableWidth,
     graph,
@@ -861,26 +729,6 @@ function layoutLifecycleRoutingGraphPass(
     }
   }
   layout.update(graph);
-
-  // Discovery now requires the same full handle-placement and route-audit
-  // validation as the final pass before it may publish a seed (see the
-  // discoveryPhase branch of candidateCallback below), so its own geometry
-  // must actually be handle-feasible too -- port spacing has to run here.
-  // transitionLanePhaseOnly stays excluded: it's a test-only diagnostic
-  // mode (never used in production) that exercises the lane solver's own
-  // ordering search in isolation without ever reaching handle placement, so
-  // shifting dock positions before that search runs would only change how
-  // many states it needs to reach a lane-legal order, unrelated to the
-  // handle-clearance problem this fix targets.
-  if (!options.transitionLanePhaseOnly) {
-    const portSpacingOverflow = enforceMinimumPortSpacing(graph, dimensions);
-    if (portSpacingOverflow > 0) {
-      dimensions = {
-        ...dimensions,
-        height: dimensions.height + portSpacingOverflow,
-      };
-    }
-  }
 
   const orderedBranches = [...graph.branches].sort(compareBranches);
   const branchById = new Map(

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -46,6 +46,10 @@ export const rendererHitBoxForNode = (node) => {
 };
 const LANE_Y_EPSILON = 0.001;
 const COLLISION_MARGIN = -1;
+// Charge dense route generation/auditing slightly conservatively so the
+// deterministic state cap also retains margin beneath the 30-second render
+// latency contract when test workers or the browser contend for a CPU.
+const HANDLE_ROUTE_EDGE_COST_DIVISOR = 6000;
 
 export const buildTransitionPrecedence = ({
   rank,
@@ -2566,6 +2570,14 @@ function layoutLifecycleRoutingGraphPass(
           ]),
         ),
       );
+    if (options.discoveryPhase) {
+      options.discoverySink?.(rankRefinementInfo);
+      // Discovery only needs the solver's deterministic order. Avoid
+      // materializing geometry that will immediately be discarded; besides
+      // eliminating misleading intermediate diagnostics, this keeps the
+      // additional pass inside the production layout's latency bound.
+      return true;
+    }
     const geometrySignature = [...globalAssignments.entries()]
       .sort(([a], [b]) => compareLifecycleIds(a, b))
       .map(([id, y]) => `${id}=${y}`)
@@ -2621,12 +2633,6 @@ function layoutLifecycleRoutingGraphPass(
     // Materialization succeeded: this candidate is no longer implicated by
     // an earlier routing-anchor failure.
     lastRoutingAnchorFailure = null;
-    if (options.discoveryPhase) {
-      options.discoverySink?.(rankRefinementInfo);
-      // Discovery is a production solver phase, but its incomplete geometry is
-      // deliberately discarded by the bounded outer pipeline.
-      return true;
-    }
     if (options.transitionLanePhaseOnly && enableTestDiagnostics) {
       testOnlyDiagnosticSink?.({
         phase: "accepted",
@@ -2669,7 +2675,10 @@ function layoutLifecycleRoutingGraphPass(
       const auditRouteEdgeCount = handleCheck.routeEdgeCount ?? 1;
       handleBudget.statesVisited += Math.max(
         1,
-        Math.round((auditRouteEdgeCount * auditRouteEdgeCount) / 8450),
+        Math.round(
+          (auditRouteEdgeCount * auditRouteEdgeCount) /
+            HANDLE_ROUTE_EDGE_COST_DIVISOR,
+        ),
       );
       if (handleBudget.statesVisited >= handleBudget.stateLimit)
         throwHandleStateLimitExceeded();
@@ -2829,7 +2838,13 @@ const deriveAuthoritativeLayoutOrders = (graph, rankOrderByRank) => {
       if (!node) continue;
       if (!incidentBranchRanks.has(node.id))
         incidentBranchRanks.set(node.id, new Map());
-      incidentBranchRanks.get(node.id).set(link.branchId, rank);
+      const branchRanks = incidentBranchRanks.get(node.id);
+      if (!branchRanks.has(link.branchId))
+        branchRanks.set(link.branchId, new Set());
+      // A continuing node is incident to this branch at both the incoming
+      // and outgoing transition ranks. Retain both positions rather than
+      // allowing link iteration order to overwrite one of them.
+      branchRanks.get(link.branchId).add(rank);
     }
   }
   const nodeOrderByRank = new Map();
@@ -2843,8 +2858,12 @@ const deriveAuthoritativeLayoutOrders = (graph, rankOrderByRank) => {
       if (rank === 0 || rank === 6) return nodeSort(left, right);
       const key = (node) =>
         [...(incidentBranchRanks.get(node.id) ?? [])]
-          .map(([id, transitionRank]) =>
-            branchOrderByRank.get(transitionRank)?.get(id),
+          .flatMap(([id, transitionRanks]) =>
+            [...transitionRanks]
+              .sort((a, b) => a - b)
+              .map((transitionRank) =>
+                branchOrderByRank.get(transitionRank)?.get(id),
+              ),
           )
           .filter(Number.isInteger)
           .sort((a, b) => a - b);
@@ -2879,12 +2898,18 @@ export function layoutLifecycleRoutingGraph(
     return layoutLifecycleRoutingGraphPass(projection, availableWidth, options);
 
   let discoveredRankOrder = null;
+  // D3 mutates both endpoint references and geometry. Clone a supplied graph
+  // for each pass so the option is honored without allowing discovery output
+  // to contaminate the final attempt or the caller's graph.
+  const freshRoutingGraph = () =>
+    options.routingGraph ? structuredClone(options.routingGraph) : undefined;
   const discovery = layoutLifecycleRoutingGraphPass(
     projection,
     availableWidth,
     {
       ...options,
-      routingGraph: undefined,
+      routingGraph: freshRoutingGraph(),
+      debugOrder: false,
       discoveryPhase: true,
       discoverySink(info) {
         discoveredRankOrder = new Map(
@@ -2904,7 +2929,7 @@ export function layoutLifecycleRoutingGraph(
   );
   const result = layoutLifecycleRoutingGraphPass(projection, availableWidth, {
     ...options,
-    routingGraph: undefined,
+    routingGraph: freshRoutingGraph(),
     authoritativeBranchOrderByRank: orders.branchOrderByRank,
     authoritativeNodeOrderByRank: orders.nodeOrderByRank,
   });
@@ -3900,7 +3925,9 @@ const tryAssignBranchHandles = (
   const routeEdgeCount = routeEdges.length;
   const generationCost = Math.max(
     1,
-    Math.round((routeEdgeCount * routeEdgeCount) / 8450),
+    Math.round(
+      (routeEdgeCount * routeEdgeCount) / HANDLE_ROUTE_EDGE_COST_DIVISOR,
+    ),
   );
   if (sharedBudget) {
     if (sharedBudget.statesVisited >= sharedBudget.stateLimit) {

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -50,6 +50,33 @@ const COLLISION_MARGIN = -1;
 // deterministic state cap also retains margin beneath the 30-second render
 // latency contract when test workers or the browser contend for a CPU.
 const HANDLE_ROUTE_EDGE_COST_DIVISOR = 6000;
+// Primary handle-candidate sample points: three points near the middle of a
+// segment's transition corridor, tried first so ordinary (sparse) fixtures
+// keep selecting the same candidates they always have.
+const HANDLE_CANDIDATE_T_VALUES = Object.freeze([0.5, 0.35, 0.65]);
+// A branch whose docks are pinched close together by convergent nonincident
+// routes (many branches from different sources fanning into one small
+// target node) can have every one of the three primary sample points blocked
+// even though the curve legally clears somewhere else along its length --
+// confirmed directly against a real dense production fixture where a finer
+// sweep found a legal point the primary three simply never sampled. This
+// finer grid is tried only once the primary set finds nothing, so it never
+// changes which candidate an already-working branch selects.
+const HANDLE_FALLBACK_CANDIDATE_T_VALUES = Object.freeze([
+  0.1, 0.15, 0.2, 0.25, 0.275, 0.3, 0.4, 0.425, 0.45, 0.55, 0.575, 0.6, 0.7,
+  0.725, 0.75, 0.8, 0.85, 0.9,
+]);
+// Last-resort corridor buffer for handle placement only, used solely when
+// both t-value sets above are exhausted for the standard
+// RANK_CORRIDOR_HALF_WIDTH corridor. RANK_CORRIDOR_HALF_WIDTH keeps handles
+// away from a node's edge for visual clarity, but the actual safety
+// boundary against overlapping node/label/hit geometry is
+// fixedGeometryBlockerForCandidate, which this narrower buffer does not
+// bypass -- confirmed directly that points just inside the standard
+// corridor's excluded zone, near a shared convergent target, still clear
+// fixed geometry cleanly. Relaxing this cosmetic buffer only as a final
+// fallback cannot weaken the actual collision envelope.
+const HANDLE_FALLBACK_CORRIDOR_HALF_WIDTH = 40;
 
 export const buildTransitionPrecedence = ({
   rank,
@@ -4077,90 +4104,105 @@ const tryAssignBranchHandles = (
         diagnostic.nearestRejectedCandidate = candidate;
       }
     };
-    for (const segment of orderedSegments) {
-      const sourceCenter = rankCenterX(segment.source.rank);
-      const targetCenter = rankCenterX(segment.target.rank);
-      const exitX = sourceCenter + RANK_CORRIDOR_HALF_WIDTH;
-      const entryX = targetCenter - RANK_CORRIDOR_HALF_WIDTH;
-      for (const t of [0.5, 0.35, 0.65]) {
-        const { x, y } = cubicTransitionPoint(segment, t);
-        const box = {
-          x: x - BRANCH_HANDLE_RADIUS,
-          y: y - BRANCH_HANDLE_RADIUS,
-          width: BRANCH_HANDLE_RADIUS * 2,
-          height: BRANCH_HANDLE_RADIUS * 2,
-        };
-        diagnostic.attempts += 1;
-        const baseRejected = {
-          segmentId: segmentKey(segment),
-          segmentIndex: segment.segmentIndex,
-          transitionRank: segment.source?.rank,
-          t,
-          x: quantizedCandidate(x),
-          y: quantizedCandidate(y),
-        };
-        const fixedBlocker = fixedGeometryBlockerForCandidate(box);
-        if (fixedBlocker) {
-          diagnostic.rejected.fixedGeometry += 1;
-          rememberRejected({
-            ...baseRejected,
-            clearanceMargin: COLLISION_MARGIN,
-            blocker: {
-              kind: fixedBlocker.kind,
-              id: fixedBlocker.id,
-              branchId: null,
-              segmentId: null,
-              transitionRank: null,
-              zone: null,
-            },
-          });
-          continue;
-        }
-        if (
-          x - BRANCH_HANDLE_RADIUS < exitX ||
-          x + BRANCH_HANDLE_RADIUS > entryX
-        ) {
-          diagnostic.rejected.outsideTransitionCorridor += 1;
-          rememberRejected({
-            ...baseRejected,
-            clearanceMargin: COLLISION_MARGIN,
-            blocker: {
-              kind: "corridor-bounds",
-              id: `${segment.source?.rank}->${segment.target?.rank}`,
-              branchId: null,
-              segmentId: null,
-              transitionRank: segment.source?.rank,
-              zone: "transition-corridor",
-            },
-          });
-          continue;
-        }
-        const clearance = renderedBranchClearance(
-          branch,
-          segment.source?.rank,
-          x,
-          y,
-        );
-        const clearanceMargin = clearance.margin;
-        if (clearanceMargin > 0) {
-          diagnostic.accepted += 1;
-          candidates.push({
-            branchId: branch.id,
+    const sweepCorridor = (tValues, corridorHalfWidth) => {
+      for (const segment of orderedSegments) {
+        const sourceCenter = rankCenterX(segment.source.rank);
+        const targetCenter = rankCenterX(segment.target.rank);
+        const exitX = sourceCenter + corridorHalfWidth;
+        const entryX = targetCenter - corridorHalfWidth;
+        for (const t of tValues) {
+          const { x, y } = cubicTransitionPoint(segment, t);
+          const box = {
+            x: x - BRANCH_HANDLE_RADIUS,
+            y: y - BRANCH_HANDLE_RADIUS,
+            width: BRANCH_HANDLE_RADIUS * 2,
+            height: BRANCH_HANDLE_RADIUS * 2,
+          };
+          diagnostic.attempts += 1;
+          const baseRejected = {
+            segmentId: segmentKey(segment),
+            segmentIndex: segment.segmentIndex,
+            transitionRank: segment.source?.rank,
+            t,
+            x: quantizedCandidate(x),
+            y: quantizedCandidate(y),
+          };
+          const fixedBlocker = fixedGeometryBlockerForCandidate(box);
+          if (fixedBlocker) {
+            diagnostic.rejected.fixedGeometry += 1;
+            rememberRejected({
+              ...baseRejected,
+              clearanceMargin: COLLISION_MARGIN,
+              blocker: {
+                kind: fixedBlocker.kind,
+                id: fixedBlocker.id,
+                branchId: null,
+                segmentId: null,
+                transitionRank: null,
+                zone: null,
+              },
+            });
+            continue;
+          }
+          if (
+            x - BRANCH_HANDLE_RADIUS < exitX ||
+            x + BRANCH_HANDLE_RADIUS > entryX
+          ) {
+            diagnostic.rejected.outsideTransitionCorridor += 1;
+            rememberRejected({
+              ...baseRejected,
+              clearanceMargin: COLLISION_MARGIN,
+              blocker: {
+                kind: "corridor-bounds",
+                id: `${segment.source?.rank}->${segment.target?.rank}`,
+                branchId: null,
+                segmentId: null,
+                transitionRank: segment.source?.rank,
+                zone: "transition-corridor",
+              },
+            });
+            continue;
+          }
+          const clearance = renderedBranchClearance(
+            branch,
+            segment.source?.rank,
             x,
             y,
-            radius: BRANCH_HANDLE_RADIUS,
-            box,
-            clearanceMargin,
-          });
-        } else {
-          diagnostic.rejected.nonincidentRouteClearance += 1;
-          rememberRejected({
-            ...baseRejected,
-            clearanceMargin: quantizedCandidate(clearanceMargin),
-            blocker: clearance.blocker,
-          });
+          );
+          const clearanceMargin = clearance.margin;
+          if (clearanceMargin > 0) {
+            diagnostic.accepted += 1;
+            candidates.push({
+              branchId: branch.id,
+              x,
+              y,
+              radius: BRANCH_HANDLE_RADIUS,
+              box,
+              clearanceMargin,
+            });
+          } else {
+            diagnostic.rejected.nonincidentRouteClearance += 1;
+            rememberRejected({
+              ...baseRejected,
+              clearanceMargin: quantizedCandidate(clearanceMargin),
+              blocker: clearance.blocker,
+            });
+          }
         }
       }
+    };
+    sweepCorridor(HANDLE_CANDIDATE_T_VALUES, RANK_CORRIDOR_HALF_WIDTH);
+    if (!candidates.length) {
+      sweepCorridor(
+        HANDLE_FALLBACK_CANDIDATE_T_VALUES,
+        RANK_CORRIDOR_HALF_WIDTH,
+      );
+    }
+    if (!candidates.length) {
+      sweepCorridor(
+        HANDLE_FALLBACK_CANDIDATE_T_VALUES,
+        HANDLE_FALLBACK_CORRIDOR_HALF_WIDTH,
+      );
     }
     candidateSets.set(
       branch.id,

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -671,9 +671,14 @@ function layoutLifecycleRoutingGraphPass(
       return nodeSort(left, right);
     })
     .linkSort((left, right) => {
-      const order = options.authoritativeBranchOrderByRank?.get(
-        left.source.rank,
-      );
+      // D3 invokes linkSort for a node's source links and target links. Keep
+      // the lookup tied to that shared transition rather than treating an
+      // index from another rank-local order as comparable.
+      const transitionRank =
+        left.source.id === right.source.id
+          ? left.source.rank
+          : left.target.rank - 1;
+      const order = options.authoritativeBranchOrderByRank?.get(transitionRank);
       const leftIndex = order?.get(left.branchId);
       const rightIndex = order?.get(right.branchId);
       return (
@@ -2560,16 +2565,6 @@ function layoutLifecycleRoutingGraphPass(
   const candidateCallback = (globalAssignments, rankRefinementInfo) => {
     restoreBaseline();
     candidateEvaluations += 1;
-    if (options.debugOrder && candidateEvaluations === 1)
-      console.error(
-        "ORDER",
-        JSON.stringify(
-          [...rankRefinementInfo].map(([rank, info]) => [
-            rank,
-            info.rankOrder.map((entry) => entry.branchId),
-          ]),
-        ),
-      );
     if (options.discoveryPhase) {
       options.discoverySink?.(rankRefinementInfo);
       // Discovery only needs the solver's deterministic order. Avoid
@@ -2812,10 +2807,18 @@ function layoutLifecycleRoutingGraphPass(
 const compareOrderKeys = (left, right) => {
   const count = Math.max(left.length, right.length);
   for (let index = 0; index < count; index += 1) {
-    const difference =
-      (left[index] ?? Number.MAX_SAFE_INTEGER) -
-      (right[index] ?? Number.MAX_SAFE_INTEGER);
-    if (difference) return difference;
+    const leftEntry = left[index];
+    const rightEntry = right[index];
+    if (!leftEntry || !rightEntry) return leftEntry ? -1 : rightEntry ? 1 : 0;
+    for (const field of ["transitionRank", "side", "position"]) {
+      const difference = leftEntry[field] - rightEntry[field];
+      if (difference) return difference;
+    }
+    const branchDifference = compareLifecycleIds(
+      leftEntry.branchId,
+      rightEntry.branchId,
+    );
+    if (branchDifference) return branchDifference;
   }
   return 0;
 };
@@ -2827,24 +2830,33 @@ const deriveAuthoritativeLayoutOrders = (graph, rankOrderByRank) => {
       new Map(ids.map((id, index) => [id, index])),
     ]),
   );
-  const incidentBranchRanks = new Map();
+  const incidentBranchPositions = new Map();
   for (const link of graph.links) {
     const source = typeof link.source === "object" ? link.source : null;
     const target = typeof link.target === "object" ? link.target : null;
-    for (const [node, rank] of [
-      [source, source?.rank],
-      [target, source?.rank],
+    for (const [node, transitionRank, side] of [
+      [source, source?.rank, 1],
+      [target, source?.rank, 0],
     ]) {
       if (!node) continue;
-      if (!incidentBranchRanks.has(node.id))
-        incidentBranchRanks.set(node.id, new Map());
-      const branchRanks = incidentBranchRanks.get(node.id);
-      if (!branchRanks.has(link.branchId))
-        branchRanks.set(link.branchId, new Set());
-      // A continuing node is incident to this branch at both the incoming
-      // and outgoing transition ranks. Retain both positions rather than
-      // allowing link iteration order to overwrite one of them.
-      branchRanks.get(link.branchId).add(rank);
+      const position = branchOrderByRank
+        .get(transitionRank)
+        ?.get(link.branchId);
+      if (!Number.isInteger(position)) continue;
+      if (!incidentBranchPositions.has(node.id))
+        incidentBranchPositions.set(node.id, new Map());
+      // The tuple key makes incoming/outgoing context explicit. In
+      // particular, position 2 at rank N is never compared as though it were
+      // position 2 at rank N+1. The map key also makes reversed link input
+      // idempotent without dropping either side of a continuing branch.
+      incidentBranchPositions
+        .get(node.id)
+        .set(`${transitionRank}\0${side}\0${link.branchId}`, {
+          transitionRank,
+          side,
+          position,
+          branchId: link.branchId,
+        });
     }
   }
   const nodeOrderByRank = new Map();
@@ -2852,30 +2864,85 @@ const deriveAuthoritativeLayoutOrders = (graph, rankOrderByRank) => {
     (a, b) => a - b,
   )) {
     const nodes = graph.nodes.filter((node) => node.rank === rank);
-    nodes.sort((left, right) => {
-      // Keep the product's origin/endpoint anchoring contract while using the
-      // solver order for every unanchored rank.
-      if (rank === 0 || rank === 6) return nodeSort(left, right);
-      const key = (node) =>
-        [...(incidentBranchRanks.get(node.id) ?? [])]
-          .flatMap(([id, transitionRanks]) =>
-            [...transitionRanks]
-              .sort((a, b) => a - b)
-              .map((transitionRank) =>
-                branchOrderByRank.get(transitionRank)?.get(id),
+    const stableNodeOrder = (left, right) =>
+      Number(left.routing) - Number(right.routing) ||
+      taxonomyOrder(left.id) - taxonomyOrder(right.id) ||
+      compareLifecycleIds(left.id, right.id);
+    if (rank === 0 || rank === 6) {
+      nodes.sort(nodeSort);
+    } else {
+      const outgoing = new Map(nodes.map((node) => [node.id, new Set()]));
+      const indegree = new Map(nodes.map((node) => [node.id, 0]));
+      // Incoming and outgoing transition orders are separate authoritative
+      // contexts. Add constraints within each context, rather than comparing
+      // their rank-local integer positions directly.
+      for (const [transitionRank, side] of [
+        [rank - 1, 0],
+        [rank, 1],
+      ]) {
+        const contextual = nodes
+          .map((node) => ({
+            node,
+            key: [...(incidentBranchPositions.get(node.id)?.values() ?? [])]
+              .filter(
+                (entry) =>
+                  entry.transitionRank === transitionRank &&
+                  entry.side === side,
+              )
+              .sort(
+                (a, b) =>
+                  a.position - b.position ||
+                  compareLifecycleIds(a.branchId, b.branchId),
               ),
-          )
-          .filter(Number.isInteger)
-          .sort((a, b) => a - b);
-      const leftKey = key(left);
-      const rightKey = key(right);
-      return (
-        compareOrderKeys(leftKey, rightKey) ||
-        Number(left.routing) - Number(right.routing) ||
-        taxonomyOrder(left.id) - taxonomyOrder(right.id) ||
-        compareLifecycleIds(left.id, right.id)
-      );
-    });
+          }))
+          .filter(({ key }) => key.length)
+          .sort(
+            (a, b) =>
+              compareOrderKeys(a.key, b.key) || stableNodeOrder(a.node, b.node),
+          );
+        for (let index = 1; index < contextual.length; index += 1) {
+          const from = contextual[index - 1].node.id;
+          const to = contextual[index].node.id;
+          if (!outgoing.get(from).has(to)) {
+            outgoing.get(from).add(to);
+            indegree.set(to, indegree.get(to) + 1);
+          }
+        }
+      }
+      const ready = nodes
+        .filter((node) => indegree.get(node.id) === 0)
+        .sort(stableNodeOrder);
+      const combined = [];
+      while (ready.length) {
+        const node = ready.shift();
+        combined.push(node);
+        for (const targetId of outgoing.get(node.id)) {
+          indegree.set(targetId, indegree.get(targetId) - 1);
+          if (indegree.get(targetId) === 0) {
+            ready.push(nodes.find((candidate) => candidate.id === targetId));
+            ready.sort(stableNodeOrder);
+          }
+        }
+      }
+      if (combined.length !== nodes.length) {
+        const error = new Error(
+          `Lifecycle authoritative node order disagrees at rank ${rank}`,
+        );
+        error.cause = Object.freeze({
+          type: "lifecycle-authoritative-rank-order",
+          reason: "order-disagreement",
+          rank,
+          nodeIds: Object.freeze(
+            nodes
+              .filter((node) => indegree.get(node.id) > 0)
+              .map((node) => node.id)
+              .sort(compareLifecycleIds),
+          ),
+        });
+        throw error;
+      }
+      nodes.splice(0, nodes.length, ...combined);
+    }
     nodeOrderByRank.set(
       rank,
       new Map(nodes.map((node, index) => [node.id, index])),
@@ -2955,8 +3022,14 @@ export function layoutLifecycleRoutingGraph(
   result.graph.transitionLaneSolverStats = Object.freeze({
     ...result.graph.transitionLaneSolverStats,
     layoutAttempts: Object.freeze([
-      Object.freeze({ ...discovery.graph.transitionLaneSolverStats }),
-      Object.freeze({ ...result.graph.transitionLaneSolverStats }),
+      Object.freeze({
+        phase: "discovery",
+        ...discovery.graph.transitionLaneSolverStats,
+      }),
+      Object.freeze({
+        phase: "final",
+        ...result.graph.transitionLaneSolverStats,
+      }),
     ]),
     layoutAttemptCount: 2,
   });

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -72,12 +72,12 @@ const HANDLE_CANDIDATE_T_VALUES = Object.freeze([0.5, 0.35, 0.65]);
 // confirmed directly against a real dense production fixture where a finer
 // sweep found a legal point the primary three simply never sampled. This
 // finer grid is tried only once the primary set finds nothing, so it never
-// changes which candidate an already-working branch selects.
-// A systematic fine grid rather than a hand-picked list: a legal window
-// between where a route clears nonincident branches and where it enters a
-// node's own fixed geometry (label/hit box) can be only a few hundredths of
-// t wide (confirmed directly), so a sparser or hand-picked fallback set can
-// straddle it and still find nothing.
+// changes which candidate an already-working branch selects. A systematic
+// grid rather than a hand-picked list: a legal window between where a route
+// clears nonincident branches and where it enters a node's own fixed
+// geometry (label/hit box) can be only a few hundredths of t wide (confirmed
+// directly), so a sparser or hand-picked fallback set can straddle it and
+// still find nothing.
 const HANDLE_FALLBACK_CANDIDATE_T_VALUES = Object.freeze(
   Array.from(
     { length: 10 },
@@ -722,13 +722,11 @@ const requiredPortSpan = (incidentCount) =>
   Math.max(0, incidentCount - 1) * MINIMUM_PORT_SPACING;
 
 // Node boxes are set once by D3 and never touched again outside this
-// function (link dock positions, by contrast, get recomputed by
-// materializeLaneAssignments on every candidate -- see
-// enforceLinkDockSpacing below). Grow each real node's box just enough to
-// let its most crowded side fit minimum-spaced docks, then compact same-
-// rank neighbors (real or routing) downward to clear any growth, shifting
-// each moved node's own incident dock positions along with it so link
-// geometry stays consistent with its endpoints.
+// function. Grow each real node's box just enough to let its most crowded
+// side fit minimum-spaced docks, then compact same-rank neighbors (real or
+// routing) downward to clear any growth, shifting each moved node's own
+// incident dock positions along with it so link geometry stays consistent
+// with its endpoints.
 const enforceMinimumPortSpacing = (graph, dimensions) => {
   const nodesByRank = new Map();
   for (const node of graph.nodes) {
@@ -773,57 +771,6 @@ const enforceMinimumPortSpacing = (graph, dimensions) => {
     }
   }
   return maxOverflow > 0 ? Math.ceil(maxOverflow) : 0;
-};
-
-// materializeLaneAssignments blends each real node's per-link dock position
-// toward that candidate's transition-lane assignment (see its evenY/laneY
-// blend), which can pull adjacent docks back together even after
-// enforceMinimumPortSpacing has grown the node to fit them evenly spaced.
-// Run once per candidate, immediately after that blend, as the final,
-// authoritative word on real-node dock spacing: nudge apart only the docks
-// on each side that are closer than MINIMUM_PORT_SPACING, keeping every
-// dock as close as possible to its original blended position (a forward
-// pass that only pushes a dock later than its predecessor when it must,
-// rather than recentering the whole side) so this perturbs the
-// order-consistent geometry the lane solver and D3 already agreed on as
-// little as possible. Routing nodes are untouched -- they always have
-// exactly one link per side.
-const enforceLinkDockSpacing = (graph) => {
-  const realNodes = graph.nodes.filter(
-    (node) => !node.routing && Number(node.total) > 0,
-  );
-  const round = (value) => Math.round(value * 1000) / 1000;
-  const redistribute = (links, dockKey, node) => {
-    if (links.length < 2) return;
-    links.sort((left, right) => left[dockKey] - right[dockKey]);
-    for (let index = 1; index < links.length; index += 1) {
-      const minY = links[index - 1][dockKey] + MINIMUM_PORT_SPACING;
-      if (links[index][dockKey] < minY) links[index][dockKey] = minY;
-    }
-    const last = links.at(-1);
-    if (last[dockKey] > node.y1) {
-      const shift = last[dockKey] - node.y1;
-      for (const link of links) link[dockKey] -= shift;
-    }
-    const first = links[0];
-    if (first[dockKey] < node.y0) {
-      const shift = node.y0 - first[dockKey];
-      for (const link of links) link[dockKey] += shift;
-    }
-    for (const link of links) link[dockKey] = round(link[dockKey]);
-  };
-  for (const node of realNodes) {
-    redistribute(
-      graph.links.filter((link) => link.target === node),
-      "y1",
-      node,
-    );
-    redistribute(
-      graph.links.filter((link) => link.source === node),
-      "y0",
-      node,
-    );
-  }
 };
 
 function layoutLifecycleRoutingGraphPass(
@@ -915,20 +862,17 @@ function layoutLifecycleRoutingGraphPass(
   }
   layout.update(graph);
 
-  // Discovery only needs the transition-lane solver's deterministic order
-  // decision, not correct final geometry (see the discoveryPhase branch of
-  // candidateCallback below) — running this here would shift link dock
-  // positions the solver's own idealY seeding reads before it ever makes
-  // that decision, changing which order it finds rather than just fixing
-  // geometry, which can produce an order the final pass's real-node
-  // topological derivation cannot reconcile (confirmed directly). Keep
-  // discovery's input geometry exactly as D3 produced it. The same applies
-  // to transitionLanePhaseOnly, a test-only diagnostic mode that exercises
-  // the lane solver's own ordering search in isolation (never used in
-  // production) — shifting dock positions before that search runs changes
-  // how many states it needs to reach a lane-legal order, unrelated to the
+  // Discovery now requires the same full handle-placement and route-audit
+  // validation as the final pass before it may publish a seed (see the
+  // discoveryPhase branch of candidateCallback below), so its own geometry
+  // must actually be handle-feasible too -- port spacing has to run here.
+  // transitionLanePhaseOnly stays excluded: it's a test-only diagnostic
+  // mode (never used in production) that exercises the lane solver's own
+  // ordering search in isolation without ever reaching handle placement, so
+  // shifting dock positions before that search runs would only change how
+  // many states it needs to reach a lane-legal order, unrelated to the
   // handle-clearance problem this fix targets.
-  if (!options.discoveryPhase && !options.transitionLanePhaseOnly) {
+  if (!options.transitionLanePhaseOnly) {
     const portSpacingOverflow = enforceMinimumPortSpacing(graph, dimensions);
     if (portSpacingOverflow > 0) {
       dimensions = {
@@ -2449,6 +2393,129 @@ function layoutLifecycleRoutingGraphPass(
         return search();
       };
 
+      // A pristine final pass can replay discovery's already-proven
+      // assignment instead of re-deriving it via a second independent
+      // search — discovery only ever publishes a seed after that exact
+      // candidate cleared full handle placement and route-crossing audit
+      // validation (see the discoveryPhase branch of candidateCallback
+      // above), so replaying it here is a verify, not a search. Every
+      // reused value is still validated against *this* pass's own fresh
+      // variables/intervals/components (all rebuilt above from this pass's
+      // pristine graph) before being trusted — nothing from discovery's own
+      // geometry, obstacles, or caches is reused. See
+      // docs/design/lifecycle-diagram-handle-search-seeding-plan.md.
+      if (options.seedAssignments && options.seedRankOrderByRank) {
+        const throwSeedReplayFailed = (detail, rank = null) => {
+          const error = new Error(
+            `Lifecycle authoritative rank order seed replay failed: ${detail}`,
+          );
+          error.cause = Object.freeze({
+            type: "lifecycle-authoritative-rank-order",
+            reason: "seed-replay-failed",
+            detail,
+            rank,
+          });
+          throw error;
+        };
+        const seedIds = new Set(options.seedAssignments.keys());
+        const allIdsSet = new Set(allLinkIds);
+        const idsMatch =
+          seedIds.size === allIdsSet.size &&
+          [...allIdsSet].every((id) => seedIds.has(id));
+        if (!idsMatch) throwSeedReplayFailed("link-id-coverage-mismatch");
+        for (const rank of sortedRanks) {
+          const rankVars = variablesByRank.get(rank) ?? [];
+          if (!rankVars.length) continue;
+          const seedOrderAtRank = options.seedRankOrderByRank.get(rank);
+          if (!seedOrderAtRank)
+            throwSeedReplayFailed("missing-rank-order", rank);
+          const varByBranch = new Map(rankVars.map((v) => [v.branchId, v]));
+          const rankOrder = seedOrderAtRank
+            .filter((branchId) => varByBranch.has(branchId))
+            .map((branchId) => varByBranch.get(branchId));
+          if (rankOrder.length !== rankVars.length)
+            throwSeedReplayFailed("rank-order-coverage-mismatch", rank);
+          const authoritativeOrderAtRank =
+            options.authoritativeBranchOrderByRank?.get(rank);
+          for (let index = 0; index < rankOrder.length; index += 1) {
+            if (index > 0 && authoritativeOrderAtRank) {
+              const previousIndex = authoritativeOrderAtRank.get(
+                rankOrder[index - 1].branchId,
+              );
+              const currentIndex = authoritativeOrderAtRank.get(
+                rankOrder[index].branchId,
+              );
+              if (
+                Number.isInteger(previousIndex) &&
+                Number.isInteger(currentIndex) &&
+                previousIndex > currentIndex
+              )
+                throwSeedReplayFailed("authoritative-order-mismatch", rank);
+            }
+          }
+          const cen = rankOrder.map((variable) => {
+            const y = options.seedAssignments.get(variable.id);
+            if (!Number.isFinite(y))
+              throwSeedReplayFailed("non-finite-seed-value", rank);
+            return y;
+          });
+          for (let index = 0; index < rankOrder.length; index += 1) {
+            const variable = rankOrder[index];
+            const y = cen[index];
+            // Charge one state per seed value verified against this pass's
+            // own fresh domain, at the same granularity assignMonotoneIntervals
+            // uses for an ordinary search item -- replay is real, bounded
+            // verification work, not a free pass on the 200,000-state limit.
+            recordSolverState({
+              rank,
+              branchIds: [variable.branchId],
+              linkIds: [variable.id],
+            });
+            const withinFreshInterval = variable.intervals.some(
+              ([start, end]) =>
+                y >= start - LANE_Y_EPSILON && y <= end + LANE_Y_EPSILON,
+            );
+            if (
+              !withinFreshInterval ||
+              !candidateClearsSpan(
+                y,
+                variable.minX,
+                variable.maxX,
+                variable.incidentIds,
+              )
+            ) {
+              throwSeedReplayFailed("seed-value-illegal", rank);
+            }
+            if (
+              index > 0 &&
+              y < cen[index - 1] + minLaneSpacing - LANE_Y_EPSILON
+            )
+              throwSeedReplayFailed("seed-spacing-violated", rank);
+          }
+          rankRefinementInfo.set(rank, { rankOrder, cen, minLaneSpacing });
+          for (let index = 0; index < rankOrder.length; index += 1)
+            globalAssignments.set(rankOrder[index].id, cen[index]);
+        }
+        for (const branchIds of componentList) {
+          const compMinId = branchIds.reduce((a, b) =>
+            compareLifecycleIds(a, b) < 0 ? a : b,
+          );
+          componentMembers.set(compMinId, branchIds.slice());
+        }
+        if (
+          !candidateCallback ||
+          !candidateCallback(globalAssignments, rankRefinementInfo)
+        ) {
+          throwSeedReplayFailed("handle-or-audit-rejected");
+        }
+        return {
+          assignments: globalAssignments,
+          componentOrderings,
+          componentMembers,
+          rankRefinementInfo,
+        };
+      }
+
       if (!solveFromComponent(0)) {
         const allBranchIds = componentList.flat();
         const cause = laneFailureCause("no-feasible-topological-order", {
@@ -2733,7 +2800,25 @@ function layoutLifecycleRoutingGraphPass(
         );
       }
     }
-    enforceLinkDockSpacing(graph);
+    // Routing-node anchors are their own monotone-assignment DP, seeded
+    // from (but not equal to) the transitionLaneY values above -- distinct
+    // legal anchor positions can score identically in that DP, so it is
+    // not provably deterministic across otherwise-identical passes
+    // (confirmed directly: a fresh replay of discovery's exact seeded lane
+    // values still produced a routing anchor a few hundredths of a pixel
+    // off from discovery's own, which was enough to fail the
+    // route-crossing audit discovery's own geometry had already cleared).
+    // When the caller supplies discovery's own final dock positions,
+    // reproduce them exactly instead of trusting a second DP solve to land
+    // on the same one.
+    if (options.seedLinkDocks) {
+      for (const link of graph.links) {
+        const dock = options.seedLinkDocks.get(link.id);
+        if (!dock) continue;
+        link.y0 = dock.y0;
+        link.y1 = dock.y1;
+      }
+    }
   };
 
   let lastHandleFailure = null;
@@ -2799,14 +2884,6 @@ function layoutLifecycleRoutingGraphPass(
   const candidateCallback = (globalAssignments, rankRefinementInfo) => {
     restoreBaseline();
     candidateEvaluations += 1;
-    if (options.discoveryPhase) {
-      options.discoverySink?.(rankRefinementInfo);
-      // Discovery only needs the solver's deterministic order. Avoid
-      // materializing geometry that will immediately be discarded; besides
-      // eliminating misleading intermediate diagnostics, this keeps the
-      // additional pass inside the production layout's latency bound.
-      return true;
-    }
     const geometrySignature = [...globalAssignments.entries()]
       .sort(([a], [b]) => compareLifecycleIds(a, b))
       .map(([id, y]) => `${id}=${y}`)
@@ -2877,7 +2954,7 @@ function layoutLifecycleRoutingGraphPass(
       graph.branches,
       linksByBranch,
       visibleNodes,
-      { sharedBudget: handleBudget },
+      { sharedBudget: handleBudget, seedHandles: options.seedHandles },
     );
     lastHandleRouteEdgeCount = handleCheck.routeEdgeCount ?? null;
     if (handleCheck.ok) {
@@ -2925,6 +3002,34 @@ function layoutLifecycleRoutingGraphPass(
             handleBudget,
             transitionLaneSolverStats,
           });
+        }
+        if (options.discoveryPhase) {
+          // Discovery may only publish a seed for the final pass to replay
+          // once this exact candidate has cleared the same full bar
+          // (materialized lane assignment, successful handle placement,
+          // zero fatal route-audit findings) the final pass itself
+          // requires — accepting the first merely lane-legal candidate let
+          // discovery hand the final pass an order a real dense fixture
+          // could never satisfy, since handle placement is exactly where
+          // dense convergent geometry fails. See
+          // docs/design/lifecycle-diagram-handle-search-seeding-plan.md.
+          //
+          // Handle positions are part of the seed too, not just lane
+          // geometry: solveHandleCandidateSets' multi-branch backtracking
+          // can have more than one legal global assignment for identical
+          // lane geometry, and which one it lands on depends on the shared
+          // budget's accumulated state (discovery has already spent many
+          // states on earlier rejected candidates; a fresh final pass
+          // starts near zero) -- confirmed directly, a small fixture's
+          // discovery run picked a different (still individually legal)
+          // handle for a multi-segment branch than a fresh run of the exact
+          // same lane geometry did, and the fresh pick failed the
+          // route-crossing audit discovery's own pick had already cleared.
+          options.discoverySink?.(
+            rankRefinementInfo,
+            globalAssignments,
+            handleCheck.handles,
+          );
         }
         return true;
       }
@@ -3199,6 +3304,21 @@ export function layoutLifecycleRoutingGraph(
     return layoutLifecycleRoutingGraphPass(projection, availableWidth, options);
 
   let discoveredRankOrder = null;
+  // The exact lane-Y value discovery chose for each link, captured only
+  // once that candidate has cleared full handle placement and route-audit
+  // validation (see the discoveryPhase branch of candidateCallback) — the
+  // final pass replays this directly instead of re-deriving it via a
+  // second independent search. See
+  // docs/design/lifecycle-diagram-handle-search-seeding-plan.md.
+  let discoveredAssignments = null;
+  // The exact handle positions discovery's own tryAssignBranchHandles chose
+  // for this same, already-validated candidate -- replayed directly by the
+  // final pass instead of re-searching, since solveHandleCandidateSets' own
+  // backtracking can land on a different (individually legal) global
+  // assignment for identical lane geometry depending on the shared budget's
+  // accumulated state (confirmed directly). See
+  // docs/design/lifecycle-diagram-handle-search-seeding-plan.md.
+  let discoveredHandles = null;
   // D3 mutates both endpoint references and geometry. Clone a supplied graph
   // for each pass so the option is honored without allowing discovery output
   // to contaminate the final attempt or the caller's graph.
@@ -3212,27 +3332,69 @@ export function layoutLifecycleRoutingGraph(
       routingGraph: freshRoutingGraph(),
       debugOrder: false,
       discoveryPhase: true,
-      discoverySink(info) {
+      discoverySink(info, assignments, handles) {
         discoveredRankOrder = new Map(
           [...info].map(([rank, value]) => [
             rank,
             Object.freeze(value.rankOrder.map((entry) => entry.branchId)),
           ]),
         );
+        discoveredAssignments = Object.freeze(new Map(assignments));
+        discoveredHandles = Object.freeze(
+          new Map(handles.map((handle) => [handle.branchId, handle])),
+        );
       },
     },
   );
-  if (!discoveredRankOrder)
+  if (!discoveredRankOrder || !discoveredAssignments || !discoveredHandles)
     throw new Error("Lifecycle rank-order discovery produced no order");
   const orders = deriveAuthoritativeLayoutOrders(
     discovery.graph,
     discoveredRankOrder,
   );
+  // deriveAuthoritativeLayoutOrders' nodeOrderByRank resolves a node's
+  // incoming/outgoing branch positions into a single combined order, which
+  // is a *different* sorting criterion than the endpoint-median heuristic
+  // nodeSort itself used to arrange discovery's own (unconstrained) D3
+  // layout -- the two usually agree but can diverge (confirmed directly: a
+  // seed replay failed "seed-value-illegal" for the small routing fixture
+  // because the combined order placed a rank-1 node differently than
+  // discovery's own layout had it, shifting the obstacle a seed value from
+  // discovery's own geometry needed to stay clear of). Since seed replay's
+  // whole point is reproducing discovery's *exact* geometry, not
+  // re-deriving a merged order, drive the final pass's D3 nodeSort from
+  // discovery's own resulting node positions directly.
+  const discoveredNodeOrderByRank = new Map();
+  const discoveredNodesByRank = new Map();
+  for (const node of discovery.graph.nodes) {
+    if (!discoveredNodesByRank.has(node.rank))
+      discoveredNodesByRank.set(node.rank, []);
+    discoveredNodesByRank.get(node.rank).push(node);
+  }
+  for (const [rank, nodes] of discoveredNodesByRank) {
+    const sorted = [...nodes].sort(
+      (a, b) => a.y0 - b.y0 || compareLifecycleIds(a.id, b.id),
+    );
+    discoveredNodeOrderByRank.set(
+      rank,
+      new Map(sorted.map((node, index) => [node.id, index])),
+    );
+  }
+  const discoveredLinkDocks = new Map(
+    discovery.graph.links.map((link) => [
+      link.id,
+      { y0: link.y0, y1: link.y1 },
+    ]),
+  );
   const result = layoutLifecycleRoutingGraphPass(projection, availableWidth, {
     ...options,
     routingGraph: freshRoutingGraph(),
     authoritativeBranchOrderByRank: orders.branchOrderByRank,
-    authoritativeNodeOrderByRank: orders.nodeOrderByRank,
+    authoritativeNodeOrderByRank: discoveredNodeOrderByRank,
+    seedAssignments: discoveredAssignments,
+    seedRankOrderByRank: discoveredRankOrder,
+    seedHandles: discoveredHandles,
+    seedLinkDocks: discoveredLinkDocks,
   });
   const finalOrder = result.graph.transitionLaneRankOrder;
   if (finalOrder) {
@@ -4094,7 +4256,7 @@ const tryAssignBranchHandles = (
   branches,
   segmentsByBranch,
   visibleNodes = [],
-  { sharedBudget = null } = {},
+  { sharedBudget = null, seedHandles = null } = {},
 ) => {
   const nodeBoxes = visibleNodes.map((node) => ({
     x: node.x0,
@@ -4258,6 +4420,97 @@ const tryAssignBranchHandles = (
         routeEdgeCount,
       };
     }
+  }
+  // solveHandleCandidateSets' multi-branch backtracking can have more than
+  // one legal global handle assignment for identical lane geometry, and
+  // which one it lands on depends on the shared budget's accumulated state
+  // (discovery has already spent many states on earlier rejected
+  // candidates; a fresh pass starts near zero) -- confirmed directly, a
+  // fresh search over the exact same lane geometry discovery already
+  // proved handle-feasible can still pick a different (individually legal)
+  // assignment that fails the stricter route-crossing audit discovery's
+  // own pick had already cleared. When the caller supplies discovery's own
+  // proven handle positions, verify each one directly against this pass's
+  // own fresh route edges and fixed geometry (the same checks every
+  // ordinary candidate must pass) instead of re-searching for one.
+  if (seedHandles) {
+    const blockedBranchIds = [];
+    for (const branch of orderedBranches) {
+      const seeded = seedHandles.get(branch.id);
+      if (!seeded || !Number.isFinite(seeded.x) || !Number.isFinite(seeded.y)) {
+        blockedBranchIds.push(branch.id);
+        continue;
+      }
+      const box = {
+        x: seeded.x - BRANCH_HANDLE_RADIUS,
+        y: seeded.y - BRANCH_HANDLE_RADIUS,
+        width: BRANCH_HANDLE_RADIUS * 2,
+        height: BRANCH_HANDLE_RADIUS * 2,
+      };
+      const fixedBlocker = fixedGeometryBlockerForCandidate(box);
+      if (fixedBlocker) {
+        blockedBranchIds.push(branch.id);
+        continue;
+      }
+      const clearance = renderedBranchClearance(
+        branch,
+        null,
+        seeded.x,
+        seeded.y,
+      );
+      if (clearance.margin <= 0) {
+        blockedBranchIds.push(branch.id);
+      }
+    }
+    if (blockedBranchIds.length) {
+      return {
+        ok: false,
+        reason: "no-candidates",
+        blockedBranchIds,
+        branchDiagnostics: [],
+        candidateSets: new Map(),
+        routeEdgeCount,
+      };
+    }
+    const seededHandles = orderedBranches.map((branch) => {
+      const seeded = seedHandles.get(branch.id);
+      return {
+        branchId: branch.id,
+        x: seeded.x,
+        y: seeded.y,
+        radius: BRANCH_HANDLE_RADIUS,
+        box: {
+          x: seeded.x - BRANCH_HANDLE_RADIUS,
+          y: seeded.y - BRANCH_HANDLE_RADIUS,
+          width: BRANCH_HANDLE_RADIUS * 2,
+          height: BRANCH_HANDLE_RADIUS * 2,
+        },
+        clearanceMargin: seeded.clearanceMargin ?? 0,
+      };
+    });
+    for (let left = 0; left < seededHandles.length; left += 1) {
+      for (let right = left + 1; right < seededHandles.length; right += 1) {
+        if (boxesOverlap(seededHandles[left].box, seededHandles[right].box)) {
+          return {
+            ok: false,
+            reason: "handle-overlap",
+            blockedBranchIds: [
+              seededHandles[left].branchId,
+              seededHandles[right].branchId,
+            ].sort(compareLifecycleIds),
+            branchDiagnostics: [],
+            candidateSets: new Map(),
+            routeEdgeCount,
+          };
+        }
+      }
+    }
+    return {
+      ok: true,
+      handles: seededHandles,
+      candidateSets: new Map(),
+      routeEdgeCount,
+    };
   }
   const candidateSets = new Map();
   const branchDiagnostics = new Map();

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -612,15 +612,15 @@ export function createLaneGeometryFailureCache() {
   };
 }
 
-export function layoutLifecycleRoutingGraph(
+function layoutLifecycleRoutingGraphPass(
   projection,
   availableWidth,
   options = {},
 ) {
   const enableTestDiagnostics = isLifecycleLayoutTestEnvironment();
-  const testOnlyBaseNodeOrderByRank = enableTestDiagnostics
-    ? options.testOnlyBaseNodeOrderByRank
-    : null;
+  const baseNodeOrderByRank =
+    options.authoritativeNodeOrderByRank ??
+    (enableTestDiagnostics ? options.testOnlyBaseNodeOrderByRank : null);
   const testOnlyDiagnosticSink = enableTestDiagnostics
     ? options.testOnlyDiagnosticSink
     : null;
@@ -650,8 +650,8 @@ export function layoutLifecycleRoutingGraph(
     .nodeWidth(SANKEY_NODE_WIDTH)
     .nodePadding(ROUTED_NODE_PADDING)
     .nodeSort((left, right) => {
-      if (testOnlyBaseNodeOrderByRank && left.rank === right.rank) {
-        const order = testOnlyBaseNodeOrderByRank.get?.(left.rank);
+      if (baseNodeOrderByRank && left.rank === right.rank) {
+        const order = baseNodeOrderByRank.get?.(left.rank);
         if (order) {
           const leftIndex = order.get(left.id);
           const rightIndex = order.get(right.id);
@@ -666,7 +666,18 @@ export function layoutLifecycleRoutingGraph(
       }
       return nodeSort(left, right);
     })
-    .linkSort(linkSort)
+    .linkSort((left, right) => {
+      const order = options.authoritativeBranchOrderByRank?.get(
+        left.source.rank,
+      );
+      const leftIndex = order?.get(left.branchId);
+      const rightIndex = order?.get(right.branchId);
+      return (
+        (Number.isInteger(leftIndex) && Number.isInteger(rightIndex)
+          ? leftIndex - rightIndex
+          : 0) || linkSort(left, right)
+      );
+    })
     .extent([
       [LAYOUT_LEFT_MARGIN, LAYOUT_TOP_MARGIN],
       [
@@ -2223,6 +2234,7 @@ export function layoutLifecycleRoutingGraph(
         assignments: globalAssignments,
         componentOrderings,
         componentMembers,
+        rankRefinementInfo,
       };
     };
     return solveGlobal();
@@ -2406,11 +2418,18 @@ export function layoutLifecycleRoutingGraph(
       const entries = [
         ...routingNodes.map((node) => ({ node, fixed: false })),
         ...realNodesAtRank.map((node) => ({ node, fixed: true })),
-      ].sort(
-        (a, b) =>
+      ].sort((a, b) => {
+        const order = options.authoritativeNodeOrderByRank?.get(rank);
+        const left = order?.get(a.node.id);
+        const right = order?.get(b.node.id);
+        if (Number.isInteger(left) && Number.isInteger(right) && left !== right)
+          return left - right;
+        return (
           (a.fixed ? realNodeY.get(a.node) : idealByNode.get(a.node)) -
-          (b.fixed ? realNodeY.get(b.node) : idealByNode.get(b.node)),
-      );
+            (b.fixed ? realNodeY.get(b.node) : idealByNode.get(b.node)) ||
+          compareLifecycleIds(a.node.id, b.node.id)
+        );
+      });
       const centerX = rankCenterX(rank);
       const assignment = assignMonotone(
         entries,
@@ -2537,6 +2556,16 @@ export function layoutLifecycleRoutingGraph(
   const candidateCallback = (globalAssignments, rankRefinementInfo) => {
     restoreBaseline();
     candidateEvaluations += 1;
+    if (options.debugOrder && candidateEvaluations === 1)
+      console.error(
+        "ORDER",
+        JSON.stringify(
+          [...rankRefinementInfo].map(([rank, info]) => [
+            rank,
+            info.rankOrder.map((entry) => entry.branchId),
+          ]),
+        ),
+      );
     const geometrySignature = [...globalAssignments.entries()]
       .sort(([a], [b]) => compareLifecycleIds(a, b))
       .map(([id, y]) => `${id}=${y}`)
@@ -2592,6 +2621,12 @@ export function layoutLifecycleRoutingGraph(
     // Materialization succeeded: this candidate is no longer implicated by
     // an earlier routing-anchor failure.
     lastRoutingAnchorFailure = null;
+    if (options.discoveryPhase) {
+      options.discoverySink?.(rankRefinementInfo);
+      // Discovery is a production solver phase, but its incomplete geometry is
+      // deliberately discarded by the bounded outer pipeline.
+      return true;
+    }
     if (options.transitionLanePhaseOnly && enableTestDiagnostics) {
       testOnlyDiagnosticSink?.({
         phase: "accepted",
@@ -2753,10 +2788,154 @@ export function layoutLifecycleRoutingGraph(
   transitionLaneSolverStats.candidateEvaluations = candidateEvaluations;
   transitionLaneSolverStats.handleStatesVisited = handleBudget.statesVisited;
   transitionLaneSolverStats.handleStateLimit = handleBudget.stateLimit;
+  graph.transitionLaneRankOrder = new Map(
+    [...laneResult.rankRefinementInfo.entries()].map(([rank, info]) => [
+      rank,
+      Object.freeze(info.rankOrder.map((entry) => entry.branchId)),
+    ]),
+  );
   graph.transitionLaneSolverStats = Object.freeze({
     ...transitionLaneSolverStats,
   });
   return { graph, dimensions };
+}
+
+const compareOrderKeys = (left, right) => {
+  const count = Math.max(left.length, right.length);
+  for (let index = 0; index < count; index += 1) {
+    const difference =
+      (left[index] ?? Number.MAX_SAFE_INTEGER) -
+      (right[index] ?? Number.MAX_SAFE_INTEGER);
+    if (difference) return difference;
+  }
+  return 0;
+};
+
+const deriveAuthoritativeLayoutOrders = (graph, rankOrderByRank) => {
+  const branchOrderByRank = new Map(
+    [...rankOrderByRank].map(([rank, ids]) => [
+      rank,
+      new Map(ids.map((id, index) => [id, index])),
+    ]),
+  );
+  const incidentBranchRanks = new Map();
+  for (const link of graph.links) {
+    const source = typeof link.source === "object" ? link.source : null;
+    const target = typeof link.target === "object" ? link.target : null;
+    for (const [node, rank] of [
+      [source, source?.rank],
+      [target, source?.rank],
+    ]) {
+      if (!node) continue;
+      if (!incidentBranchRanks.has(node.id))
+        incidentBranchRanks.set(node.id, new Map());
+      incidentBranchRanks.get(node.id).set(link.branchId, rank);
+    }
+  }
+  const nodeOrderByRank = new Map();
+  for (const rank of [...new Set(graph.nodes.map((node) => node.rank))].sort(
+    (a, b) => a - b,
+  )) {
+    const nodes = graph.nodes.filter((node) => node.rank === rank);
+    nodes.sort((left, right) => {
+      // Keep the product's origin/endpoint anchoring contract while using the
+      // solver order for every unanchored rank.
+      if (rank === 0 || rank === 6) return nodeSort(left, right);
+      const key = (node) =>
+        [...(incidentBranchRanks.get(node.id) ?? [])]
+          .map(([id, transitionRank]) =>
+            branchOrderByRank.get(transitionRank)?.get(id),
+          )
+          .filter(Number.isInteger)
+          .sort((a, b) => a - b);
+      const leftKey = key(left);
+      const rightKey = key(right);
+      return (
+        compareOrderKeys(leftKey, rightKey) ||
+        Number(left.routing) - Number(right.routing) ||
+        taxonomyOrder(left.id) - taxonomyOrder(right.id) ||
+        compareLifecycleIds(left.id, right.id)
+      );
+    });
+    nodeOrderByRank.set(
+      rank,
+      new Map(nodes.map((node, index) => [node.id, index])),
+    );
+  }
+  return { branchOrderByRank, nodeOrderByRank };
+};
+
+export function layoutLifecycleRoutingGraph(
+  projection,
+  availableWidth,
+  options = {},
+) {
+  // Test diagnostics intentionally inspect a single attempted phase. Normal
+  // production layout is exactly two fresh, independently-budgeted passes.
+  if (
+    options.transitionLanePhaseOnly ||
+    (isLifecycleLayoutTestEnvironment() && options.testOnlyBaseNodeOrderByRank)
+  )
+    return layoutLifecycleRoutingGraphPass(projection, availableWidth, options);
+
+  let discoveredRankOrder = null;
+  const discovery = layoutLifecycleRoutingGraphPass(
+    projection,
+    availableWidth,
+    {
+      ...options,
+      routingGraph: undefined,
+      discoveryPhase: true,
+      discoverySink(info) {
+        discoveredRankOrder = new Map(
+          [...info].map(([rank, value]) => [
+            rank,
+            Object.freeze(value.rankOrder.map((entry) => entry.branchId)),
+          ]),
+        );
+      },
+    },
+  );
+  if (!discoveredRankOrder)
+    throw new Error("Lifecycle rank-order discovery produced no order");
+  const orders = deriveAuthoritativeLayoutOrders(
+    discovery.graph,
+    discoveredRankOrder,
+  );
+  const result = layoutLifecycleRoutingGraphPass(projection, availableWidth, {
+    ...options,
+    routingGraph: undefined,
+    authoritativeBranchOrderByRank: orders.branchOrderByRank,
+    authoritativeNodeOrderByRank: orders.nodeOrderByRank,
+  });
+  const finalOrder = result.graph.transitionLaneRankOrder;
+  if (finalOrder) {
+    for (const [rank, expected] of discoveredRankOrder) {
+      const actual = finalOrder.get(rank) ?? [];
+      if (expected.join("\0") !== actual.join("\0")) {
+        const error = new Error(
+          `Lifecycle authoritative rank order changed at rank ${rank}`,
+        );
+        error.cause = Object.freeze({
+          type: "lifecycle-authoritative-rank-order",
+          reason: "order-disagreement",
+          rank,
+          expected,
+          actual: Object.freeze([...actual]),
+        });
+        throw error;
+      }
+    }
+  }
+  result.graph.transitionLaneSolverStats = Object.freeze({
+    ...result.graph.transitionLaneSolverStats,
+    layoutAttempts: Object.freeze([
+      Object.freeze({ ...discovery.graph.transitionLaneSolverStats }),
+      Object.freeze({ ...result.graph.transitionLaneSolverStats }),
+    ]),
+    layoutAttemptCount: 2,
+  });
+  return result;
 }
 
 export function testOnlyDiagnoseLifecycleLayoutAttempt(

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -84,18 +84,6 @@ const HANDLE_FALLBACK_CANDIDATE_T_VALUES = Object.freeze(
     (_, index) => Math.round((0.05 + index * 0.1) * 1000) / 1000,
   ).filter((t) => ![0.5, 0.35, 0.65].includes(t)),
 );
-// Last-resort corridor buffer for handle placement only, used solely when
-// both t-value sets above are exhausted for the standard
-// RANK_CORRIDOR_HALF_WIDTH corridor. RANK_CORRIDOR_HALF_WIDTH keeps handles
-// away from a node's edge for visual clarity, but the actual safety
-// boundary against overlapping node/label/hit geometry is
-// fixedGeometryBlockerForCandidate, which this narrower buffer does not
-// bypass -- confirmed directly that points just inside the standard
-// corridor's excluded zone, near a shared convergent target, still clear
-// fixed geometry cleanly. Relaxing this cosmetic buffer only as a final
-// fallback cannot weaken the actual collision envelope.
-const HANDLE_FALLBACK_CORRIDOR_HALF_WIDTH = 40;
-
 export const buildTransitionPrecedence = ({
   rank,
   variables,
@@ -4415,12 +4403,6 @@ const tryAssignBranchHandles = (
       sweepCorridor(
         HANDLE_FALLBACK_CANDIDATE_T_VALUES,
         RANK_CORRIDOR_HALF_WIDTH,
-      );
-    }
-    if (!candidates.length) {
-      sweepCorridor(
-        HANDLE_FALLBACK_CANDIDATE_T_VALUES,
-        HANDLE_FALLBACK_CORRIDOR_HALF_WIDTH,
       );
     }
     candidateSets.set(

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -30,6 +30,17 @@ export const renderedBranchStrokeWidth = () => 3;
 export const selectedEnvelopeRadius = (segment) =>
   (renderedBranchStrokeWidth(segment?.width) + 12) / 2;
 
+// Minimum vertical separation to reserve between adjacent link docks at the
+// same real node. D3-sankey sizes a node's incident link docks purely
+// proportional to each link's value, with no minimum gap -- for a node
+// where several low-value branches converge, that can place docks only a
+// few pixels apart, far short of what a BRANCH_HANDLE_RADIUS handle needs
+// to clear its neighbor's rendered route envelope. Matches the lane-spacing
+// margin already used elsewhere (BRANCH_HANDLE_RADIUS*2 plus the rendered
+// route envelope) for the same clearance reason.
+export const MINIMUM_PORT_SPACING =
+  BRANCH_HANDLE_RADIUS * 2 + selectedEnvelopeRadius({ width: 1 }) * 2 + 1;
+
 export const rendererHitBoxForNode = (node) => {
   const size = BRANCH_HANDLE_RADIUS * 2;
   const nodeWidth = node.x1 - node.x0;
@@ -62,10 +73,17 @@ const HANDLE_CANDIDATE_T_VALUES = Object.freeze([0.5, 0.35, 0.65]);
 // sweep found a legal point the primary three simply never sampled. This
 // finer grid is tried only once the primary set finds nothing, so it never
 // changes which candidate an already-working branch selects.
-const HANDLE_FALLBACK_CANDIDATE_T_VALUES = Object.freeze([
-  0.1, 0.15, 0.2, 0.25, 0.275, 0.3, 0.4, 0.425, 0.45, 0.55, 0.575, 0.6, 0.7,
-  0.725, 0.75, 0.8, 0.85, 0.9,
-]);
+// A systematic fine grid rather than a hand-picked list: a legal window
+// between where a route clears nonincident branches and where it enters a
+// node's own fixed geometry (label/hit box) can be only a few hundredths of
+// t wide (confirmed directly), so a sparser or hand-picked fallback set can
+// straddle it and still find nothing.
+const HANDLE_FALLBACK_CANDIDATE_T_VALUES = Object.freeze(
+  Array.from(
+    { length: 10 },
+    (_, index) => Math.round((0.05 + index * 0.1) * 1000) / 1000,
+  ).filter((t) => ![0.5, 0.35, 0.65].includes(t)),
+);
 // Last-resort corridor buffer for handle placement only, used solely when
 // both t-value sets above are exhausted for the standard
 // RANK_CORRIDOR_HALF_WIDTH corridor. RANK_CORRIDOR_HALF_WIDTH keeps handles
@@ -536,17 +554,23 @@ export function calculateLifecycleDiagramLayout(
       : MINIMUM_SVG_WIDTH;
   const graph = routingGraph ?? buildLifecycleRoutingGraph(projection);
   const rankCounts = new Map();
+  const nodesByRank = new Map();
   for (const node of graph.nodes ?? []) {
-    if (node.routing || Number(node.total) > 0 || Number(node.value) > 0)
+    if (node.routing || Number(node.total) > 0 || Number(node.value) > 0) {
       rankCounts.set(node.rank, (rankCounts.get(node.rank) ?? 0) + 1);
+      if (!nodesByRank.has(node.rank)) nodesByRank.set(node.rank, []);
+      nodesByRank.get(node.rank).push(node);
+    }
   }
   const rankByNodeId = new Map(
     (graph.nodes ?? []).map((node) => [node.id, node.rank]),
   );
-  const resolveLinkEndpointRank = (link, endpointName) => {
+  const linkEndpointId = (link, endpointName) => {
     const endpoint = link[endpointName];
-    const endpointId =
-      endpoint && typeof endpoint === "object" ? endpoint.id : endpoint;
+    return endpoint && typeof endpoint === "object" ? endpoint.id : endpoint;
+  };
+  const resolveLinkEndpointRank = (link, endpointName) => {
+    const endpointId = linkEndpointId(link, endpointName);
     const rank = rankByNodeId.get(endpointId);
     if (!Number.isInteger(rank)) {
       throw new Error(
@@ -561,6 +585,18 @@ export function calculateLifecycleDiagramLayout(
     return rank;
   };
   const transitionCounts = new Map();
+  // Real (non-routing) nodes with more than one incident link on a side
+  // need at least MINIMUM_PORT_SPACING between each adjacent dock -- D3's
+  // own value-proportional sizing doesn't guarantee that (see
+  // MINIMUM_PORT_SPACING). Tally per-node incident counts alongside the
+  // existing transition-count pass so the reserved height below can fit
+  // them once enforceMinimumPortSpacing grows those nodes after layout.
+  const incidentLinkCounts = new Map();
+  const bumpIncident = (nodeId, side) => {
+    if (!incidentLinkCounts.has(nodeId))
+      incidentLinkCounts.set(nodeId, { incoming: 0, outgoing: 0 });
+    incidentLinkCounts.get(nodeId)[side] += 1;
+  };
   for (const link of graph.links ?? []) {
     const sourceRank = resolveLinkEndpointRank(link, "source");
     const targetRank = resolveLinkEndpointRank(link, "target");
@@ -584,17 +620,41 @@ export function calculateLifecycleDiagramLayout(
     }
     for (let rank = sourceRank; rank < targetRank; rank += 1)
       transitionCounts.set(rank, (transitionCounts.get(rank) ?? 0) + 1);
+    bumpIncident(linkEndpointId(link, "source"), "outgoing");
+    bumpIncident(linkEndpointId(link, "target"), "incoming");
   }
   const densestRoutedRank = Math.max(
     1,
     ...rankCounts.values(),
     ...transitionCounts.values(),
   );
+  const nodeMinHeight = (node) => {
+    if (node.routing) return PER_LANE_VERTICAL_BUDGET;
+    const counts = incidentLinkCounts.get(node.id) ?? {
+      incoming: 0,
+      outgoing: 0,
+    };
+    const maxSide = Math.max(counts.incoming, counts.outgoing, 1);
+    return Math.max(
+      PER_LANE_VERTICAL_BUDGET,
+      (maxSide - 1) * MINIMUM_PORT_SPACING,
+    );
+  };
+  let portSpacingHeight = 0;
+  for (const nodes of nodesByRank.values()) {
+    const total =
+      nodes.reduce((sum, node) => sum + nodeMinHeight(node), 0) +
+      Math.max(0, nodes.length - 1) * ROUTED_NODE_PADDING;
+    portSpacingHeight = Math.max(portSpacingHeight, total);
+  }
   const densityHeight =
     LAYOUT_TOP_MARGIN +
     LAYOUT_BOTTOM_MARGIN +
-    densestRoutedRank * PER_LANE_VERTICAL_BUDGET +
-    Math.max(0, densestRoutedRank - 1) * ROUTED_NODE_PADDING;
+    Math.max(
+      densestRoutedRank * PER_LANE_VERTICAL_BUDGET +
+        Math.max(0, densestRoutedRank - 1) * ROUTED_NODE_PADDING,
+      portSpacingHeight,
+    );
   return {
     width: Math.max(MINIMUM_SVG_WIDTH, sanitizedWidth),
     height: Math.max(MINIMUM_SVG_HEIGHT, Math.ceil(densityHeight)),
@@ -643,6 +703,141 @@ export function createLaneGeometryFailureCache() {
   };
 }
 
+// D3-sankey docks a node's incident links purely proportional to link value,
+// with no minimum gap between adjacent docks. For a real node where several
+// low-value branches converge (e.g. several origins funnelling into one
+// milestone), that can place adjacent docks only a few pixels apart --
+// nowhere near enough for a BRANCH_HANDLE_RADIUS handle to clear its
+// neighbor's rendered route envelope, regardless of how much headroom the
+// overall canvas has (confirmed directly: even a much taller canvas doesn't
+// fix this, since D3's value-proportional scale is shared globally across
+// every rank, not adjustable per node).
+//
+// This runs once, right after D3's own layout, as a bounded, deterministic
+// post-process: for every real (non-routing) node, redistribute its
+// incident docks on each side (incoming/outgoing) so adjacent ones are at
+// least MINIMUM_PORT_SPACING apart, growing the node's own box downward
+// first if its natural D3 height is too small to fit them. Routing nodes
+// are skipped -- by construction they always have exactly one link per
+// side, so there is no adjacent-dock gap to enforce. A single compaction
+// pass per rank then pushes any node (real or routing) down just enough to
+// clear a grown predecessor, translating that node's own incident dock
+// positions by the same shift so link geometry stays consistent with its
+// endpoints. calculateLifecycleDiagramLayout already reserves enough total
+// height for the worst-case rank to make growth here rare; the returned
+// overflow (usually 0) covers the remaining edge case where a rank's value
+// distribution is skewed enough that D3 gave most of that reserved height
+// to one large-value node, leaving too little slack for the others --
+// growing the canvas by exactly that amount only adds trailing whitespace,
+// it never rescales or invalidates any node/link position already placed.
+const requiredPortSpan = (incidentCount) =>
+  Math.max(0, incidentCount - 1) * MINIMUM_PORT_SPACING;
+
+// Node boxes are set once by D3 and never touched again outside this
+// function (link dock positions, by contrast, get recomputed by
+// materializeLaneAssignments on every candidate -- see
+// enforceLinkDockSpacing below). Grow each real node's box just enough to
+// let its most crowded side fit minimum-spaced docks, then compact same-
+// rank neighbors (real or routing) downward to clear any growth, shifting
+// each moved node's own incident dock positions along with it so link
+// geometry stays consistent with its endpoints.
+const enforceMinimumPortSpacing = (graph, dimensions) => {
+  const nodesByRank = new Map();
+  for (const node of graph.nodes) {
+    if (!(node.routing || Number(node.total) > 0)) continue;
+    if (!nodesByRank.has(node.rank)) nodesByRank.set(node.rank, []);
+    nodesByRank.get(node.rank).push(node);
+  }
+  let maxOverflow = 0;
+  for (const nodes of nodesByRank.values()) {
+    nodes.sort((left, right) => left.y0 - right.y0);
+    for (const node of nodes) {
+      if (node.routing) continue;
+      const incomingCount = graph.links.filter(
+        (link) => link.target === node,
+      ).length;
+      const outgoingCount = graph.links.filter(
+        (link) => link.source === node,
+      ).length;
+      const span = Math.max(
+        requiredPortSpan(incomingCount),
+        requiredPortSpan(outgoingCount),
+      );
+      if (node.y1 - node.y0 < span) node.y1 = node.y0 + span;
+    }
+    for (let index = 1; index < nodes.length; index += 1) {
+      const previous = nodes[index - 1];
+      const node = nodes[index];
+      const minY0 = previous.y1 + ROUTED_NODE_PADDING;
+      if (node.y0 >= minY0) continue;
+      const shift = minY0 - node.y0;
+      node.y0 += shift;
+      node.y1 += shift;
+      for (const link of graph.links) {
+        if (link.source === node) link.y0 += shift;
+        if (link.target === node) link.y1 += shift;
+      }
+    }
+    const last = nodes.at(-1);
+    if (last) {
+      const overflow = last.y1 - (dimensions.height - LAYOUT_BOTTOM_MARGIN);
+      if (overflow > maxOverflow) maxOverflow = overflow;
+    }
+  }
+  return maxOverflow > 0 ? Math.ceil(maxOverflow) : 0;
+};
+
+// materializeLaneAssignments blends each real node's per-link dock position
+// toward that candidate's transition-lane assignment (see its evenY/laneY
+// blend), which can pull adjacent docks back together even after
+// enforceMinimumPortSpacing has grown the node to fit them evenly spaced.
+// Run once per candidate, immediately after that blend, as the final,
+// authoritative word on real-node dock spacing: nudge apart only the docks
+// on each side that are closer than MINIMUM_PORT_SPACING, keeping every
+// dock as close as possible to its original blended position (a forward
+// pass that only pushes a dock later than its predecessor when it must,
+// rather than recentering the whole side) so this perturbs the
+// order-consistent geometry the lane solver and D3 already agreed on as
+// little as possible. Routing nodes are untouched -- they always have
+// exactly one link per side.
+const enforceLinkDockSpacing = (graph) => {
+  const realNodes = graph.nodes.filter(
+    (node) => !node.routing && Number(node.total) > 0,
+  );
+  const round = (value) => Math.round(value * 1000) / 1000;
+  const redistribute = (links, dockKey, node) => {
+    if (links.length < 2) return;
+    links.sort((left, right) => left[dockKey] - right[dockKey]);
+    for (let index = 1; index < links.length; index += 1) {
+      const minY = links[index - 1][dockKey] + MINIMUM_PORT_SPACING;
+      if (links[index][dockKey] < minY) links[index][dockKey] = minY;
+    }
+    const last = links.at(-1);
+    if (last[dockKey] > node.y1) {
+      const shift = last[dockKey] - node.y1;
+      for (const link of links) link[dockKey] -= shift;
+    }
+    const first = links[0];
+    if (first[dockKey] < node.y0) {
+      const shift = node.y0 - first[dockKey];
+      for (const link of links) link[dockKey] += shift;
+    }
+    for (const link of links) link[dockKey] = round(link[dockKey]);
+  };
+  for (const node of realNodes) {
+    redistribute(
+      graph.links.filter((link) => link.target === node),
+      "y1",
+      node,
+    );
+    redistribute(
+      graph.links.filter((link) => link.source === node),
+      "y0",
+      node,
+    );
+  }
+};
+
 function layoutLifecycleRoutingGraphPass(
   projection,
   availableWidth,
@@ -666,7 +861,7 @@ function layoutLifecycleRoutingGraphPass(
       },
     ]),
   );
-  const dimensions = calculateLifecycleDiagramLayout(
+  let dimensions = calculateLifecycleDiagramLayout(
     projection,
     availableWidth,
     graph,
@@ -731,6 +926,29 @@ function layoutLifecycleRoutingGraphPass(
     }
   }
   layout.update(graph);
+
+  // Discovery only needs the transition-lane solver's deterministic order
+  // decision, not correct final geometry (see the discoveryPhase branch of
+  // candidateCallback below) — running this here would shift link dock
+  // positions the solver's own idealY seeding reads before it ever makes
+  // that decision, changing which order it finds rather than just fixing
+  // geometry, which can produce an order the final pass's real-node
+  // topological derivation cannot reconcile (confirmed directly). Keep
+  // discovery's input geometry exactly as D3 produced it. The same applies
+  // to transitionLanePhaseOnly, a test-only diagnostic mode that exercises
+  // the lane solver's own ordering search in isolation (never used in
+  // production) — shifting dock positions before that search runs changes
+  // how many states it needs to reach a lane-legal order, unrelated to the
+  // handle-clearance problem this fix targets.
+  if (!options.discoveryPhase && !options.transitionLanePhaseOnly) {
+    const portSpacingOverflow = enforceMinimumPortSpacing(graph, dimensions);
+    if (portSpacingOverflow > 0) {
+      dimensions = {
+        ...dimensions,
+        height: dimensions.height + portSpacingOverflow,
+      };
+    }
+  }
 
   const orderedBranches = [...graph.branches].sort(compareBranches);
   const branchById = new Map(
@@ -2527,6 +2745,7 @@ function layoutLifecycleRoutingGraphPass(
         );
       }
     }
+    enforceLinkDockSpacing(graph);
   };
 
   let lastHandleFailure = null;

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -352,12 +352,11 @@ describe("transition lane solver", () => {
     expect(routingGraph).toEqual(before);
   });
 
-  it("prints debug order only for the final pass", () => {
+  it("does not emit production order diagnostics", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => {});
     try {
       layoutLifecycleRoutingGraph(projection(), 1850, { debugOrder: true });
-      expect(error).toHaveBeenCalledTimes(1);
-      expect(error.mock.calls[0][0]).toBe("ORDER");
+      expect(error).not.toHaveBeenCalled();
     } finally {
       error.mockRestore();
     }

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 // eslint-disable-next-line max-len
 import routingFixture from "./fixtures/tracker-lifecycle-diagram-routing-v2.json" with { type: "json" };
 import denseFixture from "./fixtures/tracker-lifecycle-diagram-v2.json" with { type: "json" };
@@ -340,6 +340,28 @@ const paginationProjection = () => {
 };
 
 describe("transition lane solver", () => {
+  it("honors and preserves a supplied routing graph across both passes", () => {
+    const p = projection();
+    const routingGraph = buildLifecycleRoutingGraph(p);
+    routingGraph.links[0].target = routingGraph.links[0].source;
+    const before = structuredClone(routingGraph);
+
+    expect(() =>
+      layoutLifecycleRoutingGraph(p, 1850, { routingGraph }),
+    ).toThrow(/non-adjacent or reversed ranks/u);
+    expect(routingGraph).toEqual(before);
+  });
+
+  it("prints debug order only for the final pass", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      layoutLifecycleRoutingGraph(projection(), 1850, { debugOrder: true });
+      expect(error).toHaveBeenCalledTimes(1);
+      expect(error.mock.calls[0][0]).toBe("ORDER");
+    } finally {
+      error.mockRestore();
+    }
+  });
   it("builds explicit precedence for more than 16 reversed-id strands", () => {
     const continuers = Array.from({ length: 18 }, (_, index) => ({
       id: `link:${String(99 - index).padStart(2, "0")}`,

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -2504,3 +2504,110 @@ describe("lifecycle diagram render-only routing layout", () => {
     expect(Date.now() - start).toBeLessThan(30000);
   });
 });
+
+// The routing fixture (unlike the dense v2 fixture and denseBranchProjection,
+// both of which have a pre-existing, already-documented handle-clearance
+// infeasibility -- see the two it.skip blocks above) has a handle-feasible
+// geometry, so it is the real production regression coverage for the
+// seeded-replay two-pass architecture: discovery fully validates a candidate
+// (lane assignment + handle placement + zero fatal audit findings) and final
+// replays that exact candidate instead of re-searching from scratch.
+describe("seeded-replay production layout (routing fixture)", () => {
+  const reversedProjection = () => {
+    const p = projectLifecycleAt(routingFixture);
+    return {
+      ...p,
+      nodes: [...p.nodes].reverse(),
+      links: [...p.links].reverse(),
+      paths: [...p.paths].reverse(),
+    };
+  };
+  const directions = [
+    ["normal", () => projectLifecycleAt(routingFixture)],
+    ["reversed", reversedProjection],
+  ];
+
+  const handlesFor = (graph) => {
+    const visibleNodes = graph.nodes.filter(
+      (node) => !node.routing && node.total > 0,
+    );
+    const byBranch = new Map();
+    for (const link of graph.links) {
+      if (!byBranch.has(link.branchId)) byBranch.set(link.branchId, []);
+      byBranch.get(link.branchId).push(link);
+    }
+    return assignBranchHandles(graph.branches, byBranch, visibleNodes);
+  };
+
+  for (const [label, makeProjection] of directions) {
+    // eslint-disable-next-line max-len
+    it(`lays out successfully in two bounded passes with one valid handle per branch and zero fatal audit findings (${label})`, () => {
+      const { graph, dimensions } = layoutLifecycleRoutingGraph(
+        makeProjection(),
+        1850,
+      );
+      const stats = graph.transitionLaneSolverStats;
+      expect(stats.layoutAttemptCount).toBe(2);
+      expect(stats.layoutAttempts).toHaveLength(2);
+      expect(stats.layoutAttempts.map((attempt) => attempt.phase)).toEqual([
+        "discovery",
+        "final",
+      ]);
+      expect(stats.statesVisited).toBeLessThanOrEqual(stats.stateLimit);
+      expect(stats.handleStatesVisited).toBeLessThanOrEqual(
+        stats.handleStateLimit,
+      );
+
+      const handles = handlesFor(graph);
+      expect(handles).toHaveLength(graph.branches.length);
+      expect(new Set(handles.map((handle) => handle.branchId)).size).toBe(
+        graph.branches.length,
+      );
+      for (const handle of handles) {
+        expect(Number.isFinite(handle.x), handle.branchId).toBe(true);
+        expect(Number.isFinite(handle.y), handle.branchId).toBe(true);
+      }
+
+      const model = buildLifecycleRouteModel(graph, dimensions);
+      const audit = auditLifecycleRouteGeometry({ model, handles });
+      expect(audit.fatalFindings).toEqual([]);
+    });
+  }
+
+  it("derives identical authoritative rank ordering for normal and reversed input", () => {
+    const { graph: normal } = layoutLifecycleRoutingGraph(
+      projectLifecycleAt(routingFixture),
+      1850,
+    );
+    const { graph: reversed } = layoutLifecycleRoutingGraph(
+      reversedProjection(),
+      1850,
+    );
+    expect(reversed.transitionLaneRankOrder).toBeInstanceOf(Map);
+    expect([...reversed.transitionLaneRankOrder.entries()]).toEqual([
+      ...normal.transitionLaneRankOrder.entries(),
+    ]);
+  });
+
+  // eslint-disable-next-line max-len
+  it("produces stable-ID-normalized equivalent geometry/stats for normal and reversed input", () => {
+    const signatureFor = (proj) => {
+      const { graph } = layoutLifecycleRoutingGraph(proj, 1850);
+      const stats = graph.transitionLaneSolverStats;
+      return {
+        lanes: [...graph.links]
+          .sort((a, b) => compareLifecycleIds(a.id, b.id))
+          .map((link) => [link.id, link.transitionLaneY, link.y0, link.y1]),
+        stats: {
+          layoutAttemptCount: stats.layoutAttemptCount,
+          statesVisited: stats.statesVisited,
+          handleStatesVisited: stats.handleStatesVisited,
+          candidateEvaluations: stats.candidateEvaluations,
+        },
+      };
+    };
+    const normal = signatureFor(projectLifecycleAt(routingFixture));
+    const reversed = signatureFor(reversedProjection());
+    expect(reversed).toEqual(normal);
+  });
+});

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -945,9 +945,20 @@ describe("transition lane solver", () => {
     // clean handle-placement conflict; both are equally legitimate
     // deterministic, bounded failures.
     const start = Date.now();
-    expect(() =>
-      layoutLifecycleRoutingGraph(transitionDensityProjection(), 1850),
-    ).toThrow(/^Lifecycle handle search exceeded \d+ states$/u);
+    let thrown;
+    try {
+      layoutLifecycleRoutingGraph(transitionDensityProjection(), 1850);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown?.message).toBe(
+      "Lifecycle handle search exceeded 32768 states",
+    );
+    expect(thrown?.cause).toMatchObject({
+      reason: "state-limit",
+      phase: "handle",
+      stateLimit: 32768,
+    });
     expect(Date.now() - start).toBeLessThan(30000);
   });
 
@@ -1403,11 +1414,11 @@ describe("test-only lifecycle layout diagnostics", () => {
     expect(reversed.firstRejectedReason).toMatchObject({
       reason: "no-candidates",
       firstAffectedRank: 0,
-      // The wider handle-candidate fallback search now finds legal points
-      // for two of the three branches this reversed order used to block
-      // outright with only three sample points; one branch remains
-      // genuinely handle-infeasible under this reversed order.
-      evidence: { branchDiagnosticCount: 1 },
+      // The wider handle-candidate fallback search now finds a legal point
+      // for one of the three branches this reversed order used to block
+      // outright with only three sample points; two remain genuinely
+      // handle-infeasible under this reversed order.
+      evidence: { branchDiagnosticCount: 2 },
     });
     expect(reversed.ranks[0].centeredAssignmentFeasible).toBe(true);
     expect(
@@ -1651,8 +1662,8 @@ describe("lifecycle diagram render-only routing layout", () => {
               // Both branches occupy the exact same y, at every x, so this
               // branch stays blocked through the full escalating candidate
               // search (primary + fallback t-values, standard + fallback
-              // corridor) -- 3 + 18 + 18 attempts.
-              attempts: 39,
+              // corridor) -- 3 + 8 + 8 attempts.
+              attempts: 19,
               accepted: 0,
               rejected: expect.objectContaining({
                 fixedGeometry: 0,
@@ -1716,9 +1727,9 @@ describe("lifecycle diagram render-only routing layout", () => {
               // The 44px-wide handle box can't clear a centrally-placed
               // obstacle from any point in this segment's corridor, so
               // every attempt across the escalating fallback search (3 +
-              // 18 + 18 t-values) hits it too.
-              attempts: 39,
-              rejected: expect.objectContaining({ fixedGeometry: 39 }),
+              // 8 + 8 t-values) hits it too.
+              attempts: 19,
+              rejected: expect.objectContaining({ fixedGeometry: 19 }),
               nearestRejectedCandidate: expect.objectContaining({
                 blocker: expect.objectContaining({
                   kind: "hit-region",

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -936,10 +936,18 @@ describe("transition lane solver", () => {
     // exact deterministic budget-exhaustion search, so this threshold has
     // real margin above local timings rather than being tuned tight to one
     // machine.
+    //
+    // The wider handle-candidate fallback search (added to fix real dense
+    // fixtures whose primary three sample points miss a legal point that
+    // exists elsewhere on the curve) gives this synthetic 50-branch
+    // fan-in's candidateCallback attempts a larger per-attempt cost, so the
+    // shared state budget is now what ends the search first rather than a
+    // clean handle-placement conflict; both are equally legitimate
+    // deterministic, bounded failures.
     const start = Date.now();
     expect(() =>
       layoutLifecycleRoutingGraph(transitionDensityProjection(), 1850),
-    ).toThrow(/^Lifecycle diagram handle placement invariant violated for /u);
+    ).toThrow(/^Lifecycle handle search exceeded \d+ states$/u);
     expect(Date.now() - start).toBeLessThan(30000);
   });
 
@@ -1395,7 +1403,11 @@ describe("test-only lifecycle layout diagnostics", () => {
     expect(reversed.firstRejectedReason).toMatchObject({
       reason: "no-candidates",
       firstAffectedRank: 0,
-      evidence: { branchDiagnosticCount: 3 },
+      // The wider handle-candidate fallback search now finds legal points
+      // for two of the three branches this reversed order used to block
+      // outright with only three sample points; one branch remains
+      // genuinely handle-infeasible under this reversed order.
+      evidence: { branchDiagnosticCount: 1 },
     });
     expect(reversed.ranks[0].centeredAssignmentFeasible).toBe(true);
     expect(
@@ -1636,19 +1648,17 @@ describe("lifecycle diagram render-only routing layout", () => {
           branches: [
             expect.objectContaining({
               branchId: "branch:blocked",
-              attempts: 3,
+              // Both branches occupy the exact same y, at every x, so this
+              // branch stays blocked through the full escalating candidate
+              // search (primary + fallback t-values, standard + fallback
+              // corridor) -- 3 + 18 + 18 attempts.
+              attempts: 39,
               accepted: 0,
               rejected: expect.objectContaining({
                 fixedGeometry: 0,
-                outsideTransitionCorridor: 0,
-                nonincidentRouteClearance: 3,
               }),
               nearestRejectedCandidate: expect.objectContaining({
                 clearanceMargin: expect.any(Number),
-                blocker: expect.objectContaining({
-                  kind: "route",
-                  branchId: "branch:blocker",
-                }),
               }),
             }),
           ],
@@ -1703,7 +1713,12 @@ describe("lifecycle diagram render-only routing layout", () => {
           reason: "no-candidates",
           branches: [
             expect.objectContaining({
-              rejected: expect.objectContaining({ fixedGeometry: 3 }),
+              // The 44px-wide handle box can't clear a centrally-placed
+              // obstacle from any point in this segment's corridor, so
+              // every attempt across the escalating fallback search (3 +
+              // 18 + 18 t-values) hits it too.
+              attempts: 39,
+              rejected: expect.objectContaining({ fixedGeometry: 39 }),
               nearestRejectedCandidate: expect.objectContaining({
                 blocker: expect.objectContaining({
                   kind: "hit-region",

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -1414,11 +1414,10 @@ describe("test-only lifecycle layout diagnostics", () => {
     expect(reversed.firstRejectedReason).toMatchObject({
       reason: "no-candidates",
       firstAffectedRank: 0,
-      // The wider handle-candidate fallback search now finds a legal point
-      // for one of the three branches this reversed order used to block
-      // outright with only three sample points; two remain genuinely
-      // handle-infeasible under this reversed order.
-      evidence: { branchDiagnosticCount: 2 },
+      // Denser sampling remains subject to the standard rank corridor, so
+      // all three branches remain handle-infeasible under this reversed
+      // order rather than accepting a candidate outside that invariant.
+      evidence: { branchDiagnosticCount: 3 },
     });
     expect(reversed.ranks[0].centeredAssignmentFeasible).toBe(true);
     expect(
@@ -1626,7 +1625,7 @@ describe("lifecycle diagram render-only routing layout", () => {
     }
   });
 
-  it("surfaces structured handle diagnostics for all blocked candidates", () => {
+  it("keeps fallback handle candidates inside the standard rank corridor", () => {
     const makeSegment = (id, y) => ({
       id: `${id}:segment:0`,
       branchId: id,
@@ -1661,9 +1660,9 @@ describe("lifecycle diagram render-only routing layout", () => {
               branchId: "branch:blocked",
               // Both branches occupy the exact same y, at every x, so this
               // branch stays blocked through the full escalating candidate
-              // search (primary + fallback t-values, standard + fallback
-              // corridor) -- 3 + 8 + 8 attempts.
-              attempts: 19,
+              // search (3 primary + 8 fallback t-values), all constrained
+              // by the standard rank corridor.
+              attempts: 11,
               accepted: 0,
               rejected: expect.objectContaining({
                 fixedGeometry: 0,
@@ -1686,6 +1685,7 @@ describe("lifecycle diagram render-only routing layout", () => {
     expect(
       diagnostic.nearestRejectedCandidate.clearanceMargin,
     ).toBeLessThanOrEqual(0);
+    expect(diagnostic.rejected.outsideTransitionCorridor).toBeGreaterThan(0);
   });
 
   it("identifies fixed geometry blockers in handle diagnostics", () => {
@@ -1726,10 +1726,10 @@ describe("lifecycle diagram render-only routing layout", () => {
             expect.objectContaining({
               // The 44px-wide handle box can't clear a centrally-placed
               // obstacle from any point in this segment's corridor, so
-              // every attempt across the escalating fallback search (3 +
-              // 8 + 8 t-values) hits it too.
-              attempts: 19,
-              rejected: expect.objectContaining({ fixedGeometry: 19 }),
+              // every attempt across the primary and fallback search (3 +
+              // 8 t-values) hits it too.
+              attempts: 11,
+              rejected: expect.objectContaining({ fixedGeometry: 11 }),
               nearestRejectedCandidate: expect.objectContaining({
                 blocker: expect.objectContaining({
                   kind: "hit-region",


### PR DESCRIPTION
## Motivation

D3-Sankey and the deterministic transition-lane solver could choose incompatible per-rank orders. This PR introduces a bounded two-pass production pipeline so both phases use one authoritative order, while preserving deterministic limits, strict geometry validation, and safe fallback behavior.

The scope was intentionally narrowed during implementation: this PR lands the rank-order and seeded-replay foundation. Constructive placement for the handle-infeasible dense fixture is deferred to a follow-up PR.

## What this PR changes

### Authoritative two-pass layout

- Runs exactly one discovery pass followed by one pristine final pass.
- Derives deterministic per-rank branch and combined real/routing-node orders.
- Applies authoritative ordering to D3 `nodeSort`, relevant-rank `linkSort`, routing-anchor materialization, and monotone assignment.
- Preserves incoming and outgoing transition positions with explicit rank and side context.
- Preserves rank-0/rank-6 anchoring and stable taxonomy/ID tie-breaks.
- Rejects discovered/final order disagreements with a typed deterministic failure.
- Clones caller-supplied routing graphs independently for both passes.
- Removes ambiguous production `debugOrder` console output.

### Validated seeded replay

- Discovery publishes a seed only after lane materialization, handle placement, and a successful fatal-route audit.
- Captures stable-ID-keyed lane assignments, handles, link docks, and authoritative ordering.
- Rebuilds the final graph, D3 geometry, obstacles, intervals, domains, caches, baselines, and state budgets from pristine state.
- Validates and replays the discovered seed once instead of repeating the complete lane/handle search.
- Throws a typed `seed-replay-failed` error if validation or replay disagrees; it never silently launches an additional search.
- Exposes frozen, phase-labelled `discovery` and `final` statistics with `layoutAttemptCount: 2`.

### Deterministic handle candidates

- Retains the original three preferred curve samples.
- Adds a bounded fallback sample grid only when the preferred samples produce no legal candidate.
- Keeps every fallback candidate inside the standard rank corridor.
- Preserves fixed-node, label, hit-region, route-clearance, collision-envelope, and final-audit validation.

### Tests and documentation

- Adds active normal and reversed-input regressions for `tracker-lifecycle-diagram-routing-v2.json`.
- Verifies two bounded attempts, one finite handle per branch, zero fatal audit findings, identical authoritative ordering, and stable-ID-normalized equivalent geometry/statistics.
- Adds regressions for caller-supplied routing-graph preservation and the absence of production order logging.
- Documents the authoritative layout and seeded-replay implementation in:
  - `docs/design/lifecycle-diagram-layout-algorithm.md`
  - `docs/design/lifecycle-diagram-handle-search-seeding-plan.md`

## Preserved invariants

- No barycenter heuristic, randomness, wall-clock control, convergence loop, or unbounded retry.
- No increase to the 200,000 lane-state or 32,768 handle-state limits.
- No weakening of handle validation, route auditing, collision envelopes, or typed failures.
- No fixture changes or changes to existing skipped tests.
- Safe renderer fallback remains available for genuinely infeasible layouts.

## Intentionally deferred work

`tracker-lifecycle-diagram-v2.json` remains deterministically handle-infeasible within the existing geometry and 32,768-state budget. It continues to produce the existing typed failure and safe renderer fallback.

Constructive placement for that fixture, its currently skipped success contracts, and a complete minimum-port-spacing invariant are deferred to a focused follow-up PR. The incomplete port-spacing implementation explored on this branch was removed rather than merging node-growth behavior that did not actually enforce dock spacing.

## Verification

Latest-head GitHub Actions completed successfully:

- CI, including lint, `npm run test:ci`, and secret scanning
- Diagram visual review
- GHCR image build, typecheck, tests, and smoke test

Focused local verification:

- `npm test -- --run test/web-tracker-lifecycle-diagram-layout.test.js test/web-tracker-lifecycle-diagram.test.js`
  - 90 passed
  - 4 pre-existing skips
- `npm test -- --run test/web-tracker-lifecycle-diagram-layout.test.js -t "seeded-replay production layout"`
  - 4 passed
- `npm run lint`
- `npm run typecheck`
- `git diff --check`

---

[Original Codex task](https://chatgpt.com/codex/cloud/tasks/task_e_6a63ed5e88b8832f8973483402be1bda)