### PR TITLE
Scope the lifecycle-diagram joint order per hop, not per whole graph

### DIFF
--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -229,6 +229,16 @@ for one diagnosed pair) before trusting a candidate fix — then run the _entire
 files, 1189+ tests as of this writing), since a change to base layout ordering can shift geometry for
 every fixture, not just the one under investigation.
 
+**Status:** the specific formulation above (a second D3-Sankey re-run driven by a search-discovered
+`rankOrder`) is exactly what the production two-pass pipeline's final pass already does via
+`deriveAuthoritativeLayoutOrders` (see "Bounded authoritative-order pipeline" below) — that part has
+shipped. What remained open was making _discovery's own first pass_ rankOrder-aware too, instead of
+falling back to plain `nodeSort`/`linkSort`; see
+[Root-causing the routing-node joint-order destabilization](#root-causing-the-routing-node-joint-order-destabilization-shipped)
+below for how that was resolved (a purely topological, pre-search order — not a second D3 re-run —
+scoped to never touch a real node's dock), and its scope note for why this still doesn't reach the
+two corridor-width-bound extreme fan-in fixtures.
+
 ## Attempted and reverted: barycenter-based `nodeSort`/`linkSort`
 
 A follow-up session attempted the deferred fix above directly: a `computeBarycenterOrder(nodes,
@@ -383,17 +393,114 @@ routing nodes are reordered, rather than another external ordering-heuristic att
 code was changed for this investigation itself; the throwaway diagnostic script used to produce
 these numbers was deleted per the investigation's own scope constraints.
 
-**Follow-up (shipped):** the investigation above also isolated a strictly narrower
-case where the joint order is safe: graphs with **zero** real (non-routing) nodes at ranks 1–5 at
-all — i.e., no branch in the graph touches a milestone anywhere, not just "this rank happens to have
-no real node this time." `buildMilestoneFreeJointOrder` (near `layoutLifecycleRoutingGraphPass` in
-`src/web/tracker/lifecycleDiagramLayout.js`) implements exactly that narrower case: it is used as
-`nodeSort`/`linkSort`'s fallback only when `hasIntermediateRealNodes(graph)` is false and no other
-order was already supplied. This fully resolves `denseBranchProjection()` (see the "Checked-in
+**Follow-up (shipped, superseded — see "Root-causing the routing-node joint-order destabilization"
+below):** the investigation above also isolated a strictly narrower case where the joint order is
+safe: graphs with **zero** real (non-routing) nodes at ranks 1–5 at all — i.e., no branch in the
+graph touches a milestone anywhere, not just "this rank happens to have no real node this time."
+`buildMilestoneFreeJointOrder` (near `layoutLifecycleRoutingGraphPass` in
+`src/web/tracker/lifecycleDiagramLayout.js`) implemented exactly that narrower case: it was used as
+`nodeSort`/`linkSort`'s fallback only when `hasIntermediateRealNodes(graph)` was false and no other
+order was already supplied. This fully resolved `denseBranchProjection()` (see the "Checked-in
 reproduction" section below, now historical) with zero regressions across the rest of the test
-suite. It does **not** extend to any fixture with real milestone convergence — those remain exactly
-as infeasible as described above, and are the reason this fix is conditioned on
-`hasIntermediateRealNodes` rather than applied unconditionally.
+suite. At the time, it did **not** extend to any fixture with real milestone convergence — those
+remained exactly as infeasible as described above, and that was the reason this fix was conditioned
+on `hasIntermediateRealNodes` rather than applied unconditionally. **This whole-graph gate has since
+been replaced** by a per-hop-scoped version, `buildTransitionScopedJointOrder`, that safely extends
+the same mechanism to graphs with real milestone convergence too — see "Root-causing the
+routing-node joint-order destabilization" below for the root cause that made this possible and the
+evidence that it doesn't regress anything.
+
+## Root-causing the routing-node joint-order destabilization (shipped)
+
+This picks up exactly where "Investigation (2026-07-26)" above left off: that investigation ruled
+out real-node **position** changes as the sole destabilizing mechanism (a routing-only-restricted
+node order still broke both real fixtures) but did not identify the actual channel, and recommended
+instrumenting `solveFromComponent`'s deadline/`capacityOkForRemainder` logic as the next step.
+
+**Diagnosed mechanism, confirmed directly against the running solver, not assumed:**
+`solveTransitionLanes` (`src/web/tracker/lifecycleDiagramLayout.js`) computes each link's
+`sourceDockY`/`targetDockY` directly from D3-Sankey's own assigned `link.y0`/`y1`. When several
+links leave or arrive at the same node, D3 spreads each link's individual dock sub-position along
+that node's box according to `linkSort` — so a link's dock Y can change even when the node's own
+`y0`/`y1` box position never moves. `branchSpans` collapses each branch to its first/last hop's dock
+Y, keyed by the branch's real semantic source/target node id (an origin, milestone, or endpoint —
+never a routing node). `branchPrecedenceEdges` groups branches by shared semantic source/target and
+turns their relative dock-Y order into a **hard** precedence edge between siblings; those edges
+become `branchIndegree`/`compIndegree`, which hard-filters `solveFromComponent`'s `ready` list
+(`compIndegree.get(id) === 0`) — a real topological constraint on solve order, not a soft tie-break.
+
+Reordering docks at a real node is not _inherently_ unsafe — two mechanisms already shipped safely
+do exactly that: `buildMilestoneFreeJointOrder` reordered origin (rank 0) docks unconditionally, and
+the production two-pass pipeline's `deriveAuthoritativeLayoutOrders` reorders milestone docks at
+ranks 1–5 for the final pass. What made the 2026-07-26 investigation's joint order unsafe was a
+different, more specific property: checking the exact construction used there
+(`test/web-tracker-lifecycle-diagram-layout.test.js`'s `"joint-order investigation regression"`
+block, preserved as a permanent regression) shows its **node**-order override was restricted to
+zero-real-node ranks, but its **branch/link**-order override (the `linkSort` input,
+`authoritativeBranchOrderByRank`) was not restricted at all — it was applied at every rank a branch
+spans, including ranks 0 and 1–5 wherever they carry a real node. That asymmetry silently reordered
+links at a real node's own dock via `linkSort`, changing `branchPrecedenceEdges`' hard precedence
+constraints there, even though the node's `y0`/`y1` box never moved.
+
+**Fix:** `buildTransitionScopedJointOrder` (replacing `buildMilestoneFreeJointOrder`/
+`hasIntermediateRealNodes` — same location, near `layoutLifecycleRoutingGraphPass`) restricts _both_
+the node-order and the branch/link-order override, per rank/hop, to ones that never touch a real
+node on either side. Concretely: the node-order override still only applies to a rank when that rank
+itself has no real node (ranks 0 and 6 always keep `nodeSort`'s own taxonomy anchoring, exactly as
+before); the branch/link-order override additionally now only applies to a hop when _neither_ its
+source rank nor its target rank is an intermediate (1–5) rank with a real node — origin (rank 0) and
+endpoint (rank 6) reordering stays unconditional, since that's exactly what
+`buildMilestoneFreeJointOrder` already proved safe and `denseBranchProjection()` (5 real origins)
+depends on. This is no longer gated on a whole-graph `hasIntermediateRealNodes` boolean — it runs
+unconditionally whenever no explicit order is supplied, for every graph, milestone-bearing or not.
+
+**Confirmed directly, not assumed**, by comparing `graph.testOnlyBranchPrecedenceEdges` (a new
+test-only diagnostic field, populated once per pass right after `branchPrecedenceEdges` is built,
+recording each edge's kind, the shared node's id and real/routing status, and both branches' dock-Y
+values) between three constructions on `test/fixtures/tracker-lifecycle-diagram-routing-v2.json`:
+
+- **Pure default** (no joint order at all, reconstructed by passing empty `Map`s for both override
+  options to bypass `buildTransitionScopedJointOrder` entirely) and **production's shipped default**
+  (no options at all) produce **byte-identical** real-node precedence edges — the fix changes
+  nothing about real-node dock ordering, exactly as intended.
+- The **reverted, fully-ungated joint order** (the checked-in `"joint-order investigation
+regression"` construction) produces the same _count_ of real-node precedence edges but a
+  **different relative order** for at least one pair — direct proof the ungated construction reorders
+  real-node docks the shipped fix does not.
+
+And by running the actual solver end to end: the ungated joint order still deterministically exhausts
+the handle-state budget on `tracker-lifecycle-diagram-v2.json` (32,768/32,768, `reason: "state-limit"`,
+`phase: "handle"` — unchanged, still checked in as a regression), while production's own default call
+(no options, exercising the real two-pass discovery/final pipeline) succeeds — unchanged from before
+this fix at exactly 50 accepted route crossings and 500 handle states, i.e. **this fix doesn't need
+to, and doesn't, change the observable outcome for either already-passing real fixture; it only
+replaces an unsafe, reverted construction with a safe, shipped one that generalizes the same
+mechanism to milestone-bearing graphs wherever it's safe to.**
+
+A second, test-only diagnostic — `transitionLaneSolverStats.testOnlyIndegreeBlockedDeadEnds`,
+incremented at the exact point `solveFromComponent`'s `search()` returns due to an empty `ready` list
+while at least one not-yet-placed branch in the component still has nonzero `compIndegree` — was
+added per the doc's own recommendation to instrument `capacityOkForRemainder`'s blind spot (it
+reasons only about geometric deadlines, never precedence, so a precedence-caused deadlock isn't
+detected until the `ready` list is empty). Across every fixture tested here, including the ungated
+joint order's own failing runs, this counter stayed at 0: the destabilization does not manifest as a
+literal precedence-DAG deadlock inside a single candidate's lane-assignment DFS. Instead, it
+manifests one phase downstream — the ungated joint order still finds _some_ lane-consistent
+ordering, but produces geometry that is measurably harder (or, for the dense fixture, impossible
+within budget) for the separate handle-placement search to satisfy. Recorded here as an honest
+correction to the doc's own prior instrumentation recommendation: the precedence-edge identity check
+above, not the indegree-dead-end counter, is what actually discriminates the safe fix from the
+unsafe construction for these fixtures.
+
+**Scope note:** this does not change, and is not expected to change, the two genuinely infeasible
+extreme fan-in fixtures (`transitionDensityProjection()` and the historical 60-app/89-branch
+pagination fixture — see "Still infeasible for a root cause neither tolerance can reach" below).
+Their rejection evidence (`clearanceMargin === -1`, the `COLLISION_MARGIN` sentinel for a
+fixed-geometry/outside-corridor rejection) is bound by `RANK_CORRIDOR_HALF_WIDTH`, a fixed constant
+driving a static X-extent corridor check that does not depend on branch order, `nodeSort`/`linkSort`,
+or `rankOrder` in any way. No ordering fix — including this one — can relax a fixed-width geometric
+ceiling; both fixtures remain infeasible, as confirmed by re-running the full suite after this fix
+(their tests still characterize the identical infeasibility signature).
 
 ## Follow-up (shipped): bounded tolerances for route crossings and handle clearance
 
@@ -750,36 +857,50 @@ edge count (its pairwise crossing check is `O(edges-within-rank^2)`).
 This is the authoritative, current list — cross-check against the code before trusting it, since
 skip states and test names can drift. `grep -rn "it\.skip(\|test\.skip(" test/` finds all of them.
 
-1. **Deferred: make the base D3-Sankey layout `rankOrder`-aware** (a.k.a. "Option 2" above) — the
-   fix for the corridor-width/constructive-placement gap that items 2 and 3 below still can't reach:
-   the two genuinely-infeasible extreme fan-in fixtures (`transitionDensityProjection()` and the
-   60-application/89-branch pagination fixture — see "Still infeasible for a root cause neither
-   tolerance can reach" above). It is not accurately described as the fix for every item below: item
-   2's remaining tests were resolved instead by the bounded tolerances (not by this), and item 3's
-   remaining Playwright skip is a separate audit-methodology disagreement this work would not touch
-   either. Three attempts already tried and reverted or halted (see
-   [what didn't work alone](#what-didnt-work-alone),
+1. **Make the base D3-Sankey layout `rankOrder`-aware** (a.k.a. "Option 2" above) — **partially
+   resolved; see "Root-causing the routing-node joint-order destabilization" above.** Four attempts
+   were made in total (see [what didn't work alone](#what-didnt-work-alone),
    [attempted and reverted: barycenter](#attempted-and-reverted-barycenter-based-nodesortlinksort),
-   and the
-   [Investigation (2026-07-26)](#investigation-2026-07-26-a-real-node-position-preserving-joint-order-still-destabilizes-production-fixtures));
-   read all three before starting a fourth. This investigation is the most informative to date: it
-   isolates that reordering _only_ routing nodes (never touching real-node geometry at all) is
-   independently sufficient to destabilize the deadline-based DFS on fixtures with real milestone
-   convergence, which the barycenter attempt's real-node-position hypothesis alone doesn't explain —
-   see that section for the concrete open question a future attempt should root-cause first
-   (specifically inside `solveFromComponent`'s deadline/`capacityOkForRemainder` logic). Re-confirmed
-   independently by a later session that built the seeded-replay pipeline above, before the
-   route-crossing/handle-clearance tolerances below existed: even with final's redundant search
-   eliminated, discovery's own one-time combined lane+handle search for
-   `tracker-lifecycle-diagram-v2.json`, run without any tolerance, never found a working assignment —
-   raising the handle-search budget from 32,768 to 2,000,000 states (diagnostic only, not shipped)
-   still failed after 100+ seconds, and the same ~3 branches were blocked (`reason: "no-candidates"`)
-   across every one of the 98 distinct lane-order candidates tried before hitting the normal budget.
-   This rules out "the search just needs to be more efficient" for a no-tolerance, budget-only
-   approach, and confirms the gap this `rankOrder` item targets is really a constructive/greedy
-   placement strategy, not a search or plumbing fix. (`tracker-lifecycle-diagram-v2.json`'s own
+   the
+   [Investigation (2026-07-26)](#investigation-2026-07-26-a-real-node-position-preserving-joint-order-still-destabilizes-production-fixtures),
+   and
+   [Root-causing the routing-node joint-order destabilization](#root-causing-the-routing-node-joint-order-destabilization-shipped)).
+   The fourth found and fixed the specific channel the third's investigation left as an open
+   question: a blind, pre-search, purely topological joint order is unsafe not because it reorders
+   real-node docks per se (two other shipped mechanisms already do that safely) but because doing so
+   via `linkSort` at _every_ rank a branch spans — rather than only at ranks/hops that never touch a
+   real node — silently changes `branchPrecedenceEdges`' hard precedence constraints at a real node's
+   dock, even when the node's own `y0`/`y1` box never moves. `buildTransitionScopedJointOrder` (which
+   replaced `buildMilestoneFreeJointOrder`/`hasIntermediateRealNodes`) restricts the override to
+   ranks/hops that never touch a real node on either side and now runs unconditionally, safely
+   extending the mechanism to milestone-bearing graphs. Confirmed with zero regressions across the
+   full suite and byte-identical real-node dock precedence to the unconstrained default (see that
+   section for the full evidence).
+
+   **This does not close the corridor-width/constructive-placement gap** the two genuinely-infeasible
+   extreme fan-in fixtures hit (`transitionDensityProjection()` and the 60-application/89-branch
+   pagination fixture — see "Still infeasible for a root cause neither tolerance can reach" above),
+   and was not expected to: their rejection evidence (`clearanceMargin === -1`, the fixed-geometry
+   corridor sentinel) is bound by `RANK_CORRIDOR_HALF_WIDTH`, a static X-extent constant independent
+   of branch order entirely. Confirmed directly: both fixtures' tests still characterize the
+   identical infeasibility signature after this fix. It is also not accurately described as the fix
+   for every item below: item 2's remaining tests were resolved instead by the bounded tolerances
+   (not by this), and item 3's remaining Playwright skip was a separate audit-methodology
+   disagreement this work does not touch either. Re-confirmed independently by a still-earlier
+   session that built the seeded-replay pipeline above, before the route-crossing/handle-clearance
+   tolerances below existed: even with final's redundant search eliminated, discovery's own one-time
+   combined lane+handle search for `tracker-lifecycle-diagram-v2.json`, run without any tolerance,
+   never found a working assignment — raising the handle-search budget from 32,768 to 2,000,000
+   states (diagnostic only, not shipped) still failed after 100+ seconds, and the same ~3 branches
+   were blocked (`reason: "no-candidates"`) across every one of the 98 distinct lane-order candidates
+   tried before hitting the normal budget. This rules out "the search just needs to be more
+   efficient" for a no-tolerance, budget-only approach. (`tracker-lifecycle-diagram-v2.json`'s own
    layout problem was separately resolved afterward by the bounded tolerances in "Follow-up
-   (shipped)" below — a different, already-shipped mechanism, not this deferred item.)
+   (shipped)" below — a different, already-shipped mechanism, not this item.) The remaining,
+   still-open piece of this item is a genuinely different lever for the two corridor-bound
+   fixtures specifically — e.g. widening the rank corridor itself for ranks with enough incident
+   branches to need it — not another ordering change.
+
 2. **0 unit tests remain `it.skip`ed** (were 4). `HANDLE_CLEARANCE_TOLERANCE` and
    `toleratedRouteCrossingCount` (see "Follow-up (shipped): bounded tolerances..." above) fixed
    `"lays out dense fixture with bounded semantic docks and safe handles"` and

--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -444,15 +444,17 @@ constraints there, even though the node's `y0`/`y1` box never moved.
 
 **Fix:** `buildTransitionScopedJointOrder` (replacing `buildMilestoneFreeJointOrder`/
 `hasIntermediateRealNodes` — same location, near `layoutLifecycleRoutingGraphPass`) restricts _both_
-the node-order and the branch/link-order override, per rank/hop, to ones that never touch a real
-node on either side. Concretely: the node-order override still only applies to a rank when that rank
-itself has no real node (ranks 0 and 6 always keep `nodeSort`'s own taxonomy anchoring, exactly as
-before); the branch/link-order override additionally now only applies to a hop when _neither_ its
-source rank nor its target rank is an intermediate (1–5) rank with a real node — origin (rank 0) and
-endpoint (rank 6) reordering stays unconditional, since that's exactly what
-`buildMilestoneFreeJointOrder` already proved safe and `denseBranchProjection()` (5 real origins)
-depends on. This is no longer gated on a whole-graph `hasIntermediateRealNodes` boolean — it runs
-unconditionally whenever no explicit order is supplied, for every graph, milestone-bearing or not.
+the node-order and the branch/link-order override, per rank/hop, to ones that never touch an
+**intermediate** (rank 1–5) real milestone node on either side — origin (rank 0) and endpoint
+(rank 6) docks are deliberately excluded from that restriction and stay unconditionally reordered.
+Concretely: the node-order override still only applies to a rank when that rank itself has no real
+node (ranks 0 and 6 always keep `nodeSort`'s own taxonomy anchoring, exactly as before); the
+branch/link-order override additionally now only applies to a hop when _neither_ its source rank nor
+its target rank is an intermediate (1–5) rank with a real node — origin (rank 0) and endpoint
+(rank 6) reordering stays unconditional, since that's exactly what `buildMilestoneFreeJointOrder`
+already proved safe and `denseBranchProjection()` (5 real origins) depends on. This is no longer
+gated on a whole-graph `hasIntermediateRealNodes` boolean — it runs unconditionally whenever no
+explicit order is supplied, for every graph, milestone-bearing or not.
 
 **Confirmed directly, not assumed**, by comparing `graph.testOnlyBranchPrecedenceEdges` (a new
 test-only diagnostic field, populated once per pass right after `branchPrecedenceEdges` is built,
@@ -872,10 +874,11 @@ skip states and test names can drift. `grep -rn "it\.skip(\|test\.skip(" test/` 
    real node — silently changes `branchPrecedenceEdges`' hard precedence constraints at a real node's
    dock, even when the node's own `y0`/`y1` box never moves. `buildTransitionScopedJointOrder` (which
    replaced `buildMilestoneFreeJointOrder`/`hasIntermediateRealNodes`) restricts the override to
-   ranks/hops that never touch a real node on either side and now runs unconditionally, safely
-   extending the mechanism to milestone-bearing graphs. Confirmed with zero regressions across the
-   full suite and byte-identical real-node dock precedence to the unconstrained default (see that
-   section for the full evidence).
+   ranks/hops adjacent to an intermediate (rank 1-5) real milestone node — origin (rank 0) and
+   endpoint (rank 6) docks stay unconditionally reordered, exactly as the predecessor mechanism
+   already proved safe there — and now runs unconditionally, safely extending the mechanism to
+   milestone-bearing graphs. Confirmed with zero regressions across the full suite and byte-identical
+   real-node dock precedence to the unconstrained default (see that section for the full evidence).
 
    **This does not close the corridor-width/constructive-placement gap** the two genuinely-infeasible
    extreme fan-in fixtures hit (`transitionDensityProjection()` and the 60-application/89-branch

--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -236,8 +236,9 @@ shipped. What remained open was making _discovery's own first pass_ rankOrder-aw
 falling back to plain `nodeSort`/`linkSort`; see
 [Root-causing the routing-node joint-order destabilization](#root-causing-the-routing-node-joint-order-destabilization-shipped)
 below for how that was resolved (a purely topological, pre-search order — not a second D3 re-run —
-scoped to never touch a real node's dock), and its scope note for why this still doesn't reach the
-two corridor-width-bound extreme fan-in fixtures.
+scoped to never touch the dock of an intermediate, rank 1–5 real milestone node; origin (rank 0) and
+endpoint (rank 6) docks remain intentionally eligible for reordering), and its scope note for why
+this still doesn't reach the two corridor-width-bound extreme fan-in fixtures.
 
 ## Attempted and reverted: barycenter-based `nodeSort`/`linkSort`
 
@@ -870,14 +871,17 @@ skip states and test names can drift. `grep -rn "it\.skip(\|test\.skip(" test/` 
    The fourth found and fixed the specific channel the third's investigation left as an open
    question: a blind, pre-search, purely topological joint order is unsafe not because it reorders
    real-node docks per se (two other shipped mechanisms already do that safely) but because doing so
-   via `linkSort` at _every_ rank a branch spans — rather than only at ranks/hops that never touch a
-   real node — silently changes `branchPrecedenceEdges`' hard precedence constraints at a real node's
-   dock, even when the node's own `y0`/`y1` box never moves. `buildTransitionScopedJointOrder` (which
-   replaced `buildMilestoneFreeJointOrder`/`hasIntermediateRealNodes`) restricts the override to
+   via `linkSort` at _every_ rank a branch spans — rather than excluding only the ranks/hops adjacent
+   to an intermediate (rank 1-5) real milestone node — silently changes `branchPrecedenceEdges`' hard
+   precedence constraints at such a milestone's dock, even when the node's own `y0`/`y1` box never
+   moves. `buildTransitionScopedJointOrder` (which replaced
+   `buildMilestoneFreeJointOrder`/`hasIntermediateRealNodes`) excludes the override only from
    ranks/hops adjacent to an intermediate (rank 1-5) real milestone node — origin (rank 0) and
-   endpoint (rank 6) docks stay unconditionally reordered, exactly as the predecessor mechanism
-   already proved safe there — and now runs unconditionally, safely extending the mechanism to
-   milestone-bearing graphs. Confirmed with zero regressions across the full suite and byte-identical
+   endpoint (rank 6) docks remain intentionally eligible and stay unconditionally reordered, exactly
+   as the predecessor mechanism already proved safe there — and now runs unconditionally, safely
+   extending the mechanism to milestone-bearing graphs. Confirmed with zero regressions across the
+   full suite, a direct positive-engagement regression proving the topology-derived order actually
+   applies at an eligible routing-only hop, and byte-identical
    real-node dock precedence to the unconstrained default (see that section for the full evidence).
 
    **This does not close the corridor-width/constructive-placement gap** the two genuinely-infeasible

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -708,14 +708,11 @@ export function createLaneGeometryFailureCache() {
 
 // compareBranches, plus the rank-0-only origin/taxonomy tie-break normally
 // only applied inside compareBranchesForGlobalOrder (see that function,
-// below), folded into a single comparator. Used only to derive a joint
-// base-layout order for graphs with no real milestone nodes -- see
-// hasIntermediateRealNodes/buildMilestoneFreeJointOrder below and
-// docs/design/lifecycle-diagram-layout-algorithm.md's "Investigation (2026-07-26)"
-// section for why this is scoped that narrowly rather than applied
-// everywhere: the same order destabilizes the deadline-based DFS on graphs
-// with real milestone convergence, even when it never touches a real
-// node's position.
+// below), folded into a single comparator. Feeds buildTransitionScopedJointOrder
+// below. See docs/design/lifecycle-diagram-layout-algorithm.md's "Investigation
+// (2026-07-26)" and "Root-causing the routing-node joint-order destabilization"
+// sections for why a blind, pre-search topological order isn't safe to apply
+// at every rank unconditionally, and what scoping makes it safe.
 const compareBranchesJoint = (a, b) => {
   if (a.sourceRank === 0 && b.sourceRank === 0) {
     const taxonomyDiff = taxonomyOrder(a.source) - taxonomyOrder(b.source);
@@ -724,23 +721,46 @@ const compareBranchesJoint = (a, b) => {
   return compareBranches(a, b);
 };
 
-// True when any rank between the fixed origin/endpoint ranks (0 and 6) has
-// a real (non-routing) node -- i.e. this graph actually routes through a
-// milestone somewhere. buildMilestoneFreeJointOrder is only safe to use
-// when this is false.
-const hasIntermediateRealNodes = (graph) =>
-  graph.nodes.some((node) => !node.routing && node.rank >= 1 && node.rank <= 5);
-
 // Derives a single, stable-ID/topology-only order for both node rank and
-// per-transition-rank branch order, for graphs where every rank 1-5 node is
-// a routing node (no real milestone convergence anywhere in the graph).
-// Because there are no real nodes at those ranks, no real-node-vs-
-// routing-node reconciliation is needed here; ranks 0 and 6 keep nodeSort's
-// own existing taxonomy-order anchoring, which compareBranchesJoint's
-// rank-0 tie-break already agrees with by construction.
-const buildMilestoneFreeJointOrder = (graph) => {
+// per-transition-rank branch order. Unlike an earlier, whole-graph-gated
+// version of this mechanism, this is safe to apply to any graph, including
+// one with real milestone convergence, because it never overrides ordering
+// for a rank or a transition hop that touches a real (non-routing) node on
+// either side: those ranks/hops keep exactly the same nodeSort/linkSort
+// (mechanisms 1/2) behavior they always had. This scoping is what makes the
+// difference -- see docs/design/lifecycle-diagram-layout-algorithm.md's
+// "Root-causing the routing-node joint-order destabilization" section: a
+// prior, unscoped version of this same joint order (still checked in as a
+// regression under "joint-order investigation regression") reorders links at
+// a real node's own dock via linkSort even when it never moves that node's
+// y0/y1 box, which silently changes branchPrecedenceEdges' hard precedence
+// constraints there and destabilizes the deadline-based DFS on fixtures with
+// real milestone convergence. Restricting both the node-order and the
+// branch/link-order override to hops/ranks that are entirely routing (never
+// touching a real origin, milestone, or endpoint node) eliminates that
+// channel while still closing the rankOrder-blind gap for every hop where
+// it's safe to.
+const buildTransitionScopedJointOrder = (graph) => {
+  const realNodeRanks = new Set(
+    graph.nodes.filter((node) => !node.routing).map((node) => node.rank),
+  );
+  // Only ranks 1-5 (intermediate milestones) restrict the linkSort override
+  // below -- ranks 0/6 (origins/endpoints) keep the same joint-order
+  // reordering buildTransitionScopedJointOrder's predecessor already proved
+  // safe there (denseBranchProjection()'s 5 real origins rely on it).
+  // Confirmed directly: restricting rank 0/6 too (the more literal "never
+  // touch a real node at all" reading) breaks that already-solved
+  // milestone-free case instead of generalizing it -- see
+  // docs/design/lifecycle-diagram-layout-algorithm.md.
+  const isIntermediateRealRank = (rank) =>
+    rank >= 1 && rank <= 5 && realNodeRanks.has(rank);
   const jointBranches = [...graph.branches].sort(compareBranchesJoint);
-  const branchOrderByRank = new Map();
+  // Always compute a full per-hop branch order -- used below for node
+  // positioning at any rank that has no real node, independent of whether an
+  // adjacent rank does. Only the linkSort override further below is
+  // restricted by hop adjacency, since that's what actually reorders docks
+  // at a real node's own box.
+  const fullBranchOrderByRank = new Map();
   const ranksInUse = new Set();
   for (const branch of jointBranches)
     for (let rank = branch.sourceRank; rank < branch.targetRank; rank += 1)
@@ -749,18 +769,24 @@ const buildMilestoneFreeJointOrder = (graph) => {
     const active = jointBranches.filter(
       (branch) => branch.sourceRank <= rank && rank < branch.targetRank,
     );
-    branchOrderByRank.set(
+    fullBranchOrderByRank.set(
       rank,
       new Map(active.map((branch, index) => [branch.id, index])),
     );
   }
+  const branchOrderByRank = new Map(
+    [...fullBranchOrderByRank].filter(
+      ([rank]) =>
+        !isIntermediateRealRank(rank) && !isIntermediateRealRank(rank + 1),
+    ),
+  );
   const nodeOrderByRank = new Map();
   for (const rank of [...new Set(graph.nodes.map((node) => node.rank))]) {
     const nodes = graph.nodes.filter((node) => node.rank === rank);
-    if (rank === 0 || rank === 6) {
+    if (rank === 0 || rank === 6 || realNodeRanks.has(rank)) {
       nodes.sort(nodeSort);
     } else {
-      const branchIndex = branchOrderByRank.get(rank);
+      const branchIndex = fullBranchOrderByRank.get(rank);
       nodes.sort(
         (left, right) =>
           (branchIndex?.get(left.branchId) ?? 0) -
@@ -789,25 +815,27 @@ function layoutLifecycleRoutingGraphPass(
     ? options.testOnlyDiagnosticSink
     : null;
   const graph = options.routingGraph ?? buildLifecycleRoutingGraph(projection);
-  // When nothing else supplies a base order and this graph never routes
-  // through a real milestone node, discovery's own first D3 pass would
-  // otherwise use plain, rankOrder-blind nodeSort/linkSort -- the gap
-  // documented in docs/design/lifecycle-diagram-layout-algorithm.md's
-  // "Deferred: making the base D3-Sankey layout rankOrder-aware" section.
-  // buildMilestoneFreeJointOrder closes that gap for exactly this scoped
-  // case (proven safe; see that doc's "Investigation (2026-07-26)" section for why
-  // it is not applied more broadly).
-  const milestoneFreeJointOrder =
-    !explicitNodeOrderByRank &&
-    !options.authoritativeBranchOrderByRank &&
-    !hasIntermediateRealNodes(graph)
-      ? buildMilestoneFreeJointOrder(graph)
+  // When nothing else supplies a base order, discovery's own first D3 pass
+  // would otherwise use plain, rankOrder-blind nodeSort/linkSort at every
+  // rank -- the gap documented in
+  // docs/design/lifecycle-diagram-layout-algorithm.md's "Deferred: making the
+  // base D3-Sankey layout rankOrder-aware" section.
+  // buildTransitionScopedJointOrder closes that gap for every rank/hop where
+  // it's safe to (see that function's own comment for why it's scoped the
+  // way it is, and why that scoping -- not the whole-graph gate an earlier
+  // version of this used -- is what makes it safe for graphs with real
+  // milestone convergence too).
+  const transitionScopedJointOrder =
+    !explicitNodeOrderByRank && !options.authoritativeBranchOrderByRank
+      ? buildTransitionScopedJointOrder(graph)
       : null;
   const baseNodeOrderByRank =
-    explicitNodeOrderByRank ?? milestoneFreeJointOrder?.nodeOrderByRank ?? null;
+    explicitNodeOrderByRank ??
+    transitionScopedJointOrder?.nodeOrderByRank ??
+    null;
   const authoritativeBranchOrderByRank =
     options.authoritativeBranchOrderByRank ??
-    milestoneFreeJointOrder?.branchOrderByRank ??
+    transitionScopedJointOrder?.branchOrderByRank ??
     null;
   const baselineLinks = new Map(
     graph.links.map((link) => [
@@ -1224,6 +1252,7 @@ function layoutLifecycleRoutingGraphPass(
     candidateEvaluations: 0,
     handleStatesVisited: 0,
     handleStateLimit: 0,
+    ...(enableTestDiagnostics ? { testOnlyIndegreeBlockedDeadEnds: 0 } : {}),
   };
   const sortedUnique = (values) =>
     [...new Set(values.filter(Boolean))].sort(compareLifecycleIds);
@@ -1397,6 +1426,55 @@ function layoutLifecycleRoutingGraphPass(
     // continuation choices cannot postpone an unavoidable dock conflict.
     addBranchEdges(sourceGroups, "sourceDockY", "source-dock");
     addBranchEdges(targetGroups, "targetDockY", "target-dock");
+    // Test-only diagnostic snapshot of the precedence edges these dock-Y
+    // orderings impose, before any candidate backtracking begins -- lets a
+    // test compare, between two base-layout orderings of the same fixture,
+    // exactly which precedence constraints differ and whether they touch a
+    // real (non-routing) node's dock, without re-deriving this DAG itself.
+    // See docs/design/lifecycle-diagram-layout-algorithm.md's "Investigation
+    // (2026-07-26)" section for why this distinction matters.
+    if (enableTestDiagnostics) {
+      graph.testOnlyBranchPrecedenceEdges = Object.freeze(
+        branchPrecedenceEdges.map((edge) => {
+          const fromSpan = branchSpans.get(edge.fromBranchId);
+          const toSpan = branchSpans.get(edge.toBranchId);
+          const sharedNodeId =
+            edge.kind === "source-dock"
+              ? fromSpan.semanticSourceId
+              : fromSpan.semanticTargetId;
+          const sharedNode = graph.nodes.find(
+            (node) => node.id === sharedNodeId,
+          );
+          return Object.freeze({
+            fromBranchId: edge.fromBranchId,
+            toBranchId: edge.toBranchId,
+            kind: edge.kind,
+            sharedNodeId,
+            sharedNodeKind: sharedNode
+              ? sharedNode.routing
+                ? "routing"
+                : "real"
+              : null,
+            fromDockY:
+              edge.kind === "source-dock"
+                ? fromSpan.sourceDockY
+                : fromSpan.targetDockY,
+            toDockY:
+              edge.kind === "source-dock"
+                ? toSpan.sourceDockY
+                : toSpan.targetDockY,
+          });
+        }),
+      );
+      graph.testOnlyBranchSpans = Object.freeze(
+        new Map(
+          [...branchSpans].map(([id, span]) => [
+            id,
+            Object.freeze({ ...span }),
+          ]),
+        ),
+      );
+    }
     // variant: "forward" returns minimum-Y assignment; "backward" returns maximum-Y
     // assignment (null when infeasible from that direction); "centered" (default)
     // returns the DP-centered assignment, falling back to "forward" when needed.
@@ -2321,7 +2399,25 @@ function layoutLifecycleRoutingGraphPass(
                 compareLifecycleIds(a.id, b.id),
             );
 
-          if (!ready.length) return false;
+          if (!ready.length) {
+            // Distinguish "search dead-ended because geometry is infeasible"
+            // from "search dead-ended because a precedence edge (dock-Y
+            // order at a shared node, see branchPrecedenceEdges above) blocked
+            // an otherwise geometrically-ready branch" -- capacityOkForRemainder
+            // above is blind to compIndegree, so this is the first point such
+            // a precedence-caused dead end becomes observable. See
+            // docs/design/lifecycle-diagram-layout-algorithm.md's
+            // "Investigation (2026-07-26)" section.
+            if (enableTestDiagnostics) {
+              const indegreeBlocked = componentBranchIds.some(
+                (id) => !globalOrderSet.has(id) && compIndegree.get(id) > 0,
+              );
+              if (indegreeBlocked) {
+                transitionLaneSolverStats.testOnlyIndegreeBlockedDeadEnds += 1;
+              }
+            }
+            return false;
+          }
 
           for (const { id: branchId } of ready) {
             const updates = tryPlaceBranch(branchId);

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -840,6 +840,29 @@ function layoutLifecycleRoutingGraphPass(
     options.authoritativeBranchOrderByRank ??
     transitionScopedJointOrder?.branchOrderByRank ??
     null;
+  // Test-only observability seam: buildTransitionScopedJointOrder's own
+  // branchOrderByRank map already omits any hop adjacent to an intermediate
+  // (rank 1-5) real milestone node (see that function), so a rank's mere
+  // presence as a key here is itself proof that hop was eligible AND
+  // received a topology-derived linkSort override -- not just that the
+  // mechanism ran, but that it actually produced an entry for that specific
+  // hop. Exposed only under isLifecycleLayoutTestEnvironment() so a test can
+  // positively confirm engagement on an eligible hop (and absence on an
+  // excluded one) without relying on the resulting geometry happening to
+  // differ from plain nodeSort/linkSort, which isn't guaranteed for every
+  // fixture. See docs/design/lifecycle-diagram-layout-algorithm.md's
+  // "Root-causing the routing-node joint-order destabilization" section.
+  if (enableTestDiagnostics) {
+    graph.testOnlyTransitionScopedJointOrder = transitionScopedJointOrder
+      ? Object.freeze({
+          branchOrderByRank: new Map(
+            [...transitionScopedJointOrder.branchOrderByRank].map(
+              ([rank, order]) => [rank, new Map(order)],
+            ),
+          ),
+        })
+      : null;
+  }
   const baselineLinks = new Map(
     graph.links.map((link) => [
       link.id,

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -724,22 +724,25 @@ const compareBranchesJoint = (a, b) => {
 // Derives a single, stable-ID/topology-only order for both node rank and
 // per-transition-rank branch order. Unlike an earlier, whole-graph-gated
 // version of this mechanism, this is safe to apply to any graph, including
-// one with real milestone convergence, because it never overrides ordering
-// for a rank or a transition hop that touches a real (non-routing) node on
-// either side: those ranks/hops keep exactly the same nodeSort/linkSort
-// (mechanisms 1/2) behavior they always had. This scoping is what makes the
-// difference -- see docs/design/lifecycle-diagram-layout-algorithm.md's
-// "Root-causing the routing-node joint-order destabilization" section: a
-// prior, unscoped version of this same joint order (still checked in as a
-// regression under "joint-order investigation regression") reorders links at
-// a real node's own dock via linkSort even when it never moves that node's
-// y0/y1 box, which silently changes branchPrecedenceEdges' hard precedence
-// constraints there and destabilizes the deadline-based DFS on fixtures with
-// real milestone convergence. Restricting both the node-order and the
-// branch/link-order override to hops/ranks that are entirely routing (never
-// touching a real origin, milestone, or endpoint node) eliminates that
-// channel while still closing the rankOrder-blind gap for every hop where
-// it's safe to.
+// one with real milestone convergence, because it never overrides node or
+// link ordering for a rank or a transition hop adjacent to an intermediate
+// (rank 1-5) real (non-routing) milestone node: those ranks/hops keep
+// exactly the same nodeSort/linkSort (mechanisms 1/2) behavior they always
+// had. Origin (rank 0) and endpoint (rank 6) docks are NOT included in that
+// restriction -- both the node-order and link-order overrides still apply
+// there, exactly as this mechanism's whole-graph-gated predecessor already
+// proved safe (see below). This scoping is what makes the difference -- see
+// docs/design/lifecycle-diagram-layout-algorithm.md's "Root-causing the
+// routing-node joint-order destabilization" section: a prior, unscoped
+// version of this same joint order (still checked in as a regression under
+// "joint-order investigation regression") reorders links at an intermediate
+// real milestone node's own dock via linkSort even when it never moves that
+// node's y0/y1 box, which silently changes branchPrecedenceEdges' hard
+// precedence constraints there and destabilizes the deadline-based DFS on
+// fixtures with real milestone convergence. Restricting both overrides to
+// hops/ranks that never touch an intermediate real milestone node eliminates
+// that channel while still closing the rankOrder-blind gap for every hop
+// where it's safe to.
 const buildTransitionScopedJointOrder = (graph) => {
   const realNodeRanks = new Set(
     graph.nodes.filter((node) => !node.routing).map((node) => node.rank),

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -1501,13 +1501,14 @@ describe("test-only lifecycle layout diagnostics", () => {
   // candidate_withdrew) -- getting zero legal handle candidates anywhere
   // along their curve, with states.handle in the low thousands (far below
   // the 32768 budget -- not a narrow budget miss). Fixed by
-  // buildMilestoneFreeJointOrder giving discovery's own first D3 pass a
+  // buildTransitionScopedJointOrder giving discovery's own first D3 pass a
   // topology-derived order instead of the plain, rankOrder-blind
   // nodeSort/linkSort it fell back to before (this fixture has no real
-  // milestone nodes, so it's in-scope for that fix) -- see the design
-  // doc's "Investigation (2026-07-26)" section. This test now characterizes the
-  // fixed behavior: the same fixture, still deterministic and
-  // order-independent, now succeeds outright.
+  // milestone nodes, so every rank/hop is in scope for that fix) -- see the
+  // design doc's "Investigation (2026-07-26)" and "Root-causing the
+  // routing-node joint-order destabilization" sections. This test now
+  // characterizes the fixed behavior: the same fixture, still deterministic
+  // and order-independent, now succeeds outright.
   it("characterizes dense routing-only handle feasibility deterministically", () => {
     const reversedDenseBranchProjection = () => {
       const p = denseBranchProjection();
@@ -1595,17 +1596,23 @@ describe("test-only lifecycle layout diagnostics", () => {
     ).toBe(275);
   });
 
-  // Preserves the joint-order investigation behind
-  // buildMilestoneFreeJointOrder (see docs/design/lifecycle-diagram-layout-algorithm.md's
-  // "Investigation (2026-07-26)" section) as a permanent, deterministic
-  // regression, rather than a deleted scratch script. This is intentionally
-  // NOT wired into production eligibility: buildMilestoneFreeJointOrder
-  // stays gated on hasIntermediateRealNodes exactly as shipped. This test
-  // reconstructs the same joint-order/rank-restriction logic independently
-  // (using only exported symbols and the testOnlyBaseNodeOrderByRank /
-  // authoritativeBranchOrderByRank test hooks) and applies it WITHOUT that
-  // gate, to both prove the routing-only success case one more time and
-  // lock in the regression that justifies keeping the gate.
+  // Preserves the joint-order investigation (see
+  // docs/design/lifecycle-diagram-layout-algorithm.md's "Investigation
+  // (2026-07-26)" section) as a permanent, deterministic regression, rather
+  // than a deleted scratch script. This test reconstructs an UNGATED
+  // joint-order/rank-restriction (no exclusion at all for hops/ranks that
+  // touch a real node) independently of production, using only exported
+  // symbols and the testOnlyBaseNodeOrderByRank/authoritativeBranchOrderByRank
+  // test hooks, and applies it directly. Production itself no longer uses
+  // this unrestricted construction or a whole-graph gate -- it now ships
+  // buildTransitionScopedJointOrder unconditionally (see "root-causing the
+  // routing-node joint-order destabilization" below and the design doc's
+  // "Root-causing the routing-node joint-order destabilization" section),
+  // which instead restricts the override per hop/rank to ones that never
+  // touch a real node. This block's job is to keep proving that the
+  // UNGATED construction still regresses real fixtures, i.e. that
+  // production's actual per-hop restriction remains load-bearing, not
+  // optional.
   describe("joint-order investigation regression", () => {
     const compareBranchesJoint = (a, b) => {
       if (a.sourceRank === 0 && b.sourceRank === 0) {
@@ -1633,9 +1640,10 @@ describe("test-only lifecycle layout diagnostics", () => {
       const nodeOrderByRank = new Map();
       for (const rank of [...new Set(graph.nodes.map((node) => node.rank))]) {
         const nodes = graph.nodes.filter((node) => node.rank === rank);
-        // Deliberately UNGATED: unlike buildMilestoneFreeJointOrder, this
-        // reorders any rank with zero real nodes regardless of whether the
-        // graph as a whole has milestones elsewhere -- exactly the
+        // Deliberately UNGATED: unlike production's buildTransitionScopedJointOrder,
+        // this reorders every rank/hop uniformly with no real-node-adjacency
+        // restriction at all (its branchOrderByRank below overrides linkSort
+        // even at ranks/hops touching a real node) -- exactly the
         // construction the investigation found regresses real fixtures.
         if (nodes.some((node) => !node.routing)) {
           nodes.sort(nodeSort);
@@ -1674,11 +1682,14 @@ describe("test-only lifecycle layout diagnostics", () => {
     });
 
     it("regresses the reference fixture from zero crossings to a tolerated one", () => {
-      // Production's own gated approach (buildMilestoneFreeJointOrder,
-      // never engaging here since this fixture has milestones) keeps this
-      // fixture at exactly 0 accepted crossings -- see the seeded-replay
-      // suite above. Applying the same joint order ungated introduces a
-      // crossing production's default ordering never needed to tolerate.
+      // Production's own per-hop-scoped approach (buildTransitionScopedJointOrder,
+      // which leaves this fixture's real-node-adjacent hops untouched even
+      // though it does engage for this fixture's routing-only hops) keeps
+      // this fixture at exactly 0 accepted crossings -- see the
+      // seeded-replay suite above. Applying the same joint order fully
+      // ungated (no real-node-adjacency restriction at all) introduces a
+      // crossing production's actual default ordering never needed to
+      // tolerate.
       const result = layoutWithUngatedJointOrder(
         projectLifecycleAt(routingFixture),
       );
@@ -1700,6 +1711,81 @@ describe("test-only lifecycle layout diagnostics", () => {
         reason: "state-limit",
         phase: "handle",
         stateLimit: 32768,
+      });
+    });
+
+    // Root-causes exactly why the ungated joint order above destabilizes
+    // real milestone-bearing fixtures, and confirms the fix production now
+    // ships (buildTransitionScopedJointOrder, unconditionally applied inside
+    // layoutLifecycleRoutingGraphPass whenever no explicit order is
+    // supplied -- see docs/design/lifecycle-diagram-layout-algorithm.md's
+    // "Root-causing the routing-node joint-order destabilization" section).
+    // graph.testOnlyBranchPrecedenceEdges is a test-only diagnostic field
+    // production now stamps on every returned graph: the hard branch
+    // precedence constraints (branchIndegree/compIndegree in
+    // solveFromComponent) derived from each branch's dock-Y at its real
+    // semantic source/target node.
+    describe("real-node dock precedence diagnostics", () => {
+      const realEdgeKeys = (graph) =>
+        (graph.testOnlyBranchPrecedenceEdges ?? [])
+          .filter((edge) => edge.sharedNodeKind === "real")
+          .map(
+            (edge) => `${edge.fromBranchId}\0${edge.toBranchId}\0${edge.kind}`,
+          )
+          .sort();
+      // Bypasses buildTransitionScopedJointOrder entirely (it only applies
+      // when neither override option is supplied) to reconstruct plain,
+      // rankOrder-blind nodeSort/linkSort -- the historical default for any
+      // milestone-bearing graph before this investigation's fix.
+      const pureDefaultOrder = (projection, width = 1850) =>
+        layoutLifecycleRoutingGraph(projection, width, {
+          transitionLanePhaseOnly: true,
+          authoritativeNodeOrderByRank: new Map(),
+          authoritativeBranchOrderByRank: new Map(),
+        });
+
+      it("shipped order leaves real-node precedence identical to the unconstrained default", () => {
+        const shipped = layoutLifecycleRoutingGraph(
+          projectLifecycleAt(routingFixture),
+          1850,
+          { transitionLanePhaseOnly: true },
+        );
+        const pure = pureDefaultOrder(projectLifecycleAt(routingFixture));
+        const shippedKeys = realEdgeKeys(shipped.graph);
+        expect(shippedKeys.length).toBeGreaterThan(0);
+        expect(shippedKeys).toEqual(realEdgeKeys(pure.graph));
+      });
+
+      it("the reverted ungated joint order changes real-node precedence, unlike the fix", () => {
+        const pure = pureDefaultOrder(projectLifecycleAt(routingFixture));
+        const ungated = layoutWithUngatedJointOrder(
+          projectLifecycleAt(routingFixture),
+        );
+        const pureKeys = realEdgeKeys(pure.graph);
+        const ungatedKeys = realEdgeKeys(ungated.graph);
+        // Same count (every branch pair sharing a real dock still gets
+        // exactly one precedence edge either way) but not the same relative
+        // order -- the ungated joint order's unrestricted linkSort override
+        // reorders links along a real node's own box even though it never
+        // moves that node's y0/y1.
+        expect(ungatedKeys.length).toBe(pureKeys.length);
+        expect(ungatedKeys).not.toEqual(pureKeys);
+      });
+
+      it("shipped order solves the real dense fixture the ungated joint order cannot", () => {
+        // The ungated variant above already asserts this fixture throws a
+        // state-limit failure. Production's own default call (no options at
+        // all) applies buildTransitionScopedJointOrder internally and
+        // succeeds -- the same real-node-dock-precedence preservation this
+        // describe block otherwise proves is what makes the difference.
+        const result = layoutLifecycleRoutingGraph(
+          projectLifecycleAt(denseFixture),
+          1850,
+        );
+        expect(result.graph.acceptedRouteCrossingCount).toBe(50);
+        expect(result.graph.transitionLaneSolverStats.handleStatesVisited).toBe(
+          500,
+        );
       });
     });
   });
@@ -2662,7 +2748,7 @@ describe("lifecycle diagram render-only routing layout", () => {
   });
 
   // denseBranchProjection() has no real milestone nodes (every branch is a
-  // direct origin->endpoint link), so buildMilestoneFreeJointOrder now
+  // direct origin->endpoint link), so buildTransitionScopedJointOrder now
   // gives discovery's own first D3 pass a topology-derived, cross-rank-
   // consistent node/link order instead of the plain, rankOrder-blind
   // nodeSort/linkSort it used to fall back to -- see
@@ -2754,7 +2840,7 @@ describe("lifecycle diagram render-only routing layout", () => {
     // denseBranchProjection()'s multi-rank routing had no
     // handle-clearance-feasible lane arrangement discovery's plain,
     // rankOrder-blind nodeSort/linkSort could find. Fixed by
-    // buildMilestoneFreeJointOrder (see
+    // buildTransitionScopedJointOrder (see
     // docs/design/lifecycle-diagram-layout-algorithm.md's
     // "Investigation (2026-07-26)" section) -- this fixture has no real
     // milestone nodes, so it's in-scope for that fix. The search itself is
@@ -2782,7 +2868,7 @@ describe("lifecycle diagram render-only routing layout", () => {
 // contract that's easy to assert without also having to replay tolerance state.
 // The dense v2 fixture and denseBranchProjection() now succeed too (both are exercised
 // by other tests above), but only via mechanisms this section doesn't need: the bounded
-// tolerances for v2, buildMilestoneFreeJointOrder for denseBranchProjection() -- see
+// tolerances for v2, buildTransitionScopedJointOrder for denseBranchProjection() -- see
 // docs/design/lifecycle-diagram-layout-algorithm.md's "Follow-up (shipped)" and
 // "Investigation (2026-07-26)" sections.
 describe("seeded-replay production layout (routing fixture)", () => {

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -1601,18 +1601,23 @@ describe("test-only lifecycle layout diagnostics", () => {
   // (2026-07-26)" section) as a permanent, deterministic regression, rather
   // than a deleted scratch script. This test reconstructs an UNGATED
   // joint-order/rank-restriction (no exclusion at all for hops/ranks that
-  // touch a real node) independently of production, using only exported
-  // symbols and the testOnlyBaseNodeOrderByRank/authoritativeBranchOrderByRank
-  // test hooks, and applies it directly. Production itself no longer uses
-  // this unrestricted construction or a whole-graph gate -- it now ships
+  // touch a real node -- origin, intermediate milestone, or endpoint alike)
+  // independently of production, using only exported symbols and the
+  // testOnlyBaseNodeOrderByRank/authoritativeBranchOrderByRank test hooks,
+  // and applies it directly. Production itself no longer uses this
+  // unrestricted construction or a whole-graph gate -- it now ships
   // buildTransitionScopedJointOrder unconditionally (see "root-causing the
   // routing-node joint-order destabilization" below and the design doc's
   // "Root-causing the routing-node joint-order destabilization" section),
-  // which instead restricts the override per hop/rank to ones that never
-  // touch a real node. This block's job is to keep proving that the
-  // UNGATED construction still regresses real fixtures, i.e. that
-  // production's actual per-hop restriction remains load-bearing, not
-  // optional.
+  // which instead only suppresses the override for a hop/rank adjacent to an
+  // INTERMEDIATE (rank 1-5) real milestone node -- origin (rank 0) and
+  // endpoint (rank 6) docks remain intentionally eligible for reordering,
+  // exactly like this ungated construction (see the "positively engages the
+  // scoped joint order" block below for a direct regression proving that
+  // eligibility, not just the milestone-adjacent exclusion this block
+  // covers). This block's job is to keep proving that the UNGATED
+  // construction still regresses real fixtures, i.e. that production's
+  // actual per-hop restriction remains load-bearing, not optional.
   describe("joint-order investigation regression", () => {
     const compareBranchesJoint = (a, b) => {
       if (a.sourceRank === 0 && b.sourceRank === 0) {
@@ -1683,13 +1688,14 @@ describe("test-only lifecycle layout diagnostics", () => {
 
     it("regresses the reference fixture from zero crossings to a tolerated one", () => {
       // Production's own per-hop-scoped approach (buildTransitionScopedJointOrder,
-      // which leaves this fixture's real-node-adjacent hops untouched even
-      // though it does engage for this fixture's routing-only hops) keeps
-      // this fixture at exactly 0 accepted crossings -- see the
-      // seeded-replay suite above. Applying the same joint order fully
-      // ungated (no real-node-adjacency restriction at all) introduces a
-      // crossing production's actual default ordering never needed to
-      // tolerate.
+      // which leaves this fixture's intermediate-milestone-adjacent hops
+      // untouched while still engaging at its routing-only hops -- including
+      // ones adjacent to its real origin/endpoint docks) keeps this fixture
+      // at exactly 0 accepted crossings -- see the seeded-replay suite
+      // above. Applying the same joint order fully ungated (no
+      // real-node-adjacency restriction at all, origin/endpoint included)
+      // introduces a crossing production's actual default ordering never
+      // needed to tolerate.
       const result = layoutWithUngatedJointOrder(
         projectLifecycleAt(routingFixture),
       );
@@ -1786,6 +1792,87 @@ describe("test-only lifecycle layout diagnostics", () => {
         expect(result.graph.transitionLaneSolverStats.handleStatesVisited).toBe(
           500,
         );
+      });
+    });
+
+    // The tests above prove the shipped order leaves real-node dock
+    // precedence untouched and that milestone-adjacent hops keep default
+    // ordering, but neither directly proves buildTransitionScopedJointOrder
+    // actually *engages* anywhere for a milestone-bearing graph -- they would
+    // still pass if it silently became a no-op, since routingFixture's own
+    // eligible hops (see below) happen to coincide with plain nodeSort's own
+    // ordering for this fixture's data (confirmed directly: comparing the
+    // shipped and pure-default outputs at those hops shows identical
+    // geometry). Observable rendered geometry therefore cannot reliably
+    // prove engagement here, so this uses the minimal test-only seam
+    // (graph.testOnlyTransitionScopedJointOrder, populated only under
+    // isLifecycleLayoutTestEnvironment()) to assert the mechanism's own
+    // branchOrderByRank map directly: its mere presence for a rank is proof
+    // that hop was eligible (buildTransitionScopedJointOrder's own filter
+    // already omits any hop adjacent to an intermediate rank 1-5 real
+    // milestone node -- see that function), and its recorded order is
+    // cross-checked against an independent recomputation of the same
+    // topological comparator, so a bypass, an emptied map, or a silently
+    // wrong order all fail this test.
+    describe("positively engages the scoped joint order", () => {
+      const compareBranchesJoint = (a, b) => {
+        if (a.sourceRank === 0 && b.sourceRank === 0) {
+          const taxonomyDiff =
+            taxonomyOrder(a.source) - taxonomyOrder(b.source);
+          if (taxonomyDiff !== 0) return taxonomyDiff;
+        }
+        return compareBranches(a, b);
+      };
+      const expectedJointOrderAtRank = (graph, rank) =>
+        [...graph.branches]
+          .filter(
+            (branch) => branch.sourceRank <= rank && rank < branch.targetRank,
+          )
+          .sort(compareBranchesJoint)
+          .map((branch) => branch.id);
+
+      it("applies the topology-derived order on eligible hops, excludes milestone hops", () => {
+        const graph = buildLifecycleRoutingGraph(
+          projectLifecycleAt(routingFixture),
+        );
+        const realNodeRanks = new Set(
+          graph.nodes.filter((node) => !node.routing).map((node) => node.rank),
+        );
+        // Confirmed directly (not assumed): this fixture's real nodes sit at
+        // ranks 0, 1, 2, 3, and 6, leaving ranks 4 and 5 as its only
+        // fully-routing hops -- neither adjacent to any real milestone node.
+        expect([...realNodeRanks].sort((a, b) => a - b)).toEqual([
+          0, 1, 2, 3, 6,
+        ]);
+
+        const { graph: shippedGraph } = layoutLifecycleRoutingGraph(
+          projectLifecycleAt(routingFixture),
+          1850,
+          { transitionLanePhaseOnly: true },
+        );
+        const engaged = shippedGraph.testOnlyTransitionScopedJointOrder;
+        expect(engaged).not.toBeNull();
+
+        for (const eligibleRank of [4, 5]) {
+          const order = engaged.branchOrderByRank.get(eligibleRank);
+          expect(
+            order,
+            `rank ${eligibleRank} should be eligible`,
+          ).toBeDefined();
+          const actualOrder = [...order.entries()]
+            .sort((a, b) => a[1] - b[1])
+            .map(([branchId]) => branchId);
+          expect(actualOrder).toEqual(
+            expectedJointOrderAtRank(graph, eligibleRank),
+          );
+        }
+
+        for (const excludedRank of [0, 1, 2, 3]) {
+          expect(
+            engaged.branchOrderByRank.has(excludedRank),
+            `rank ${excludedRank} should be excluded (adjacent to a real milestone node)`,
+          ).toBe(false);
+        }
       });
     });
   });

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -1720,11 +1720,11 @@ describe("test-only lifecycle layout diagnostics", () => {
     // layoutLifecycleRoutingGraphPass whenever no explicit order is
     // supplied -- see docs/design/lifecycle-diagram-layout-algorithm.md's
     // "Root-causing the routing-node joint-order destabilization" section).
-    // graph.testOnlyBranchPrecedenceEdges is a test-only diagnostic field
-    // production now stamps on every returned graph: the hard branch
-    // precedence constraints (branchIndegree/compIndegree in
-    // solveFromComponent) derived from each branch's dock-Y at its real
-    // semantic source/target node.
+    // graph.testOnlyBranchPrecedenceEdges is a test-only diagnostic field,
+    // populated only under isLifecycleLayoutTestEnvironment() (this test
+    // run), never in production: the hard branch precedence constraints
+    // (branchIndegree/compIndegree in solveFromComponent) derived from each
+    // branch's dock-Y at its real semantic source/target node.
     describe("real-node dock precedence diagnostics", () => {
       const realEdgeKeys = (graph) =>
         (graph.testOnlyBranchPrecedenceEdges ?? [])

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -878,7 +878,7 @@ describe("lifecycle diagram P6 pagination and hardening", () => {
   // of direct origin->endpoint applications with no intermediate milestone
   // -- the same shape as denseBranchProjection() in
   // test/web-tracker-lifecycle-diagram-layout.test.js, which
-  // buildMilestoneFreeJointOrder makes fully handle-feasible. Built as a
+  // buildTransitionScopedJointOrder makes fully handle-feasible. Built as a
   // snapshot directly (not via app()/ev()/projectLifecycleAt reconciliation
   // events): only 8 of the 11 taxonomy endpoints are reachable as a direct,
   // milestone-free lifecycle-event outcome (interviewing and


### PR DESCRIPTION
## Summary

- Diagnoses why the previously reverted joint-order attempt destabilized milestone-bearing fixtures without moving real-node boxes: its unrestricted `linkSort` changed individual link docks at intermediate real milestone nodes, which changed the solver’s hard `branchPrecedenceEdges`.
- Replaces the whole-graph `buildMilestoneFreeJointOrder` gate with `buildTransitionScopedJointOrder`:
  - routing-only ranks receive topology-derived node ordering;
  - branch/link ordering is excluded from hops adjacent to intermediate rank-1–5 real milestone nodes;
  - origin rank 0 and endpoint rank 6 remain intentionally eligible for branch/link reordering.
- Adds test-only diagnostics for precedence edges, branch spans, indegree-blocked dead ends, and the selected transition-scoped order. These fields are populated only in the test environment.
- Adds load-bearing regressions proving that:
  - eligible hops in a milestone-bearing graph actually receive the topology-derived order;
  - milestone-adjacent hops remain excluded;
  - real-node dock precedence remains identical to the unconstrained default;
  - the reverted ungated construction still changes real-node precedence and regresses existing fixtures.
- Documents that `transitionDensityProjection()` and the historical 60-application/89-branch fixture remain infeasible because of the fixed-width rank corridor, which ordering changes cannot address.

## Compatibility

This changes lifecycle-diagram layout ordering only. It introduces no public API, persisted-data, configuration, or migration requirements.

## Test plan

- [x] `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js`
- [x] `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js test/web-tracker-lifecycle-diagram.test.js`
- [x] `npx playwright test test/playwright/lifecycle-diagram.spec.js test/playwright/static-smoke.spec.js`
- [x] `npm run test:ci` — the local environment reports only the same three `claude-validate.test.js` bubblewrap-sandboxing failures reproduced on `main`; latest-head GitHub CI remains authoritative
- [x] `npm run lint -- --quiet`
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npx prettier --check` on all touched files
- [x] `git diff --check`
- [x] `rg -n '(it|test)\.skip\(' test` — no skipped tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)