### PR TITLE
Add handle-clearance tolerance; unblocks the real dense production fixture

### DIFF
--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -388,36 +388,88 @@ suite. It does **not** extend to any fixture with real milestone convergence —
 as infeasible as described above, and are the reason this fix is conditioned on
 `hasIntermediateRealNodes` rather than applied unconditionally.
 
-## Follow-up (shipped): a small, bounded route-crossing tolerance
+## Follow-up (shipped): bounded tolerances for route crossings and handle clearance
 
-Historically, `candidateCallback` required a candidate to have exactly zero fatal route-crossing
-findings (`routeAudit.fatalFindings.length === 0`) to be accepted — the same all-or-nothing bar as
-handle placement. For some fixtures no zero-crossing arrangement is reachable within the
-deterministic budget (or exists at all), so the search burned its whole budget and then threw,
-rendering the "Unable to lay out lifecycle diagram." fallback for what may just be a visually busy
-diagram, not a broken one.
+Historically, `candidateCallback` required exactly zero fatal route-crossing findings
+(`routeAudit.fatalFindings.length === 0`) _and_ every handle to have strictly positive clearance
+from every nonincident route, with no tolerance for either. For fixtures with real milestone
+convergence, no arrangement meeting both bars is reachable within the deterministic budget (or
+exists at all), so the search burned its whole budget and threw, rendering the "Unable to lay out
+lifecycle diagram." fallback for diagrams that may just be visually busy, not broken.
 
-`candidateCallback` now accepts a **handle-feasible** candidate (handle placement itself is
-unchanged and stays a hard, zero-tolerance requirement — an unclickable or ambiguous handle is a
-real usability bug) whose fatal route-crossing count is at or below `toleratedRouteCrossingCount`
-(`Math.min(8, Math.ceil(branchCount * 0.03))`, near `HANDLE_ROUTE_EDGE_COST_DIVISOR`). The accepted
-count is recorded as `graph.acceptedRouteCrossingCount` and
-`transitionLaneSolverStats.acceptedRouteCrossingCount` so callers/tests can tell a perfectly clean
-layout (`0`) apart from a merely acceptable one. Because the seed-replay validation path
-(`solveGlobal`'s seed-replay branch) invokes this exact same `candidateCallback` closure for its
-one-time acceptance check, this relaxation applies uniformly to discovery, single-pass/diagnostic
-calls, and the final pass's seed replay with no separate plumbing.
+Two separate, narrowly-scoped tolerances were shipped together, since the first alone proved
+insufficient (see the dead-end note below):
 
-**This does not, by itself, fix every currently-`it.skip`'d fixture.** Confirmed directly:
-`tracker-lifecycle-diagram-v2.json` still exhausts the handle-state budget (32,920/32,768) under
-this change — it never reaches the route-crossing check at all, because its bottleneck (per the
-"Checked-in reproduction" section) is that specific branches have **zero legal handle positions
-anywhere on their curve**, not merely a route crossing. The reference routing fixture is unaffected
-(still 0 accepted crossings, unchanged geometry). Making more fixtures succeed further requires
-either improving handle-candidate availability itself or a comparable, deliberately-scoped tolerance
-on handle placement — a materially different (and more consequential, since it touches click-target
-usability rather than a purely visual concern) relaxation than this one, tracked as further
-follow-up work rather than assumed to already be covered here.
+1. **Route-crossing tolerance** (`toleratedRouteCrossingCount`, near `HANDLE_ROUTE_EDGE_COST_DIVISOR`).
+   Scales with how much of the shared search budget has already been spent, not a flat constant —
+   confirmed directly that a flat, generous bound is unsafe: it let the search settle for an early
+   non-zero-crossing candidate on the reference fixture, which was already finding a perfectly clean
+   one, regressing it from 0 to 2 accepted crossings. Staying strict while budget is plentiful
+   preserves that a fixture the search can solve cleanly still does; only once budget pressure
+   crosses 50% does the bound loosen (linearly, toward `Math.min(120, branchCount * 2)`) toward a
+   much larger one.
+2. **Handle-clearance tolerance** (`HANDLE_CLEARANCE_TOLERANCE = 20`, exported near
+   `BRANCH_HANDLE_RADIUS`). A handle candidate whose clearance from a _nonincident_ route (not the
+   fixed geometry or another handle) is negative but within this bound is now collected as a
+   last-resort candidate, used only when a branch has zero fully-clear candidates anywhere across
+   both the primary and fallback t-value sweeps. Fixed-geometry avoidance and handle-vs-handle
+   non-overlap remain hard, zero-tolerance requirements throughout — an unclickable/ambiguous handle,
+   or one on top of a label, is a real usability bug; a handle a few pixels closer than ideal to an
+   unrelated line is not.
+
+Both tolerances record what they accepted (`graph.acceptedRouteCrossingCount` /
+`transitionLaneSolverStats.acceptedRouteCrossingCount`; each handle's own `clearanceMargin`) so
+callers/tests can tell a perfectly clean layout apart from a merely acceptable one.
+
+**Threading through the two-pass seed-replay contract required two additional fixes**, both
+confirmed necessary by directly reproducing the failure before fixing it:
+
+- The seed-replay validation path (`solveGlobal`'s seed-replay branch, and the direct
+  `seedHandles`-verification branch inside `tryAssignBranchHandles`) invokes `candidateCallback`
+  fresh, with its own budget pressure starting near zero. Discovery's own accepted crossing count is
+  threaded through as `seedAcceptedRouteCrossingCount` and used as the replay's bound directly,
+  instead of re-deriving one from the final pass's own near-zero pressure — replaying an
+  already-decided outcome exactly, not applying a fresh relaxation. The `seedHandles` verification
+  branch's own clearance check was widened by the same `HANDLE_CLEARANCE_TOLERANCE` for the same
+  reason.
+- `candidateCallback`'s two state-limit checks used to fire _before_ the tolerant-acceptance check
+  ever ran, so a candidate evaluated right at the budget boundary could never actually be accepted
+  under budget pressure — the hard throw always won the race. The charge, audit, and tolerant-accept
+  check now run first; the state-limit throw only fires afterward, if the candidate was both over
+  budget and not good enough to accept.
+
+**Dead end confirmed directly, not assumed:** the route-crossing tolerance alone, even generously
+sized, does not fix a fixture whose bottleneck is handle placement itself — confirmed directly
+against `tracker-lifecycle-diagram-v2.json`, which kept exhausting the handle-state budget without
+ever reaching the crossing check at all until the handle-clearance tolerance was added too. Handle
+placement had to be relaxed as its own, separately-justified change (still far more conservative
+than the crossing tolerance, since click-target usability is a harder requirement than visual
+crossing-freedom), not folded into the crossing tolerance's framing.
+
+**Result:** `tracker-lifecycle-diagram-v2.json` (the real dense production fixture named throughout
+this document — 16 applications, 21 nodes, previously infeasible even at 150x the handle budget) now
+lays out successfully end-to-end through the full two-pass pipeline, accepting 37 tolerated route
+crossings within normal budget usage (502/32768 handle states). The reference fixture is unaffected
+(still exactly 0 accepted crossings). `denseBranchProjection()` (Milestone 1's `buildMilestoneFreeJointOrder`
+target) also still succeeds cleanly, unaffected by either tolerance.
+
+**Still not fixed — two fixtures with a different, more extreme fan-in shape remain infeasible even
+under both tolerances**, confirmed directly, not assumed:
+
+- `transitionDensityProjection()` (50 branches funnelled through a single shared milestone) now
+  fails fast and deterministically with a genuine `no-candidates` invariant (not a budget
+  exhaustion) — a specific branch still has zero legal handle candidates anywhere on its curve even
+  with `HANDLE_CLEARANCE_TOLERANCE` applied. This is a materially harder convergence shape (50-into-1)
+  than the real dense fixture's (24-branch, multi-milestone) shape.
+- The 60-application/89-branch fixture in `test/web-tracker-lifecycle-diagram.test.js`'s
+  `"paginates more than 50 endpoint-conditioned flow rows without losing reachability"` still
+  exhausts the handle-state budget outright (same signature as
+  `transitionDensityProjection()` above).
+
+Both remain `it.skip`'d with comments describing this exact status. Making them succeed needs either
+a larger tolerance (with the same regression-safety verification this section's tolerances required)
+or a structurally different placement strategy for this specific convergence shape — tracked as
+further follow-up, not attempted here.
 
 ## Separately: the deterministic-budget fix
 

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -26,6 +26,17 @@ export const MINIMUM_SVG_WIDTH =
   6 * MINIMUM_RANK_CENTER_SPACING;
 export const BRANCH_STROKE_OPACITY = 0.82;
 export const BRANCH_HANDLE_RADIUS = 22;
+// A handle candidate's clearance from a *nonincident* route (a different
+// branch's line passing nearby) is a softer concern than clearance from
+// fixed geometry (a node/label box) or from another handle: it's the same
+// "sufficiently spread out, a little overlap is fine" tolerance
+// toleratedRouteCrossingCount applies to route-vs-route crossings, applied
+// here to handle-vs-route clearance instead. Fixed-geometry avoidance and
+// handle-vs-handle non-overlap remain hard, zero-tolerance requirements --
+// an unclickable/ambiguous handle, or one sitting on top of a label, is a
+// real usability bug; a handle a few pixels closer than ideal to an
+// unrelated line is not.
+export const HANDLE_CLEARANCE_TOLERANCE = 20;
 export const renderedBranchStrokeWidth = () => 3;
 export const selectedEnvelopeRadius = (segment) =>
   (renderedBranchStrokeWidth(segment?.width) + 12) / 2;
@@ -61,11 +72,27 @@ const HANDLE_ROUTE_EDGE_COST_DIVISOR = 6000;
 // sections). candidateCallback accepts a handle-feasible candidate whose
 // route-crossing count is at or below this bound instead of continuing to
 // search for (or ultimately failing to find) a perfectly crossing-free
-// arrangement. Kept small and roughly proportional to branch count so a
-// tiny diagram still expects a clean layout while a dense one gets a
-// little slack.
-const toleratedRouteCrossingCount = (branchCount) =>
-  Math.min(8, Math.ceil(branchCount * 0.03));
+// arrangement.
+//
+// The bound scales with how much of the shared search budget has already
+// been spent, not a flat constant -- confirmed directly that a flat,
+// generous bound is unsafe: it let the search settle for an early
+// non-zero-crossing candidate on a fixture that was already finding a
+// perfectly clean one, regressing a previously-zero-crossing fixture to 2
+// crossings. Staying strict (near zero tolerance) while budget is
+// plentiful preserves that a fixture the search can solve cleanly still
+// does; only once the search is genuinely struggling (spending most of its
+// budget without accepting anything) does the bound loosen toward a much
+// larger one, so a fixture with no reachable low-crossing arrangement gets
+// a real chance to succeed at all instead of exhausting the budget and
+// falling back to "Unable to lay out lifecycle diagram."
+const toleratedRouteCrossingCount = (branchCount, budgetFraction = 0) => {
+  const strict = Math.min(8, Math.ceil(branchCount * 0.03));
+  if (budgetFraction < 0.5) return strict;
+  const relaxed = Math.min(120, Math.ceil(branchCount * 2));
+  const pressure = Math.min(1, (budgetFraction - 0.5) / 0.45);
+  return Math.round(strict + (relaxed - strict) * pressure);
+};
 // Primary handle-candidate sample points: three points near the middle of a
 // segment's transition corridor, tried first so ordinary (sparse) fixtures
 // keep selecting the same candidates they always have.
@@ -2929,9 +2956,14 @@ function layoutLifecycleRoutingGraphPass(
       // Charged against the same shared budget as generation (see
       // tryAssignBranchHandles), scaled the same way (routeEdges squared)
       // since the audit's own cost is comparably driven by edge count — its
-      // pairwise crossing check is O(edges-within-rank^2).
-      if (handleBudget.statesVisited >= handleBudget.stateLimit)
-        throwHandleStateLimitExceeded();
+      // pairwise crossing check is O(edges-within-rank^2). The state-limit
+      // check that used to sit here (and again immediately after charging)
+      // fired before the tolerant-acceptance check below ever ran, which
+      // meant a candidate evaluated right at the budget boundary could
+      // never actually be accepted under budget pressure -- the hard throw
+      // always won the race. Charge first, then decide accept/reject, and
+      // only throw afterward if this candidate was both over budget and
+      // not good enough to accept.
       const auditRouteEdgeCount = handleCheck.routeEdgeCount ?? 1;
       handleBudget.statesVisited += Math.max(
         1,
@@ -2940,17 +2972,25 @@ function layoutLifecycleRoutingGraphPass(
             HANDLE_ROUTE_EDGE_COST_DIVISOR,
         ),
       );
-      if (handleBudget.statesVisited >= handleBudget.stateLimit)
-        throwHandleStateLimitExceeded();
       const routeAudit = auditLifecycleRouteGeometry({
         graph,
         dimensions,
         handles: handleCheck.handles,
       });
-      if (
-        routeAudit.fatalFindings.length <=
-        toleratedRouteCrossingCount(graph.branches.length)
-      ) {
+      const budgetFraction = Math.max(
+        handleBudget.statesVisited / handleBudget.stateLimit,
+        transitionLaneSolverStats.statesVisited /
+          transitionLaneSolverStats.stateLimit,
+      );
+      // Seed replay (final pass) validates a specific, already-accepted
+      // candidate rather than searching -- reproduce discovery's own bound
+      // exactly instead of deriving a fresh, near-zero-pressure one.
+      const routeCrossingBound = Number.isInteger(
+        options.seedAcceptedRouteCrossingCount,
+      )
+        ? options.seedAcceptedRouteCrossingCount
+        : toleratedRouteCrossingCount(graph.branches.length, budgetFraction);
+      if (routeAudit.fatalFindings.length <= routeCrossingBound) {
         // Route crossings are tolerated up to the small bound above; handle
         // placement itself was still a hard requirement (handleCheck.ok,
         // checked before this block runs). Record the exact accepted
@@ -2997,6 +3037,11 @@ function layoutLifecycleRoutingGraphPass(
         }
         return true;
       }
+      // Not good enough to accept even with the tolerance above -- now it's
+      // safe to check whether this candidate's own charge exhausted the
+      // budget and throw, instead of continuing to search with no room left.
+      if (handleBudget.statesVisited >= handleBudget.stateLimit)
+        throwHandleStateLimitExceeded();
       const blockedBranchIds = [
         ...new Set(
           routeAudit.fatalFindings.flatMap(
@@ -3352,6 +3397,17 @@ export function layoutLifecycleRoutingGraph(
       { y0: link.y0, y1: link.y1 },
     ]),
   );
+  // Discovery may have accepted a candidate with some tolerated route
+  // crossings (see toleratedRouteCrossingCount) under budget pressure. The
+  // final pass validates the seed with a single, fresh candidateCallback
+  // invocation -- its own budget pressure starts near zero, since it isn't
+  // searching, so the same pressure-scaled tolerance would reject the exact
+  // geometry discovery already committed to. Replaying discovery's own
+  // already-accepted crossing count as the bound (rather than re-deriving
+  // one from the final pass's own near-zero pressure) is exact reproduction
+  // of an already-decided outcome, not a fresh relaxation.
+  const discoveredAcceptedRouteCrossingCount =
+    discovery.graph.acceptedRouteCrossingCount ?? 0;
   const result = layoutLifecycleRoutingGraphPass(projection, availableWidth, {
     ...options,
     routingGraph: freshRoutingGraph(),
@@ -3361,6 +3417,7 @@ export function layoutLifecycleRoutingGraph(
     seedRankOrderByRank: discoveredRankOrder,
     seedHandles: discoveredHandles,
     seedLinkDocks: discoveredLinkDocks,
+    seedAcceptedRouteCrossingCount: discoveredAcceptedRouteCrossingCount,
   });
   const finalOrder = result.graph.transitionLaneRankOrder;
   if (finalOrder) {
@@ -4424,7 +4481,12 @@ const tryAssignBranchHandles = (
         seeded.x,
         seeded.y,
       );
-      if (clearance.margin <= 0) {
+      // Match the same last-resort tolerance the normal candidate-generation
+      // sweep applies (see HANDLE_CLEARANCE_TOLERANCE) -- a seeded handle
+      // discovery already accepted under that tolerance must still verify
+      // here, or replay would reject exactly what discovery just committed
+      // to.
+      if (clearance.margin <= -HANDLE_CLEARANCE_TOLERANCE) {
         blockedBranchIds.push(branch.id);
       }
     }
@@ -4495,6 +4557,11 @@ const tryAssignBranchHandles = (
       ...segments.filter((segment) => segment !== preferred),
     ].filter(Boolean);
     const candidates = [];
+    // Last-resort candidates whose clearance from a nonincident route is
+    // negative but within HANDLE_CLEARANCE_TOLERANCE -- only used if this
+    // branch has zero fully-clear candidates anywhere (see below), and
+    // still sorted so the least-bad one is preferred first.
+    const degradedCandidates = [];
     const diagnostic = {
       branchId: branch.id,
       segmentsExamined: orderedSegments.length,
@@ -4606,6 +4673,16 @@ const tryAssignBranchHandles = (
               box,
               clearanceMargin,
             });
+          } else if (clearanceMargin > -HANDLE_CLEARANCE_TOLERANCE) {
+            diagnostic.accepted += 1;
+            degradedCandidates.push({
+              branchId: branch.id,
+              x,
+              y,
+              radius: BRANCH_HANDLE_RADIUS,
+              box,
+              clearanceMargin,
+            });
           } else {
             diagnostic.rejected.nonincidentRouteClearance += 1;
             rememberRejected({
@@ -4624,9 +4701,13 @@ const tryAssignBranchHandles = (
         RANK_CORRIDOR_HALF_WIDTH,
       );
     }
+    // Only fall back to a degraded (small negative clearance) candidate
+    // when this branch has no fully-clear candidate anywhere across both
+    // sweeps -- a clean candidate is always preferred when one exists.
+    const finalCandidates = candidates.length ? candidates : degradedCandidates;
     candidateSets.set(
       branch.id,
-      candidates.sort(
+      finalCandidates.sort(
         (a, b) =>
           b.clearanceMargin - a.clearanceMargin || a.y - b.y || a.x - b.x,
       ),

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -9,6 +9,7 @@ import {
 import {
   BRANCH_HANDLE_RADIUS,
   BRANCH_STROKE_OPACITY,
+  HANDLE_CLEARANCE_TOLERANCE,
   ENDPOINT_BRANCH_COLORS,
   LAYOUT_BOTTOM_MARGIN,
   LAYOUT_TOP_MARGIN,
@@ -927,23 +928,20 @@ describe("transition lane solver", () => {
 
   it("resolves un-phased dense fan-in fast, without exponential blowup", () => {
     // transitionDensityProjection()'s 50-branch fan-in to one milestone has
-    // no handle-clearance-feasible lane arrangement (see the skipped tests
-    // above for the root-cause analysis), so this always throws — but the
-    // point of this regression test is that it must do so FAST (bounded and
-    // deterministic — never the multi-minute exponential-blowup hang the
-    // original bug report measured), not necessarily sub-10-second: shared
-    // CI runners measured ~2-3x slower than local dev hardware for this
-    // exact deterministic budget-exhaustion search, so this threshold has
-    // real margin above local timings rather than being tuned tight to one
-    // machine.
+    // no handle-clearance-feasible lane arrangement, even accounting for
+    // HANDLE_CLEARANCE_TOLERANCE's small last-resort clearance allowance
+    // (see the skipped test above for the root-cause analysis) -- so this
+    // always throws. The point of this regression test is that it must do
+    // so FAST and deterministically (never the multi-minute
+    // exponential-blowup hang the original bug report measured).
     //
-    // The wider handle-candidate fallback search (added to fix real dense
-    // fixtures whose primary three sample points miss a legal point that
-    // exists elsewhere on the curve) gives this synthetic 50-branch
-    // fan-in's candidateCallback attempts a larger per-attempt cost, so the
-    // shared state budget is now what ends the search first rather than a
-    // clean handle-placement conflict; both are equally legitimate
-    // deterministic, bounded failures.
+    // Historical baseline: before HANDLE_CLEARANCE_TOLERANCE, this exhausted
+    // the shared handle-state budget (32768/32768, "state-limit"). With the
+    // tolerance in place, the search now converges on a genuine, cheaper
+    // "no-candidates" invariant instead -- still deterministic and bounded,
+    // just a different (faster) failure signature for the same underlying
+    // infeasibility: at least one branch still has zero legal handle
+    // candidates anywhere along its curve even with the tolerance applied.
     const start = Date.now();
     let thrown;
     try {
@@ -951,14 +949,11 @@ describe("transition lane solver", () => {
     } catch (error) {
       thrown = error;
     }
-    expect(thrown?.message).toBe(
-      "Lifecycle handle search exceeded 32768 states",
-    );
     expect(thrown?.cause).toMatchObject({
-      reason: "state-limit",
-      phase: "handle",
-      stateLimit: 32768,
+      type: "lifecycle-handle-placement",
+      reason: "no-candidates",
     });
+    expect(thrown?.cause?.blockedBranchIds?.length).toBeGreaterThan(0);
     expect(Date.now() - start).toBeLessThan(30000);
   });
 
@@ -1410,15 +1405,21 @@ describe("test-only lifecycle layout diagnostics", () => {
       1850,
       { baseNodeOrderByRank: reversedBaseOrderFrom(baseline) },
     );
-    expect(reversed.firstRejectedPhase).toBe("handle");
+    // With HANDLE_CLEARANCE_TOLERANCE, every branch now has at least one
+    // legal handle candidate under this reversed order (branchDiagnosticCount
+    // 0 -- handle placement itself no longer rejects), but the resulting
+    // geometry has more route crossings than the strict (near-zero budget
+    // pressure) tolerance allows on a first candidate, so rejection now
+    // happens one phase later, at the route-crossing audit.
+    expect(reversed.firstRejectedPhase).toBe("route-crossing");
     expect(reversed.firstRejectedReason).toMatchObject({
-      reason: "no-candidates",
+      reason: "route-crossing",
       firstAffectedRank: 0,
-      // Denser sampling remains subject to the standard rank corridor, so
-      // all three branches remain handle-infeasible under this reversed
-      // order rather than accepting a candidate outside that invariant.
-      evidence: { branchDiagnosticCount: 3 },
+      evidence: { branchDiagnosticCount: 0 },
     });
+    expect(
+      reversed.firstRejectedReason.evidence.routeFindingCount,
+    ).toBeGreaterThan(0);
     expect(reversed.ranks[0].centeredAssignmentFeasible).toBe(true);
     expect(
       reversed.ranks[0].domains.every((domain) => domain.domainSize > 0),
@@ -2426,22 +2427,25 @@ describe("lifecycle diagram render-only routing layout", () => {
     }
   });
 
-  // Skipped: this fixture's dense multi-rank routing has no
-  // handle-clearance-feasible lane arrangement — confirmed by direct
-  // instrumentation, the set of blocked branches is identical across
-  // hundreds of distinct coordinate assignments the lane-refinement search
-  // tries. That's a pre-existing gap between what refineGlobalLaneCoordinates
-  // searches over (lane-spacing legality) and what handle placement
-  // actually needs (route-to-route clearance at sampled handle points), out
-  // of scope for the exponential-blowup fix this PR makes. The search
-  // itself is now fast and deterministic (was exponential before this PR),
-  // it just cannot currently find a working answer for this fixture.
-  // Tracked as a follow-up.
-  it.skip("lays out dense fixture with bounded semantic docks and safe handles", () => {
+  // Historical baseline (pre-fix): this fixture's dense multi-rank routing
+  // had no handle-clearance-feasible lane arrangement at all -- confirmed by
+  // direct instrumentation, the set of blocked branches was identical
+  // across hundreds of distinct coordinate assignments the lane-refinement
+  // search tried. Fixed by two independent, deliberately narrow tolerances
+  // introduced alongside this test (see
+  // docs/design/lifecycle-diagram-layout-algorithm.md): a small, last-resort
+  // nonincident-route clearance allowance for handle placement
+  // (HANDLE_CLEARANCE_TOLERANCE) and a small, budget-pressure-scaled
+  // tolerance for route-to-route crossings (toleratedRouteCrossingCount).
+  // Both apply only as a last resort -- a fixture that already finds a
+  // perfectly clean layout is unaffected. Handle-vs-handle overlap and
+  // fixed-geometry avoidance remain hard, zero-tolerance requirements.
+  it("lays out dense fixture with bounded semantic docks and safe handles", () => {
     const { graph } = layoutLifecycleRoutingGraph(
       projectLifecycleAt(denseFixture),
       1850,
     );
+    expect(graph.acceptedRouteCrossingCount).toBeGreaterThanOrEqual(0);
     const visibleNodes = graph.nodes.filter(
       (node) => !node.routing && node.total > 0,
     );
@@ -2472,13 +2476,30 @@ describe("lifecycle diagram render-only routing layout", () => {
     expect(new Set(handles.map((handle) => handle.branchId)).size).toBe(
       graph.branches.length,
     );
+    // Every t-value the candidate-generation sweep can ever select from
+    // (three primary points, plus the ten-point fallback grid tried only
+    // when the primary three find nothing) -- a degraded (tolerated)
+    // candidate can land on any of them, not just the primary three.
+    const allSampleTValues = [
+      0.5,
+      0.35,
+      0.65,
+      ...Array.from(
+        { length: 10 },
+        (_, index) => Math.round((0.05 + index * 0.1) * 1000) / 1000,
+      ).filter((t) => ![0.5, 0.35, 0.65].includes(t)),
+    ];
     for (const handle of handles) {
       expect(Number.isFinite(handle.x), handle.branchId).toBe(true);
       expect(Number.isFinite(handle.y), handle.branchId).toBe(true);
-      expect(handle.clearanceMargin, handle.branchId).toBeGreaterThan(0);
+      // Handle-vs-handle overlap and fixed-geometry avoidance stay strict;
+      // nonincident-route clearance allows the small, last-resort tolerance.
+      expect(handle.clearanceMargin, handle.branchId).toBeGreaterThan(
+        -HANDLE_CLEARANCE_TOLERANCE,
+      );
       const segments = byBranch.get(handle.branchId);
       const allowed = segments.flatMap((segment) =>
-        [0.5, 0.35, 0.65].map((t) => ({
+        allSampleTValues.map((t) => ({
           segment,
           ...cubicTransitionPoint(segment, t),
         })),

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -865,19 +865,18 @@ describe("lifecycle diagram P6 pagination and hardening", () => {
   });
 
   // Skipped: this 60-application, 89-branch fixture funnels many origins
-  // through a small number of milestones/endpoints, which has no
-  // handle-clearance-feasible lane arrangement — confirmed by direct
-  // instrumentation on equivalent fixtures, the set of blocked branches is
-  // identical across hundreds of distinct coordinate assignments the
-  // lane-refinement search tries. That's a pre-existing gap between what
-  // refineGlobalLaneCoordinates searches over (lane-spacing legality) and
-  // what handle placement actually needs (route-to-route clearance at
-  // sampled handle points), out of scope for the exponential-blowup fix
-  // this PR makes. The search itself is now fast and deterministic (was
-  // exponential before this PR), it just cannot currently find a working
-  // answer for this fixture, so layoutLifecycleRoutingGraph throws and the
-  // pagination UI this test wants to exercise never renders. Tracked as a
-  // follow-up.
+  // through a small number of milestones/endpoints. HANDLE_CLEARANCE_TOLERANCE
+  // and toleratedRouteCrossingCount (see
+  // docs/design/lifecycle-diagram-layout-algorithm.md's "Investigation
+  // (2026-07-26)" section and its follow-ups) fixed the real
+  // tracker-lifecycle-diagram-v2.json dense fixture and denseBranchProjection(),
+  // but this fixture's specific fan-in shape still exhausts the shared
+  // handle-state budget (confirmed directly, same signature as
+  // transitionDensityProjection() below) -- so layoutLifecycleRoutingGraph
+  // still throws and the pagination UI this test wants to exercise still
+  // never renders. Tracked as further follow-up: either a larger tolerance
+  // or a structurally different placement strategy for this class of dense
+  // fan-in is needed, out of scope for the tolerances shipped so far.
   // eslint-disable-next-line max-len
   it.skip("paginates more than 50 endpoint-conditioned flow rows without losing reachability", () => {
     const origins = LIFECYCLE_DIAGRAM_TAXONOMY.origins.map(({ id }) => id);


### PR DESCRIPTION
## Summary

- Stacked on #1169 (base branch: `milestone2-relax-crossing-strictness`).
- Extends the route-crossing tolerance with a matching, more conservative tolerance for handle placement: a handle candidate whose clearance from a *nonincident route* is small and negative (within `HANDLE_CLEARANCE_TOLERANCE`) is now used as a last resort, only when a branch has zero fully-clear candidates anywhere. Fixed-geometry avoidance and handle-vs-handle non-overlap stay hard, zero-tolerance requirements.
- Two bugs found and fixed while wiring this through the two-pass seed-replay contract (both confirmed by reproducing the failure directly before fixing it):
  - `candidateCallback`'s state-limit throws fired *before* the tolerant-accept check ever ran, so a candidate evaluated right at the budget boundary could never actually be accepted under pressure -- reordered so the throw only fires if the candidate was both over budget and not good enough.
  - The seed-replay verification path (a separate code path from normal candidate generation) didn't know about either tolerance, so it rejected exactly the geometry discovery had just accepted -- fixed by threading discovery's own accepted crossing count through as `seedAcceptedRouteCrossingCount`, and widening the seed-handle verification's clearance check by the same tolerance.

## Result

`tracker-lifecycle-diagram-v2.json` -- the real dense production fixture named throughout the design doc's investigation history, previously infeasible even at 150x the handle budget -- now lays out successfully end-to-end through the full two-pass pipeline (37 tolerated crossings, 502/32768 handle states). The reference fixture is unaffected (still exactly 0 accepted crossings).

Un-skips `"lays out dense fixture with bounded semantic docks and safe handles"`. Two fixtures with a more extreme fan-in shape (50-into-one-milestone convergence) remain genuinely infeasible even under both tolerances -- confirmed directly, not assumed -- and stay `it.skip`'d with updated, accurate comments describing the new (faster, more precise) failure signature.

## Test plan
- [x] `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js test/web-tracker-lifecycle-diagram.test.js` -- 93 passed, 2 skipped (down from 3 in #1169's baseline)
- [x] `npm run test:ci` -- 146/147 files, 1218/1220 non-skipped tests pass (same 3 pre-existing, unrelated `test/claude-validate.test.js` bubblewrap-sandbox failures as prior PRs in this stack)
- [x] `npm run lint -- --quiet`, `npm run typecheck`, `npx prettier --check` on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)