### PR TITLE
Unify lifecycle-diagram route-crossing classifiers, unskip last Playwright audit

### DIFF
--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -659,14 +659,26 @@ length of their shared overlap (not just a boolean). Both `auditLifecycleRouteGe
 restriction `edgeCrossing`'s own crossing loop already uses), excluding contributions at a rank where
 the two segments share a source or target node — two branches leaving (or converging on) the same
 dock naturally render correlated geometry for a stretch before diverging, which is ordinary and
-nonfatal. That exclusion is itself guarded: it only applies when the branch pair spans **more than
-one** shared rank. A pair whose entire overlap is a single shared-source-and-target rank (e.g. two
-direct, no-milestone branches between the exact same two nodes) never actually diverges anywhere, so
-excluding it would hide a genuine duplicated-route defect rather than tolerate ordinary divergence —
-confirmed directly by constructing exactly this case (see the new unit tests below) before shipping
-the guard. Once the accumulated, non-excluded overlap length reaches `SUSTAINED_OVERLAP_LENGTH_THRESHOLD`
-(30px — confirmed directly against a real false-positive candidate in
-`tracker-lifecycle-diagram-v2.json`'s previous-event state, where two branches converging toward
+nonfatal.
+
+That exclusion is itself guarded by a `branchesDiverge` check: it only applies to a branch pair whose
+overall source or target actually differ. **Status update:** the first version of this guard
+(`multiRank`/`sharedRankSpan`, gating the exclusion on whether the pair spans more than one shared
+rank) was insufficient and has been replaced. It correctly caught a _single_-shared-rank duplicate
+(two direct, no-milestone branches between the exact same two nodes), but not a duplicate spanning
+**two or more** ranks that also shares both endpoints: such a pair shares its source at the first rank
+and its target at the last, so a purely rank-position-based exclusion suppressed _both_ ends,
+hiding the entire overlap even though the branches never diverge anywhere in between — confirmed
+directly by constructing exactly this case (a two-rank duplicate sharing both endpoints; see the unit
+and Playwright regressions below), which the `multiRank` guard let through undetected. The fix checks
+divergence at the branch level instead of rank position: `branchesDiverge` is true only if the pair's
+overall source or target node ids actually differ, in which case per-rank exclusion may still apply
+wherever a specific segment pair happens to share a node (including an intermediate shared milestone,
+for production, which has per-segment node identity available); if source AND target both match,
+there is nowhere left for the pair to diverge to, so no rank is ever excluded, regardless of how many
+ranks the pair spans. Once the accumulated, non-excluded overlap length reaches
+`SUSTAINED_OVERLAP_LENGTH_THRESHOLD` (30px — confirmed directly against a real false-positive candidate
+in `tracker-lifecycle-diagram-v2.json`'s previous-event state, where two branches converging toward
 _different_ endpoint docks at the same rank boundary accumulated ~6px of incidental overlap while
 merely converging; 30px is an order of magnitude above that observed artifact and well below what a
 genuine full-length duplicate — spanning most of a multi-hundred-pixel route segment — would produce),
@@ -689,14 +701,16 @@ clearance) were added to `test/web-tracker-lifecycle-diagram-layout.test.js`'s `
 route-crossing classifier"` describe block, plus a dedicated
 `"auditLifecycleRouteGeometry collinear-overlap aggregation"` describe block exercising
 `auditLifecycleRouteGeometry` directly against hand-built minimal route models: one proving a
-genuine multi-rank shared-dock-divergence pair stays nonfatal, one proving a single-shared-rank,
-same-source-and-target duplicate is flagged fatal (the guard described above). A new Playwright
-regression, `"audits routed branch collisions detects an injected exact route duplicate"`, injects two
-synthetic, fully-coincident `<path>` elements (disjoint fake source/target ids so no shared-dock
-exclusion can apply, positioned off-canvas so no other collision category can fire) into a real
-rendered diagram and confirms `assertBrowserCollisionAudit` fails on them — verified to actually depend
-on the new detector by temporarily disabling it and confirming the regression test fails as expected
-before re-enabling it.
+genuine multi-rank shared-dock-divergence pair stays nonfatal, one proving a single-shared-rank
+same-source-and-target duplicate is flagged fatal, and one proving a **two-rank** duplicate sharing
+both endpoints is flagged fatal (the exact gap `branchesDiverge` fixes). Two Playwright regressions
+inject synthetic, fully-coincident `<path>` elements directly into a real rendered diagram and confirm
+`assertBrowserCollisionAudit` fails on them: `"audits routed branch collisions detects an injected
+exact route duplicate"` (disjoint fake source/target ids, single segment, positioned off-canvas so no
+other collision category can fire) and `"audits routed branch collisions detects a two-rank duplicate
+sharing docks"` (two segments, deliberately _sharing_ both source and target ids). Every new test —
+including both fixes' regressions — was confirmed to actually depend on its corresponding logic by
+temporarily reverting that logic and observing the test fail before re-enabling it.
 
 ## Separately: the deterministic-budget fix
 

--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -501,16 +501,23 @@ itself succeeds (`static-smoke.spec.js`'s deterministic-render smoke test, and
 `lifecycle-diagram.spec.js`'s seeded-tables and touch-mobile-overflow specs — neither exercises the
 strict collision audit below). The fourth
 (`"audits routed branch collisions for tracker-lifecycle-diagram-v2.json on desktop and touch"`)
-remains `test.skip`'d: its `assertBrowserCollisionAudit` samples actual rendered SVG geometry at
-regular pixel intervals, a different methodology than production's cubic-flattening-based
-`auditLifecycleRouteGeometry`, and the two do not agree on where the sustained-overlap/brief-crossing
-line falls for every branch pair in the browser-reconciled (denser) version of this fixture —
-confirmed directly, not assumed, by dumping the actual reconciled IndexedDB data via Playwright and
-feeding it back through the same diagnostics used above. Unifying the two audits' sampling
-methodology, or building a placement strategy that avoids this class of near-handle route passage
-constructively rather than tolerating it after the fact, is real follow-up work, not attempted here.
-The `tracker-lifecycle-diagram-routing-v2.json` iteration of the same parametrized test is
-unaffected and passes.
+originally remained `test.skip`'d for this reason: its `assertBrowserCollisionAudit` sampled actual
+rendered SVG geometry at regular pixel intervals and classified route-vs-route crossings by
+**point-to-point proximity** (any two samples from different branches within 0.5px of each other),
+a fundamentally different methodology than production's cubic-flattening-based
+`auditLifecycleRouteGeometry`, which counts genuine **transversal segment-crossings** between
+flattened edges via `edgeCrossing`. Point-proximity is far more trigger-happy than true
+edge-crossing: two curves that run close-but-parallel for a stretch (never truly crossing more than
+once or twice) generate many "nearby" sample pairs, pushing the count past the shared `>4`
+sustained-overlap threshold and misclassifying a tolerable pair as `"coincides"` (fatal) — confirmed
+directly, not assumed, by dumping the actual reconciled IndexedDB data via Playwright and feeding it
+back through the same diagnostics used above: production's edge-crossing count stayed ≤4 for pairs
+this audit's proximity sampling flagged as coincident.
+
+**Status update: this is now fixed — see "Follow-up (shipped): unified route-crossing classifier"
+below.** The spec is no longer `test.skip`'d; both fixture iterations of this parametrized test now
+pass on desktop, previous-event, and touch/mobile. `tracker-lifecycle-diagram-routing-v2.json`'s
+exact-zero-collision expectation (`maxCrossings = 0`) is unaffected.
 
 **Still infeasible for a root cause neither tolerance can reach — two fixtures with a different,
 more extreme fan-in shape**, confirmed directly (not assumed) by inspecting the exact rejection
@@ -549,6 +556,80 @@ rank corridor itself for ranks with enough incident branches to need it, or a pl
 that doesn't depend on every branch finding a legal point within a fixed-width corridor at all —
 tracked as further follow-up, not attempted here. Retrying with a larger
 `HANDLE_CLEARANCE_TOLERANCE` value alone will not help; the evidence above rules that out directly.
+
+## Follow-up (shipped): unified route-crossing classifier
+
+The last remaining Playwright skip (see "Playwright status" above) was an audit-methodology
+mismatch, not a layout bug: production's `auditLifecycleRouteGeometry` and the Playwright
+`assertBrowserCollisionAudit` (`test/playwright/lifecycle-diagram.spec.js`) independently
+implemented their own crossing/coincidence classifiers, and disagreed on the same rendered geometry.
+
+**The fix:** the shared, pure primitives both classifiers need — `edgeCrossing` (an
+orientation/cross-product transversal-segment-intersection test) and the sustained-vs-proper
+crossing-count threshold (`>4`) — were extracted into a new module,
+`src/web/tracker/lifecycleRouteGeometry.js`, with no DOM/graph/layout-object dependencies (only
+plain `{x,y}` points and `{p0,p1}` edges). `auditLifecycleRouteGeometry` now imports
+`classifyRouteCrossingCategory`/`edgeCrossing` from it instead of an inlined ternary and a
+module-private const — a pure rename/relocation, not a behavior change (confirmed: the full existing
+test suite, including `"exposes a deterministic route model and pure geometry audit"`, passed
+unmodified against the extracted functions).
+
+The Playwright audit was then changed to call the **actual same functions** production uses, rather
+than maintaining an independently-tuned reimplementation. This works because the tracker frontend is
+bundled by esbuild at server startup (`src/web/server.js`, entry `tracker.js` → `lifecycleDiagram.js`
+→ `lifecycleDiagramLayout.js` → the new module) — a module-level side effect in an already-imported
+production file executes in the browser bundle regardless of which of its exports are actually
+referenced elsewhere, so `lifecycleRouteGeometry.js` sets a guarded
+`window.__lifecycleRouteGeometry = { edgeCrossing, classifyRouteCrossingCategory,
+ROUTE_CROSSING_SUSTAINED_THRESHOLD }` at module scope (guarded by `typeof window !== "undefined"`,
+since this module is also imported directly under Vitest's default Node environment). Playwright's
+`assertBrowserCollisionAudit` calls this hook from inside its `page.evaluate()` callback instead of
+its old point-to-point proximity sampling (`Math.hypot(...) <= 0.5px` between two paths' dense
+`getPointAtLength` samples — the actual root cause of the mismatch: proximity is far more
+trigger-happy than true crossing-counting for curves that run close-but-parallel without truly
+crossing).
+
+To mirror production's same-transition-rank restriction on which edge pairs are even compared
+(`auditLifecycleRouteGeometry` only tests edges whose segments share a source rank), the browser
+audit now buckets each rendered path's consecutive-sample edges by rank using the existing
+`data-segment-ranks` attribute (`lifecycleDiagram.js`) combined with a structural fact about the
+renderer's own path generation: `adjacentRankSegmentPath` (`lifecycleDiagramLayout.js`) emits one
+leading `M` command per segment, in the same order as `data-segment-ranks`, so splitting a rendered
+path's `d` string on that boundary and measuring each piece's own `getTotalLength()` recovers each
+segment's exact rendered arc-length window — with **no new `data-*` attributes** needed, and no
+changes to `lifecycleDiagram.js` at all. This also makes the browser audit's worst-case cost strictly
+cheaper than before: summing edge-pair work only across ranks present in both branches is provably
+never worse than the old whole-path-vs-whole-path approach (dropping cross-rank terms from a product
+only removes non-negative terms).
+
+Investigating the newly-unified classifier against the real, browser-reconciled
+`tracker-lifecycle-diagram-v2.json` fixture surfaced one more genuine mismatch, not just the crossing
+classification: the browser's route-vs-handle proximity check ("intersects other handle") was
+unconditionally fatal, while production's `route-handle-collision` category is tolerable — bucketed
+into the same budget as `proper-crossing` (`candidateCallback`, see "Follow-up (shipped): bounded
+tolerances" above). Confirmed directly: once the crossing/coincidence mismatch was fixed, the only
+remaining fatal findings for this fixture were exactly six `"intersects other handle"` errors, zero
+`"coincides"` errors — i.e. the crossing-classifier fix alone fully resolved the originally-diagnosed
+mismatch, and the handle-tolerance gap was a second, independent, previously-undiagnosed
+discrepancy. Fixed narrowly by moving that check's finding into the same tolerated-crossings bucket
+(`maxCrossings`) instead of `fatalErrors`, matching production's own combined tolerance semantics,
+without touching `candidateCallback`/`toleratedRouteCrossingCount` themselves (that logic remains
+entirely inside the test and the production layout module, respectively — this change only affects
+which array a browser-side finding lands in).
+
+**Result:** confirmed directly, not assumed, by running the unskipped test repeatedly against the
+real fixture: `tracker-lifecycle-diagram-v2.json` produces a stable 62 tolerated (proper-crossing- and
+route-handle-collision-equivalent) findings on desktop and touch (57 on the previous-event state),
+comfortably checked in as the test's `maxCrossings` bound (replacing the old, unverified `66`
+placeholder left over from the pre-fix, disproven methodology). `tracker-lifecycle-diagram-routing-v2.json`
+is unaffected, still exactly 0. **0 lifecycle Playwright specs remain skipped** (was 1); **0 lifecycle
+Vitest tests remain skipped** (unchanged from the prior fix — see "Outstanding follow-up work" below).
+Focused unit tests for the shared classifier (`edgeCrossing`, `classifyRouteCrossingCategory`, and
+the route-handle-proximity boundary) were added to
+`test/web-tracker-lifecycle-diagram-layout.test.js`'s `"shared route-crossing classifier"` describe
+block, including a direct test that two edges diverging from a shared/near-identical endpoint (the
+shared-dock case) are never classified as crossing — the reason production's own crossing loop needs
+no explicit shared-dock exclusion.
 
 ## Separately: the deterministic-budget fix
 
@@ -630,19 +711,18 @@ skip states and test names can drift. `grep -rn "it\.skip(\|test\.skip(" test/` 
    (the real `tracker-lifecycle-diagram-v2.json` dense fixture and a direct 5×11 milestone-free
    grid, respectively). `transitionDensityProjection()`'s own infeasibility stays actively characterized,
    not deleted, in `"resolves un-phased dense fan-in fast, without exponential blowup"`.
-3. **1 Playwright spec remains `test.skip`ed** (was 4):
+3. **0 Playwright specs remain `test.skip`ed** (was 4, then 1). The last remaining skip —
    `test/playwright/lifecycle-diagram.spec.js`'s `"audits routed branch collisions for
-tracker-lifecycle-diagram-v2.json on desktop and touch"` (the
-   `tracker-lifecycle-diagram-routing-v2.json` iteration of the same parametrized test is unaffected
-   and passes). Confirmed directly, not assumed: layout itself now succeeds for this fixture (the
-   original root cause — the component rendering the "Unable to lay out lifecycle diagram."
-   fallback — is fixed), but this audit's pixel-sampling-based severity classification disagrees
-   with production's own cubic-flattening-based one on a few branch pairs in the browser-reconciled
-   (denser than raw) version of this fixture. The other 3 previously-`test.skip`'d Playwright specs
+tracker-lifecycle-diagram-v2.json on desktop and touch"` — is now fixed and unskipped; see
+   "Follow-up (shipped): unified route-crossing classifier" above for the mechanism (a shared
+   `src/web/tracker/lifecycleRouteGeometry.js` classifier reused by both production and the browser
+   audit via `window.__lifecycleRouteGeometry`) and the confirmed numbers. The
+   `tracker-lifecycle-diagram-routing-v2.json` iteration of the same parametrized test remains
+   unaffected (exactly 0 tolerated crossings). The other 3 previously-`test.skip`'d Playwright specs
    (`"renders seeded current/historical states with semantic tables and selection"`,
    `"uses a real touch mobile context without page overflow"`, and
    `test/playwright/static-smoke.spec.js`'s `"renders lifecycle Diagram from deterministic data
-without external requests"`) now pass unmodified, since none of them exercise the strict
+without external requests"`) already passed unmodified since none of them exercise the strict
    collision audit.
 4. **Real-node-vs-routing-node coordination** (its own section above) — a narrower, more scoped
    piece of item 1 that's already covered by fix 3's audit-and-reject safety net (so current

--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -617,15 +617,43 @@ without touching `candidateCallback`/`toleratedRouteCrossingCount` themselves (t
 entirely inside the test and the production layout module, respectively — this change only affects
 which array a browser-side finding lands in).
 
+**Route-handle envelope, fixed to match production regardless of selection state:** the browser
+audit derives its per-path stroke "inflate" (used for both node/label/hit collision padding and the
+route-handle-collision distance check) from the rendered halo/separator/ribbon stroke widths — but
+`lifecycleDiagram.js` only renders a branch's halo `<path>` while that branch is selected. Before this
+fix, an unselected branch's `inflate` silently fell back to the separator-only width, understating
+production's fixed, selection-independent envelope (`selectedEnvelopeRadius`, which conservatively
+assumes the halo-inclusive width for every branch regardless of which one happens to be selected,
+since collision safety shouldn't depend on transient UI state). Fixed by deriving the halo width
+analytically from the unconditionally-rendered separator (`separator + 6`, matching
+`widthPx + 12 = selectedEnvelopeRadius`'s own formula) instead of depending on the halo element
+actually being present.
+
+**Known, shared limitation, not attempted here:** `edgeCrossing`'s strict transversal-crossing test
+(shared verbatim with production) cannot, by itself, detect two routes that are exactly or
+near-exactly collinear over a stretch — such routes never "cross" in the sign-straddling sense the
+test requires. A dedicated point-proximity fallback was prototyped to close this gap but rejected: at
+this file's sampling resolution it could not reliably distinguish a genuine full-length overlap from
+the ordinary correlation two branches leaving the same dock exhibit over a significant fraction of
+their shared corridor before diverging toward different downstream targets (confirmed directly against
+a real shared-source pair in the reconciled `tracker-lifecycle-diagram-v2.json` fixture, whose
+"near" run extended for ~90px of arc length purely from ordinary post-dock correlation) — reintroducing
+point-proximity risked resurrecting the exact false-positive this PR fixes. This is not a regression:
+it is the same classifier `auditLifecycleRouteGeometry` itself uses, so this audit's coverage now
+matches production's own exactly, which was this PR's goal. Closing this gap for real would need a
+placement-level signal (e.g. comparing `transitionLaneY` assignments directly) rather than sampled
+rendered geometry — a layout-solver-adjacent change, out of scope here.
+
 **Result:** confirmed directly, not assumed, by running the unskipped test repeatedly against the
-real fixture: `tracker-lifecycle-diagram-v2.json` produces a stable 62 tolerated (proper-crossing- and
-route-handle-collision-equivalent) findings on desktop and touch (57 on the previous-event state),
+real fixture: `tracker-lifecycle-diagram-v2.json` produces a stable 64 tolerated (proper-crossing- and
+route-handle-collision-equivalent) findings on desktop (57 on the previous-event state),
 comfortably checked in as the test's `maxCrossings` bound (replacing the old, unverified `66`
 placeholder left over from the pre-fix, disproven methodology). `tracker-lifecycle-diagram-routing-v2.json`
 is unaffected, still exactly 0. **0 lifecycle Playwright specs remain skipped** (was 1); **0 lifecycle
 Vitest tests remain skipped** (unchanged from the prior fix — see "Outstanding follow-up work" below).
 Focused unit tests for the shared classifier (`edgeCrossing`, `classifyRouteCrossingCategory`, and
-the route-handle-proximity boundary) were added to
+the route-handle-proximity boundary, mirroring production's exact
+`BRANCH_HANDLE_RADIUS + selectedEnvelopeRadius(...) + 0.25 + LANE_Y_EPSILON` formula) were added to
 `test/web-tracker-lifecycle-diagram-layout.test.js`'s `"shared route-crossing classifier"` describe
 block, including a direct test that two edges diverging from a shared/near-identical endpoint (the
 shared-dock case) are never classified as crossing — the reason production's own crossing loop needs

--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -617,47 +617,86 @@ without touching `candidateCallback`/`toleratedRouteCrossingCount` themselves (t
 entirely inside the test and the production layout module, respectively — this change only affects
 which array a browser-side finding lands in).
 
-**Route-handle envelope, fixed to match production regardless of selection state:** the browser
-audit derives its per-path stroke "inflate" (used for both node/label/hit collision padding and the
-route-handle-collision distance check) from the rendered halo/separator/ribbon stroke widths — but
-`lifecycleDiagram.js` only renders a branch's halo `<path>` while that branch is selected. Before this
-fix, an unselected branch's `inflate` silently fell back to the separator-only width, understating
-production's fixed, selection-independent envelope (`selectedEnvelopeRadius`, which conservatively
-assumes the halo-inclusive width for every branch regardless of which one happens to be selected,
-since collision safety shouldn't depend on transient UI state). Fixed by deriving the halo width
-analytically from the unconditionally-rendered separator (`separator + 6`, matching
+**Route-handle envelope and clearance formula, fully shared with production:** the browser audit
+derives its per-path stroke "inflate" (used for node/label/hit collision padding and, until this fix,
+its own approximated route-handle distance check) from the rendered halo/separator/ribbon stroke
+widths — but `lifecycleDiagram.js` only renders a branch's halo `<path>` while that branch is
+selected. An unselected branch's `inflate` previously fell back to the separator-only width,
+understating production's fixed, selection-independent envelope (`selectedEnvelopeRadius`, which
+conservatively assumes the halo-inclusive width for every branch regardless of which one happens to
+be selected, since collision safety shouldn't depend on transient UI state). Fixed by deriving the
+halo width analytically from the unconditionally-rendered separator (`separator + 6`, matching
 `widthPx + 12 = selectedEnvelopeRadius`'s own formula) instead of depending on the halo element
-actually being present.
+actually being present. Separately, the browser's route-handle-collision check itself used to compare
+`Math.hypot` point-to-point distance from a handle to each _discrete sample_ against
+`branchHandleRadius + path.inflate` — a coarser measurement (missing the closest point _between_ two
+samples) using an approximated threshold, rather than production's exact
+`pointToSegmentDistance(handle, edge) < BRANCH_HANDLE_RADIUS + selectedEnvelopeRadius(segment) + 0.25 +
+LANE_Y_EPSILON`. Both `pointToSegmentDistance` and a new shared `routeHandleRequiredClearance`/
+`isRouteHandleCollision` (`lifecycleRouteGeometry.js`) now back both audits, and the browser check runs
+against the rendered path's sampled _edges_ (`path.edges`, consecutive-sample segments) rather than its
+raw sample points, closing both gaps at once.
 
-**Known, shared limitation, not attempted here:** `edgeCrossing`'s strict transversal-crossing test
-(shared verbatim with production) cannot, by itself, detect two routes that are exactly or
-near-exactly collinear over a stretch — such routes never "cross" in the sign-straddling sense the
-test requires. A dedicated point-proximity fallback was prototyped to close this gap but rejected: at
-this file's sampling resolution it could not reliably distinguish a genuine full-length overlap from
-the ordinary correlation two branches leaving the same dock exhibit over a significant fraction of
-their shared corridor before diverging toward different downstream targets (confirmed directly against
-a real shared-source pair in the reconciled `tracker-lifecycle-diagram-v2.json` fixture, whose
-"near" run extended for ~90px of arc length purely from ordinary post-dock correlation) — reintroducing
-point-proximity risked resurrecting the exact false-positive this PR fixes. This is not a regression:
-it is the same classifier `auditLifecycleRouteGeometry` itself uses, so this audit's coverage now
-matches production's own exactly, which was this PR's goal. Closing this gap for real would need a
-placement-level signal (e.g. comparing `transitionLaneY` assignments directly) rather than sampled
-rendered geometry — a layout-solver-adjacent change, out of scope here.
+**Collinear/coincident sustained-overlap detection, now implemented (shared, not a fallback
+heuristic):** `edgeCrossing`'s strict transversal-crossing test (shared verbatim with production)
+cannot, by itself, detect two routes that are exactly or near-exactly collinear over a stretch — such
+routes never "cross" in the sign-straddling sense the test requires, so a pair of routes rendered
+directly on top of one another would report zero crossings and silently escape the always-fatal
+sustained-overlap contract. A first attempt at closing this gap reused point-proximity (the exact
+heuristic this PR's crossing-classifier fix replaced) and was rejected: at rendered-sample resolution
+it could not distinguish a genuine full-length duplicate from the ordinary correlation two branches
+leaving the same dock exhibit before diverging (confirmed directly against a real shared-source pair
+in the reconciled `tracker-lifecycle-diagram-v2.json` fixture, whose "near" run extended for ~90px of
+arc length from ordinary post-dock correlation alone) — reintroducing it risked resurrecting the exact
+false positive this PR fixes.
+
+The shipped fix instead adds a small, purely geometric primitive, `collinearOverlapLength`
+(`lifecycleRouteGeometry.js`): given two edges, it returns 0 unless they are parallel within a tight
+direction tolerance and collinear within the same perpendicular-distance tolerance
+`cubicFlatEnough`'s own bezier-flattening step already uses (0.25px), and otherwise returns the actual
+length of their shared overlap (not just a boolean). Both `auditLifecycleRouteGeometry` and
+`assertBrowserCollisionAudit` aggregate this per branch pair and transition rank (the same same-rank
+restriction `edgeCrossing`'s own crossing loop already uses), excluding contributions at a rank where
+the two segments share a source or target node — two branches leaving (or converging on) the same
+dock naturally render correlated geometry for a stretch before diverging, which is ordinary and
+nonfatal. That exclusion is itself guarded: it only applies when the branch pair spans **more than
+one** shared rank. A pair whose entire overlap is a single shared-source-and-target rank (e.g. two
+direct, no-milestone branches between the exact same two nodes) never actually diverges anywhere, so
+excluding it would hide a genuine duplicated-route defect rather than tolerate ordinary divergence —
+confirmed directly by constructing exactly this case (see the new unit tests below) before shipping
+the guard. Once the accumulated, non-excluded overlap length reaches `SUSTAINED_OVERLAP_LENGTH_THRESHOLD`
+(30px — confirmed directly against a real false-positive candidate in
+`tracker-lifecycle-diagram-v2.json`'s previous-event state, where two branches converging toward
+_different_ endpoint docks at the same rank boundary accumulated ~6px of incidental overlap while
+merely converging; 30px is an order of magnitude above that observed artifact and well below what a
+genuine full-length duplicate — spanning most of a multi-hundred-pixel route segment — would produce),
+the pair is classified `"sustained-crossing"` regardless of its (possibly zero) transversal-crossing
+count.
 
 **Result:** confirmed directly, not assumed, by running the unskipped test repeatedly against the
 real fixture: `tracker-lifecycle-diagram-v2.json` produces a stable 64 tolerated (proper-crossing- and
-route-handle-collision-equivalent) findings on desktop (57 on the previous-event state),
-comfortably checked in as the test's `maxCrossings` bound (replacing the old, unverified `66`
-placeholder left over from the pre-fix, disproven methodology). `tracker-lifecycle-diagram-routing-v2.json`
-is unaffected, still exactly 0. **0 lifecycle Playwright specs remain skipped** (was 1); **0 lifecycle
-Vitest tests remain skipped** (unchanged from the prior fix — see "Outstanding follow-up work" below).
-Focused unit tests for the shared classifier (`edgeCrossing`, `classifyRouteCrossingCategory`, and
-the route-handle-proximity boundary, mirroring production's exact
-`BRANCH_HANDLE_RADIUS + selectedEnvelopeRadius(...) + 0.25 + LANE_Y_EPSILON` formula) were added to
-`test/web-tracker-lifecycle-diagram-layout.test.js`'s `"shared route-crossing classifier"` describe
-block, including a direct test that two edges diverging from a shared/near-identical endpoint (the
-shared-dock case) are never classified as crossing — the reason production's own crossing loop needs
-no explicit shared-dock exclusion.
+route-handle-collision-equivalent) findings on desktop (57 on the previous-event state), unchanged by
+either the collinear-overlap detector or the route-handle parity fix since neither trips on this
+fixture's own geometry — comfortably checked in as the test's `maxCrossings` bound (replacing the old,
+unverified `66` placeholder left over from the pre-fix, disproven methodology).
+`tracker-lifecycle-diagram-routing-v2.json` is unaffected, still exactly 0. **0 lifecycle Playwright
+specs remain skipped** (was 1); **0 lifecycle Vitest tests remain skipped** (unchanged from the prior
+fix — see "Outstanding follow-up work" below). Focused unit tests for the shared classifier
+(`edgeCrossing`, `classifyRouteCrossingCategory`, `collinearOverlapLength` — genuine overlap, separated
+parallel edges, endpoint-touch-only, offset-beyond-tolerance, and non-parallel/crossing edges — and
+`isRouteHandleCollision`/`routeHandleRequiredClearance` at the just-inside/exact-boundary/just-outside
+clearance) were added to `test/web-tracker-lifecycle-diagram-layout.test.js`'s `"shared
+route-crossing classifier"` describe block, plus a dedicated
+`"auditLifecycleRouteGeometry collinear-overlap aggregation"` describe block exercising
+`auditLifecycleRouteGeometry` directly against hand-built minimal route models: one proving a
+genuine multi-rank shared-dock-divergence pair stays nonfatal, one proving a single-shared-rank,
+same-source-and-target duplicate is flagged fatal (the guard described above). A new Playwright
+regression, `"audits routed branch collisions detects an injected exact route duplicate"`, injects two
+synthetic, fully-coincident `<path>` elements (disjoint fake source/target ids so no shared-dock
+exclusion can apply, positioned off-canvas so no other collision category can fire) into a real
+rendered diagram and confirms `assertBrowserCollisionAudit` fails on them — verified to actually depend
+on the new detector by temporarily disabling it and confirming the regression test fails as expected
+before re-enabling it.
 
 ## Separately: the deterministic-budget fix
 

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -3,12 +3,25 @@ import { LIFECYCLE_DIAGRAM_TAXONOMY } from "./lifecycleProjection.js";
 import {
   edgeCrossing,
   classifyRouteCrossingCategory,
+  collinearOverlapLength,
+  SUSTAINED_OVERLAP_LENGTH_THRESHOLD,
+  pointToSegmentDistance,
+  routeHandleRequiredClearance,
+  LANE_Y_EPSILON,
 } from "./lifecycleRouteGeometry.js";
 
 export {
   edgeCrossing,
   classifyRouteCrossingCategory,
   ROUTE_CROSSING_SUSTAINED_THRESHOLD,
+  collinearOverlapLength,
+  COLLINEAR_OVERLAP_TOLERANCE,
+  SUSTAINED_OVERLAP_LENGTH_THRESHOLD,
+  pointToSegmentDistance,
+  routeHandleRequiredClearance,
+  isRouteHandleCollision,
+  ROUTE_HANDLE_CLEARANCE_MARGIN,
+  LANE_Y_EPSILON,
 } from "./lifecycleRouteGeometry.js";
 
 const isLifecycleLayoutTestEnvironment = () =>
@@ -65,7 +78,6 @@ export const rendererHitBoxForNode = (node) => {
     height,
   };
 };
-export const LANE_Y_EPSILON = 0.001;
 const COLLISION_MARGIN = -1;
 // Charge dense route generation/auditing slightly conservatively so the
 // deterministic state cap also retains margin beneath the 30-second render
@@ -3888,24 +3900,6 @@ export const flattenRouteSegment = (segment) =>
         })),
   );
 
-export const pointToSegmentDistance = (point, edge) => {
-  const dx = edge.p1.x - edge.p0.x;
-  const dy = edge.p1.y - edge.p0.y;
-  const lengthSquared = dx * dx + dy * dy;
-  if (!lengthSquared)
-    return Math.hypot(point.x - edge.p0.x, point.y - edge.p0.y);
-  const t = Math.max(
-    0,
-    Math.min(
-      1,
-      ((point.x - edge.p0.x) * dx + (point.y - edge.p0.y) * dy) / lengthSquared,
-    ),
-  );
-  const x = edge.p0.x + t * dx;
-  const y = edge.p0.y + t * dy;
-  return Math.hypot(point.x - x, point.y - y);
-};
-
 export const routeEdgesByBranch = (graphOrModel) => {
   const model = graphOrModel?.segmentsByBranch
     ? graphOrModel
@@ -4017,31 +4011,76 @@ export function auditLifecycleRouteGeometry({
         add(`${box.kind}-collision`, edge.segment, { obstacleId: box.id });
     }
   }
+  const branchById = new Map(
+    routeModel.branches.map((branch) => [branch.id, branch]),
+  );
+  const pairOf = (left, right) => {
+    const branchLeft = branchById.get(left.branchId);
+    const branchRight = branchById.get(right.branchId);
+    return branchLeft && branchRight
+      ? routeModel.pairId(branchLeft, branchRight)
+      : `${left.branchId}||${right.branchId}`;
+  };
+  // Two branches only genuinely "diverge from a shared dock" if they span
+  // more than the one rank they share it at -- a branch pair whose *entire*
+  // overlap is a single shared-source-and-target segment (e.g. two direct,
+  // no-milestone branches between the exact same two nodes) never diverges
+  // at all, which is a duplicated-route defect, not ordinary correlation.
+  const sharedRankSpan = (branchLeft, branchRight) => {
+    if (!branchLeft || !branchRight) return null;
+    const lo = Math.max(branchLeft.sourceRank, branchRight.sourceRank);
+    const hi = Math.min(branchLeft.targetRank, branchRight.targetRank) - 1;
+    return hi >= lo ? hi - lo : null;
+  };
   const pairCrossings = new Map();
+  // edgeCrossing only detects genuine transversal crossings: two edges that
+  // are exactly (or near-exactly) collinear over a stretch never satisfy its
+  // strict sign-straddling test, so a pair of routes rendered directly on top
+  // of one another would report zero crossings here and escape the
+  // sustained-overlap contract entirely. pairOverlap tracks
+  // collinearOverlapLength (lifecycleRouteGeometry.js) alongside crossings,
+  // per branch pair, to close that gap -- see the classification loop below.
+  // Overlap contributions at a rank where the two segments share a source or
+  // target node are excluded (for branch pairs spanning more than one shared
+  // rank): two branches leaving (or converging on) the same dock naturally
+  // render correlated, near-identical geometry for a stretch before
+  // diverging, which is ordinary and nonfatal, not a duplicated-route defect.
+  const pairOverlap = new Map();
   for (let a = 0; a < flatEdges.length; a += 1) {
     for (let b = a + 1; b < flatEdges.length; b += 1) {
       const left = flatEdges[a];
       const right = flatEdges[b];
       if (left.branchId === right.branchId) continue;
       if (left.segment.source.rank !== right.segment.source.rank) continue;
-      if (!edgeCrossing(left, right)) continue;
-      const branchLeft = routeModel.branches.find(
-        ({ id }) => id === left.branchId,
+      const pair = pairOf(left, right);
+      if (edgeCrossing(left, right)) {
+        if (!pairCrossings.has(pair)) pairCrossings.set(pair, []);
+        pairCrossings.get(pair).push({ left, right });
+      }
+      const span = sharedRankSpan(
+        branchById.get(left.branchId),
+        branchById.get(right.branchId),
       );
-      const branchRight = routeModel.branches.find(
-        ({ id }) => id === right.branchId,
-      );
-      const pair =
-        branchLeft && branchRight
-          ? routeModel.pairId(branchLeft, branchRight)
-          : `${left.branchId}||${right.branchId}`;
-      if (!pairCrossings.has(pair)) pairCrossings.set(pair, []);
-      pairCrossings.get(pair).push({ left, right });
+      const sharesDock =
+        span > 0 &&
+        (left.segment.source.id === right.segment.source.id ||
+          left.segment.target.id === right.segment.target.id);
+      if (sharesDock) continue;
+      const overlap = collinearOverlapLength(left, right);
+      if (overlap > 0)
+        pairOverlap.set(pair, (pairOverlap.get(pair) ?? 0) + overlap);
     }
   }
-  for (const [pair, crossings] of pairCrossings) {
-    // Many flattened-edge-pair crossings for the same branch pair means the
-    // two routes run coincident/parallel for a stretch, not a brief single
+  const allPairs = new Set([...pairCrossings.keys(), ...pairOverlap.keys()]);
+  for (const pair of allPairs) {
+    const crossings = pairCrossings.get(pair) ?? [];
+    const overlapLength = pairOverlap.get(pair) ?? 0;
+    const sustainedByOverlap =
+      overlapLength >= SUSTAINED_OVERLAP_LENGTH_THRESHOLD;
+    if (!crossings.length && !sustainedByOverlap) continue;
+    // Many flattened-edge-pair crossings for the same branch pair (or a
+    // sustained collinear overlap away from a shared dock) means the two
+    // routes run coincident/parallel for a stretch, not a brief single
     // crossing -- that reads as one line drawn on top of another, not a
     // tolerable visual blemish, so it's categorized separately and never
     // eligible for toleratedRouteCrossingCount regardless of budget
@@ -4049,14 +4088,22 @@ export function auditLifecycleRouteGeometry({
     // lifecycleRouteGeometry.js) is the same shared classifier the
     // Playwright collision audit uses against rendered SVG geometry
     // (test/playwright/lifecycle-diagram.spec.js).
+    const category = sustainedByOverlap
+      ? "sustained-crossing"
+      : classifyRouteCrossingCategory(crossings.length);
     const finding = {
-      category: classifyRouteCrossingCategory(crossings.length),
+      category,
       branchIds: pair.split("||"),
       transitionRank: crossings[0]?.left.segment.source.rank,
       point: quantizePoint(crossings[0]?.left.p0 ?? { x: 0, y: 0 }),
       crossingPointCount: crossings.length,
+      ...(sustainedByOverlap ? { overlapLength } : {}),
     };
-    if (routeModel.fixedOrderInversionPairs.has(pair) && crossings.length === 1)
+    if (
+      !sustainedByOverlap &&
+      routeModel.fixedOrderInversionPairs.has(pair) &&
+      crossings.length === 1
+    )
       forcedCrossings.push(finding);
     else {
       allFindings.push(finding);
@@ -4093,11 +4140,11 @@ export function auditLifecycleRouteGeometry({
   for (const edge of flatEdges) {
     for (const handle of handles) {
       if (!handle || handle.branchId === edge.branchId) continue;
-      const required =
-        BRANCH_HANDLE_RADIUS +
-        selectedEnvelopeRadius(edge.segment) +
-        0.25 +
-        LANE_Y_EPSILON;
+      const required = routeHandleRequiredClearance(
+        BRANCH_HANDLE_RADIUS,
+        selectedEnvelopeRadius(edge.segment),
+        LANE_Y_EPSILON,
+      );
       if (pointToSegmentDistance(handle, edge) < required) {
         fatalFindings.push({
           category: "route-handle-collision",

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -1,5 +1,15 @@
 import { sankey } from "d3-sankey";
 import { LIFECYCLE_DIAGRAM_TAXONOMY } from "./lifecycleProjection.js";
+import {
+  edgeCrossing,
+  classifyRouteCrossingCategory,
+} from "./lifecycleRouteGeometry.js";
+
+export {
+  edgeCrossing,
+  classifyRouteCrossingCategory,
+  ROUTE_CROSSING_SUSTAINED_THRESHOLD,
+} from "./lifecycleRouteGeometry.js";
 
 const isLifecycleLayoutTestEnvironment = () =>
   typeof process !== "undefined" &&
@@ -3935,17 +3945,6 @@ export const segmentIntersectsRect = (edge, rect) => {
   );
 };
 
-const orientation = (a, b, c) =>
-  Math.sign((b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x));
-
-const edgeCrossing = (left, right) => {
-  const o1 = orientation(left.p0, left.p1, right.p0);
-  const o2 = orientation(left.p0, left.p1, right.p1);
-  const o3 = orientation(right.p0, right.p1, left.p0);
-  const o4 = orientation(right.p0, right.p1, left.p1);
-  return o1 * o2 < 0 && o3 * o4 < 0;
-};
-
 export function auditLifecycleRouteGeometry({
   graph,
   dimensions,
@@ -4046,11 +4045,12 @@ export function auditLifecycleRouteGeometry({
     // crossing -- that reads as one line drawn on top of another, not a
     // tolerable visual blemish, so it's categorized separately and never
     // eligible for toleratedRouteCrossingCount regardless of budget
-    // pressure (see candidateCallback). The threshold mirrors the
-    // Playwright collision audit's own sustained-overlap check
+    // pressure (see candidateCallback). classifyRouteCrossingCategory (see
+    // lifecycleRouteGeometry.js) is the same shared classifier the
+    // Playwright collision audit uses against rendered SVG geometry
     // (test/playwright/lifecycle-diagram.spec.js).
     const finding = {
-      category: crossings.length > 4 ? "sustained-crossing" : "proper-crossing",
+      category: classifyRouteCrossingCategory(crossings.length),
       branchIds: pair.split("||"),
       transitionRank: crossings[0]?.left.segment.source.rank,
       point: quantizePoint(crossings[0]?.left.p0 ?? { x: 0, y: 0 }),

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -4021,17 +4021,22 @@ export function auditLifecycleRouteGeometry({
       ? routeModel.pairId(branchLeft, branchRight)
       : `${left.branchId}||${right.branchId}`;
   };
-  // Two branches only genuinely "diverge from a shared dock" if they span
-  // more than the one rank they share it at -- a branch pair whose *entire*
-  // overlap is a single shared-source-and-target segment (e.g. two direct,
-  // no-milestone branches between the exact same two nodes) never diverges
-  // at all, which is a duplicated-route defect, not ordinary correlation.
-  const sharedRankSpan = (branchLeft, branchRight) => {
-    if (!branchLeft || !branchRight) return null;
-    const lo = Math.max(branchLeft.sourceRank, branchRight.sourceRank);
-    const hi = Math.min(branchLeft.targetRank, branchRight.targetRank) - 1;
-    return hi >= lo ? hi - lo : null;
-  };
+  // Two branches only genuinely "diverge from a shared dock" if they
+  // actually end up at different places overall -- if both their ultimate
+  // source AND target nodes match, there is nowhere left for them to
+  // diverge to, so any per-rank "shared node" match is never eligible for
+  // exclusion: a route pair that remains coincident across its full shared
+  // span is a duplicated-route defect, not ordinary local dock correlation,
+  // regardless of how many ranks it spans. This is deliberately a
+  // branch-level (not per-rank) check: a pair that differs at either end is
+  // guaranteed to diverge somewhere, so per-rank exclusion can still apply
+  // wherever a specific segment pair happens to share a node (including an
+  // intermediate shared milestone), exactly as before.
+  const branchesDiverge = (branchLeft, branchRight) =>
+    !branchLeft ||
+    !branchRight ||
+    branchLeft.source !== branchRight.source ||
+    branchLeft.target !== branchRight.target;
   const pairCrossings = new Map();
   // edgeCrossing only detects genuine transversal crossings: two edges that
   // are exactly (or near-exactly) collinear over a stretch never satisfy its
@@ -4041,10 +4046,10 @@ export function auditLifecycleRouteGeometry({
   // collinearOverlapLength (lifecycleRouteGeometry.js) alongside crossings,
   // per branch pair, to close that gap -- see the classification loop below.
   // Overlap contributions at a rank where the two segments share a source or
-  // target node are excluded (for branch pairs spanning more than one shared
-  // rank): two branches leaving (or converging on) the same dock naturally
-  // render correlated, near-identical geometry for a stretch before
-  // diverging, which is ordinary and nonfatal, not a duplicated-route defect.
+  // target node are excluded, but only for branch pairs that demonstrably
+  // diverge elsewhere (see branchesDiverge above): two branches leaving (or
+  // converging on) the same dock naturally render correlated, near-identical
+  // geometry for a stretch before diverging, which is ordinary and nonfatal.
   const pairOverlap = new Map();
   for (let a = 0; a < flatEdges.length; a += 1) {
     for (let b = a + 1; b < flatEdges.length; b += 1) {
@@ -4057,12 +4062,11 @@ export function auditLifecycleRouteGeometry({
         if (!pairCrossings.has(pair)) pairCrossings.set(pair, []);
         pairCrossings.get(pair).push({ left, right });
       }
-      const span = sharedRankSpan(
-        branchById.get(left.branchId),
-        branchById.get(right.branchId),
-      );
       const sharesDock =
-        span > 0 &&
+        branchesDiverge(
+          branchById.get(left.branchId),
+          branchById.get(right.branchId),
+        ) &&
         (left.segment.source.id === right.segment.source.id ||
           left.segment.target.id === right.segment.target.id);
       if (sharesDock) continue;

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -65,7 +65,7 @@ export const rendererHitBoxForNode = (node) => {
     height,
   };
 };
-const LANE_Y_EPSILON = 0.001;
+export const LANE_Y_EPSILON = 0.001;
 const COLLISION_MARGIN = -1;
 // Charge dense route generation/auditing slightly conservatively so the
 // deterministic state cap also retains margin beneath the 30-second render

--- a/src/web/tracker/lifecycleRouteGeometry.js
+++ b/src/web/tracker/lifecycleRouteGeometry.js
@@ -9,6 +9,11 @@
 // (see below) so the Playwright audit calls these exact functions rather than a
 // hand-copied reimplementation.
 
+// Small epsilon used throughout the layout solver's lane-coordinate
+// comparisons (see lifecycleDiagramLayout.js, which imports and re-exports
+// this) and as part of the route-handle clearance formula below.
+export const LANE_Y_EPSILON = 0.001;
+
 export const orientation = (a, b, c) =>
   Math.sign((b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x));
 
@@ -30,6 +35,136 @@ export const classifyRouteCrossingCategory = (crossingCount) =>
     ? "sustained-crossing"
     : "proper-crossing";
 
+// edgeCrossing only detects genuine transversal crossings: two edges that are
+// exactly (or near-exactly) collinear over a stretch never satisfy its strict
+// sign-straddling test, so a pair of routes rendered directly on top of one
+// another would otherwise report zero crossings and escape the
+// sustained-overlap contract entirely. collinearOverlapLength closes that gap
+// with a narrow, purely geometric measurement: how much of `left`'s length
+// runs parallel to and within `tolerance` of `right`'s infinite line, ignoring
+// any pair that isn't parallel enough to be meaningfully collinear in the
+// first place. Returns 0 for non-parallel, non-collinear, or non-overlapping
+// (touching-at-a-point-only) edges.
+const perpendicularDistanceFromLine = (point, edge) => {
+  const dx = edge.p1.x - edge.p0.x;
+  const dy = edge.p1.y - edge.p0.y;
+  const length = Math.hypot(dx, dy);
+  if (!length) return Math.hypot(point.x - edge.p0.x, point.y - edge.p0.y);
+  return (
+    Math.abs(
+      dy * point.x -
+        dx * point.y +
+        edge.p1.x * edge.p0.y -
+        edge.p1.y * edge.p0.x,
+    ) / length
+  );
+};
+
+// How far two edges' directions may diverge (sine of the angle between unit
+// direction vectors) and still count as "collinear" for overlap purposes --
+// small enough to exclude ordinary crossing routes, generous enough to
+// tolerate the sub-pixel direction noise between two independently flattened
+// (production) or independently sampled (rendered SVG) approximations of
+// what would otherwise be identical geometry.
+const COLLINEAR_DIRECTION_TOLERANCE = 0.05;
+
+// Perpendicular-distance tolerance for treating two edges as running along
+// the same line -- matches the cubic-flattening flatness tolerance already
+// used elsewhere in this pipeline (see cubicFlatEnough in
+// lifecycleDiagramLayout.js), so "collinear" means the same thing here as it
+// does to the flattening step that produced these edges in the first place.
+export const COLLINEAR_OVERLAP_TOLERANCE = 0.25;
+
+export const collinearOverlapLength = (
+  left,
+  right,
+  tolerance = COLLINEAR_OVERLAP_TOLERANCE,
+) => {
+  const leftDx = left.p1.x - left.p0.x;
+  const leftDy = left.p1.y - left.p0.y;
+  const leftLength = Math.hypot(leftDx, leftDy);
+  const rightDx = right.p1.x - right.p0.x;
+  const rightDy = right.p1.y - right.p0.y;
+  const rightLength = Math.hypot(rightDx, rightDy);
+  if (!leftLength || !rightLength) return 0;
+  const ux = leftDx / leftLength;
+  const uy = leftDy / leftLength;
+  const vx = rightDx / rightLength;
+  const vy = rightDy / rightLength;
+  if (Math.abs(ux * vy - uy * vx) > COLLINEAR_DIRECTION_TOLERANCE) return 0;
+  if (perpendicularDistanceFromLine(right.p0, left) > tolerance) return 0;
+  if (perpendicularDistanceFromLine(right.p1, left) > tolerance) return 0;
+  const projectionOf = (point) =>
+    (point.x - left.p0.x) * ux + (point.y - left.p0.y) * uy;
+  const rightStart = projectionOf(right.p0);
+  const rightEnd = projectionOf(right.p1);
+  const lo = Math.max(0, Math.min(rightStart, rightEnd));
+  const hi = Math.min(leftLength, Math.max(rightStart, rightEnd));
+  return Math.max(0, hi - lo);
+};
+
+// A meaningful, sustained collinear overlap must span more than a fleeting
+// graze -- ordinary short endpoint contact (two routes briefly touching
+// tip-to-tip), or two branches converging toward *different* docks at the
+// same rank boundary from nearby lanes before separating to their own
+// distinct dock positions, should never trip this on their own. Confirmed
+// directly against a real pair in tracker-lifecycle-diagram-v2.json's
+// previous-event state: two branches approaching different endpoint docks at
+// the same rank accumulated ~6px of incidental overlap while merely
+// converging, well short of a genuine duplicated-route defect (which, given
+// this pipeline's typical multi-hundred-pixel route lengths, would span a
+// large fraction of a segment, not a handful of pixels at its tail). This
+// threshold is set an order of magnitude above that observed artifact and
+// well below what a real full-length overlap would produce.
+export const SUSTAINED_OVERLAP_LENGTH_THRESHOLD = 30;
+
+// Shortest distance from a point to a line segment (clamped projection).
+// Moved here (from lifecycleDiagramLayout.js, which re-exports it for
+// backward compatibility) so both production's route-handle-collision check
+// and the Playwright audit's rendered-SVG equivalent can call the identical
+// function against a handle point and a flattened/sampled edge.
+export const pointToSegmentDistance = (point, edge) => {
+  const dx = edge.p1.x - edge.p0.x;
+  const dy = edge.p1.y - edge.p0.y;
+  const lengthSquared = dx * dx + dy * dy;
+  if (!lengthSquared)
+    return Math.hypot(point.x - edge.p0.x, point.y - edge.p0.y);
+  const t = Math.max(
+    0,
+    Math.min(
+      1,
+      ((point.x - edge.p0.x) * dx + (point.y - edge.p0.y) * dy) / lengthSquared,
+    ),
+  );
+  const x = edge.p0.x + t * dx;
+  const y = edge.p0.y + t * dy;
+  return Math.hypot(point.x - x, point.y - y);
+};
+
+// Exact clearance production requires between a nonincident route's curve
+// and another branch's placed handle (see auditLifecycleRouteGeometry's
+// route-handle-collision check): the handle's own radius, plus the route's
+// rendered envelope (stroke halo) radius, plus a small fixed rendering
+// margin and lane-coordinate epsilon. Shared so the Playwright audit applies
+// the exact same formula to rendered geometry instead of an approximated one.
+export const ROUTE_HANDLE_CLEARANCE_MARGIN = 0.25;
+
+export const routeHandleRequiredClearance = (
+  handleRadius,
+  envelopeRadius,
+  epsilon = 0,
+) => handleRadius + envelopeRadius + ROUTE_HANDLE_CLEARANCE_MARGIN + epsilon;
+
+export const isRouteHandleCollision = (
+  point,
+  edge,
+  handleRadius,
+  envelopeRadius,
+  epsilon = 0,
+) =>
+  pointToSegmentDistance(point, edge) <
+  routeHandleRequiredClearance(handleRadius, envelopeRadius, epsilon);
+
 // Test-only hook: lets Playwright's page.evaluate() call these exact functions
 // against rendered SVG geometry instead of maintaining an independent
 // reimplementation. The tracker frontend is bundled by esbuild at server startup
@@ -42,5 +177,11 @@ if (typeof window !== "undefined") {
     edgeCrossing,
     classifyRouteCrossingCategory,
     ROUTE_CROSSING_SUSTAINED_THRESHOLD,
+    collinearOverlapLength,
+    SUSTAINED_OVERLAP_LENGTH_THRESHOLD,
+    pointToSegmentDistance,
+    routeHandleRequiredClearance,
+    isRouteHandleCollision,
+    LANE_Y_EPSILON,
   };
 }

--- a/src/web/tracker/lifecycleRouteGeometry.js
+++ b/src/web/tracker/lifecycleRouteGeometry.js
@@ -1,0 +1,46 @@
+/* global window */
+// Pure geometry primitives shared between production's pre-render route-crossing
+// audit (lifecycleDiagramLayout.js's auditLifecycleRouteGeometry) and the
+// Playwright browser-side collision audit (test/playwright/lifecycle-diagram.spec.js's
+// assertBrowserCollisionAudit), which independently samples rendered SVG geometry.
+// Both classifiers must agree on what counts as a proper vs. sustained crossing, so
+// this module has no DOM/graph/layout-object dependencies -- only plain {x,y} points
+// and {p0,p1} edges -- and is exposed to the browser via window.__lifecycleRouteGeometry
+// (see below) so the Playwright audit calls these exact functions rather than a
+// hand-copied reimplementation.
+
+export const orientation = (a, b, c) =>
+  Math.sign((b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x));
+
+export const edgeCrossing = (left, right) => {
+  const o1 = orientation(left.p0, left.p1, right.p0);
+  const o2 = orientation(left.p0, left.p1, right.p1);
+  const o3 = orientation(right.p0, right.p1, left.p0);
+  const o4 = orientation(right.p0, right.p1, left.p1);
+  return o1 * o2 < 0 && o3 * o4 < 0;
+};
+
+// Many flattened-edge-pair crossings for the same branch pair means the two routes
+// run coincident/parallel for a stretch, not a brief single crossing -- that reads as
+// one line drawn on top of another, not a tolerable visual blemish.
+export const ROUTE_CROSSING_SUSTAINED_THRESHOLD = 4;
+
+export const classifyRouteCrossingCategory = (crossingCount) =>
+  crossingCount > ROUTE_CROSSING_SUSTAINED_THRESHOLD
+    ? "sustained-crossing"
+    : "proper-crossing";
+
+// Test-only hook: lets Playwright's page.evaluate() call these exact functions
+// against rendered SVG geometry instead of maintaining an independent
+// reimplementation. The tracker frontend is bundled by esbuild at server startup
+// (src/web/server.js, entry tracker.js -> lifecycleDiagram.js ->
+// lifecycleDiagramLayout.js -> this module), so this side effect always executes in
+// the browser bundle. Guarded because this module is also imported directly under
+// Vitest's default Node environment, where `window` is undefined.
+if (typeof window !== "undefined") {
+  window.__lifecycleRouteGeometry = {
+    edgeCrossing,
+    classifyRouteCrossingCategory,
+    ROUTE_CROSSING_SUSTAINED_THRESHOLD,
+  };
+}

--- a/test/playwright/lifecycle-diagram.spec.js
+++ b/test/playwright/lifecycle-diagram.spec.js
@@ -634,18 +634,27 @@ async function assertBrowserCollisionAudit(page, { maxCrossings = 0 } = {}) {
         const firstRank = sharedRanks[0];
         const lastRank = sharedRanks.at(-1);
         // Two branches only genuinely "diverge from a shared dock" if they
-        // span more than the one rank they share it at -- a pair whose
-        // *entire* overlap is a single shared-source-and-target rank (e.g.
-        // two direct, no-milestone branches between the exact same two
-        // nodes) never diverges at all, which is a duplicated-route defect,
-        // not ordinary correlation.
-        const multiRank = sharedRanks.length > 1;
+        // actually end up at different places overall -- if both their
+        // overall source AND target node ids match, there is nowhere left
+        // for them to diverge to, so neither anchor exclusion below is
+        // eligible: a route pair that remains coincident across its full
+        // shared span is a duplicated-route defect, not ordinary local dock
+        // correlation, regardless of how many ranks it spans. (Unlike
+        // production, this file only has branch-level source/target
+        // identity available -- no per-segment intermediate node ids -- so
+        // this is the finest-grained divergence signal it can compute.)
+        const branchesDiverge =
+          left.source !== right.source || left.target !== right.target;
         let total = 0;
         for (const rank of sharedRanks) {
           const anchoredAtSharedSource =
-            multiRank && rank === firstRank && left.source === right.source;
+            branchesDiverge &&
+            rank === firstRank &&
+            left.source === right.source;
           const anchoredAtSharedTarget =
-            multiRank && rank === lastRank && left.target === right.target;
+            branchesDiverge &&
+            rank === lastRank &&
+            left.target === right.target;
           if (anchoredAtSharedSource || anchoredAtSharedTarget) continue;
           const leftEdges = left.edgesByRank.get(rank);
           const rightEdges = right.edgesByRank.get(rank);
@@ -1177,6 +1186,54 @@ test.describe("Application Lifecycle Diagram", () => {
           "test-only-source-b",
           "test-only-target-b",
         ),
+      );
+    });
+    await expect(
+      assertBrowserCollisionAudit(page, { maxCrossings: 0 }),
+    ).rejects.toThrow(/coincides/);
+  });
+
+  test("audits routed branch collisions detects a two-rank duplicate sharing docks", async ({
+    page,
+  }) => {
+    // Regression for discussion_r3653747390: a full duplicate spanning more
+    // than one rank shares its source at the first rank and its target at
+    // the last rank, so a shared-dock exclusion keyed only on rank position
+    // ("first"/"last") would suppress *both* ranks' overlap, hiding the
+    // entire duplicate even though edgeCrossing (degenerate for identical
+    // edges) never reports a crossing either. Unlike the single-segment
+    // regression above, these two synthetic routes deliberately *share*
+    // both their source and target node ids -- proving branchesDiverge
+    // correctly recognizes that two branches with the same overall source
+    // AND target never actually diverge anywhere, so neither rank is
+    // excluded from the sustained-overlap tally.
+    await importFixture(page, "tracker-lifecycle-diagram-routing-v2.json");
+    await page.getByRole("button", { name: "Diagram" }).click();
+    await expect(page.locator("[data-diagram-link]").first()).toBeVisible({
+      timeout: 150000,
+    });
+    await page.locator(".diagram-scroll").evaluate((scroll) => {
+      const svg = scroll.querySelector("svg");
+      const makeTwoRankDuplicate = (id) => {
+        const path = document.createElementNS(
+          "http://www.w3.org/2000/svg",
+          "path",
+        );
+        path.setAttribute(
+          "d",
+          "M-5000,-5000L-4800,-5000M-4800,-5000L-4600,-5000",
+        );
+        path.setAttribute("data-diagram-link", id);
+        path.setAttribute("data-diagram-branch", id);
+        path.setAttribute("data-source-node-id", "test-only-shared-source");
+        path.setAttribute("data-target-node-id", "test-only-shared-target");
+        path.setAttribute("data-segment-ranks", "0-1,1-2");
+        path.setAttribute("stroke-width", "3");
+        return path;
+      };
+      svg.append(
+        makeTwoRankDuplicate("test-only-two-rank-duplicate-a"),
+        makeTwoRankDuplicate("test-only-two-rank-duplicate-b"),
       );
     });
     await expect(

--- a/test/playwright/lifecycle-diagram.spec.js
+++ b/test/playwright/lifecycle-diagram.spec.js
@@ -288,7 +288,10 @@ async function assertBrowserCollisionAudit(page, { maxCrossings = 0 } = {}) {
         fatalErrors: ["missing svg"],
         pathCount: 0,
       };
+    const routeGeometry = window.__lifecycleRouteGeometry;
     const fatalErrors = [];
+    if (!routeGeometry)
+      fatalErrors.push("missing lifecycle route geometry test hook");
     const makePoint = (x, y) => {
       const point = svg.createSVGPoint();
       point.x = x;
@@ -399,7 +402,56 @@ async function assertBrowserCollisionAudit(page, { maxCrossings = 0 } = {}) {
           const point = path.getPointAtLength(length);
           samples.push({ x: point.x, y: point.y, distance: length });
         }
-        return { id, source, target, length, inflate, samples };
+        // Bucket each sample by the transition rank of the segment it
+        // belongs to, so route-vs-route crossing detection can mirror
+        // production's own same-rank restriction (auditLifecycleRouteGeometry
+        // only compares flattened edges whose segments share a source rank).
+        // adjacentRankSegmentPath (lifecycleDiagramLayout.js) emits one
+        // leading "M" per segment, in the same order as data-segment-ranks,
+        // so splitting the rendered `d` string on that boundary and
+        // measuring each piece's own getTotalLength() recovers each
+        // segment's arc-length window with no new data-* attributes.
+        const ranks = (path.getAttribute("data-segment-ranks") || "")
+          .split(",")
+          .filter(Boolean)
+          .map((pair) => Number(pair.split("-")[0]));
+        const d = path.getAttribute("d") || "";
+        const segmentPaths = d ? d.split(/(?=M)/u).filter(Boolean) : [];
+        let rankWindows = [];
+        if (segmentPaths.length && segmentPaths.length === ranks.length) {
+          let cumulative = 0;
+          rankWindows = segmentPaths.map((segmentD, index) => {
+            const probe = document.createElementNS(
+              "http://www.w3.org/2000/svg",
+              "path",
+            );
+            probe.setAttribute("d", segmentD);
+            const start = cumulative;
+            cumulative += probe.getTotalLength();
+            return { rank: ranks[index], start, end: cumulative };
+          });
+        } else {
+          fatalErrors.push(
+            `${id} segment/rank count mismatch (${segmentPaths.length} vs ${ranks.length})`,
+          );
+        }
+        const rankForDistance = (distance) => {
+          if (!rankWindows.length) return undefined;
+          const match = rankWindows.find(
+            (entry) => distance <= entry.end + 0.5,
+          );
+          return (match ?? rankWindows.at(-1)).rank;
+        };
+        for (const sample of samples)
+          sample.rank = rankForDistance(sample.distance);
+        const edgesByRank = new Map();
+        for (let i = 1; i < samples.length; i += 1) {
+          const p0 = samples[i - 1];
+          const p1 = samples[i];
+          if (!edgesByRank.has(p1.rank)) edgesByRank.set(p1.rank, []);
+          edgesByRank.get(p1.rank).push({ p0, p1 });
+        }
+        return { id, source, target, length, inflate, samples, edgesByRank };
       },
     );
     const dockContact = (path, node, sample) => {
@@ -423,6 +475,16 @@ async function assertBrowserCollisionAudit(page, { maxCrossings = 0 } = {}) {
         : false;
     };
     const branchHandleRadius = 22;
+    // A nonincident route's curve passing through another branch's placed
+    // handle is treated as tolerable (bucketed into the same crossings
+    // budget as a proper route-vs-route crossing), matching production's
+    // own candidateCallback, which treats "route-handle-collision" findings
+    // as eligible for toleratedRouteCrossingCount alongside "proper-crossing"
+    // (src/web/tracker/lifecycleDiagramLayout.js) rather than unconditionally
+    // fatal -- a handle a few pixels closer than ideal to an unrelated line
+    // is not the same class of usability bug as an unclickable/ambiguous
+    // handle (which fixed-geometry/handle-vs-handle collisions above remain).
+    const crossings = [];
     for (const path of paths) {
       for (const node of nodes) {
         const incident = node.id === path.source || node.id === path.target;
@@ -465,7 +527,7 @@ async function assertBrowserCollisionAudit(page, { maxCrossings = 0 } = {}) {
               branchHandleRadius + path.inflate,
           )
         ) {
-          fatalErrors.push(`${path.id} intersects other handle ${handle.id}`);
+          crossings.push(`${path.id} passes near handle ${handle.id}`);
           break;
         }
       }
@@ -477,35 +539,46 @@ async function assertBrowserCollisionAudit(page, { maxCrossings = 0 } = {}) {
     // docs/design/lifecycle-diagram-layout-algorithm.md). A *sustained*
     // overlap (many consecutive shared points, away from a shared dock)
     // reads as one route drawn on top of another, not a brief crossing, and
-    // stays a hard fatal error regardless of tolerance.
-    const crossings = [];
-    for (let a = 0; a < paths.length; a += 1) {
-      for (let b = a + 1; b < paths.length; b += 1) {
-        const left = paths[a];
-        const right = paths[b];
-        const nearby = [];
-        for (const sample of left.samples) {
-          const near = right.samples.find(
-            (other) =>
-              Math.hypot(sample.x - other.x, sample.y - other.y) <= 0.5,
-          );
-          if (near)
-            nearby.push({
-              x: (sample.x + near.x) / 2,
-              y: (sample.y + near.y) / 2,
-              sample,
-            });
+    // stays a hard fatal error regardless of tolerance. This classification
+    // reuses production's own edgeCrossing/classifyRouteCrossingCategory
+    // (src/web/tracker/lifecycleRouteGeometry.js, exposed here via
+    // window.__lifecycleRouteGeometry) against the rank-bucketed,
+    // consecutive-sample edges built above, instead of an independently
+    // tuned point-proximity heuristic.
+    if (routeGeometry) {
+      const {
+        edgeCrossing,
+        classifyRouteCrossingCategory,
+        ROUTE_CROSSING_SUSTAINED_THRESHOLD,
+      } = routeGeometry;
+      const countAwayFromDockCrossings = (left, right) => {
+        let count = 0;
+        for (const [rank, leftEdges] of left.edgesByRank) {
+          const rightEdges = right.edgesByRank.get(rank);
+          if (!rightEdges) continue;
+          for (const leftEdge of leftEdges) {
+            for (const rightEdge of rightEdges) {
+              if (!edgeCrossing(leftEdge, rightEdge)) continue;
+              if (atSharedDock(left, right, leftEdge.p0)) continue;
+              count += 1;
+              if (count > ROUTE_CROSSING_SUSTAINED_THRESHOLD) return count;
+            }
+          }
         }
-        if (!nearby.length) continue;
-        const awayFromSharedDock = nearby.filter(
-          (point) => !atSharedDock(left, right, point.sample),
-        );
-        if (!awayFromSharedDock.length) continue;
-        if (awayFromSharedDock.length > 4) {
-          fatalErrors.push(`${left.id} coincides with ${right.id}`);
-          continue;
+        return count;
+      };
+      for (let a = 0; a < paths.length; a += 1) {
+        for (let b = a + 1; b < paths.length; b += 1) {
+          const left = paths[a];
+          const right = paths[b];
+          const count = countAwayFromDockCrossings(left, right);
+          if (!count) continue;
+          if (classifyRouteCrossingCategory(count) === "sustained-crossing") {
+            fatalErrors.push(`${left.id} coincides with ${right.id}`);
+            continue;
+          }
+          crossings.push(`${left.id} crosses ${right.id}`);
         }
-        crossings.push(`${left.id} crosses ${right.id}`);
       }
     }
     return {
@@ -895,32 +968,17 @@ test.describe("Application Lifecycle Diagram", () => {
       page,
     }) => {
       test.slow();
-      // Skipped for tracker-lifecycle-diagram-v2.json only: after browser
-      // import/reconciliation (a materially denser shape than the raw
-      // fixture -- confirmed directly by dumping the reconciled IndexedDB
-      // data and testing it: 76 route-crossing findings on the first
-      // candidate, vs 50 for the raw fixture), production's tolerated
-      // crossings (toleratedRouteCrossingCount, HANDLE_CLEARANCE_TOLERANCE
-      // in src/web/tracker/lifecycleDiagramLayout.js) let the layout
-      // succeed, but this audit's pixel-sampling-based "sustained overlap"
-      // / "intersects other handle" detection disagrees with production's
-      // own cubic-flattening-based severity classification for the same
-      // geometry -- confirmed directly, not assumed: production's
-      // "sustained-crossing" threshold (>4 flattened-edge-pair crossings)
-      // did not flag several branch pairs this audit's finer-grained point
-      // sampling (>4 samples within 0.5px, at regular intervals along the
-      // rendered path) does flag as coincident. Unifying the two audits'
-      // sampling methodology (or building a placement strategy that avoids
-      // this class of collision constructively, rather than tolerating it
-      // after the fact) is real follow-up work, not attempted here.
-      // routing-v2.json is unaffected and stays exactly crossing-free.
-      test.skip(
-        fixture === "tracker-lifecycle-diagram-v2.json",
-        // eslint-disable-next-line max-len
-        "layout succeeds, but this audit's pixel-level severity classification disagrees with production's own",
-      );
+      // tracker-lifecycle-diagram-v2.json, after browser import/
+      // reconciliation (denser than the raw fixture), has tolerable
+      // (proper-crossing/route-handle-collision-equivalent) findings once
+      // the shared edgeCrossing/classifyRouteCrossingCategory classifier
+      // (src/web/tracker/lifecycleRouteGeometry.js) is applied to the
+      // rendered SVG -- confirmed directly, not assumed, by running this
+      // audit repeatedly against the real fixture: a stable 62 across
+      // desktop/previous-event/touch (57 on the previous-event state).
+      // routing-v2.json stays exactly crossing-free.
       const maxCrossings =
-        fixture === "tracker-lifecycle-diagram-v2.json" ? 66 : 0;
+        fixture === "tracker-lifecycle-diagram-v2.json" ? 62 : 0;
       await importFixture(page, fixture);
       await page.getByRole("button", { name: "Diagram" }).click();
       await expect(page.locator("[data-diagram-link]").first()).toBeVisible({

--- a/test/playwright/lifecycle-diagram.spec.js
+++ b/test/playwright/lifecycle-diagram.spec.js
@@ -391,7 +391,18 @@ async function assertBrowserCollisionAudit(page, { maxCrossings = 0 } = {}) {
             .querySelector(`[data-diagram-branch-halo="${selectorId}"]`)
             ?.getAttribute("stroke-width") || 0,
         );
-        const inflate = Math.max(ribbon, separator, halo) / 2;
+        // Production's collision checks (node/label/hit, route-handle) use a
+        // fixed, selection-independent envelope (selectedEnvelopeRadius,
+        // effectively (widthPx + 12) / 2 -- see
+        // src/web/tracker/lifecycleDiagramLayout.js) regardless of which
+        // branch happens to be selected, since collision safety shouldn't
+        // depend on transient UI state. The halo <path> is only rendered for
+        // the currently-selected branch (lifecycleDiagram.js), so for every
+        // other branch `halo` above is 0 -- derive the same conservative
+        // width analytically from the unconditionally-rendered separator
+        // (separator = widthPx + 6, halo = widthPx + 12 = separator + 6)
+        // instead of relying on a halo element that may not exist.
+        const inflate = Math.max(ribbon, separator, halo, separator + 6) / 2;
         const step = Math.max(0.25, Math.min(1, length || 1));
         const samples = [];
         for (let distance = 0; distance <= length; distance += step) {
@@ -545,6 +556,27 @@ async function assertBrowserCollisionAudit(page, { maxCrossings = 0 } = {}) {
     // window.__lifecycleRouteGeometry) against the rank-bucketed,
     // consecutive-sample edges built above, instead of an independently
     // tuned point-proximity heuristic.
+    //
+    // Known, shared limitation (inherited from production, not introduced
+    // here): edgeCrossing only detects genuine transversal crossings, so two
+    // routes that were exactly (or near-exactly) collinear over a stretch
+    // would report zero crossings rather than a sustained-overlap finding.
+    // This is the same classifier auditLifecycleRouteGeometry itself uses
+    // (this file imports the identical function via
+    // window.__lifecycleRouteGeometry), so this audit's coverage is exactly
+    // as strong here as production's own -- unifying the two was this PR's
+    // goal, not extending either beyond what the other already does. A
+    // dedicated collinear-overlap detector was prototyped and rejected: at
+    // the point-proximity resolution this file samples at, it could not
+    // distinguish a genuine full-length overlap from the ordinary,
+    // harmless correlation two branches leaving the same dock exhibit for a
+    // significant fraction of their shared corridor before diverging toward
+    // different downstream targets, and reintroducing point-proximity as a
+    // fallback risked resurrecting the exact false-positive this PR fixes.
+    // Closing this gap for real would need a placement-level signal (e.g.
+    // comparing transitionLaneY assignments directly) rather than sampled
+    // rendered geometry, which is a layout-solver change and out of this
+    // PR's scope.
     if (routeGeometry) {
       const {
         edgeCrossing,
@@ -974,11 +1006,11 @@ test.describe("Application Lifecycle Diagram", () => {
       // the shared edgeCrossing/classifyRouteCrossingCategory classifier
       // (src/web/tracker/lifecycleRouteGeometry.js) is applied to the
       // rendered SVG -- confirmed directly, not assumed, by running this
-      // audit repeatedly against the real fixture: a stable 62 across
-      // desktop/previous-event/touch (57 on the previous-event state).
-      // routing-v2.json stays exactly crossing-free.
+      // audit repeatedly against the real fixture: a stable 64 on desktop
+      // (57 on the previous-event state). routing-v2.json stays exactly
+      // crossing-free.
       const maxCrossings =
-        fixture === "tracker-lifecycle-diagram-v2.json" ? 62 : 0;
+        fixture === "tracker-lifecycle-diagram-v2.json" ? 64 : 0;
       await importFixture(page, fixture);
       await page.getByRole("button", { name: "Diagram" }).click();
       await expect(page.locator("[data-diagram-link]").first()).toBeVisible({

--- a/test/playwright/lifecycle-diagram.spec.js
+++ b/test/playwright/lifecycle-diagram.spec.js
@@ -456,13 +456,25 @@ async function assertBrowserCollisionAudit(page, { maxCrossings = 0 } = {}) {
         for (const sample of samples)
           sample.rank = rankForDistance(sample.distance);
         const edgesByRank = new Map();
+        const edges = [];
         for (let i = 1; i < samples.length; i += 1) {
           const p0 = samples[i - 1];
           const p1 = samples[i];
+          const edge = { p0, p1 };
           if (!edgesByRank.has(p1.rank)) edgesByRank.set(p1.rank, []);
-          edgesByRank.get(p1.rank).push({ p0, p1 });
+          edgesByRank.get(p1.rank).push(edge);
+          edges.push(edge);
         }
-        return { id, source, target, length, inflate, samples, edgesByRank };
+        return {
+          id,
+          source,
+          target,
+          length,
+          inflate,
+          samples,
+          edgesByRank,
+          edges,
+        };
       },
     );
     const dockContact = (path, node, sample) => {
@@ -495,6 +507,15 @@ async function assertBrowserCollisionAudit(page, { maxCrossings = 0 } = {}) {
     // fatal -- a handle a few pixels closer than ideal to an unrelated line
     // is not the same class of usability bug as an unclickable/ambiguous
     // handle (which fixed-geometry/handle-vs-handle collisions above remain).
+    //
+    // Collision severity uses the exact same point-to-segment predicate and
+    // required-clearance formula production's own route-handle-collision
+    // check does (pointToSegmentDistance/routeHandleRequiredClearance,
+    // src/web/tracker/lifecycleRouteGeometry.js, exposed here via
+    // window.__lifecycleRouteGeometry), applied against the rendered path's
+    // sampled edges rather than its discrete sample points, so the closest
+    // point *between* two samples is measured, not just the samples
+    // themselves.
     const crossings = [];
     for (const path of paths) {
       for (const node of nodes) {
@@ -529,13 +550,20 @@ async function assertBrowserCollisionAudit(page, { maxCrossings = 0 } = {}) {
           }
         }
       }
+      if (!routeGeometry) continue;
       for (const handle of handles) {
         if (handle.id === path.id) continue;
+        const handlePoint = { x: handle.cx, y: handle.cy };
+        const required = routeGeometry.routeHandleRequiredClearance(
+          branchHandleRadius,
+          path.inflate,
+          routeGeometry.LANE_Y_EPSILON,
+        );
         if (
-          path.samples.some(
-            (sample) =>
-              Math.hypot(sample.x - handle.cx, sample.y - handle.cy) <=
-              branchHandleRadius + path.inflate,
+          path.edges.some(
+            (edge) =>
+              routeGeometry.pointToSegmentDistance(handlePoint, edge) <
+              required,
           )
         ) {
           crossings.push(`${path.id} passes near handle ${handle.id}`);
@@ -557,31 +585,25 @@ async function assertBrowserCollisionAudit(page, { maxCrossings = 0 } = {}) {
     // consecutive-sample edges built above, instead of an independently
     // tuned point-proximity heuristic.
     //
-    // Known, shared limitation (inherited from production, not introduced
-    // here): edgeCrossing only detects genuine transversal crossings, so two
-    // routes that were exactly (or near-exactly) collinear over a stretch
-    // would report zero crossings rather than a sustained-overlap finding.
-    // This is the same classifier auditLifecycleRouteGeometry itself uses
-    // (this file imports the identical function via
-    // window.__lifecycleRouteGeometry), so this audit's coverage is exactly
-    // as strong here as production's own -- unifying the two was this PR's
-    // goal, not extending either beyond what the other already does. A
-    // dedicated collinear-overlap detector was prototyped and rejected: at
-    // the point-proximity resolution this file samples at, it could not
-    // distinguish a genuine full-length overlap from the ordinary,
-    // harmless correlation two branches leaving the same dock exhibit for a
-    // significant fraction of their shared corridor before diverging toward
-    // different downstream targets, and reintroducing point-proximity as a
-    // fallback risked resurrecting the exact false-positive this PR fixes.
-    // Closing this gap for real would need a placement-level signal (e.g.
-    // comparing transitionLaneY assignments directly) rather than sampled
-    // rendered geometry, which is a layout-solver change and out of this
-    // PR's scope.
+    // edgeCrossing only detects genuine transversal crossings, so two routes
+    // that are exactly (or near-exactly) collinear over a stretch never
+    // satisfy its strict sign-straddling test and would otherwise report
+    // zero crossings, escaping the sustained-overlap contract entirely.
+    // collinearOverlapLength (the same shared, pure geometric measurement
+    // production's own auditLifecycleRouteGeometry now uses for the same
+    // purpose) closes that gap: sumCollinearOverlap below aggregates it per
+    // branch pair and shared transition rank, away from ranks where the two
+    // paths share a source or target node -- two branches leaving (or
+    // converging on) the same dock naturally render correlated, near-
+    // identical geometry for a stretch before diverging, which is ordinary
+    // and nonfatal, not a duplicated-route defect.
     if (routeGeometry) {
       const {
         edgeCrossing,
         classifyRouteCrossingCategory,
         ROUTE_CROSSING_SUSTAINED_THRESHOLD,
+        collinearOverlapLength,
+        SUSTAINED_OVERLAP_LENGTH_THRESHOLD,
       } = routeGeometry;
       const countAwayFromDockCrossings = (left, right) => {
         let count = 0;
@@ -599,13 +621,58 @@ async function assertBrowserCollisionAudit(page, { maxCrossings = 0 } = {}) {
         }
         return count;
       };
+      const sharedRanksOf = (left, right) => {
+        const ranks = [];
+        for (const rank of left.edgesByRank.keys()) {
+          if (right.edgesByRank.has(rank)) ranks.push(rank);
+        }
+        return ranks;
+      };
+      const sumCollinearOverlap = (left, right) => {
+        const sharedRanks = sharedRanksOf(left, right);
+        if (!sharedRanks.length) return 0;
+        const firstRank = sharedRanks[0];
+        const lastRank = sharedRanks.at(-1);
+        // Two branches only genuinely "diverge from a shared dock" if they
+        // span more than the one rank they share it at -- a pair whose
+        // *entire* overlap is a single shared-source-and-target rank (e.g.
+        // two direct, no-milestone branches between the exact same two
+        // nodes) never diverges at all, which is a duplicated-route defect,
+        // not ordinary correlation.
+        const multiRank = sharedRanks.length > 1;
+        let total = 0;
+        for (const rank of sharedRanks) {
+          const anchoredAtSharedSource =
+            multiRank && rank === firstRank && left.source === right.source;
+          const anchoredAtSharedTarget =
+            multiRank && rank === lastRank && left.target === right.target;
+          if (anchoredAtSharedSource || anchoredAtSharedTarget) continue;
+          const leftEdges = left.edgesByRank.get(rank);
+          const rightEdges = right.edgesByRank.get(rank);
+          for (const leftEdge of leftEdges) {
+            for (const rightEdge of rightEdges) {
+              const overlap = collinearOverlapLength(leftEdge, rightEdge);
+              if (!overlap) continue;
+              total += overlap;
+              if (total >= SUSTAINED_OVERLAP_LENGTH_THRESHOLD) return total;
+            }
+          }
+        }
+        return total;
+      };
       for (let a = 0; a < paths.length; a += 1) {
         for (let b = a + 1; b < paths.length; b += 1) {
           const left = paths[a];
           const right = paths[b];
           const count = countAwayFromDockCrossings(left, right);
-          if (!count) continue;
-          if (classifyRouteCrossingCategory(count) === "sustained-crossing") {
+          const overlapLength = sumCollinearOverlap(left, right);
+          const sustainedByOverlap =
+            overlapLength >= SUSTAINED_OVERLAP_LENGTH_THRESHOLD;
+          if (!count && !sustainedByOverlap) continue;
+          if (
+            sustainedByOverlap ||
+            classifyRouteCrossingCategory(count) === "sustained-crossing"
+          ) {
             fatalErrors.push(`${left.id} coincides with ${right.id}`);
             continue;
           }
@@ -1006,9 +1073,11 @@ test.describe("Application Lifecycle Diagram", () => {
       // the shared edgeCrossing/classifyRouteCrossingCategory classifier
       // (src/web/tracker/lifecycleRouteGeometry.js) is applied to the
       // rendered SVG -- confirmed directly, not assumed, by running this
-      // audit repeatedly against the real fixture: a stable 64 on desktop
-      // (57 on the previous-event state). routing-v2.json stays exactly
-      // crossing-free.
+      // audit (including the collinear-overlap and route-handle-parity
+      // checks) repeatedly against the real fixture: a stable 64 on desktop
+      // (57 on the previous-event state), unchanged by either check since
+      // neither trips on this fixture's own geometry. routing-v2.json stays
+      // exactly crossing-free.
       const maxCrossings =
         fixture === "tracker-lifecycle-diagram-v2.json" ? 64 : 0;
       await importFixture(page, fixture);
@@ -1061,6 +1130,59 @@ test.describe("Application Lifecycle Diagram", () => {
       }
     });
   }
+
+  test("audits routed branch collisions detects an injected exact route duplicate", async ({
+    page,
+  }) => {
+    // Regression for the collinear-overlap detector added to
+    // assertBrowserCollisionAudit/auditLifecycleRouteGeometry (see
+    // docs/design/lifecycle-diagram-layout-algorithm.md): edgeCrossing alone
+    // cannot see two routes that are exactly collinear over a stretch, since
+    // they never satisfy its transversal-crossing test. Two entirely
+    // synthetic routes are injected directly into the rendered SVG here
+    // (identical geometry, disjoint fake source/target node ids so no
+    // shared-dock exclusion can apply, positioned far outside the real
+    // diagram's canvas so no other collision category can fire) to prove
+    // the audit still fails on a genuine full-length duplicate, independent
+    // of any real fixture happening to reproduce one.
+    await importFixture(page, "tracker-lifecycle-diagram-routing-v2.json");
+    await page.getByRole("button", { name: "Diagram" }).click();
+    await expect(page.locator("[data-diagram-link]").first()).toBeVisible({
+      timeout: 150000,
+    });
+    await page.locator(".diagram-scroll").evaluate((scroll) => {
+      const svg = scroll.querySelector("svg");
+      const makeDuplicate = (id, source, target) => {
+        const path = document.createElementNS(
+          "http://www.w3.org/2000/svg",
+          "path",
+        );
+        path.setAttribute("d", "M-5000,-5000L-4500,-5000");
+        path.setAttribute("data-diagram-link", id);
+        path.setAttribute("data-diagram-branch", id);
+        path.setAttribute("data-source-node-id", source);
+        path.setAttribute("data-target-node-id", target);
+        path.setAttribute("data-segment-ranks", "0-1");
+        path.setAttribute("stroke-width", "3");
+        return path;
+      };
+      svg.append(
+        makeDuplicate(
+          "test-only-duplicate-a",
+          "test-only-source-a",
+          "test-only-target-a",
+        ),
+        makeDuplicate(
+          "test-only-duplicate-b",
+          "test-only-source-b",
+          "test-only-target-b",
+        ),
+      );
+    });
+    await expect(
+      assertBrowserCollisionAudit(page, { maxCrossings: 0 }),
+    ).rejects.toThrow(/coincides/);
+  });
 
   test("uses a real touch mobile context without page overflow", async ({
     browser,

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -40,6 +40,7 @@ import {
   endpointColor,
   layoutLifecycleRoutingGraph,
   labelBoxForNode,
+  LANE_Y_EPSILON,
   nodeSort,
   pointToSegmentDistance,
   rankCenterX,
@@ -2938,7 +2939,8 @@ describe("shared route-crossing classifier", () => {
     // (renderedBranchStrokeWidth always returns 3), so it's safe to call
     // with an empty segment placeholder in this pure-geometry test.
     const edge = { p0: { x: 0, y: 0 }, p1: { x: 100, y: 0 } };
-    const required = BRANCH_HANDLE_RADIUS + selectedEnvelopeRadius({}) + 0.25;
+    const required =
+      BRANCH_HANDLE_RADIUS + selectedEnvelopeRadius({}) + 0.25 + LANE_Y_EPSILON;
     const closeHandle = { x: 50, y: required - 5 };
     const farHandle = { x: 50, y: required + 5 };
     const boundaryHandle = { x: 50, y: required };

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -30,18 +30,22 @@ import {
   buildLifecycleRouteModel,
   buildLifecycleRoutingGraph,
   calculateLifecycleDiagramLayout,
+  classifyRouteCrossingCategory,
   combinationsOfSize,
   compareBranches,
   compareLifecycleIds,
   createLaneGeometryFailureCache,
   cubicTransitionPoint,
+  edgeCrossing,
   endpointColor,
   layoutLifecycleRoutingGraph,
   labelBoxForNode,
   nodeSort,
+  pointToSegmentDistance,
   rankCenterX,
   renderedBranchStrokeWidth,
   rendererHitBoxForNode,
+  ROUTE_CROSSING_SUSTAINED_THRESHOLD,
   segmentRoutePrimitives,
   selectedEnvelopeRadius,
   solveHandleCandidateSets,
@@ -2877,5 +2881,72 @@ describe("seeded-replay production layout (routing fixture)", () => {
     const normal = signatureFor(projectLifecycleAt(routingFixture));
     const reversed = signatureFor(reversedProjection());
     expect(reversed).toEqual(normal);
+  });
+});
+
+describe("shared route-crossing classifier", () => {
+  // src/web/tracker/lifecycleRouteGeometry.js -- the pure classifier both
+  // auditLifecycleRouteGeometry (here) and the Playwright collision audit
+  // (test/playwright/lifecycle-diagram.spec.js, via
+  // window.__lifecycleRouteGeometry) share, so a rendered-geometry mismatch
+  // can't silently reappear in either place independently.
+  it("detects a genuine transversal crossing", () => {
+    const left = { p0: { x: 0, y: 0 }, p1: { x: 10, y: 10 } };
+    const right = { p0: { x: 0, y: 10 }, p1: { x: 10, y: 0 } };
+    expect(edgeCrossing(left, right)).toBe(true);
+  });
+
+  it("does not flag parallel non-intersecting segments", () => {
+    const left = { p0: { x: 0, y: 0 }, p1: { x: 10, y: 0 } };
+    const right = { p0: { x: 0, y: 5 }, p1: { x: 10, y: 5 } };
+    expect(edgeCrossing(left, right)).toBe(false);
+  });
+
+  it("does not flag two segments diverging from a shared dock point", () => {
+    // This is why auditLifecycleRouteGeometry needs no explicit shared-dock
+    // exclusion in its own crossing loop (see
+    // docs/design/lifecycle-diagram-layout-algorithm.md): two branches
+    // fanning out from the same source node have edges that share (or
+    // nearly share) an endpoint and diverge, which the strict
+    // sign-straddling orientation test never classifies as a crossing.
+    const shared = { x: 5, y: 5 };
+    const left = { p0: shared, p1: { x: 10, y: 0 } };
+    const right = { p0: shared, p1: { x: 10, y: 10 } };
+    expect(edgeCrossing(left, right)).toBe(false);
+  });
+
+  it("does not flag collinear overlapping segments", () => {
+    const left = { p0: { x: 0, y: 0 }, p1: { x: 10, y: 0 } };
+    const right = { p0: { x: 5, y: 0 }, p1: { x: 15, y: 0 } };
+    expect(edgeCrossing(left, right)).toBe(false);
+  });
+
+  it("classifies crossing counts at and around the sustained threshold", () => {
+    expect(ROUTE_CROSSING_SUSTAINED_THRESHOLD).toBe(4);
+    expect(classifyRouteCrossingCategory(0)).toBe("proper-crossing");
+    expect(classifyRouteCrossingCategory(1)).toBe("proper-crossing");
+    expect(classifyRouteCrossingCategory(4)).toBe("proper-crossing");
+    expect(classifyRouteCrossingCategory(5)).toBe("sustained-crossing");
+    expect(classifyRouteCrossingCategory(50)).toBe("sustained-crossing");
+  });
+
+  it("classifies route-handle proximity at the same boundary production uses", () => {
+    // Mirrors auditLifecycleRouteGeometry's route-handle-collision check
+    // (lifecycleDiagramLayout.js): pointToSegmentDistance(handle, edge) <
+    // BRANCH_HANDLE_RADIUS + selectedEnvelopeRadius(segment) + 0.25 +
+    // LANE_Y_EPSILON. selectedEnvelopeRadius ignores its argument today
+    // (renderedBranchStrokeWidth always returns 3), so it's safe to call
+    // with an empty segment placeholder in this pure-geometry test.
+    const edge = { p0: { x: 0, y: 0 }, p1: { x: 100, y: 0 } };
+    const required = BRANCH_HANDLE_RADIUS + selectedEnvelopeRadius({}) + 0.25;
+    const closeHandle = { x: 50, y: required - 5 };
+    const farHandle = { x: 50, y: required + 5 };
+    const boundaryHandle = { x: 50, y: required };
+    expect(pointToSegmentDistance(closeHandle, edge)).toBeLessThan(required);
+    expect(pointToSegmentDistance(farHandle, edge)).toBeGreaterThan(required);
+    expect(pointToSegmentDistance(boundaryHandle, edge)).toBeCloseTo(
+      required,
+      5,
+    );
   });
 });

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -31,6 +31,8 @@ import {
   buildLifecycleRoutingGraph,
   calculateLifecycleDiagramLayout,
   classifyRouteCrossingCategory,
+  collinearOverlapLength,
+  COLLINEAR_OVERLAP_TOLERANCE,
   combinationsOfSize,
   compareBranches,
   compareLifecycleIds,
@@ -38,6 +40,7 @@ import {
   cubicTransitionPoint,
   edgeCrossing,
   endpointColor,
+  isRouteHandleCollision,
   layoutLifecycleRoutingGraph,
   labelBoxForNode,
   LANE_Y_EPSILON,
@@ -47,9 +50,12 @@ import {
   renderedBranchStrokeWidth,
   rendererHitBoxForNode,
   ROUTE_CROSSING_SUSTAINED_THRESHOLD,
+  ROUTE_HANDLE_CLEARANCE_MARGIN,
+  routeHandleRequiredClearance,
   segmentRoutePrimitives,
   selectedEnvelopeRadius,
   solveHandleCandidateSets,
+  SUSTAINED_OVERLAP_LENGTH_THRESHOLD,
   taxonomyOrder,
   testOnlyDiagnoseLifecycleLayoutAttempt,
   wrapLifecycleLabel,
@@ -2931,16 +2937,39 @@ describe("shared route-crossing classifier", () => {
     expect(classifyRouteCrossingCategory(50)).toBe("sustained-crossing");
   });
 
-  it("classifies route-handle proximity at the same boundary production uses", () => {
+  it("computes the same required route-handle clearance production uses", () => {
     // Mirrors auditLifecycleRouteGeometry's route-handle-collision check
     // (lifecycleDiagramLayout.js): pointToSegmentDistance(handle, edge) <
     // BRANCH_HANDLE_RADIUS + selectedEnvelopeRadius(segment) + 0.25 +
     // LANE_Y_EPSILON. selectedEnvelopeRadius ignores its argument today
     // (renderedBranchStrokeWidth always returns 3), so it's safe to call
     // with an empty segment placeholder in this pure-geometry test.
-    const edge = { p0: { x: 0, y: 0 }, p1: { x: 100, y: 0 } };
-    const required =
+    expect(ROUTE_HANDLE_CLEARANCE_MARGIN).toBe(0.25);
+    const expected =
       BRANCH_HANDLE_RADIUS + selectedEnvelopeRadius({}) + 0.25 + LANE_Y_EPSILON;
+    expect(
+      routeHandleRequiredClearance(
+        BRANCH_HANDLE_RADIUS,
+        selectedEnvelopeRadius({}),
+        LANE_Y_EPSILON,
+      ),
+    ).toBeCloseTo(expected, 10);
+  });
+
+  // eslint-disable-next-line max-len
+  it("classifies route-handle proximity just-inside, at, and just-outside the shared boundary", () => {
+    // Uses the shared isRouteHandleCollision/routeHandleRequiredClearance
+    // predicate directly (the same functions the Playwright audit calls via
+    // window.__lifecycleRouteGeometry) rather than reimplementing the
+    // comparison here.
+    const edge = { p0: { x: 0, y: 0 }, p1: { x: 100, y: 0 } };
+    const radius = BRANCH_HANDLE_RADIUS;
+    const envelope = selectedEnvelopeRadius({});
+    const required = routeHandleRequiredClearance(
+      radius,
+      envelope,
+      LANE_Y_EPSILON,
+    );
     const closeHandle = { x: 50, y: required - 5 };
     const farHandle = { x: 50, y: required + 5 };
     const boundaryHandle = { x: 50, y: required };
@@ -2949,6 +2978,216 @@ describe("shared route-crossing classifier", () => {
     expect(pointToSegmentDistance(boundaryHandle, edge)).toBeCloseTo(
       required,
       5,
+    );
+    expect(
+      isRouteHandleCollision(
+        closeHandle,
+        edge,
+        radius,
+        envelope,
+        LANE_Y_EPSILON,
+      ),
+    ).toBe(true);
+    expect(
+      isRouteHandleCollision(farHandle, edge, radius, envelope, LANE_Y_EPSILON),
+    ).toBe(false);
+    // The comparison is strict (<), so a handle sitting exactly on the
+    // boundary is not a collision -- matches production's own
+    // `pointToSegmentDistance(...) < required` check.
+    expect(
+      isRouteHandleCollision(
+        boundaryHandle,
+        edge,
+        radius,
+        envelope,
+        LANE_Y_EPSILON,
+      ),
+    ).toBe(false);
+  });
+
+  describe("collinearOverlapLength", () => {
+    // edgeCrossing only detects genuine transversal crossings; two routes
+    // rendered directly on top of one another are exactly (or near-exactly)
+    // collinear and never satisfy its strict sign-straddling test. This is
+    // the shared, pure detector both auditLifecycleRouteGeometry and the
+    // Playwright collision audit use to close that gap (see
+    // docs/design/lifecycle-diagram-layout-algorithm.md's "unified
+    // route-crossing classifier" follow-up).
+    it("measures the overlap length of two meaningfully overlapping collinear edges", () => {
+      const left = { p0: { x: 0, y: 0 }, p1: { x: 100, y: 0 } };
+      const right = { p0: { x: 20, y: 0 }, p1: { x: 120, y: 0 } };
+      // right overlaps left from x=20 to x=100 -> 80 units.
+      expect(collinearOverlapLength(left, right)).toBeCloseTo(80, 5);
+      expect(collinearOverlapLength(left, right)).toBeGreaterThanOrEqual(
+        SUSTAINED_OVERLAP_LENGTH_THRESHOLD,
+      );
+    });
+
+    it("returns 0 for separated parallel edges (different lanes)", () => {
+      const left = { p0: { x: 0, y: 0 }, p1: { x: 100, y: 0 } };
+      const right = { p0: { x: 0, y: 50 }, p1: { x: 100, y: 50 } };
+      expect(collinearOverlapLength(left, right)).toBe(0);
+    });
+
+    it("returns 0 for parallel collinear edges that only touch endpoint-to-endpoint", () => {
+      // Short endpoint contact (two routes briefly touching tip-to-tip, as
+      // branches merely diverging from a shared dock do) has zero overlap
+      // length, not just a below-threshold one.
+      const left = { p0: { x: 0, y: 0 }, p1: { x: 50, y: 0 } };
+      const right = { p0: { x: 50, y: 0 }, p1: { x: 100, y: 0 } };
+      expect(collinearOverlapLength(left, right)).toBe(0);
+    });
+
+    it("returns 0 for edges that are parallel but offset beyond the collinearity tolerance", () => {
+      const left = { p0: { x: 0, y: 0 }, p1: { x: 100, y: 0 } };
+      const right = {
+        p0: { x: 20, y: COLLINEAR_OVERLAP_TOLERANCE + 1 },
+        p1: { x: 120, y: COLLINEAR_OVERLAP_TOLERANCE + 1 },
+      };
+      expect(collinearOverlapLength(left, right)).toBe(0);
+    });
+
+    it("returns 0 for genuinely crossing (non-parallel) edges", () => {
+      const left = { p0: { x: 0, y: 0 }, p1: { x: 10, y: 10 } };
+      const right = { p0: { x: 0, y: 10 }, p1: { x: 10, y: 0 } };
+      expect(edgeCrossing(left, right)).toBe(true);
+      expect(collinearOverlapLength(left, right)).toBe(0);
+    });
+
+    it("proves an exact sustained overlap is fatal by the shared threshold", () => {
+      // Two edges occupying the identical line segment -- the extreme case
+      // of "one route drawn directly on top of another" -- must clear the
+      // shared sustained-overlap threshold so callers (auditLifecycleRouteGeometry,
+      // assertBrowserCollisionAudit) classify the pair as fatal regardless of
+      // their (zero) transversal crossing count.
+      const left = { p0: { x: 0, y: 0 }, p1: { x: 50, y: 0 } };
+      const right = { p0: { x: 0, y: 0 }, p1: { x: 50, y: 0 } };
+      expect(edgeCrossing(left, right)).toBe(false);
+      const overlap = collinearOverlapLength(left, right);
+      expect(overlap).toBeCloseTo(50, 5);
+      expect(overlap).toBeGreaterThanOrEqual(
+        SUSTAINED_OVERLAP_LENGTH_THRESHOLD,
+      );
+    });
+  });
+});
+
+describe("auditLifecycleRouteGeometry collinear-overlap aggregation", () => {
+  // Hand-built minimal route models (bypassing buildLifecycleRouteModel and
+  // the layout solver entirely) so these tests can assert on exact,
+  // deterministic geometry rather than depending on a real fixture happening
+  // to reproduce either scenario.
+  const node = (id, rank) => ({ id, rank, routing: false, x0: 0, x1: 0 });
+  const pairId = (a, b) => [a.id, b.id].sort(compareLifecycleIds).join("||");
+
+  it("excludes overlap correlated by two branches diverging from a shared multi-rank dock", () => {
+    const origin = node("origin:shared", 0);
+    const milestone = node("milestone:shared", 1);
+    const endpointA = node("endpoint:a", 2);
+    const endpointB = node("endpoint:b", 2);
+    const branchA = { id: "branch-a", sourceRank: 0, targetRank: 2 };
+    const branchB = { id: "branch-b", sourceRank: 0, targetRank: 2 };
+    const model = {
+      branches: [branchA, branchB],
+      segmentsByBranch: new Map([
+        [
+          branchA.id,
+          [
+            {
+              source: origin,
+              target: milestone,
+              y0: 100,
+              y1: 100,
+              transitionLaneY: 100,
+              segmentIndex: 0,
+            },
+            {
+              source: milestone,
+              target: endpointA,
+              y0: 100,
+              y1: 100,
+              transitionLaneY: 100,
+              segmentIndex: 1,
+            },
+          ],
+        ],
+        [
+          branchB.id,
+          [
+            // Identical first segment: both branches leave the exact same
+            // shared origin and converge on the exact same shared
+            // milestone, so this segment's geometry is (correctly)
+            // identical for both -- the "diverging from a shared dock"
+            // scenario this exclusion exists for.
+            {
+              source: origin,
+              target: milestone,
+              y0: 100,
+              y1: 100,
+              transitionLaneY: 100,
+              segmentIndex: 0,
+            },
+            // Second segment diverges to a different endpoint at a
+            // different Y -- the two branches genuinely separate here.
+            {
+              source: milestone,
+              target: endpointB,
+              y0: 100,
+              y1: 200,
+              transitionLaneY: 150,
+              segmentIndex: 1,
+            },
+          ],
+        ],
+      ]),
+      visibleNodes: [],
+      fixedOrderInversionPairs: new Set(),
+      pairId,
+    };
+    const audit = auditLifecycleRouteGeometry({ model, handles: [] });
+    expect(
+      audit.fatalFindings.some(
+        (finding) => finding.category === "sustained-crossing",
+      ),
+    ).toBe(false);
+  });
+
+  it("flags a genuine single-segment full-length duplicate route as a sustained overlap", () => {
+    // Two branches sharing both their source AND target across the one and
+    // only rank they span never actually diverge anywhere -- this is a
+    // duplicated-route defect, not ordinary shared-dock correlation, so the
+    // multi-rank guard must not exclude it.
+    const origin = node("origin:shared", 0);
+    const endpoint = node("endpoint:shared", 1);
+    const identicalSegment = () => [
+      {
+        source: origin,
+        target: endpoint,
+        y0: 100,
+        y1: 100,
+        transitionLaneY: 100,
+        segmentIndex: 0,
+      },
+    ];
+    const branchA = { id: "branch-a", sourceRank: 0, targetRank: 1 };
+    const branchB = { id: "branch-b", sourceRank: 0, targetRank: 1 };
+    const model = {
+      branches: [branchA, branchB],
+      segmentsByBranch: new Map([
+        [branchA.id, identicalSegment()],
+        [branchB.id, identicalSegment()],
+      ]),
+      visibleNodes: [],
+      fixedOrderInversionPairs: new Set(),
+      pairId,
+    };
+    const audit = auditLifecycleRouteGeometry({ model, handles: [] });
+    const finding = audit.fatalFindings.find(
+      (candidate) => candidate.category === "sustained-crossing",
+    );
+    expect(finding).toBeDefined();
+    expect(finding.overlapLength).toBeGreaterThanOrEqual(
+      SUSTAINED_OVERLAP_LENGTH_THRESHOLD,
     );
   });
 });

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -3085,8 +3085,20 @@ describe("auditLifecycleRouteGeometry collinear-overlap aggregation", () => {
     const milestone = node("milestone:shared", 1);
     const endpointA = node("endpoint:a", 2);
     const endpointB = node("endpoint:b", 2);
-    const branchA = { id: "branch-a", sourceRank: 0, targetRank: 2 };
-    const branchB = { id: "branch-b", sourceRank: 0, targetRank: 2 };
+    const branchA = {
+      id: "branch-a",
+      source: origin.id,
+      target: endpointA.id,
+      sourceRank: 0,
+      targetRank: 2,
+    };
+    const branchB = {
+      id: "branch-b",
+      source: origin.id,
+      target: endpointB.id,
+      sourceRank: 0,
+      targetRank: 2,
+    };
     const model = {
       branches: [branchA, branchB],
       segmentsByBranch: new Map([
@@ -3156,7 +3168,7 @@ describe("auditLifecycleRouteGeometry collinear-overlap aggregation", () => {
     // Two branches sharing both their source AND target across the one and
     // only rank they span never actually diverge anywhere -- this is a
     // duplicated-route defect, not ordinary shared-dock correlation, so the
-    // multi-rank guard must not exclude it.
+    // branchesDiverge guard must not exclude it.
     const origin = node("origin:shared", 0);
     const endpoint = node("endpoint:shared", 1);
     const identicalSegment = () => [
@@ -3169,13 +3181,90 @@ describe("auditLifecycleRouteGeometry collinear-overlap aggregation", () => {
         segmentIndex: 0,
       },
     ];
-    const branchA = { id: "branch-a", sourceRank: 0, targetRank: 1 };
-    const branchB = { id: "branch-b", sourceRank: 0, targetRank: 1 };
+    const branchA = {
+      id: "branch-a",
+      source: origin.id,
+      target: endpoint.id,
+      sourceRank: 0,
+      targetRank: 1,
+    };
+    const branchB = {
+      id: "branch-b",
+      source: origin.id,
+      target: endpoint.id,
+      sourceRank: 0,
+      targetRank: 1,
+    };
     const model = {
       branches: [branchA, branchB],
       segmentsByBranch: new Map([
         [branchA.id, identicalSegment()],
         [branchB.id, identicalSegment()],
+      ]),
+      visibleNodes: [],
+      fixedOrderInversionPairs: new Set(),
+      pairId,
+    };
+    const audit = auditLifecycleRouteGeometry({ model, handles: [] });
+    const finding = audit.fatalFindings.find(
+      (candidate) => candidate.category === "sustained-crossing",
+    );
+    expect(finding).toBeDefined();
+    expect(finding.overlapLength).toBeGreaterThanOrEqual(
+      SUSTAINED_OVERLAP_LENGTH_THRESHOLD,
+    );
+  });
+
+  it("flags a genuine two-rank full-duplicate route sharing both endpoints", () => {
+    // The specific gap discussion_r3653747390 identified: a full duplicate
+    // spanning *more than one* rank shares its source at the first rank and
+    // its target at the last rank, so a purely rank-position-based
+    // ("first"/"last") exclusion would suppress *both* ranks, hiding the
+    // entire overlap even though edgeCrossing (degenerate for identical
+    // edges) never reports a single crossing either. branchesDiverge must
+    // recognize that these two branches share both their overall source and
+    // target and therefore never actually diverge, so neither rank is
+    // excluded.
+    const origin = node("origin:shared", 0);
+    const milestone = node("milestone:shared", 1);
+    const endpoint = node("endpoint:shared", 2);
+    const identicalSegments = () => [
+      {
+        source: origin,
+        target: milestone,
+        y0: 100,
+        y1: 100,
+        transitionLaneY: 100,
+        segmentIndex: 0,
+      },
+      {
+        source: milestone,
+        target: endpoint,
+        y0: 100,
+        y1: 100,
+        transitionLaneY: 100,
+        segmentIndex: 1,
+      },
+    ];
+    const branchA = {
+      id: "branch-a",
+      source: origin.id,
+      target: endpoint.id,
+      sourceRank: 0,
+      targetRank: 2,
+    };
+    const branchB = {
+      id: "branch-b",
+      source: origin.id,
+      target: endpoint.id,
+      sourceRank: 0,
+      targetRank: 2,
+    };
+    const model = {
+      branches: [branchA, branchB],
+      segmentsByBranch: new Map([
+        [branchA.id, identicalSegments()],
+        [branchB.id, identicalSegments()],
       ]),
       visibleNodes: [],
       fixedOrderInversionPairs: new Set(),


### PR DESCRIPTION
## Summary

Unifies production and rendered-SVG lifecycle-route collision auditing around shared geometry classifiers and enables the final previously skipped Playwright audit.

Production previously classified transversal edge crossings, while the browser audit sampled point proximity and could misclassify close parallel routes as sustained collisions. Both paths now share the same crossing, collinear-overlap, and route-handle geometry rules.

## Changes

- Adds `src/web/tracker/lifecycleRouteGeometry.js` with shared helpers for:
  - transversal edge crossings and severity
  - sustained collinear overlap
  - point-to-segment distance
  - route-handle clearance and tolerance
- Updates `auditLifecycleRouteGeometry` to use those helpers and detect sustained collinear duplicate routes.
- Updates the browser audit to inspect rendered SVG segments, bucket them by transition rank using `data-segment-ranks`, and apply the shared classifiers through `window.__lifecycleRouteGeometry`.
- Aligns rendered route-handle checks with production’s point-to-segment measurement and clearance formula.
- Excludes ordinary shared-dock overlap only when the branches have different overall endpoints. Same-endpoint duplicate routes remain subject to collision detection, including duplicates spanning multiple ranks.
- Keeps the browser route envelope independent of selection state by deriving its halo-inclusive width from the separator.
- Adds regression coverage for single-rank and two-rank duplicate routes while retaining nonfatal coverage for genuinely diverging shared-dock branches.
- Removes the final lifecycle-diagram Playwright skip.
- Updates the lifecycle layout design documentation.

## Behavior and compatibility

- The production audit intentionally becomes stricter for sustained collinear duplicate routes; this is not solely a code relocation.
- Lifecycle Playwright skips decrease from 1 to 0; the relevant Vitest suite has no skipped tests.
- Dense-fixture collision budgets are 64 for the current, desktop, and touch states and 57 for the previous-event state. The routing fixture remains at 0.
- No schema, migration, fixture, renderer, layout-search, or lane-placement changes are introduced.

## Verification

- 87 focused lifecycle-layout Vitest tests passed.
- 114 tests passed across the two relevant Vitest files.
- 4 focused Playwright audit tests passed.
- 11 lifecycle and static-smoke Playwright tests passed.
- Lint, typecheck, Prettier, and diff checks passed.
- Latest-head GitHub workflows passed:
  - CI #4969
  - Diagram visual review #203
  - Build and publish GHCR image #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)