### PR TITLE
Tolerate a small, bounded route-crossing count instead of requiring zero

### DIFF
--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -388,6 +388,37 @@ suite. It does **not** extend to any fixture with real milestone convergence —
 as infeasible as described above, and are the reason this fix is conditioned on
 `hasIntermediateRealNodes` rather than applied unconditionally.
 
+## Follow-up (shipped): a small, bounded route-crossing tolerance
+
+Historically, `candidateCallback` required a candidate to have exactly zero fatal route-crossing
+findings (`routeAudit.fatalFindings.length === 0`) to be accepted — the same all-or-nothing bar as
+handle placement. For some fixtures no zero-crossing arrangement is reachable within the
+deterministic budget (or exists at all), so the search burned its whole budget and then threw,
+rendering the "Unable to lay out lifecycle diagram." fallback for what may just be a visually busy
+diagram, not a broken one.
+
+`candidateCallback` now accepts a **handle-feasible** candidate (handle placement itself is
+unchanged and stays a hard, zero-tolerance requirement — an unclickable or ambiguous handle is a
+real usability bug) whose fatal route-crossing count is at or below `toleratedRouteCrossingCount`
+(`Math.min(8, Math.ceil(branchCount * 0.03))`, near `HANDLE_ROUTE_EDGE_COST_DIVISOR`). The accepted
+count is recorded as `graph.acceptedRouteCrossingCount` and
+`transitionLaneSolverStats.acceptedRouteCrossingCount` so callers/tests can tell a perfectly clean
+layout (`0`) apart from a merely acceptable one. Because the seed-replay validation path
+(`solveGlobal`'s seed-replay branch) invokes this exact same `candidateCallback` closure for its
+one-time acceptance check, this relaxation applies uniformly to discovery, single-pass/diagnostic
+calls, and the final pass's seed replay with no separate plumbing.
+
+**This does not, by itself, fix every currently-`it.skip`'d fixture.** Confirmed directly:
+`tracker-lifecycle-diagram-v2.json` still exhausts the handle-state budget (32,920/32,768) under
+this change — it never reaches the route-crossing check at all, because its bottleneck (per the
+"Checked-in reproduction" section) is that specific branches have **zero legal handle positions
+anywhere on their curve**, not merely a route crossing. The reference routing fixture is unaffected
+(still 0 accepted crossings, unchanged geometry). Making more fixtures succeed further requires
+either improving handle-candidate availability itself or a comparable, deliberately-scoped tolerance
+on handle placement — a materially different (and more consequential, since it touches click-target
+usability rather than a purely visual concern) relaxation than this one, tracked as further
+follow-up work rather than assumed to already be covered here.
+
 ## Separately: the deterministic-budget fix
 
 Unrelated to the ordering-systems problem above (shipped first, in an earlier commit on this same

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -50,6 +50,22 @@ const COLLISION_MARGIN = -1;
 // deterministic state cap also retains margin beneath the 30-second render
 // latency contract when test workers or the browser contend for a CPU.
 const HANDLE_ROUTE_EDGE_COST_DIVISOR = 6000;
+// Handle placement (no overlapping click targets) stays a hard requirement
+// with zero tolerance -- an unclickable or ambiguous handle is a real
+// usability bug, not an aesthetic one. Route-to-route line crossings are a
+// separate, softer concern: a handful of crossings in a dense diagram with
+// many branches is a minor visual blemish, not a broken diagram, and
+// requiring exactly zero of them makes some genuinely dense fixtures
+// unsolvable in bounded search time (see
+// docs/design/lifecycle-diagram-layout-algorithm.md's investigation
+// sections). candidateCallback accepts a handle-feasible candidate whose
+// route-crossing count is at or below this bound instead of continuing to
+// search for (or ultimately failing to find) a perfectly crossing-free
+// arrangement. Kept small and roughly proportional to branch count so a
+// tiny diagram still expects a clean layout while a dense one gets a
+// little slack.
+const toleratedRouteCrossingCount = (branchCount) =>
+  Math.min(8, Math.ceil(branchCount * 0.03));
 // Primary handle-candidate sample points: three points near the middle of a
 // segment's transition corridor, tried first so ordinary (sparse) fixtures
 // keep selecting the same candidates they always have.
@@ -2931,7 +2947,17 @@ function layoutLifecycleRoutingGraphPass(
         dimensions,
         handles: handleCheck.handles,
       });
-      if (routeAudit.fatalFindings.length === 0) {
+      if (
+        routeAudit.fatalFindings.length <=
+        toleratedRouteCrossingCount(graph.branches.length)
+      ) {
+        // Route crossings are tolerated up to the small bound above; handle
+        // placement itself was still a hard requirement (handleCheck.ok,
+        // checked before this block runs). Record the exact accepted
+        // crossing count so callers/tests can tell a perfectly clean layout
+        // (0) apart from a merely acceptable one (>0) instead of only
+        // knowing whether layout succeeded at all.
+        graph.acceptedRouteCrossingCount = routeAudit.fatalFindings.length;
         if (testOnlyDiagnosticSink) {
           testOnlyDiagnosticSink({
             phase: "accepted",
@@ -3069,6 +3095,8 @@ function layoutLifecycleRoutingGraphPass(
   transitionLaneSolverStats.candidateEvaluations = candidateEvaluations;
   transitionLaneSolverStats.handleStatesVisited = handleBudget.statesVisited;
   transitionLaneSolverStats.handleStateLimit = handleBudget.stateLimit;
+  transitionLaneSolverStats.acceptedRouteCrossingCount =
+    graph.acceptedRouteCrossingCount ?? 0;
   graph.transitionLaneRankOrder = new Map(
     [...laneResult.rankRefinementInfo.entries()].map(([rank, info]) => [
       rank,

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -2659,6 +2659,12 @@ describe("seeded-replay production layout (routing fixture)", () => {
       expect(stats.handleStatesVisited).toBeLessThanOrEqual(
         stats.handleStateLimit,
       );
+      // The route-crossing tolerance introduced alongside this test only
+      // relaxes acceptance for candidates that would otherwise exhaust the
+      // budget; this fixture already finds a perfectly clean layout, so its
+      // accepted crossing count must stay exactly 0, not merely "small".
+      expect(graph.acceptedRouteCrossingCount).toBe(0);
+      expect(stats.acceptedRouteCrossingCount).toBe(0);
 
       const handles = handlesFor(graph);
       expect(handles).toHaveLength(graph.branches.length);


### PR DESCRIPTION
## Summary

- Stacked on #1168 (base branch: `p4-milestone1-joint-order-milestone-free`).
- `candidateCallback` used to require exactly zero fatal route-crossing findings to accept a layout candidate -- the same all-or-nothing bar as handle placement. For fixtures with no zero-crossing arrangement reachable in bounded search time, this meant burning the whole budget and falling back to "Unable to lay out lifecycle diagram." for what may just be a visually busy diagram, not a broken one.
- Handle placement itself is unchanged and stays a hard, zero-tolerance requirement -- an unclickable or ambiguous handle is a real usability bug. Route-to-route line crossings are a separate, softer concern: a handle-feasible candidate is now accepted if its fatal crossing count is at or below a small, branch-count-proportional bound (`toleratedRouteCrossingCount`). The accepted count is exposed via `graph.acceptedRouteCrossingCount` / `transitionLaneSolverStats.acceptedRouteCrossingCount` so callers can tell a perfectly clean layout apart from a merely acceptable one.
- Because the seed-replay validation path invokes the exact same `candidateCallback` closure for its one-time acceptance check, this relaxation applies uniformly to discovery, single-pass/diagnostic calls, and the final pass's seed replay -- no separate plumbing needed.
- **Does not, by itself, fix every remaining skipped fixture.** Confirmed directly: `tracker-lifecycle-diagram-v2.json` still exhausts the handle-state budget -- it never reaches the route-crossing check at all, because its bottleneck is specific branches having zero legal handle positions anywhere on their curve, a different problem. Documented as further follow-up in `docs/design/lifecycle-diagram-layout-algorithm.md`.

## Test plan
- [x] `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js test/web-tracker-lifecycle-diagram.test.js` -- 92 passed, 3 skipped, no regressions vs. #1168's baseline
- [x] `npm run test:ci` -- 146/147 files, 1217/1220 non-skipped tests pass (3 pre-existing, unrelated `test/claude-validate.test.js` bubblewrap-sandbox failures, reproduced identically with these changes stashed out)
- [x] `npm run lint -- --quiet`, `npm run typecheck`, `npx prettier --check` on all touched files
- [x] Reference fixture confirmed to still produce exactly 0 accepted crossings (new assertion added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)