### PR TITLE
Fix dense fan-out lifecycle layout for milestone-free diagrams

### DIFF
--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -300,9 +300,9 @@ real/routing-node positions, interval/domain sizes, centered-assignment feasibil
 phase/reason, and deterministic state counts. It is intentionally not a production debugging API and
 does not log to the console.
 
-## P4 investigation (2026-07-26): a real-node-position-preserving joint order still destabilizes production fixtures
+## Investigation (2026-07-26): a real-node-position-preserving joint order still destabilizes production fixtures
 
-A follow-up investigation (task "P4 — Implement rankOrder-aware cross-rank lifecycle routing")
+A follow-up investigation into making the base D3-Sankey layout rankOrder-aware
 attempted the deferred fix above ([Option 2](#deferred-making-the-base-d3-sankey-layout-rankorder-aware))
 a second time, this time deliberately different from the reverted barycenter attempt: instead of an
 iterative, sweep-based repositioning heuristic, it used a single deterministic, purely topological
@@ -362,18 +362,31 @@ fixture needs are, at least under this construction, in direct tension: applying
 exactly the fixture with no real-node convergence and hurts exactly the fixtures that have it.
 
 **Conclusion and status:** per the task's own staged plan, this is a **no-go** for proceeding to a
-full implementation as scoped — the joint-order approach is not safe to wire into production
-`nodeSort`/`linkSort` in this form. It is, however, the most precisely localized negative result this
-line of investigation has produced to date (previous attempts changed real-node geometry and could
-not distinguish "real-node coupling" from "routing-node-order coupling" as the destabilizing factor;
-this one isolates the latter). A future attempt should treat "why does reordering _only_ routing nodes
-within an already-fixed rank structure destabilize the DFS on fixtures with real-node convergence, even
-with zero real-node geometry change" as the concrete open question — likely requiring instrumentation
-inside `solveFromComponent`'s deadline/`capacityOkForRemainder` logic itself (not just the diagnostic
-seam's before/after snapshots) to see which specific deadline or capacity check first flips as routing
-nodes are reordered, rather than another external ordering-heuristic attempt. No production code was
-changed for this investigation; the throwaway diagnostic script used to produce these numbers was
-deleted per the investigation's own scope constraints.
+full implementation covering every currently-`it.skip`'d fixture — the joint-order approach is not
+safe to wire into production `nodeSort`/`linkSort` unconditionally. It is, however, the most
+precisely localized negative result this line of investigation has produced to date (previous
+attempts changed real-node geometry and could not distinguish "real-node coupling" from
+"routing-node-order coupling" as the destabilizing factor; this one isolates the latter). A future
+attempt should treat "why does reordering _only_ routing nodes within an already-fixed rank
+structure destabilize the DFS on fixtures with real-node convergence, even with zero real-node
+geometry change" as the concrete open question — likely requiring instrumentation inside
+`solveFromComponent`'s deadline/`capacityOkForRemainder` logic itself (not just the diagnostic
+seam's before/after snapshots) to see which specific deadline or capacity check first flips as
+routing nodes are reordered, rather than another external ordering-heuristic attempt. No production
+code was changed for this investigation itself; the throwaway diagnostic script used to produce
+these numbers was deleted per the investigation's own scope constraints.
+
+**Follow-up (shipped):** the investigation above also isolated a strictly narrower
+case where the joint order is safe: graphs with **zero** real (non-routing) nodes at ranks 1–5 at
+all — i.e., no branch in the graph touches a milestone anywhere, not just "this rank happens to have
+no real node this time." `buildMilestoneFreeJointOrder` (near `layoutLifecycleRoutingGraphPass` in
+`src/web/tracker/lifecycleDiagramLayout.js`) implements exactly that narrower case: it is used as
+`nodeSort`/`linkSort`'s fallback only when `hasIntermediateRealNodes(graph)` is false and no other
+order was already supplied. This fully resolves `denseBranchProjection()` (see the "Checked-in
+reproduction" section below, now historical) with zero regressions across the rest of the test
+suite. It does **not** extend to any fixture with real milestone convergence — those remain exactly
+as infeasible as described above, and are the reason this fix is conditioned on
+`hasIntermediateRealNodes` rather than applied unconditionally.
 
 ## Separately: the deterministic-budget fix
 
@@ -416,8 +429,8 @@ skip states and test names can drift. `grep -rn "it\.skip(\|test\.skip(" test/` 
    [what didn't work alone](#what-didnt-work-alone),
    [attempted and reverted: barycenter](#attempted-and-reverted-barycenter-based-nodesortlinksort),
    and the
-   [P4 investigation (2026-07-26)](#p4-investigation-2026-07-26-a-real-node-position-preserving-joint-order-still-destabilizes-production-fixtures));
-   read all three before starting a fourth. The P4 investigation is the most informative to date: it
+   [Investigation (2026-07-26)](#investigation-2026-07-26-a-real-node-position-preserving-joint-order-still-destabilizes-production-fixtures));
+   read all three before starting a fourth. This investigation is the most informative to date: it
    isolates that reordering _only_ routing nodes (never touching real-node geometry at all) is
    independently sufficient to destabilize the deadline-based DFS on fixtures with real milestone
    convergence, which the barycenter attempt's real-node-position hypothesis alone doesn't explain —
@@ -541,13 +554,25 @@ still infeasible even under this pipeline. It only removes the wasted, unguided
 second search final used to run against a problem discovery had already spent its own
 budget solving (or, for that fixture, failing to solve — see below).
 
-## Checked-in reproduction: dense routing-only handle infeasibility is structural, not a budget gap
+## Checked-in reproduction: dense routing-only handle infeasibility is structural, not a budget gap (historical -- fixed for this fixture)
+
+**Status update:** the investigation above led to a shipped fix
+(`buildMilestoneFreeJointOrder`) for exactly the fixture this section
+originally characterized as infeasible — `denseBranchProjection()` has no real milestone nodes, so
+it is in-scope for that fix. The test this section describes has been renamed
+`"characterizes dense routing-only handle feasibility deterministically"` and now asserts success.
+This section is retained as the historical record of the pre-fix baseline (the exact numbers below
+are what the fix eliminated), not as a description of current behavior. The general
+milestone-convergence case (real milestone nodes, e.g. `tracker-lifecycle-diagram-v2.json`) is
+**not** fixed by this — see the investigation section above for why the same approach does not
+extend there, and [Outstanding follow-up work item 1](#outstanding-follow-up-work-as-of-this-writing)
+for the remaining scope.
 
 `test/web-tracker-lifecycle-diagram-layout.test.js`'s `"characterizes dense routing-only handle
 infeasibility deterministically"` (in the `"test-only lifecycle layout diagnostics"` describe
-block) is a durable, fast (~1s) regression for the structural finding below, so future work on
-item 1 can distinguish real progress from another ineffective spacing-constant, clearance-exemption,
-or budget change. It calls `testOnlyDiagnoseLifecycleLayoutAttempt` directly against
+block) was a durable, fast (~1s) regression for the structural finding below, so future work on
+item 1 could distinguish real progress from another ineffective spacing-constant, clearance-exemption,
+or budget change. It called `testOnlyDiagnoseLifecycleLayoutAttempt` directly against
 `denseBranchProjection()` (5 origins × 11 endpoints = 55 direct origin→endpoint branches, each
 routed through the taxonomy's 5 fixed milestone ranks) and stops at the diagnostic's first candidate
 snapshot — it never runs the fixture through full budget exhaustion, unlike the

--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -300,6 +300,81 @@ real/routing-node positions, interval/domain sizes, centered-assignment feasibil
 phase/reason, and deterministic state counts. It is intentionally not a production debugging API and
 does not log to the console.
 
+## P4 investigation (2026-07-26): a real-node-position-preserving joint order still destabilizes production fixtures
+
+A follow-up investigation (task "P4 — Implement rankOrder-aware cross-rank lifecycle routing")
+attempted the deferred fix above ([Option 2](#deferred-making-the-base-d3-sankey-layout-rankorder-aware))
+a second time, this time deliberately different from the reverted barycenter attempt: instead of an
+iterative, sweep-based repositioning heuristic, it used a single deterministic, purely topological
+sort — `compareBranches` (line 341) with the existing rank-0-only origin/taxonomy tie-break (normally
+only inside `compareBranchesForGlobalOrder`, line 2136) folded in — computed once from stable IDs,
+`endpointIndex`, `taxonomyOrder`, and rank, with **zero** dependency on any prior pass's geometry.
+Per-rank branch order was derived by _filtering_ this one global order (never re-sorting
+independently per rank), and per-rank node order for ranks mixing real and routing nodes reused
+(via a local, unmodified copy) `deriveAuthoritativeLayoutOrders`'s existing incoming/outgoing
+topological-merge algorithm (line 3013), adapted to run pre-layout against plain string
+source/target ids instead of post-layout node-object references.
+
+**This fully solved the exact structural gap the checked-in characterization test below documents.**
+Wired into `testOnlyDiagnoseLifecycleLayoutAttempt`'s `baseNodeOrderByRank`/
+`authoritativeBranchOrderByRank` hooks against `denseBranchProjection()` (55 branches, 5 pure-routing
+ranks, no real milestone nodes at all): the first candidate went from `firstRejectedPhase: "handle"`
+/ `reason: "no-candidates"` / 14 blocked branches (the historical baseline the characterization test
+below asserts) to **fully accepted** (`firstRejectedPhase: null`) — every rank stayed
+centered-assignment-feasible at the same ~59.251px spacing, and a full, unbypassed search succeeded
+in ~1.1s using only 5,637 of the 32,768 handle-state budget and 993 of the 200,000 transition-state
+budget. Reversed and rotated input reproduced byte-identical diagnostics, confirming the joint order
+is itself array-position-independent.
+
+**The same joint order reliably breaks both real fixtures**, even under a refinement specifically
+designed to avoid the barycenter attempt's leading suspect (changing real nodes' `y0`/`y1` via
+`nodeSort`): restricting the joint order's _node_-ordering override to ranks containing **zero** real
+nodes (i.e., only ever reordering routing-only ranks, never touching a real milestone/origin/endpoint
+node's position or relative order) eliminated the topological-merge's own `order-disagreement` failure
+(which the _unrestricted_ version hit deterministically at rank 3, always at the same node,
+`milestone:technical_interview`, on both `test/fixtures/tracker-lifecycle-diagram-routing-v2.json`
+and `test/fixtures/tracker-lifecycle-diagram-v2.json` — the incoming-side and outgoing-side branch
+position contexts the merge tries to reconcile there are genuinely inconsistent under a purely static
+order, unlike under a search-derived order where continuous-valued geometry avoids the conflict by
+construction). But even with real-node positions provably untouched:
+
+- The reference routing fixture (`tracker-lifecycle-diagram-routing-v2.json`, currently 0 fatal audit
+  findings under normal two-pass production layout) exhausted the handle-state budget at 32,806 of
+  32,768 states when run as a single full search under the routing-only-restricted joint order —
+  essentially _at_ the ceiling, the same "exhausted the entire budget, not just short of it" signature
+  the barycenter attempt and the raised-budget diagnostic (see
+  ["Outstanding follow-up work" item 1](#outstanding-follow-up-work-as-of-this-writing)) both produced.
+- `tracker-lifecycle-diagram-v2.json` (the real dense production fixture) went from 3 blocked branches
+  at the handle phase under the current baseline to **12** blocked branches under the joint order (a
+  regression, not an improvement), and a full search exhausted the handle-state budget at 32,965 of
+  32,768 states — again essentially at the ceiling.
+
+**Why this matters beyond reproducing the known failure mode:** it rules out the design doc's leading
+hypothesis for the barycenter mystery — "changing real nodes' actual `y0`/`y1` positions... changes
+every geometry-derived input" (see
+["Attempted and reverted: barycenter"](#attempted-and-reverted-barycenter-based-nodesortlinksort)) —
+as the _sole_ mechanism, since this variant never changes a single real node's position or relative
+order. Reordering **only** the routing nodes within their own already-routing-only ranks, via a
+well-behaved, deterministic, stable-ID-based order that fully solves the routing-only characterization
+fixture, is _independently_ sufficient to destabilize the deadline-based DFS on fixtures with real
+milestone convergence points. The fix this task needs and the fix the routing-only characterization
+fixture needs are, at least under this construction, in direct tension: applying the joint order helps
+exactly the fixture with no real-node convergence and hurts exactly the fixtures that have it.
+
+**Conclusion and status:** per the task's own staged plan, this is a **no-go** for proceeding to a
+full implementation as scoped — the joint-order approach is not safe to wire into production
+`nodeSort`/`linkSort` in this form. It is, however, the most precisely localized negative result this
+line of investigation has produced to date (previous attempts changed real-node geometry and could
+not distinguish "real-node coupling" from "routing-node-order coupling" as the destabilizing factor;
+this one isolates the latter). A future attempt should treat "why does reordering _only_ routing nodes
+within an already-fixed rank structure destabilize the DFS on fixtures with real-node convergence, even
+with zero real-node geometry change" as the concrete open question — likely requiring instrumentation
+inside `solveFromComponent`'s deadline/`capacityOkForRemainder` logic itself (not just the diagnostic
+seam's before/after snapshots) to see which specific deadline or capacity check first flips as routing
+nodes are reordered, rather than another external ordering-heuristic attempt. No production code was
+changed for this investigation; the throwaway diagnostic script used to produce these numbers was
+deleted per the investigation's own scope constraints.
+
 ## Separately: the deterministic-budget fix
 
 Unrelated to the ordering-systems problem above (shipped first, in an earlier commit on this same
@@ -337,21 +412,25 @@ This is the authoritative, current list — cross-check against the code before 
 skip states and test names can drift. `grep -rn "it\.skip(\|test\.skip(" test/` finds all of them.
 
 1. **Deferred: make the base D3-Sankey layout `rankOrder`-aware** (a.k.a. "Option 2" above) — the
-   real fix for every remaining item below. Two attempts already tried and reverted (see
-   [what didn't work alone](#what-didnt-work-alone) and
-   [attempted and reverted: barycenter](#attempted-and-reverted-barycenter-based-nodesortlinksort));
-   read both before starting a third. The barycenter attempt's unsolved mystery (node-position
-   changes destabilizing the deadline-based DFS in an unexplained way) is the most likely blocker
-   and should be root-caused first — see that section's closing paragraph for where to start
-   looking. Re-confirmed independently by a later session that built the seeded-replay pipeline
-   above: even with final's redundant search eliminated, discovery's own one-time combined
-   lane+handle search for `tracker-lifecycle-diagram-v2.json` never finds a working assignment —
-   raising the handle-search budget from 32,768 to 2,000,000 states (diagnostic only, not shipped)
-   still failed after 100+ seconds, and the same ~3 branches were blocked (`reason: "no-candidates"`)
-   across every one of the 98 distinct lane-order candidates tried before hitting the normal
-   budget. This rules out "the search just needs to be more efficient" and confirms the gap really
-   is what this section already says: a constructive/greedy placement strategy, not a search
-   or plumbing fix.
+   real fix for every remaining item below. Three attempts already tried and reverted or halted (see
+   [what didn't work alone](#what-didnt-work-alone),
+   [attempted and reverted: barycenter](#attempted-and-reverted-barycenter-based-nodesortlinksort),
+   and the
+   [P4 investigation (2026-07-26)](#p4-investigation-2026-07-26-a-real-node-position-preserving-joint-order-still-destabilizes-production-fixtures));
+   read all three before starting a fourth. The P4 investigation is the most informative to date: it
+   isolates that reordering _only_ routing nodes (never touching real-node geometry at all) is
+   independently sufficient to destabilize the deadline-based DFS on fixtures with real milestone
+   convergence, which the barycenter attempt's real-node-position hypothesis alone doesn't explain —
+   see that section for the concrete open question a future attempt should root-cause first
+   (specifically inside `solveFromComponent`'s deadline/`capacityOkForRemainder` logic). Re-confirmed
+   independently by a later session that built the seeded-replay pipeline above: even with final's
+   redundant search eliminated, discovery's own one-time combined lane+handle search for
+   `tracker-lifecycle-diagram-v2.json` never finds a working assignment — raising the handle-search
+   budget from 32,768 to 2,000,000 states (diagnostic only, not shipped) still failed after 100+
+   seconds, and the same ~3 branches were blocked (`reason: "no-candidates"`) across every one of the
+   98 distinct lane-order candidates tried before hitting the normal budget. This rules out "the
+   search just needs to be more efficient" and confirms the gap really is what this section already
+   says: a constructive/greedy placement strategy, not a search or plumbing fix.
 2. **4 unit tests remain `it.skip`ed**, all for the same reason (a genuinely infeasible
    crossing-free arrangement in the current domain, not a bug this document's fixes address):
    - `test/web-tracker-lifecycle-diagram-layout.test.js`: `"shares a single handle budget across

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -641,19 +641,109 @@ export function createLaneGeometryFailureCache() {
   };
 }
 
+// compareBranches, plus the rank-0-only origin/taxonomy tie-break normally
+// only applied inside compareBranchesForGlobalOrder (see that function,
+// below), folded into a single comparator. Used only to derive a joint
+// base-layout order for graphs with no real milestone nodes -- see
+// hasIntermediateRealNodes/buildMilestoneFreeJointOrder below and
+// docs/design/lifecycle-diagram-layout-algorithm.md's "Investigation (2026-07-26)"
+// section for why this is scoped that narrowly rather than applied
+// everywhere: the same order destabilizes the deadline-based DFS on graphs
+// with real milestone convergence, even when it never touches a real
+// node's position.
+const compareBranchesJoint = (a, b) => {
+  if (a.sourceRank === 0 && b.sourceRank === 0) {
+    const taxonomyDiff = taxonomyOrder(a.source) - taxonomyOrder(b.source);
+    if (taxonomyDiff !== 0) return taxonomyDiff;
+  }
+  return compareBranches(a, b);
+};
+
+// True when any rank between the fixed origin/endpoint ranks (0 and 6) has
+// a real (non-routing) node -- i.e. this graph actually routes through a
+// milestone somewhere. buildMilestoneFreeJointOrder is only safe to use
+// when this is false.
+const hasIntermediateRealNodes = (graph) =>
+  graph.nodes.some((node) => !node.routing && node.rank >= 1 && node.rank <= 5);
+
+// Derives a single, stable-ID/topology-only order for both node rank and
+// per-transition-rank branch order, for graphs where every rank 1-5 node is
+// a routing node (no real milestone convergence anywhere in the graph).
+// Because there are no real nodes at those ranks, no real-node-vs-
+// routing-node reconciliation is needed here; ranks 0 and 6 keep nodeSort's
+// own existing taxonomy-order anchoring, which compareBranchesJoint's
+// rank-0 tie-break already agrees with by construction.
+const buildMilestoneFreeJointOrder = (graph) => {
+  const jointBranches = [...graph.branches].sort(compareBranchesJoint);
+  const branchOrderByRank = new Map();
+  const ranksInUse = new Set();
+  for (const branch of jointBranches)
+    for (let rank = branch.sourceRank; rank < branch.targetRank; rank += 1)
+      ranksInUse.add(rank);
+  for (const rank of ranksInUse) {
+    const active = jointBranches.filter(
+      (branch) => branch.sourceRank <= rank && rank < branch.targetRank,
+    );
+    branchOrderByRank.set(
+      rank,
+      new Map(active.map((branch, index) => [branch.id, index])),
+    );
+  }
+  const nodeOrderByRank = new Map();
+  for (const rank of [...new Set(graph.nodes.map((node) => node.rank))]) {
+    const nodes = graph.nodes.filter((node) => node.rank === rank);
+    if (rank === 0 || rank === 6) {
+      nodes.sort(nodeSort);
+    } else {
+      const branchIndex = branchOrderByRank.get(rank);
+      nodes.sort(
+        (left, right) =>
+          (branchIndex?.get(left.branchId) ?? 0) -
+            (branchIndex?.get(right.branchId) ?? 0) ||
+          compareLifecycleIds(left.id, right.id),
+      );
+    }
+    nodeOrderByRank.set(
+      rank,
+      new Map(nodes.map((node, index) => [node.id, index])),
+    );
+  }
+  return { nodeOrderByRank, branchOrderByRank };
+};
+
 function layoutLifecycleRoutingGraphPass(
   projection,
   availableWidth,
   options = {},
 ) {
   const enableTestDiagnostics = isLifecycleLayoutTestEnvironment();
-  const baseNodeOrderByRank =
+  const explicitNodeOrderByRank =
     options.authoritativeNodeOrderByRank ??
     (enableTestDiagnostics ? options.testOnlyBaseNodeOrderByRank : null);
   const testOnlyDiagnosticSink = enableTestDiagnostics
     ? options.testOnlyDiagnosticSink
     : null;
   const graph = options.routingGraph ?? buildLifecycleRoutingGraph(projection);
+  // When nothing else supplies a base order and this graph never routes
+  // through a real milestone node, discovery's own first D3 pass would
+  // otherwise use plain, rankOrder-blind nodeSort/linkSort -- the gap
+  // documented in docs/design/lifecycle-diagram-layout-algorithm.md's
+  // "Deferred: making the base D3-Sankey layout rankOrder-aware" section.
+  // buildMilestoneFreeJointOrder closes that gap for exactly this scoped
+  // case (proven safe; see that doc's "Investigation (2026-07-26)" section for why
+  // it is not applied more broadly).
+  const milestoneFreeJointOrder =
+    !explicitNodeOrderByRank &&
+    !options.authoritativeBranchOrderByRank &&
+    !hasIntermediateRealNodes(graph)
+      ? buildMilestoneFreeJointOrder(graph)
+      : null;
+  const baseNodeOrderByRank =
+    explicitNodeOrderByRank ?? milestoneFreeJointOrder?.nodeOrderByRank ?? null;
+  const authoritativeBranchOrderByRank =
+    options.authoritativeBranchOrderByRank ??
+    milestoneFreeJointOrder?.branchOrderByRank ??
+    null;
   const baselineLinks = new Map(
     graph.links.map((link) => [
       link.id,
@@ -703,7 +793,7 @@ function layoutLifecycleRoutingGraphPass(
         left.source.id === right.source.id
           ? left.source.rank
           : left.target.rank - 1;
-      const order = options.authoritativeBranchOrderByRank?.get(transitionRank);
+      const order = authoritativeBranchOrderByRank?.get(transitionRank);
       const leftIndex = order?.get(left.branchId);
       const rightIndex = order?.get(right.branchId);
       return (

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -1456,51 +1456,27 @@ describe("test-only lifecycle layout diagnostics", () => {
     ).toBe(true);
   });
 
-  // Characterizes (without exhausting the shared handle-search budget) the
-  // structural cause documented in
-  // docs/design/lifecycle-diagram-layout-algorithm.md: denseBranchProjection()
-  // (5 origins x 11 endpoints = 55 direct origin->endpoint branches, each
-  // routed through the taxonomy's 5 fixed milestone ranks) already fails at
-  // the *first* candidate's handle-placement phase, not from narrowly
-  // exhausting the lane or handle search. Confirmed by direct instrumentation
-  // (testOnlyDiagnoseLifecycleLayoutAttempt stops at the first candidate
-  // snapshot, so this never runs the fixture through full budget
-  // exhaustion): 14 "long diagonal" branches -- later-ordered origins
-  // (referral, recruiter_company_outreach, other_unknown) paired with
-  // later-ordered endpoints (offer_declined, offer_expired_rescinded,
-  // offer_accepted, closed_archived, unknown, candidate_withdrew) -- get zero
-  // legal handle candidates anywhere along their curve, even though every
-  // rank's lane domains and centered assignment remain feasible at the
-  // fixture's own ~59.251px minimum lane spacing. The five routing-only
-  // ranks (one per fixed milestone) each host all 55 branches' routing
-  // nodes (275 total), which is the actual source of the geometric
-  // contention -- not real-node dock spacing, port pitch, or a clearance
-  // exemption, all of which prior attempts already tried and reverted (see
-  // the design doc's "Outstanding follow-up work" section).
-  it("characterizes dense routing-only handle infeasibility deterministically", () => {
-    const EXPECTED_BLOCKED_BRANCH_IDS = [
-      "branch:link:origin:other_unknown->endpoint:closed_archived:endpoint:closed_archived",
-      "branch:link:origin:other_unknown->endpoint:offer_accepted:endpoint:offer_accepted",
-      "branch:link:origin:other_unknown->endpoint:offer_declined:endpoint:offer_declined",
-      // eslint-disable-next-line max-len
-      "branch:link:origin:other_unknown->endpoint:offer_expired_rescinded:endpoint:offer_expired_rescinded",
-      "branch:link:origin:other_unknown->endpoint:unknown:endpoint:unknown",
-      // eslint-disable-next-line max-len
-      "branch:link:origin:recruiter_company_outreach->endpoint:closed_archived:endpoint:closed_archived",
-      // eslint-disable-next-line max-len
-      "branch:link:origin:recruiter_company_outreach->endpoint:offer_accepted:endpoint:offer_accepted",
-      // eslint-disable-next-line max-len
-      "branch:link:origin:recruiter_company_outreach->endpoint:offer_declined:endpoint:offer_declined",
-      // eslint-disable-next-line max-len
-      "branch:link:origin:recruiter_company_outreach->endpoint:offer_expired_rescinded:endpoint:offer_expired_rescinded",
-      "branch:link:origin:recruiter_company_outreach->endpoint:unknown:endpoint:unknown",
-      "branch:link:origin:referral->endpoint:candidate_withdrew:endpoint:candidate_withdrew",
-      "branch:link:origin:referral->endpoint:closed_archived:endpoint:closed_archived",
-      "branch:link:origin:referral->endpoint:offer_accepted:endpoint:offer_accepted",
-      // eslint-disable-next-line max-len
-      "branch:link:origin:referral->endpoint:offer_expired_rescinded:endpoint:offer_expired_rescinded",
-    ].sort(compareLifecycleIds);
-
+  // Historical baseline (pre-fix, see
+  // docs/design/lifecycle-diagram-layout-algorithm.md's "Checked-in
+  // reproduction" section): denseBranchProjection() (5 origins x 11
+  // endpoints = 55 direct origin->endpoint branches, each routed through
+  // the taxonomy's 5 fixed milestone ranks) used to fail at the *first*
+  // candidate's handle-placement phase (firstRejectedPhase: "handle",
+  // reason: "no-candidates"), with 14 "long diagonal" branches -- later-
+  // ordered origins (referral, recruiter_company_outreach, other_unknown)
+  // paired with later-ordered endpoints (offer_declined,
+  // offer_expired_rescinded, offer_accepted, closed_archived, unknown,
+  // candidate_withdrew) -- getting zero legal handle candidates anywhere
+  // along their curve, with states.handle in the low thousands (far below
+  // the 32768 budget -- not a narrow budget miss). Fixed by
+  // buildMilestoneFreeJointOrder giving discovery's own first D3 pass a
+  // topology-derived order instead of the plain, rankOrder-blind
+  // nodeSort/linkSort it fell back to before (this fixture has no real
+  // milestone nodes, so it's in-scope for that fix) -- see the design
+  // doc's "Investigation (2026-07-26)" section. This test now characterizes the
+  // fixed behavior: the same fixture, still deterministic and
+  // order-independent, now succeeds outright.
+  it("characterizes dense routing-only handle feasibility deterministically", () => {
     const reversedDenseBranchProjection = () => {
       const p = denseBranchProjection();
       return {
@@ -1541,21 +1517,23 @@ describe("test-only lifecycle layout diagnostics", () => {
     expect(reversed).toEqual(baseline);
     expect(shuffled).toEqual(baseline);
 
-    // First candidate already fails at handle placement, not lane search or
-    // budget exhaustion -- states stay far below the 32768 handle-state
-    // budget the production path eventually exhausts.
-    expect(baseline.firstRejectedPhase).toBe("handle");
+    // First candidate is now fully accepted (firstRejectedPhase: null),
+    // using only a small fraction of the 32768 handle-state budget.
+    // Historical baseline before the fix (see the comment above this
+    // test): firstRejectedPhase was "handle", reason "no-candidates", with
+    // exactly these 14 blocked branch IDs and states.handle far below
+    // 32768 but nonzero:
+    //   other_unknown -> closed_archived, offer_accepted, offer_declined,
+    //     offer_expired_rescinded, unknown
+    //   recruiter_company_outreach -> closed_archived, offer_accepted,
+    //     offer_declined, offer_expired_rescinded, unknown
+    //   referral -> candidate_withdrew, closed_archived, offer_accepted,
+    //     offer_expired_rescinded
+    //   (full branch IDs: "branch:link:origin:<origin>->endpoint:<endpoint>:endpoint:<endpoint>")
+    expect(baseline.firstRejectedPhase).toBeNull();
+    expect(baseline.firstRejectedReason).toBeNull();
     expect(baseline.states.handle).toBeGreaterThan(0);
     expect(baseline.states.handle).toBeLessThan(32768);
-    expect(baseline.firstRejectedReason).toMatchObject({
-      reason: "no-candidates",
-      evidence: { branchDiagnosticCount: 14 },
-    });
-    expect(
-      [...baseline.firstRejectedReason.evidence.blockedBranchIds].sort(
-        compareLifecycleIds,
-      ),
-    ).toEqual(EXPECTED_BLOCKED_BRANCH_IDS);
 
     // Lane domains and the centered assignment remain feasible at every
     // rank's own minimum spacing -- this is not a spacing-constant problem.
@@ -2517,19 +2495,15 @@ describe("lifecycle diagram render-only routing layout", () => {
     }
   });
 
-  // Skipped: denseBranchProjection()'s multi-rank routing (each branch
-  // spans several ranks via routing nodes) has no handle-clearance-feasible
-  // lane arrangement — confirmed by direct instrumentation, the set of
-  // blocked branches is identical across hundreds of distinct coordinate
-  // assignments the lane-refinement search tries. That's a pre-existing gap
-  // between what refineGlobalLaneCoordinates searches over (lane-spacing
-  // legality) and what handle placement actually needs (route-to-route
-  // clearance at sampled handle points), out of scope for the
-  // exponential-blowup fix this PR makes. The search itself is now fast and
-  // deterministic (was exponential before this PR), it just cannot
-  // currently find a working answer for this fixture. Tracked as a
-  // follow-up.
-  it.skip("keeps handle invariants with more than 32 display branches", () => {
+  // denseBranchProjection() has no real milestone nodes (every branch is a
+  // direct origin->endpoint link), so buildMilestoneFreeJointOrder now
+  // gives discovery's own first D3 pass a topology-derived, cross-rank-
+  // consistent node/link order instead of the plain, rankOrder-blind
+  // nodeSort/linkSort it used to fall back to -- see
+  // docs/design/lifecycle-diagram-layout-algorithm.md's "Investigation (2026-07-26)"
+  // section. Before that fix, this fixture had no handle-clearance-feasible
+  // lane arrangement the search could find.
+  it("keeps handle invariants with more than 32 display branches", () => {
     const { graph } = layoutLifecycleRoutingGraph(
       denseBranchProjection(),
       1850,
@@ -2608,28 +2582,27 @@ describe("lifecycle diagram render-only routing layout", () => {
   });
 
   it("resolves un-phased dense multi-rank fan-in fast, without exponential blowup", () => {
-    // denseBranchProjection()'s multi-rank routing has no
-    // handle-clearance-feasible lane arrangement (see the skipped test
-    // above for the root-cause analysis), so this direct production-path
-    // regression must fail with deterministic handle-phase evidence while
-    // staying bounded.
+    // Historical baseline (pre-fix): this direct production-path call used
+    // to fail deterministically with "Lifecycle handle search exceeded
+    // 32768 states" (reason: "state-limit", phase: "handle"), since
+    // denseBranchProjection()'s multi-rank routing had no
+    // handle-clearance-feasible lane arrangement discovery's plain,
+    // rankOrder-blind nodeSort/linkSort could find. Fixed by
+    // buildMilestoneFreeJointOrder (see
+    // docs/design/lifecycle-diagram-layout-algorithm.md's
+    // "Investigation (2026-07-26)" section) -- this fixture has no real
+    // milestone nodes, so it's in-scope for that fix. The search itself is
+    // now fast and deterministic (was exponential before PR #1147;
+    // state-limited before this fix), and now finds a legal arrangement
+    // well within budget.
     const start = Date.now();
-    let thrown;
-    try {
-      layoutLifecycleRoutingGraph(denseBranchProjection(), 1850);
-    } catch (error) {
-      thrown = error;
-    }
-    expect(thrown?.message).toBe(
-      "Lifecycle handle search exceeded 32768 states",
+    const { graph } = layoutLifecycleRoutingGraph(
+      denseBranchProjection(),
+      1850,
     );
-    expect(thrown?.cause).toMatchObject({
-      reason: "state-limit",
-      phase: "handle",
-      stateLimit: 32768,
-    });
-    expect(thrown?.cause?.statesVisited).toBeGreaterThanOrEqual(32768);
-    expect(thrown?.cause?.routeEdgeCount).toBeGreaterThan(0);
+    const stats = graph.transitionLaneSolverStats;
+    expect(stats.handleStatesVisited).toBeGreaterThan(0);
+    expect(stats.handleStatesVisited).toBeLessThan(32768);
     expect(Date.now() - start).toBeLessThan(30000);
   });
 });


### PR DESCRIPTION
## Summary

- Fixes a real (not just test-scale) limitation: lifecycle diagrams with many direct origin->endpoint branches and no milestone stops (e.g. a job seeker with applications spread across many different origin/outcome combinations) previously had no handle-clearance-feasible layout at all, and would render "Unable to lay out lifecycle diagram."
- Root cause: discovery's own first D3-Sankey pass always used a plain, rankOrder-blind `nodeSort`/`linkSort`. A prior investigation (see `docs/design/lifecycle-diagram-layout-algorithm.md`'s "Investigation (2026-07-26)" section) found that a purely topological joint order fixes this completely for graphs with **zero** real milestone nodes, but destabilizes the search on fixtures with real milestone convergence — so this ships only the proven-safe, narrower case.
- `buildMilestoneFreeJointOrder` derives a single deterministic order from stable IDs/endpoint/taxonomy and uses it as `nodeSort`/`linkSort`'s fallback, gated on `hasIntermediateRealNodes(graph)` being false and no other order already supplied. The final (seeded-replay) pass and any fixture with a real milestone node are completely unaffected.
- Un-skips `"keeps handle invariants with more than 32 display branches"`; updates the two tests that encoded the old failure mode, keeping their determinism/reversed-input invariants.

## Test plan
- [x] `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js test/web-tracker-lifecycle-diagram.test.js` — 92 passed, 3 skipped (the remaining milestone-convergence cases, follow-up work)
- [x] `npm run test:ci` — 146/147 files, 1217/1220 non-skipped tests pass (3 pre-existing, unrelated `test/claude-validate.test.js` bubblewrap-sandbox failures reproduced identically with these changes stashed out)
- [x] `npm run lint -- --quiet`, `npm run typecheck`, `npx prettier --check` on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)