### PR TITLE
Characterize dense lifecycle corridor boundary

### DIFF
--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -667,6 +667,44 @@ that doesn't depend on every branch finding a legal point within a fixed-width c
 tracked as further follow-up, not attempted here. Retrying with a larger
 `HANDLE_CLEARANCE_TOLERANCE` value alone will not help; the evidence above rules that out directly.
 
+### Follow-up investigation (2026-07-27): the boundary is not a scalar density threshold
+
+The test-only first-candidate diagnostic now aggregates the two horizontal rejection counters that
+were previously available only inside each blocked branch: `fixedGeometry` and
+`outsideTransitionCorridor`, plus the stable set of nearest-blocker kinds. The checked-in regression
+runs both extreme fixtures in normal and reversed input order and requires byte-identical evidence.
+Both reject during handle placement with `reason: "no-candidates"`; both record positive horizontal
+rejection counts and include `corridor-bounds` among their nearest blockers. This makes the binding
+constraint explicit without inferring it indirectly from the shared `clearanceMargin === -1`
+sentinel.
+
+A bounded density-only rank-spacing experiment was also evaluated and deliberately not shipped. It
+kept the protected half-corridor at 100px and increased every rank-center gap in 48px steps above 32
+links per transition, capped at 384px of expansion. For the 50-link transition fixture this selected
+144px of expansion (272px to 416px rank spacing, and therefore 72px to 216px of usable transition
+span). That removed the original narrow-span shape but did **not** make the production pipeline
+complete: the fixture still rejected after about five seconds, while established dense-fixture
+solver statistics changed (5,637 to 12,613 states) and two focused diagnostics exceeded the
+30-second test contract. It also demonstrated why every consumer must share one geometry object:
+tests or consumers retaining the baseline `rankCenterX` no longer audited the same X span as the
+solver.
+
+The evidence therefore does not support an authoritative production formula based on maximum link
+count alone. A milestone-free 55-branch graph is already supported at the baseline 272px spacing,
+while the 50-branch shared-milestone shape is not; topology and the distribution of incident docks,
+not just the maximum transition count, determine whether added horizontal span produces legal,
+non-overlapping handles. There is consequently no honest scalar “supported through N branches”
+limit. The currently established boundary is shape-specific: ordinary and existing real fixtures,
+including the milestone-free 55-branch graph, remain supported; the checked-in 50-branch
+shared-milestone and 60-application paginated fan-in shapes remain rejected deterministically.
+
+The next architectural lever must first derive a per-hop demand measure from candidate-bearing route
+geometry (including incident dock distribution), then thread a single immutable horizontal-geometry
+value through layout, lane domains, route primitives, renderer, handle placement, and audit. That is
+larger than safely inferring a spacing formula from these two fixtures. Until that demand model is
+proved against ordinary-fixture invariants and the bounded two-pass search, retaining typed failure
+is safer than a speculative width expansion that merely moves the rejection downstream.
+
 ## Follow-up (shipped): unified route-crossing classifier
 
 The last remaining Playwright skip (see "Playwright status" above) was an audit-methodology

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -3667,6 +3667,22 @@ export function testOnlyDiagnoseLifecycleLayoutAttempt(
     );
   const structuredReason = (phase, reason, ranks = []) => {
     if (!reason) return null;
+    const branchDiagnostics = reason.branchDiagnostics ?? [];
+    const horizontalRejections = branchDiagnostics.reduce(
+      (totals, diagnostic) => {
+        totals.fixedGeometry += diagnostic.rejected?.fixedGeometry ?? 0;
+        totals.outsideTransitionCorridor +=
+          diagnostic.rejected?.outsideTransitionCorridor ?? 0;
+        const blocker = diagnostic.nearestRejectedCandidate?.blocker;
+        if (blocker?.kind) totals.nearestBlockerKinds.add(blocker.kind);
+        return totals;
+      },
+      {
+        fixedGeometry: 0,
+        outsideTransitionCorridor: 0,
+        nearestBlockerKinds: new Set(),
+      },
+    );
     const affectedRanks = [
       reason.rank,
       ...(reason.routeFindings ?? []).map((finding) => finding.rank),
@@ -3690,6 +3706,14 @@ export function testOnlyDiagnoseLifecycleLayoutAttempt(
         blockedBranchIds: reason.blockedBranchIds ?? [],
         routeFindingCount: reason.routeFindings?.length ?? 0,
         branchDiagnosticCount: reason.branchDiagnostics?.length ?? 0,
+        horizontalRejections: {
+          fixedGeometry: horizontalRejections.fixedGeometry,
+          outsideTransitionCorridor:
+            horizontalRejections.outsideTransitionCorridor,
+          nearestBlockerKinds: [
+            ...horizontalRejections.nearestBlockerKinds,
+          ].sort(compareLifecycleIds),
+        },
       },
     };
   };

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -1488,6 +1488,40 @@ describe("test-only lifecycle layout diagnostics", () => {
     ).toBe(true);
   });
 
+  it.each([
+    ["50-branch shared-milestone fan-in", transitionDensityProjection],
+    ["60-application paginated fan-in", paginationProjection],
+  ])("identifies the horizontal rejection boundary for %s", (_, fixture) => {
+    const projectionValue = fixture();
+    const reversed = {
+      ...projectionValue,
+      nodes: [...projectionValue.nodes].reverse(),
+      links: [...projectionValue.links].reverse(),
+      paths: [...projectionValue.paths].reverse(),
+    };
+    const baseline = testOnlyDiagnoseLifecycleLayoutAttempt(
+      projectionValue,
+      1850,
+    );
+    expect(testOnlyDiagnoseLifecycleLayoutAttempt(reversed, 1850)).toEqual(
+      baseline,
+    );
+    expect(baseline.firstRejectedPhase).toBe("handle");
+    expect(baseline.firstRejectedReason).toMatchObject({
+      reason: "no-candidates",
+      evidence: {
+        horizontalRejections: {
+          nearestBlockerKinds: expect.arrayContaining(["corridor-bounds"]),
+        },
+      },
+    });
+    const horizontal =
+      baseline.firstRejectedReason.evidence.horizontalRejections;
+    expect(
+      horizontal.fixedGeometry + horizontal.outsideTransitionCorridor,
+    ).toBeGreaterThan(0);
+  });
+
   // Historical baseline (pre-fix, see
   // docs/design/lifecycle-diagram-layout-algorithm.md's "Checked-in
   // reproduction" section): denseBranchProjection() (5 origins x 11


### PR DESCRIPTION
### Motivation

- Two extreme fan-in fixtures (`transitionDensityProjection()` and the historical 60-application paginated fixture) remain deterministically infeasible and repeatedly report `nearestRejectedCandidate.clearanceMargin === -1`, which conflates fixed-geometry and transition-corridor rejections.  The goal was to precisely identify which horizontal constraint is rejecting these stress fixtures before attempting any production geometry change.

### Description

- Add a test-only diagnostic aggregation that summarizes per-branch horizontal rejections (`fixedGeometry` and `outsideTransitionCorridor`) and records the stable set of nearest-blocker kinds so failures can be attributed to corridor bounds vs. fixed geometry in the first-candidate snapshot. (`src/web/tracker/lifecycleDiagramLayout.js`)
- Add focused, order-independence regression tests that exercise both problematic fixtures (50-branch shared-milestone fan-in and 60-application paginated fan-in) and assert the failure signature is stable under input reversal and that `corridor-bounds` appears among nearest blockers. (`test/web-tracker-lifecycle-diagram-layout.test.js`)
- Document the investigation, the evaluated bounded density-only spacing experiment (kept as a deliberately-not-shipped experiment), the diagnosed root cause (a fixed X-extent protected corridor driven by `RANK_CORRIDOR_HALF_WIDTH`), and the recommended next architectural lever (derive a per-hop demand measure and thread one immutable horizontal geometry through all consumers). (`docs/design/lifecycle-diagram-layout-algorithm.md`)
- Important: no production geometry, budgets, solver behavior, tolerances, two-pass seeding/replay, renderer contracts, or audits were changed; the PR preserves typed failure for the two genuinely infeasible fixtures and only improves diagnostics/tests and documentation.

### Testing

- `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js -t "identifies the horizontal rejection boundary"` — PASS (the two new normal/reversed fixture assertions passed). 
- `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js` — WARN (92/93 tests passed; one pre-existing long-running shared-handle-budget test repeatedly exceeded the 30s wall-clock test timeout on this host). 
- `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js test/web-tracker-lifecycle-diagram.test.js test/web-tracker-lifecycle-diagram-performance.test.js` — WARN (same single pre-existing timeout reproduced). 
- `npx playwright test test/playwright/lifecycle-diagram.spec.js test/playwright/static-smoke.spec.js` — WARN: browser binaries initially missing, then Chromium and host deps installed; after that, a subset of Playwright specs passed but some long seeded browser tests exceeded the existing test timeouts on this constrained host (these are environment/time-budget issues, not regressions in the audit code). 
- `npm run lint -- --quiet` — PASS. 
- `npm run typecheck` — PASS. 
- `npm run build` — PASS. 
- `npx prettier --check` on the touched files — PASS. 

Residual notes and intentional limits

- Diagnosed root cause: the binding horizontal constraint is the fixed per-rank protected corridor X-extent (tied to `RANK_CORRIDOR_HALF_WIDTH`) and not an ordering/tolerance/solver-budget issue; both stress fixtures continue to fail with `no-candidates` and nearest-blocker evidence that includes `corridor-bounds`.
- A bounded density-only spacing experiment (described in the docs) was evaluated but deliberately not shipped because it moved the rejection (and worsened solver statistics and runtime) without reliably completing production layout across shapes; topology and dock distribution — not only link count — determine feasibility. 
- Next safe step is architectural: derive a deterministic per-hop demand measure from candidate-bearing route geometry, compute one immutable horizontal-geometry object from it, and consume that object across layout, lane domains, route primitives, renderer, handle placement, and audit; that is out of scope for this focused PR and explicitly left as follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67053df988832fbbf8580d03534868)