### PR TITLE
Add lifecycle horizontal geometry seam

### DIFF
--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -892,10 +892,21 @@ other routes, handle overlap, and the route audit together. A safe formula needs
 proof (or an exhaustive bounded test over the supported density domain) connecting density to all
 three rejection classes. The currently established boundary is therefore: ordinary fixtures and
 the existing milestone-free dense grid remain supported, while a 50-way convergence on one real
-milestone is rejected deterministically. The next architectural lever remains one shared
-horizontal-geometry object consumed by layout, lane solving, route primitives, handle generation,
-and audit. That shared per-hop demand/immutable-horizontal-geometry design remains deferred
-follow-up work; its expansion rule must be validated before replacing the baseline constants.
+milestone is rejected deterministically.
+
+P8 ships the architectural seam, but no expansion: one deeply immutable horizontal-geometry value
+owns keyed rank centers and keyed adjacent-hop geometry, including exit and entry positions, control
+and protected-corridor extents, transition and usable handle-center spans, margins, and SVG width.
+The same instance is threaded through base layout, lane solving, routing-anchor materialization,
+route/path generation, handle placement, rendering, auditing, and diagnostics. Compatibility helper
+defaults still select the single baseline instance. Consequently, production geometry and the
+supported-density boundary described above are unchanged: the two extreme fan-in fixtures retain
+their exact deterministic failures and diagnostics.
+
+P9 remains responsible for defining and validating adaptive per-hop demand and expansion. P8 does
+not calculate density demand, alter rank spacing, change candidate samples or budgets, or make
+either extreme fixture feasible. Any P9 expansion rule still needs the constructive proof (or
+exhaustive bounded test) described above before it can replace the baseline constructor inputs.
 
 This is the authoritative, current list — cross-check against the code before trusting it, since
 skip states and test names can drift. `grep -rn "it\.skip(\|test\.skip(" test/` finds all of them.

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -12,6 +12,7 @@ import {
   layoutLifecycleRoutingGraph,
   labelBoxForNode,
   renderedBranchStrokeWidth,
+  rendererHitBoxForNode,
   wrapLifecycleLabel,
 } from "./lifecycleDiagramLayout.js";
 export { calculateLifecycleDiagramLayout };
@@ -686,11 +687,15 @@ export function createLifecycleDiagramView(root, options = {}) {
             label: nodeLabel,
             applicationIds: node.applicationIds,
           });
+        const hitBox = rendererHitBoxForNode(
+          node,
+          dimensions.horizontalGeometry,
+        );
         const hitRect = svgEl("rect", {
-          x: node.x0 - Math.max(0, 44 - (node.x1 - node.x0)) / 2,
-          y: node.y0 - Math.max(0, 44 - (node.y1 - node.y0)) / 2,
-          width: Math.max(44, node.x1 - node.x0),
-          height: Math.max(44, node.y1 - node.y0),
+          x: hitBox.x,
+          y: hitBox.y,
+          width: hitBox.width,
+          height: hitBox.height,
           fill: "transparent",
           "pointer-events": "all",
           "aria-hidden": "true",

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -465,6 +465,9 @@ export function createLifecycleDiagramView(root, options = {}) {
       ({ graph, dimensions } = layoutLifecycleRoutingGraph(
         projection,
         root.clientWidth,
+        options.horizontalGeometry
+          ? { horizontalGeometry: options.horizontalGeometry }
+          : undefined,
       ));
     } catch {
       scroll.append(

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -530,9 +530,12 @@ export function createLifecycleDiagramView(root, options = {}) {
         handles = graph.acceptedHandles;
       } else {
         handles = new Map(
-          assignBranchHandles(branches, segmentsByBranch, visibleNodes).map(
-            (h) => [h.branchId, h],
-          ),
+          assignBranchHandles(
+            branches,
+            segmentsByBranch,
+            visibleNodes,
+            dimensions.horizontalGeometry,
+          ).map((h) => [h.branchId, h]),
         );
       }
     } catch {
@@ -548,7 +551,10 @@ export function createLifecycleDiagramView(root, options = {}) {
       const segments = segmentsByBranch
         .get(branch.id)
         .sort((a, b) => a.segmentIndex - b.segmentIndex);
-      const pathData = compoundBranchPath(segments);
+      const pathData = compoundBranchPath(
+        segments,
+        dimensions.horizontalGeometry,
+      );
       if (!pathData || /NaN|Infinity/u.test(pathData)) continue;
       const from = TAXONOMY.get(branch.source)?.label ?? branch.source;
       const to = TAXONOMY.get(branch.target)?.label ?? branch.target;
@@ -716,7 +722,7 @@ export function createLifecycleDiagramView(root, options = {}) {
           event.stopPropagation();
           selectNode();
         });
-        const labelBox = labelBoxForNode(node);
+        const labelBox = labelBoxForNode(node, dimensions.horizontalGeometry);
         const label = svgEl("text", {
           x: labelBox.x + labelBox.width / 2,
           y: labelBox.y + 12,

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -49,6 +49,121 @@ export const MINIMUM_SVG_WIDTH =
   6 * MINIMUM_RANK_CENTER_SPACING;
 export const BRANCH_STROKE_OPACITY = 0.82;
 export const BRANCH_HANDLE_RADIUS = 22;
+
+const LIFECYCLE_RANKS = Object.freeze([0, 1, 2, 3, 4, 5, 6]);
+
+export function createLifecycleHorizontalGeometry({
+  rankCenters = Object.fromEntries(
+    LIFECYCLE_RANKS.map((rank) => [
+      rank,
+      LAYOUT_LEFT_MARGIN +
+        SANKEY_NODE_WIDTH / 2 +
+        rank * MINIMUM_RANK_CENTER_SPACING,
+    ]),
+  ),
+  corridorHalfWidth = RANK_CORRIDOR_HALF_WIDTH,
+  controlOffset = TRANSITION_CONTROL_OFFSET,
+  leftMargin = LAYOUT_LEFT_MARGIN,
+  rightMargin = LAYOUT_RIGHT_MARGIN,
+  nodeWidth = SANKEY_NODE_WIDTH,
+  minimumSvgWidth = MINIMUM_SVG_WIDTH,
+  handleRadius = BRANCH_HANDLE_RADIUS,
+} = {}) {
+  const centers = {};
+  for (const rank of LIFECYCLE_RANKS) {
+    const value = rankCenters[rank];
+    if (!Number.isFinite(value))
+      throw new Error(
+        `Lifecycle horizontal geometry missing finite rank ${rank} center`,
+      );
+    if (rank > 0 && value <= centers[rank - 1])
+      throw new Error(
+        "Lifecycle horizontal geometry rank centers must increase monotonically",
+      );
+    centers[rank] = value;
+  }
+  const scalars = {
+    corridorHalfWidth,
+    controlOffset,
+    leftMargin,
+    rightMargin,
+    nodeWidth,
+    minimumSvgWidth,
+    handleRadius,
+  };
+  for (const [name, value] of Object.entries(scalars)) {
+    if (!Number.isFinite(value) || value < 0)
+      throw new Error(
+        `Lifecycle horizontal geometry ${name} must be finite and nonnegative`,
+      );
+  }
+  if (minimumSvgWidth < centers[6] + nodeWidth / 2 + rightMargin)
+    throw new Error(
+      "Lifecycle horizontal geometry SVG width does not cover every rank",
+    );
+  const hops = {};
+  for (let sourceRank = 0; sourceRank < 6; sourceRank += 1) {
+    const targetRank = sourceRank + 1;
+    const sourceCenter = centers[sourceRank];
+    const targetCenter = centers[targetRank];
+    const rankCenterSpacing = targetCenter - sourceCenter;
+    const exitX = sourceCenter + corridorHalfWidth;
+    const entryX = targetCenter - corridorHalfWidth;
+    const transitionSpan = entryX - exitX;
+    const controlMinX = exitX + controlOffset;
+    const controlMaxX = entryX - controlOffset;
+    if (
+      transitionSpan < MINIMUM_TRANSITION_WIDTH ||
+      controlMinX > controlMaxX ||
+      transitionSpan < handleRadius * 2
+    )
+      throw new Error(
+        [
+          "Lifecycle horizontal geometry minimum span invariant violated for",
+          `${sourceRank}->${targetRank}`,
+        ].join(" "),
+      );
+    hops[`${sourceRank}->${targetRank}`] = Object.freeze({
+      sourceRank,
+      targetRank,
+      sourceCenter,
+      targetCenter,
+      rankCenterSpacing,
+      exitX,
+      entryX,
+      controlMinX,
+      controlMaxX,
+      controlSpan: controlMaxX - controlMinX,
+      clearanceMinX: sourceCenter - corridorHalfWidth,
+      clearanceMaxX: targetCenter + corridorHalfWidth,
+      protectedCorridorWidth: corridorHalfWidth * 2,
+      transitionSpan,
+      usableHandleCenterSpan: transitionSpan - handleRadius * 2,
+    });
+  }
+  return Object.freeze({
+    rankCenters: Object.freeze(centers),
+    hops: Object.freeze(hops),
+    ...scalars,
+    svgWidth: minimumSvgWidth,
+  });
+}
+
+export const BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY =
+  createLifecycleHorizontalGeometry();
+
+const horizontalGeometryFor = (value) =>
+  value?.rankCenters && value?.hops
+    ? value
+    : (value?.horizontalGeometry ?? BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY);
+const hopGeometry = (geometry, sourceRank, targetRank = sourceRank + 1) => {
+  const hop = geometry.hops[`${sourceRank}->${targetRank}`];
+  if (!hop)
+    throw new Error(
+      `Lifecycle horizontal geometry missing adjacent hop ${sourceRank}->${targetRank}`,
+    );
+  return hop;
+};
 // A handle candidate's clearance from a *nonincident* route (a different
 // branch's line passing nearby) is a softer concern than clearance from
 // fixed geometry (a node/label box) or from another handle: it's the same
@@ -64,8 +179,12 @@ export const renderedBranchStrokeWidth = () => 3;
 export const selectedEnvelopeRadius = (segment) =>
   (renderedBranchStrokeWidth(segment?.width) + 12) / 2;
 
-export const rendererHitBoxForNode = (node) => {
-  const size = BRANCH_HANDLE_RADIUS * 2;
+export const rendererHitBoxForNode = (
+  node,
+  horizontalGeometry = horizontalGeometryFor(node),
+) => {
+  horizontalGeometry = horizontalGeometryFor(horizontalGeometry);
+  const size = horizontalGeometry.handleRadius * 2;
   const nodeWidth = node.x1 - node.x0;
   const nodeHeight = node.y1 - node.y0;
   const width = Math.max(size, nodeWidth);
@@ -588,12 +707,13 @@ export function calculateLifecycleDiagramLayout(
   projection,
   availableWidth,
   routingGraph,
+  horizontalGeometry = BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
 ) {
   const integerWidth = Math.floor(Number(availableWidth));
   const sanitizedWidth =
     Number.isFinite(integerWidth) && integerWidth > 0
       ? integerWidth
-      : MINIMUM_SVG_WIDTH;
+      : horizontalGeometry.svgWidth;
   const graph = routingGraph ?? buildLifecycleRoutingGraph(projection);
   const rankCounts = new Map();
   for (const node of graph.nodes ?? []) {
@@ -659,7 +779,7 @@ export function calculateLifecycleDiagramLayout(
     densestRoutedRank * PER_LANE_VERTICAL_BUDGET +
     Math.max(0, densestRoutedRank - 1) * ROUTED_NODE_PADDING;
   return {
-    width: Math.max(MINIMUM_SVG_WIDTH, sanitizedWidth),
+    width: Math.max(horizontalGeometry.svgWidth, sanitizedWidth),
     height: Math.max(MINIMUM_SVG_HEIGHT, Math.ceil(densityHeight)),
     nodePadding: ROUTED_NODE_PADDING,
     topMargin: LAYOUT_TOP_MARGIN,
@@ -668,10 +788,10 @@ export function calculateLifecycleDiagramLayout(
   };
 }
 
-export const rankCenterX = (rank) =>
-  LAYOUT_LEFT_MARGIN +
-  SANKEY_NODE_WIDTH / 2 +
-  rank * MINIMUM_RANK_CENTER_SPACING;
+export const rankCenterX = (
+  rank,
+  horizontalGeometry = BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
+) => horizontalGeometry.rankCenters[rank];
 
 // Layout-wide cache of full-geometry signatures already proven infeasible by
 // layoutLifecycleRoutingGraph's candidateCallback, keyed to the specific
@@ -810,6 +930,8 @@ function layoutLifecycleRoutingGraphPass(
   availableWidth,
   options = {},
 ) {
+  const horizontalGeometry =
+    options.horizontalGeometry ?? BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY;
   const enableTestDiagnostics = isLifecycleLayoutTestEnvironment();
   const explicitNodeOrderByRank =
     options.authoritativeNodeOrderByRank ??
@@ -877,7 +999,18 @@ function layoutLifecycleRoutingGraphPass(
     projection,
     availableWidth,
     graph,
+    horizontalGeometry,
   );
+  Object.defineProperty(dimensions, "horizontalGeometry", {
+    value: horizontalGeometry,
+    enumerable: false,
+    configurable: true,
+  });
+  Object.defineProperty(graph, "horizontalGeometry", {
+    value: horizontalGeometry,
+    enumerable: false,
+    configurable: true,
+  });
   const rankLayers = [...new Set(graph.nodes.map((node) => node.rank))].sort(
     (left, right) => left - right,
   );
@@ -885,7 +1018,7 @@ function layoutLifecycleRoutingGraphPass(
   const layout = sankey()
     .nodeId((d) => d.id)
     .nodeAlign((node) => layerByRank.get(node.rank) ?? 0)
-    .nodeWidth(SANKEY_NODE_WIDTH)
+    .nodeWidth(horizontalGeometry.nodeWidth)
     .nodePadding(ROUTED_NODE_PADDING)
     .nodeSort((left, right) => {
       if (baseNodeOrderByRank && left.rank === right.rank) {
@@ -922,19 +1055,19 @@ function layoutLifecycleRoutingGraphPass(
       );
     })
     .extent([
-      [LAYOUT_LEFT_MARGIN, LAYOUT_TOP_MARGIN],
+      [horizontalGeometry.leftMargin, LAYOUT_TOP_MARGIN],
       [
-        dimensions.width - LAYOUT_RIGHT_MARGIN,
+        dimensions.width - horizontalGeometry.rightMargin,
         dimensions.height - LAYOUT_BOTTOM_MARGIN,
       ],
     ]);
   layout(graph);
   for (const node of graph.nodes) {
-    const center = rankCenterX(node.rank);
+    const center = rankCenterX(node.rank, horizontalGeometry);
     if (node.routing) node.x0 = node.x1 = center;
     else {
-      node.x0 = center - SANKEY_NODE_WIDTH / 2;
-      node.x1 = center + SANKEY_NODE_WIDTH / 2;
+      node.x0 = center - horizontalGeometry.nodeWidth / 2;
+      node.x1 = center + horizontalGeometry.nodeWidth / 2;
     }
   }
   layout.update(graph);
@@ -982,19 +1115,22 @@ function layoutLifecycleRoutingGraphPass(
   const labelBoxes = visibleNodes.map((node) => ({
     kind: "label",
     id: node.id,
-    ...labelBoxForNode(node),
+    ...labelBoxForNode(node, horizontalGeometry),
   }));
   const hitBoxes = visibleNodes.map((node) => ({
     kind: "hit",
-    ...rendererHitBoxForNode(node),
+    ...rendererHitBoxForNode(node, horizontalGeometry),
   }));
   const laneObstacles = [...nodeBoxes, ...labelBoxes, ...hitBoxes];
-  const laneTop = BRANCH_HANDLE_RADIUS + 4;
-  const laneBottom = dimensions.height - BRANCH_HANDLE_RADIUS - 4;
+  const laneTop = horizontalGeometry.handleRadius + 4;
+  const laneBottom = dimensions.height - horizontalGeometry.handleRadius - 4;
   const routeEnvelopeRadius = selectedEnvelopeRadius({ width: 1 });
   const clearancePad = routeEnvelopeRadius + 0.25 + LANE_Y_EPSILON;
   const minLaneSpacing =
-    BRANCH_HANDLE_RADIUS * 2 + routeEnvelopeRadius * 2 + 0.25 + LANE_Y_EPSILON;
+    horizontalGeometry.handleRadius * 2 +
+    routeEnvelopeRadius * 2 +
+    0.25 +
+    LANE_Y_EPSILON;
   const quantizeY = (value) => Math.round(value * 1000) / 1000;
   const clampLaneY = (value) =>
     quantizeY(Math.min(laneBottom, Math.max(laneTop, value)));
@@ -1326,10 +1462,8 @@ function layoutLifecycleRoutingGraphPass(
     const variables = links
       .map((link) => {
         const rank = link.source.rank;
-        const exitX = rankCenterX(rank) + RANK_CORRIDOR_HALF_WIDTH;
-        const entryX = rankCenterX(link.target.rank) - RANK_CORRIDOR_HALF_WIDTH;
-        const controlMinX = exitX + TRANSITION_CONTROL_OFFSET;
-        const controlMaxX = entryX - TRANSITION_CONTROL_OFFSET;
+        const hop = hopGeometry(horizontalGeometry, rank, link.target.rank);
+        const { controlMinX, controlMaxX } = hop;
         if (controlMinX > controlMaxX + LANE_Y_EPSILON) {
           throw new Error(
             `Lifecycle transition lane control span invariant violated for ${link.id}`,
@@ -1338,9 +1472,7 @@ function layoutLifecycleRoutingGraphPass(
         // The constant transition lane Y controls the cubic plateau, while
         // clearance is guaranteed across the full source-to-target corridor
         // exercised by the renderer-level obstacle contract.
-        const clearanceMinX = rankCenterX(rank) - RANK_CORRIDOR_HALF_WIDTH;
-        const clearanceMaxX =
-          rankCenterX(link.target.rank) + RANK_CORRIDOR_HALF_WIDTH;
+        const { clearanceMinX, clearanceMaxX } = hop;
         const incidentIds = new Set([link.source.id, link.target.id]);
         const sourceDockY = Number.isFinite(link.y0)
           ? link.y0
@@ -2864,7 +2996,7 @@ function layoutLifecycleRoutingGraphPass(
           compareLifecycleIds(a.node.id, b.node.id)
         );
       });
-      const centerX = rankCenterX(rank);
+      const centerX = rankCenterX(rank, horizontalGeometry);
       const assignment = assignMonotone(
         entries,
         (entry, idealY) =>
@@ -3079,7 +3211,11 @@ function layoutLifecycleRoutingGraphPass(
       graph.branches,
       linksByBranch,
       visibleNodes,
-      { sharedBudget: handleBudget, seedHandles: options.seedHandles },
+      {
+        sharedBudget: handleBudget,
+        seedHandles: options.seedHandles,
+        horizontalGeometry,
+      },
     );
     lastHandleRouteEdgeCount = handleCheck.routeEdgeCount ?? null;
     if (handleCheck.ok) {
@@ -3291,7 +3427,7 @@ function layoutLifecycleRoutingGraphPass(
       error.cause?.reason === "no-feasible-topological-order" &&
       lastHandleFailure
     ) {
-      throw handlePlacementError(lastHandleFailure);
+      throw handlePlacementError(lastHandleFailure, horizontalGeometry);
     }
     // Exhaustive search proved every viable candidate failed routing-anchor
     // materialization (no candidate ever reached handle placement): surface
@@ -3692,6 +3828,7 @@ export function testOnlyDiagnoseLifecycleLayoutAttempt(
         branchDiagnosticCount: reason.branchDiagnostics?.length ?? 0,
         horizontalConstraints: summarizeHandleCandidateConstraints(
           reason.branchDiagnostics ?? [],
+          options.horizontalGeometry ?? BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
         ),
       },
     };
@@ -3815,21 +3952,26 @@ export function testOnlyDiagnoseLifecycleLayoutAttempt(
 }
 
 const point = (x, y) => `${Number(x).toFixed(3)},${Number(y).toFixed(3)}`;
-export function segmentRoutePrimitives(segment) {
-  const sourceCenter = rankCenterX(segment.source.rank);
-  const targetCenter = rankCenterX(segment.target.rank);
+export function segmentRoutePrimitives(
+  segment,
+  horizontalGeometry = horizontalGeometryFor(segment),
+) {
+  const hop = hopGeometry(
+    horizontalGeometry,
+    segment.source.rank,
+    segment.target.rank,
+  );
+  const { sourceCenter, targetCenter, exitX, entryX } = hop;
   const sourceY = segment.y0;
   const targetY = segment.y1;
   const sourceDockX = segment.source.routing ? sourceCenter : segment.source.x1;
   const targetDockX = segment.target.routing ? targetCenter : segment.target.x0;
-  const exitX = sourceCenter + RANK_CORRIDOR_HALF_WIDTH;
-  const entryX = targetCenter - RANK_CORRIDOR_HALF_WIDTH;
   const laneY = Number.isFinite(segment.transitionLaneY)
     ? segment.transitionLaneY
     : targetY;
   const p0 = { x: exitX, y: sourceY };
-  const p1 = { x: exitX + TRANSITION_CONTROL_OFFSET, y: laneY };
-  const p2 = { x: entryX - TRANSITION_CONTROL_OFFSET, y: laneY };
+  const p1 = { x: hop.controlMinX, y: laneY };
+  const p2 = { x: hop.controlMaxX, y: laneY };
   const p3 = { x: entryX, y: targetY };
   return [
     {
@@ -3850,8 +3992,14 @@ export function segmentRoutePrimitives(segment) {
   ];
 }
 
-export function adjacentRankSegmentPath(segment) {
-  const [source, cubic, target] = segmentRoutePrimitives(segment);
+export function adjacentRankSegmentPath(
+  segment,
+  horizontalGeometry = horizontalGeometryFor(segment),
+) {
+  const [source, cubic, target] = segmentRoutePrimitives(
+    segment,
+    horizontalGeometry,
+  );
   return [
     `M${point(source.p0.x, source.p0.y)}`,
     `L${point(source.p1.x, source.p1.y)}`,
@@ -3864,8 +4012,13 @@ export function adjacentRankSegmentPath(segment) {
   ].join("");
 }
 
-export function compoundBranchPath(segments) {
-  return segments.map(adjacentRankSegmentPath).join("");
+export function compoundBranchPath(
+  segments,
+  horizontalGeometry = horizontalGeometryFor(segments[0]),
+) {
+  return segments
+    .map((segment) => adjacentRankSegmentPath(segment, horizontalGeometry))
+    .join("");
 }
 
 export function wrapLifecycleLabel(
@@ -3890,17 +4043,25 @@ export function wrapLifecycleLabel(
   );
 }
 
-export function labelBoxForNode(node) {
+export function labelBoxForNode(
+  node,
+  horizontalGeometry = horizontalGeometryFor(node),
+) {
+  horizontalGeometry = horizontalGeometryFor(horizontalGeometry);
   const lines = wrapLifecycleLabel(node.label);
   const width = NODE_LABEL_MAX_WIDTH;
   const height = lines.length * 16;
-  const x = Math.max(0, rankCenterX(node.rank) - width / 2);
+  const x = Math.max(0, rankCenterX(node.rank, horizontalGeometry) - width / 2);
   const y = Math.max(0, node.y0 - height - 12);
   return { x, y, width, height, lines };
 }
 
-export const cubicTransitionPoint = (segment, t) => {
-  const cubic = segmentRoutePrimitives(segment)[1];
+export const cubicTransitionPoint = (
+  segment,
+  t,
+  horizontalGeometry = horizontalGeometryFor(segment),
+) => {
+  const cubic = segmentRoutePrimitives(segment, horizontalGeometry)[1];
   const oneMinus = 1 - t;
   return {
     x:
@@ -3925,6 +4086,8 @@ const segmentKey = (segment) =>
   `${segment.branchId ?? ""}:${segment.segmentIndex ?? ""}:${segment.id ?? ""}`;
 
 export function buildLifecycleRouteModel(graph, dimensions) {
+  const horizontalGeometry =
+    dimensions?.horizontalGeometry ?? horizontalGeometryFor(graph);
   const branches = [...(graph.branches ?? [])].sort(compareBranches);
   const segmentsByBranch = new Map();
   const segmentsByTransitionRank = Array.from({ length: 6 }, () => []);
@@ -3972,6 +4135,7 @@ export function buildLifecycleRouteModel(graph, dimensions) {
   return {
     graph,
     dimensions,
+    horizontalGeometry,
     branches,
     segmentsByBranch,
     segmentsByTransitionRank,
@@ -4015,8 +4179,11 @@ export function flattenLifecycleCubic(cubic, depth = 0) {
   );
 }
 
-export const flattenRouteSegment = (segment) =>
-  segmentRoutePrimitives(segment).flatMap((primitive) =>
+export const flattenRouteSegment = (
+  segment,
+  horizontalGeometry = horizontalGeometryFor(segment),
+) =>
+  segmentRoutePrimitives(segment, horizontalGeometry).flatMap((primitive) =>
     primitive.type === "line"
       ? [{ p0: primitive.p0, p1: primitive.p1, primitive }]
       : flattenLifecycleCubic(primitive).map((edge) => ({
@@ -4034,16 +4201,18 @@ export const routeEdgesByBranch = (graphOrModel) => {
     const edges = [];
     for (const segment of segments) {
       edges.push(
-        ...flattenRouteSegment(segment).map((edge) => ({
-          ...edge,
-          branchId,
-          segmentId: segmentKey(segment),
-          segmentIndex: segment.segmentIndex,
-          transitionRank: segment.source?.rank,
-          zone: edge.primitive?.zone,
-          envelopeRadius: selectedEnvelopeRadius(segment),
-          segment,
-        })),
+        ...flattenRouteSegment(segment, model.horizontalGeometry).map(
+          (edge) => ({
+            ...edge,
+            branchId,
+            segmentId: segmentKey(segment),
+            segmentIndex: segment.segmentIndex,
+            transitionRank: segment.source?.rank,
+            zone: edge.primitive?.zone,
+            envelopeRadius: selectedEnvelopeRadius(segment),
+            segment,
+          }),
+        ),
       );
     }
     edgesByBranch.set(branchId, edges);
@@ -4097,11 +4266,13 @@ export function auditLifecycleRouteGeometry({
       }
       try {
         flatEdges.push(
-          ...flattenRouteSegment(segment).map((edge) => ({
-            ...edge,
-            branchId,
-            segment,
-          })),
+          ...flattenRouteSegment(segment, routeModel.horizontalGeometry).map(
+            (edge) => ({
+              ...edge,
+              branchId,
+              segment,
+            }),
+          ),
         );
       } catch (error) {
         add("cubic-flattening-depth", segment, { message: error.message });
@@ -4117,8 +4288,15 @@ export function auditLifecycleRouteGeometry({
       width: node.x1 - node.x0,
       height: node.y1 - node.y0,
     },
-    { kind: "label", id: node.id, ...labelBoxForNode(node) },
-    { kind: "hit", ...rendererHitBoxForNode(node) },
+    {
+      kind: "label",
+      id: node.id,
+      ...labelBoxForNode(node, routeModel.horizontalGeometry),
+    },
+    {
+      kind: "hit",
+      ...rendererHitBoxForNode(node, routeModel.horizontalGeometry),
+    },
   ]);
   for (const edge of flatEdges) {
     const pad = selectedEnvelopeRadius(edge.segment) + 0.25 + LANE_Y_EPSILON;
@@ -4241,10 +4419,10 @@ export function auditLifecycleRouteGeometry({
   }
   for (const handle of handles) {
     const box = handle.box ?? {
-      x: handle.x - BRANCH_HANDLE_RADIUS,
-      y: handle.y - BRANCH_HANDLE_RADIUS,
-      width: BRANCH_HANDLE_RADIUS * 2,
-      height: BRANCH_HANDLE_RADIUS * 2,
+      x: handle.x - routeModel.horizontalGeometry.handleRadius,
+      y: handle.y - routeModel.horizontalGeometry.handleRadius,
+      width: routeModel.horizontalGeometry.handleRadius * 2,
+      height: routeModel.horizontalGeometry.handleRadius * 2,
     };
     for (const fixed of fixedBoxes) {
       if (boxesOverlap(box, fixed))
@@ -4270,7 +4448,7 @@ export function auditLifecycleRouteGeometry({
     for (const handle of handles) {
       if (!handle || handle.branchId === edge.branchId) continue;
       const required = routeHandleRequiredClearance(
-        BRANCH_HANDLE_RADIUS,
+        routeModel.horizontalGeometry.handleRadius,
         selectedEnvelopeRadius(edge.segment),
         LANE_Y_EPSILON,
       );
@@ -4510,7 +4688,10 @@ export const solveHandleCandidateSets = (
   return { ok: true, selected };
 };
 
-const handlePlacementError = (result) => {
+const handlePlacementError = (
+  result,
+  horizontalGeometry = BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
+) => {
   const branchId = result.blockedBranchIds?.[0] ?? "unknown branch";
   const error = new Error(
     `Lifecycle diagram handle placement invariant violated for ${branchId}`,
@@ -4524,13 +4705,17 @@ const handlePlacementError = (result) => {
     branches: [...(result.branchDiagnostics ?? [])],
     horizontalConstraints: summarizeHandleCandidateConstraints(
       result.branchDiagnostics ?? [],
+      horizontalGeometry,
     ),
     component: result.component ?? null,
   });
   return error;
 };
 
-export function summarizeHandleCandidateConstraints(branchDiagnostics) {
+export function summarizeHandleCandidateConstraints(
+  branchDiagnostics,
+  horizontalGeometry = BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
+) {
   const emptySweep = () => ({
     attempts: 0,
     rejected: {
@@ -4562,8 +4747,7 @@ export function summarizeHandleCandidateConstraints(branchDiagnostics) {
         (nearestBlockerKinds[blockerKind] ?? 0) + 1;
     }
   }
-  const transitionSpan =
-    MINIMUM_RANK_CENTER_SPACING - 2 * RANK_CORRIDOR_HALF_WIDTH;
+  const hop = hopGeometry(horizontalGeometry, 0);
   return {
     attempts,
     rejected,
@@ -4573,11 +4757,11 @@ export function summarizeHandleCandidateConstraints(branchDiagnostics) {
         compareLifecycleIds(left, right),
       ),
     ),
-    rankCenterSpacing: MINIMUM_RANK_CENTER_SPACING,
-    protectedCorridorWidth: 2 * RANK_CORRIDOR_HALF_WIDTH,
-    transitionSpan,
-    handleDiameter: 2 * BRANCH_HANDLE_RADIUS,
-    usableHandleCenterSpan: transitionSpan - 2 * BRANCH_HANDLE_RADIUS,
+    rankCenterSpacing: hop.rankCenterSpacing,
+    protectedCorridorWidth: hop.protectedCorridorWidth,
+    transitionSpan: hop.transitionSpan,
+    handleDiameter: 2 * horizontalGeometry.handleRadius,
+    usableHandleCenterSpan: hop.usableHandleCenterSpan,
   };
 }
 
@@ -4585,7 +4769,11 @@ const tryAssignBranchHandles = (
   branches,
   segmentsByBranch,
   visibleNodes = [],
-  { sharedBudget = null, seedHandles = null } = {},
+  {
+    sharedBudget = null,
+    seedHandles = null,
+    horizontalGeometry = BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
+  } = {},
 ) => {
   const nodeBoxes = visibleNodes.map((node) => ({
     x: node.x0,
@@ -4593,12 +4781,14 @@ const tryAssignBranchHandles = (
     width: node.x1 - node.x0,
     height: node.y1 - node.y0,
   }));
-  const labelBoxes = visibleNodes.map(labelBoxForNode);
+  const labelBoxes = visibleNodes.map((node) =>
+    labelBoxForNode(node, horizontalGeometry),
+  );
   const routeEdges = [];
   for (const [branchId, segments] of segmentsByBranch) {
     for (const segment of segments) {
       routeEdges.push(
-        ...flattenRouteSegment(segment).map((edge) => ({
+        ...flattenRouteSegment(segment, horizontalGeometry).map((edge) => ({
           ...edge,
           branchId,
           segmentId: segmentKey(segment),
@@ -4611,7 +4801,9 @@ const tryAssignBranchHandles = (
       );
     }
   }
-  const hitBoxes = visibleNodes.map(rendererHitBoxForNode);
+  const hitBoxes = visibleNodes.map((node) =>
+    rendererHitBoxForNode(node, horizontalGeometry),
+  );
   const routeEdgesByTransitionRank = new Map();
   for (const edge of routeEdges) {
     const rank = edge.transitionRank ?? null;
@@ -4629,7 +4821,10 @@ const tryAssignBranchHandles = (
     group.maxX = Math.max(group.maxX, edge.p0.x, edge.p1.x);
     group.maxRequired = Math.max(
       group.maxRequired,
-      BRANCH_HANDLE_RADIUS + edge.envelopeRadius + 0.25 + LANE_Y_EPSILON,
+      horizontalGeometry.handleRadius +
+        edge.envelopeRadius +
+        0.25 +
+        LANE_Y_EPSILON,
     );
   }
   const fixedGeometry = [
@@ -4665,7 +4860,10 @@ const tryAssignBranchHandles = (
       for (const edge of group.edges) {
         if (edge.branchId === branch.id) continue;
         const required =
-          BRANCH_HANDLE_RADIUS + edge.envelopeRadius + 0.25 + LANE_Y_EPSILON;
+          horizontalGeometry.handleRadius +
+          edge.envelopeRadius +
+          0.25 +
+          LANE_Y_EPSILON;
         const distance = pointToSegmentDistance({ x, y }, edge);
         const margin = distance - required;
         if (
@@ -4771,10 +4969,10 @@ const tryAssignBranchHandles = (
         continue;
       }
       const box = {
-        x: seeded.x - BRANCH_HANDLE_RADIUS,
-        y: seeded.y - BRANCH_HANDLE_RADIUS,
-        width: BRANCH_HANDLE_RADIUS * 2,
-        height: BRANCH_HANDLE_RADIUS * 2,
+        x: seeded.x - horizontalGeometry.handleRadius,
+        y: seeded.y - horizontalGeometry.handleRadius,
+        width: horizontalGeometry.handleRadius * 2,
+        height: horizontalGeometry.handleRadius * 2,
       };
       const fixedBlocker = fixedGeometryBlockerForCandidate(box);
       if (fixedBlocker) {
@@ -4812,12 +5010,12 @@ const tryAssignBranchHandles = (
         branchId: branch.id,
         x: seeded.x,
         y: seeded.y,
-        radius: BRANCH_HANDLE_RADIUS,
+        radius: horizontalGeometry.handleRadius,
         box: {
-          x: seeded.x - BRANCH_HANDLE_RADIUS,
-          y: seeded.y - BRANCH_HANDLE_RADIUS,
-          width: BRANCH_HANDLE_RADIUS * 2,
-          height: BRANCH_HANDLE_RADIUS * 2,
+          x: seeded.x - horizontalGeometry.handleRadius,
+          y: seeded.y - horizontalGeometry.handleRadius,
+          width: horizontalGeometry.handleRadius * 2,
+          height: horizontalGeometry.handleRadius * 2,
         },
         clearanceMargin: seeded.clearanceMargin ?? 0,
       };
@@ -4923,17 +5121,20 @@ const tryAssignBranchHandles = (
     };
     const sweepCorridor = (sweepName, tValues, corridorHalfWidth) => {
       for (const segment of orderedSegments) {
-        const sourceCenter = rankCenterX(segment.source.rank);
-        const targetCenter = rankCenterX(segment.target.rank);
-        const exitX = sourceCenter + corridorHalfWidth;
-        const entryX = targetCenter - corridorHalfWidth;
+        const hop = hopGeometry(
+          horizontalGeometry,
+          segment.source.rank,
+          segment.target.rank,
+        );
+        const exitX = hop.sourceCenter + corridorHalfWidth;
+        const entryX = hop.targetCenter - corridorHalfWidth;
         for (const t of tValues) {
-          const { x, y } = cubicTransitionPoint(segment, t);
+          const { x, y } = cubicTransitionPoint(segment, t, horizontalGeometry);
           const box = {
-            x: x - BRANCH_HANDLE_RADIUS,
-            y: y - BRANCH_HANDLE_RADIUS,
-            width: BRANCH_HANDLE_RADIUS * 2,
-            height: BRANCH_HANDLE_RADIUS * 2,
+            x: x - horizontalGeometry.handleRadius,
+            y: y - horizontalGeometry.handleRadius,
+            width: horizontalGeometry.handleRadius * 2,
+            height: horizontalGeometry.handleRadius * 2,
           };
           diagnostic.attempts += 1;
           diagnostic.sweeps[sweepName].attempts += 1;
@@ -4964,8 +5165,8 @@ const tryAssignBranchHandles = (
             continue;
           }
           if (
-            x - BRANCH_HANDLE_RADIUS < exitX ||
-            x + BRANCH_HANDLE_RADIUS > entryX
+            x - horizontalGeometry.handleRadius < exitX ||
+            x + horizontalGeometry.handleRadius > entryX
           ) {
             diagnostic.rejected.outsideTransitionCorridor += 1;
             diagnostic.sweeps[sweepName].rejected.outsideTransitionCorridor +=
@@ -4997,7 +5198,7 @@ const tryAssignBranchHandles = (
               branchId: branch.id,
               x,
               y,
-              radius: BRANCH_HANDLE_RADIUS,
+              radius: horizontalGeometry.handleRadius,
               box,
               clearanceMargin,
             });
@@ -5007,7 +5208,7 @@ const tryAssignBranchHandles = (
               branchId: branch.id,
               x,
               y,
-              radius: BRANCH_HANDLE_RADIUS,
+              radius: horizontalGeometry.handleRadius,
               box,
               clearanceMargin,
             });
@@ -5027,13 +5228,13 @@ const tryAssignBranchHandles = (
     sweepCorridor(
       "primary",
       HANDLE_CANDIDATE_T_VALUES,
-      RANK_CORRIDOR_HALF_WIDTH,
+      horizontalGeometry.corridorHalfWidth,
     );
     if (!candidates.length) {
       sweepCorridor(
         "fallback",
         HANDLE_FALLBACK_CANDIDATE_T_VALUES,
-        RANK_CORRIDOR_HALF_WIDTH,
+        horizontalGeometry.corridorHalfWidth,
       );
     }
     // Only fall back to a degraded (small negative clearance) candidate
@@ -5096,12 +5297,14 @@ export function assignBranchHandles(
   branches,
   segmentsByBranch,
   visibleNodes = [],
+  horizontalGeometry = BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
 ) {
   const result = tryAssignBranchHandles(
     branches,
     segmentsByBranch,
     visibleNodes,
+    { horizontalGeometry },
   );
   if (result.ok) return result.handles;
-  throw handlePlacementError(result);
+  throw handlePlacementError(result, horizontalGeometry);
 }

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -53,20 +53,21 @@ export const BRANCH_HANDLE_RADIUS = 22;
 const LIFECYCLE_RANKS = Object.freeze([0, 1, 2, 3, 4, 5, 6]);
 
 export function createLifecycleHorizontalGeometry({
+  leftMargin = LAYOUT_LEFT_MARGIN,
+  rightMargin = LAYOUT_RIGHT_MARGIN,
+  nodeWidth = SANKEY_NODE_WIDTH,
   rankCenters = Object.fromEntries(
     LIFECYCLE_RANKS.map((rank) => [
       rank,
-      LAYOUT_LEFT_MARGIN +
-        SANKEY_NODE_WIDTH / 2 +
-        rank * MINIMUM_RANK_CENTER_SPACING,
+      leftMargin + nodeWidth / 2 + rank * MINIMUM_RANK_CENTER_SPACING,
     ]),
   ),
   corridorHalfWidth = RANK_CORRIDOR_HALF_WIDTH,
   controlOffset = TRANSITION_CONTROL_OFFSET,
-  leftMargin = LAYOUT_LEFT_MARGIN,
-  rightMargin = LAYOUT_RIGHT_MARGIN,
-  nodeWidth = SANKEY_NODE_WIDTH,
-  minimumSvgWidth = MINIMUM_SVG_WIDTH,
+  minimumSvgWidth = leftMargin +
+    rightMargin +
+    nodeWidth +
+    6 * MINIMUM_RANK_CENTER_SPACING,
   handleRadius = BRANCH_HANDLE_RADIUS,
 } = {}) {
   const centers = {};
@@ -4747,8 +4748,32 @@ export function summarizeHandleCandidateConstraints(
         (nearestBlockerKinds[blockerKind] ?? 0) + 1;
     }
   }
-  const hop = hopGeometry(horizontalGeometry, 0);
-  return {
+  const transitionRanks = [
+    ...new Set(
+      branchDiagnostics.flatMap((diagnostic) =>
+        diagnostic.transitionRanks?.length
+          ? diagnostic.transitionRanks
+          : [diagnostic.nearestRejectedCandidate?.transitionRank],
+      ),
+    ),
+  ]
+    .filter(Number.isInteger)
+    .sort((left, right) => left - right);
+  const constrainedHops = Object.fromEntries(
+    transitionRanks.map((sourceRank) => {
+      const hop = hopGeometry(horizontalGeometry, sourceRank);
+      return [
+        `${sourceRank}->${sourceRank + 1}`,
+        {
+          rankCenterSpacing: hop.rankCenterSpacing,
+          protectedCorridorWidth: hop.protectedCorridorWidth,
+          transitionSpan: hop.transitionSpan,
+          usableHandleCenterSpan: hop.usableHandleCenterSpan,
+        },
+      ];
+    }),
+  );
+  const result = {
     attempts,
     rejected,
     sweeps,
@@ -4757,12 +4782,15 @@ export function summarizeHandleCandidateConstraints(
         compareLifecycleIds(left, right),
       ),
     ),
-    rankCenterSpacing: hop.rankCenterSpacing,
-    protectedCorridorWidth: hop.protectedCorridorWidth,
-    transitionSpan: hop.transitionSpan,
+    hops: constrainedHops,
     handleDiameter: 2 * horizontalGeometry.handleRadius,
-    usableHandleCenterSpan: hop.usableHandleCenterSpan,
   };
+  const distinctConstraints = [
+    ...new Set(Object.values(constrainedHops).map(JSON.stringify)),
+  ];
+  if (distinctConstraints.length === 1)
+    Object.assign(result, JSON.parse(distinctConstraints[0]));
+  return result;
 }
 
 const tryAssignBranchHandles = (
@@ -5068,6 +5096,11 @@ const tryAssignBranchHandles = (
     const degradedCandidates = [];
     const diagnostic = {
       branchId: branch.id,
+      transitionRanks: [
+        ...new Set(orderedSegments.map((segment) => segment.source?.rank)),
+      ]
+        .filter(Number.isInteger)
+        .sort((left, right) => left - right),
       segmentsExamined: orderedSegments.length,
       attempts: 0,
       accepted: 0,

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -51,6 +51,9 @@ export const BRANCH_STROKE_OPACITY = 0.82;
 export const BRANCH_HANDLE_RADIUS = 22;
 
 const LIFECYCLE_RANKS = Object.freeze([0, 1, 2, 3, 4, 5, 6]);
+const HANDLE_DIAGNOSTIC_TRANSITION_RANKS = Symbol(
+  "handleDiagnosticTransitionRanks",
+);
 
 export function createLifecycleHorizontalGeometry({
   leftMargin = LAYOUT_LEFT_MARGIN,
@@ -4766,9 +4769,11 @@ export function summarizeHandleCandidateConstraints(
   const transitionRanks = [
     ...new Set(
       branchDiagnostics.flatMap((diagnostic) =>
-        diagnostic.transitionRanks?.length
-          ? diagnostic.transitionRanks
-          : [diagnostic.nearestRejectedCandidate?.transitionRank],
+        diagnostic[HANDLE_DIAGNOSTIC_TRANSITION_RANKS]?.length
+          ? diagnostic[HANDLE_DIAGNOSTIC_TRANSITION_RANKS]
+          : diagnostic.transitionRanks?.length
+            ? diagnostic.transitionRanks
+            : [diagnostic.nearestRejectedCandidate?.transitionRank],
       ),
     ),
   ]
@@ -4800,15 +4805,22 @@ export function summarizeHandleCandidateConstraints(
         compareLifecycleIds(left, right),
       ),
     ),
-    handleDiameter: 2 * horizontalGeometry.handleRadius,
   };
   const distinctConstraints = [
     ...new Set(Object.values(constrainedHops).map(JSON.stringify)),
   ];
   if (distinctConstraints.length <= 1) {
     const [constraints] = Object.values(constrainedHops);
-    if (constraints) Object.assign(result, constraints);
+    if (constraints) {
+      result.rankCenterSpacing = constraints.rankCenterSpacing;
+      result.protectedCorridorWidth = constraints.protectedCorridorWidth;
+      result.transitionSpan = constraints.transitionSpan;
+    }
+    result.handleDiameter = 2 * horizontalGeometry.handleRadius;
+    if (constraints)
+      result.usableHandleCenterSpan = constraints.usableHandleCenterSpan;
   } else {
+    result.handleDiameter = 2 * horizontalGeometry.handleRadius;
     result.hops = constrainedHops;
   }
   return result;
@@ -5117,11 +5129,6 @@ const tryAssignBranchHandles = (
     const degradedCandidates = [];
     const diagnostic = {
       branchId: branch.id,
-      transitionRanks: [
-        ...new Set(orderedSegments.map((segment) => segment.source?.rank)),
-      ]
-        .filter(Number.isInteger)
-        .sort((left, right) => left - right),
       segmentsExamined: orderedSegments.length,
       attempts: 0,
       accepted: 0,
@@ -5150,6 +5157,16 @@ const tryAssignBranchHandles = (
       },
       nearestRejectedCandidate: null,
     };
+    Object.defineProperty(diagnostic, HANDLE_DIAGNOSTIC_TRANSITION_RANKS, {
+      value: Object.freeze(
+        [...new Set(orderedSegments.map((segment) => segment.source?.rank))]
+          .filter(Number.isInteger)
+          .sort((left, right) => left - right),
+      ),
+      enumerable: false,
+      writable: false,
+      configurable: false,
+    });
     const rememberRejected = (candidate) => {
       if (
         !diagnostic.nearestRejectedCandidate ||

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -64,12 +64,17 @@ export function createLifecycleHorizontalGeometry({
   ),
   corridorHalfWidth = RANK_CORRIDOR_HALF_WIDTH,
   controlOffset = TRANSITION_CONTROL_OFFSET,
-  minimumSvgWidth = leftMargin +
-    rightMargin +
-    nodeWidth +
-    6 * MINIMUM_RANK_CENTER_SPACING,
+  minimumSvgWidth,
   handleRadius = BRANCH_HANDLE_RADIUS,
 } = {}) {
+  const rankKeys = Object.keys(rankCenters).sort();
+  if (
+    rankKeys.length !== LIFECYCLE_RANKS.length ||
+    rankKeys.some((rank, index) => rank !== String(LIFECYCLE_RANKS[index]))
+  )
+    throw new Error(
+      "Lifecycle horizontal geometry rank centers must cover exactly ranks 0..6",
+    );
   const centers = {};
   for (const rank of LIFECYCLE_RANKS) {
     const value = rankCenters[rank];
@@ -83,13 +88,19 @@ export function createLifecycleHorizontalGeometry({
       );
     centers[rank] = value;
   }
+  const baselineWidth =
+    leftMargin + rightMargin + nodeWidth + 6 * MINIMUM_RANK_CENTER_SPACING;
+  const leftOuterExtent = centers[0] - nodeWidth / 2;
+  const rightOuterExtent = centers[6] + nodeWidth / 2;
+  const svgWidth =
+    minimumSvgWidth ?? Math.max(baselineWidth, rightOuterExtent + rightMargin);
   const scalars = {
     corridorHalfWidth,
     controlOffset,
     leftMargin,
     rightMargin,
     nodeWidth,
-    minimumSvgWidth,
+    minimumSvgWidth: svgWidth,
     handleRadius,
   };
   for (const [name, value] of Object.entries(scalars)) {
@@ -98,7 +109,11 @@ export function createLifecycleHorizontalGeometry({
         `Lifecycle horizontal geometry ${name} must be finite and nonnegative`,
       );
   }
-  if (minimumSvgWidth < centers[6] + nodeWidth / 2 + rightMargin)
+  if (leftOuterExtent < leftMargin)
+    throw new Error(
+      "Lifecycle horizontal geometry left outer extent does not preserve its margin",
+    );
+  if (svgWidth < rightOuterExtent + rightMargin)
     throw new Error(
       "Lifecycle horizontal geometry SVG width does not cover every rank",
     );
@@ -146,7 +161,7 @@ export function createLifecycleHorizontalGeometry({
     rankCenters: Object.freeze(centers),
     hops: Object.freeze(hops),
     ...scalars,
-    svgWidth: minimumSvgWidth,
+    svgWidth,
   });
 }
 
@@ -4759,8 +4774,11 @@ export function summarizeHandleCandidateConstraints(
   ]
     .filter(Number.isInteger)
     .sort((left, right) => left - right);
+  const representedTransitionRanks = transitionRanks.length
+    ? transitionRanks
+    : [0];
   const constrainedHops = Object.fromEntries(
-    transitionRanks.map((sourceRank) => {
+    representedTransitionRanks.map((sourceRank) => {
       const hop = hopGeometry(horizontalGeometry, sourceRank);
       return [
         `${sourceRank}->${sourceRank + 1}`,
@@ -4782,14 +4800,17 @@ export function summarizeHandleCandidateConstraints(
         compareLifecycleIds(left, right),
       ),
     ),
-    hops: constrainedHops,
     handleDiameter: 2 * horizontalGeometry.handleRadius,
   };
   const distinctConstraints = [
     ...new Set(Object.values(constrainedHops).map(JSON.stringify)),
   ];
-  if (distinctConstraints.length === 1)
-    Object.assign(result, JSON.parse(distinctConstraints[0]));
+  if (distinctConstraints.length <= 1) {
+    const [constraints] = Object.values(constrainedHops);
+    if (constraints) Object.assign(result, constraints);
+  } else {
+    result.hops = constrainedHops;
+  }
   return result;
 }
 
@@ -5152,15 +5173,14 @@ const tryAssignBranchHandles = (
         diagnostic.nearestRejectedCandidate = candidate;
       }
     };
-    const sweepCorridor = (sweepName, tValues, corridorHalfWidth) => {
+    const sweepCorridor = (sweepName, tValues) => {
       for (const segment of orderedSegments) {
         const hop = hopGeometry(
           horizontalGeometry,
           segment.source.rank,
           segment.target.rank,
         );
-        const exitX = hop.sourceCenter + corridorHalfWidth;
-        const entryX = hop.targetCenter - corridorHalfWidth;
+        const { exitX, entryX } = hop;
         for (const t of tValues) {
           const { x, y } = cubicTransitionPoint(segment, t, horizontalGeometry);
           const box = {
@@ -5258,17 +5278,9 @@ const tryAssignBranchHandles = (
         }
       }
     };
-    sweepCorridor(
-      "primary",
-      HANDLE_CANDIDATE_T_VALUES,
-      horizontalGeometry.corridorHalfWidth,
-    );
+    sweepCorridor("primary", HANDLE_CANDIDATE_T_VALUES);
     if (!candidates.length) {
-      sweepCorridor(
-        "fallback",
-        HANDLE_FALLBACK_CANDIDATE_T_VALUES,
-        horizontalGeometry.corridorHalfWidth,
-      );
+      sweepCorridor("fallback", HANDLE_FALLBACK_CANDIDATE_T_VALUES);
     }
     // Only fall back to a degraded (small negative clearance) candidate
     // when this branch has no fully-clear candidate anywhere across both

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -7,6 +7,7 @@ import {
   projectLifecycleAt,
 } from "../src/web/tracker/lifecycleProjection.js";
 import {
+  BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
   BRANCH_HANDLE_RADIUS,
   BRANCH_STROKE_OPACITY,
   HANDLE_CLEARANCE_TOLERANCE,
@@ -37,6 +38,7 @@ import {
   compareBranches,
   compareLifecycleIds,
   createLaneGeometryFailureCache,
+  createLifecycleHorizontalGeometry,
   cubicTransitionPoint,
   edgeCrossing,
   endpointColor,
@@ -63,6 +65,85 @@ import {
 } from "../src/web/tracker/lifecycleDiagramLayout.js";
 
 const projection = () => projectLifecycleAt(routingFixture);
+
+describe("lifecycle horizontal geometry", () => {
+  it("constructs deterministic deeply immutable baseline rank and hop geometry", () => {
+    const first = createLifecycleHorizontalGeometry();
+    const second = createLifecycleHorizontalGeometry();
+
+    expect(first).toEqual(second);
+    expect(first).toEqual(BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(Object.isFrozen(first.rankCenters)).toBe(true);
+    expect(Object.isFrozen(first.hops)).toBe(true);
+    expect(Object.isFrozen(first.hops["0->1"])).toBe(true);
+    expect(first.rankCenters[0]).toBe(109);
+    expect(first.rankCenters[6]).toBe(1741);
+    expect(first.hops["0->1"]).toMatchObject({
+      sourceRank: 0,
+      targetRank: 1,
+      rankCenterSpacing: 272,
+      protectedCorridorWidth: 200,
+      transitionSpan: 72,
+      controlSpan: 24,
+      usableHandleCenterSpan: 28,
+    });
+    expect(first.handleRadius * 2).toBe(44);
+    expect(first.svgWidth).toBe(MINIMUM_SVG_WIDTH);
+  });
+
+  it("validates finite, complete, monotonic rank centers and hop spans", () => {
+    const centers = { ...BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY.rankCenters };
+    expect(() =>
+      createLifecycleHorizontalGeometry({
+        rankCenters: { ...centers, 3: Number.NaN },
+      }),
+    ).toThrow(/finite rank 3 center/u);
+    expect(() =>
+      createLifecycleHorizontalGeometry({
+        rankCenters: { ...centers, 3: 653 },
+      }),
+    ).toThrow(/increase monotonically/u);
+    expect(() =>
+      createLifecycleHorizontalGeometry({
+        rankCenters: { ...centers, 1: 300 },
+      }),
+    ).toThrow(/minimum span invariant/u);
+    expect(() =>
+      createLifecycleHorizontalGeometry({ controlOffset: Infinity }),
+    ).toThrow(/must be finite and nonnegative/u);
+  });
+
+  it("uses rank and hop keys rather than array-position identity", () => {
+    const centers = Object.fromEntries(
+      Object.entries(
+        BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY.rankCenters,
+      ).reverse(),
+    );
+    const geometry = createLifecycleHorizontalGeometry({
+      rankCenters: centers,
+    });
+    expect(geometry.rankCenters[4]).toBe(rankCenterX(4));
+    expect(geometry.hops["4->5"].exitX).toBe(1297);
+    expect(geometry.hops["4->5"].entryX).toBe(1369);
+  });
+
+  it("threads one geometry identity through layout and the route model", () => {
+    const horizontalGeometry = createLifecycleHorizontalGeometry();
+    const { graph, dimensions } = layoutLifecycleRoutingGraph(
+      projection(),
+      1850,
+      {
+        horizontalGeometry,
+      },
+    );
+    const model = buildLifecycleRouteModel(graph, dimensions);
+
+    expect(graph.horizontalGeometry).toBe(horizontalGeometry);
+    expect(dimensions.horizontalGeometry).toBe(horizontalGeometry);
+    expect(model.horizontalGeometry).toBe(horizontalGeometry);
+  });
+});
 const deepFreeze = (value) => {
   if (!value || typeof value !== "object" || Object.isFrozen(value))
     return value;

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -114,6 +114,58 @@ describe("lifecycle horizontal geometry", () => {
     ).toThrow(/must be finite and nonnegative/u);
   });
 
+  it("derives default rank centers and width from overridden frame dimensions", () => {
+    const geometry = createLifecycleHorizontalGeometry({
+      leftMargin: 140,
+      rightMargin: 120,
+      nodeWidth: 30,
+    });
+
+    expect(geometry.rankCenters[0]).toBe(155);
+    expect(geometry.rankCenters[6]).toBe(1787);
+    expect(geometry.svgWidth).toBe(1922);
+  });
+
+  it("summarizes the nonuniform hops that constrained handle candidates", () => {
+    const rankCenters = {
+      ...BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY.rankCenters,
+    };
+    for (let rank = 3; rank <= 6; rank += 1) rankCenters[rank] += 100;
+    const geometry = createLifecycleHorizontalGeometry({
+      rankCenters,
+      minimumSvgWidth: 2000,
+    });
+    const diagnostics = [
+      {
+        branchId: "branch:a",
+        transitionRanks: [0, 2],
+        attempts: 0,
+        rejected: {},
+        sweeps: {},
+      },
+    ];
+
+    const constraints = summarizeHandleCandidateConstraints(
+      diagnostics,
+      geometry,
+    );
+    expect(constraints.hops).toEqual({
+      "0->1": {
+        rankCenterSpacing: 272,
+        protectedCorridorWidth: 200,
+        transitionSpan: 72,
+        usableHandleCenterSpan: 28,
+      },
+      "2->3": {
+        rankCenterSpacing: 372,
+        protectedCorridorWidth: 200,
+        transitionSpan: 172,
+        usableHandleCenterSpan: 128,
+      },
+    });
+    expect(constraints).not.toHaveProperty("rankCenterSpacing");
+  });
+
   it("uses rank and hop keys rather than array-position identity", () => {
     const centers = Object.fromEntries(
       Object.entries(
@@ -2758,6 +2810,12 @@ describe("lifecycle diagram render-only routing layout", () => {
       (visible.y0 + visible.y1) / 2,
       6,
     );
+    const smallerTarget = rendererHitBoxForNode(
+      visible,
+      createLifecycleHorizontalGeometry({ handleRadius: 16 }),
+    );
+    expect(smallerTarget.width).toBe(Math.max(32, visible.x1 - visible.x0));
+    expect(smallerTarget.height).toBe(Math.max(32, visible.y1 - visible.y0));
   });
 
   it("uses exact protected-corridor width calculations and deterministic sorting", () => {

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -112,6 +112,16 @@ describe("lifecycle horizontal geometry", () => {
     expect(() =>
       createLifecycleHorizontalGeometry({ controlOffset: Infinity }),
     ).toThrow(/must be finite and nonnegative/u);
+    expect(() =>
+      createLifecycleHorizontalGeometry({
+        rankCenters: { ...centers, 7: 2000 },
+      }),
+    ).toThrow(/cover exactly ranks 0\.\.6/u);
+    expect(() =>
+      createLifecycleHorizontalGeometry({
+        rankCenters: { ...centers, 0: 90 },
+      }),
+    ).toThrow(/left outer extent/u);
   });
 
   it("derives default rank centers and width from overridden frame dimensions", () => {
@@ -124,6 +134,21 @@ describe("lifecycle horizontal geometry", () => {
     expect(geometry.rankCenters[0]).toBe(155);
     expect(geometry.rankCenters[6]).toBe(1787);
     expect(geometry.svgWidth).toBe(1922);
+
+    const translatedCenters = Object.fromEntries(
+      Object.entries(geometry.rankCenters).map(([rank, center]) => [
+        rank,
+        center + 300,
+      ]),
+    );
+    const translated = createLifecycleHorizontalGeometry({
+      leftMargin: 140,
+      rightMargin: 120,
+      nodeWidth: 30,
+      rankCenters: translatedCenters,
+    });
+    expect(translated.svgWidth).toBe(2222);
+    expect(translated.svgWidth - translated.rankCenters[6] - 15).toBe(120);
   });
 
   it("summarizes the nonuniform hops that constrained handle candidates", () => {
@@ -194,6 +219,8 @@ describe("lifecycle horizontal geometry", () => {
     expect(graph.horizontalGeometry).toBe(horizontalGeometry);
     expect(dimensions.horizontalGeometry).toBe(horizontalGeometry);
     expect(model.horizontalGeometry).toBe(horizontalGeometry);
+    expect(Object.keys(graph)).not.toContain("horizontalGeometry");
+    expect(Object.keys(dimensions)).not.toContain("horizontalGeometry");
   });
 });
 const deepFreeze = (value) => {

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -1099,7 +1099,46 @@ describe("transition lane solver", () => {
     ).toBe(true);
   });
 
-  it("resolves un-phased dense fan-in fast, without exponential blowup", () => {
+  it("preserves baseline diagnostic serialization", () => {
+    const serialized = JSON.stringify(
+      summarizeHandleCandidateConstraints([
+        { branchId: "branch:a", attempts: 1, rejected: {}, sweeps: {} },
+      ]),
+    );
+    expect(serialized).toBe(
+      JSON.stringify({
+        attempts: 1,
+        rejected: {
+          fixedGeometry: 0,
+          outsideTransitionCorridor: 0,
+          nonincidentRouteClearance: 0,
+        },
+        sweeps: {
+          primary: {
+            attempts: 0,
+            rejected: {
+              fixedGeometry: 0,
+              outsideTransitionCorridor: 0,
+              nonincidentRouteClearance: 0,
+            },
+          },
+          fallback: {
+            attempts: 0,
+            rejected: {
+              fixedGeometry: 0,
+              outsideTransitionCorridor: 0,
+              nonincidentRouteClearance: 0,
+            },
+          },
+        },
+        nearestBlockerKinds: {},
+        rankCenterSpacing: 272,
+        protectedCorridorWidth: 200,
+        transitionSpan: 72,
+        handleDiameter: 44,
+        usableHandleCenterSpan: 28,
+      }),
+    );
     // transitionDensityProjection()'s 50-branch fan-in to one milestone has
     // no handle-clearance-feasible lane arrangement, even accounting for
     // HANDLE_CLEARANCE_TOLERANCE's small last-resort clearance allowance --
@@ -1133,6 +1172,14 @@ describe("transition lane solver", () => {
       reason: "no-candidates",
     });
     expect(thrown?.cause?.blockedBranchIds?.length).toBeGreaterThan(0);
+    expect(
+      thrown?.cause?.branches?.every(
+        (branch) => !Object.keys(branch).includes("transitionRanks"),
+      ),
+    ).toBe(true);
+    expect(JSON.stringify(thrown?.cause?.branches)).not.toContain(
+      "transitionRanks",
+    );
     expect(
       thrown?.cause?.branches?.every(
         (branch) => branch.nearestRejectedCandidate?.clearanceMargin === -1,

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -8,6 +8,7 @@ import {
 } from "../src/web/tracker/lifecycleDiagram.js";
 import * as lifecycleLayout from "../src/web/tracker/lifecycleDiagramLayout.js";
 import { buildLifecycleDisplayBranches } from "../src/web/tracker/lifecycleDiagramLayout.js";
+import { createLifecycleHorizontalGeometry } from "../src/web/tracker/lifecycleDiagramLayout.js";
 import {
   buildLifecycleTimeline,
   LIFECYCLE_DIAGRAM_TAXONOMY,
@@ -123,9 +124,14 @@ function setup() {
   });
   return document.querySelector("[data-lifecycle-diagram]");
 }
-function render(b, selectedBucketId = "current", onBucketChange = vi.fn()) {
+function render(
+  b,
+  selectedBucketId = "current",
+  onBucketChange = vi.fn(),
+  options = {},
+) {
   const root = setup();
-  const view = createLifecycleDiagramView(root, { onBucketChange });
+  const view = createLifecycleDiagramView(root, { onBucketChange, ...options });
   const timeline = buildLifecycleTimeline(b);
   const snapshot = projectLifecycleAt(b, selectedBucketId);
   view.update({
@@ -210,6 +216,32 @@ describe("calculateLifecycleDiagramLayout", () => {
 });
 
 describe("lifecycle diagram view", () => {
+  it("renders node hit boxes from the shared non-baseline geometry", () => {
+    const horizontalGeometry = createLifecycleHorizontalGeometry({
+      handleRadius: 30,
+    });
+    const { root } = render(
+      bundle([app("a")], [ev("o", "a", "application_submitted", "2026-01-01")]),
+      "current",
+      vi.fn(),
+      { horizontalGeometry },
+    );
+    const visible = root.querySelector(
+      "[data-diagram-node='origin:application_submitted'] rect:not([data-diagram-node-hit])",
+    );
+    const hit = root.querySelector(
+      "[data-diagram-node-hit='origin:application_submitted']",
+    );
+    const visibleBox = rectBox(visible);
+    const hitBox = rectBox(hit);
+
+    expect(hitBox.width).toBe(Math.max(60, visibleBox.width));
+    expect(hitBox.height).toBe(Math.max(60, visibleBox.height));
+    expect(hitBox.x + hitBox.width / 2).toBe(
+      visibleBox.x + visibleBox.width / 2,
+    );
+  });
+
   beforeEach(() => vi.useRealTimers());
   it("parses and validates PNG dimensions for visual artifacts", async () => {
     const { readPngDimensions } = await import(


### PR DESCRIPTION
### Motivation

- Introduce one immutable, authoritative horizontal-geometry seam so future density-aware per-hop spacing can be added without rewriting consumers.
- Preserve baseline geometry, diagnostics, solver behavior, candidate sampling, and UI behavior.

### Implementation

- Added `createLifecycleHorizontalGeometry()`, producing deeply immutable rank- and hop-keyed geometry with validated centers, margins, SVG width, exit/entry positions, control spans, protected corridors, transition spans, and usable handle-center spans.
- Added `BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY`; legacy horizontal constants remain only as baseline inputs or compatibility exports.
- Made omitted rank centers derive from the effective margins and node width, validated exact rank coverage `0..6`, and ensured translated or uneven centers cannot be clipped.
- Threaded the same geometry instance through layout sizing, node placement, lane solving, routing-anchor materialization, route generation and flattening, handle placement, rendering, route auditing, and diagnostics.
- Synchronized rendered node hit targets with the shared geometry.
- Made handle diagnostics report the hops that actually constrained candidates while preserving the exact baseline serialized diagnostic shape and field order.
- Added focused constructor, immutability, validation, keyed-lookup, identity-threading, renderer, nonuniform-hop, and diagnostic-serialization tests.
- Updated the design document to describe the P8 seam and defer adaptive per-hop expansion to P9.

### Behavior and compatibility

Baseline production geometry remains unchanged:

- Rank-center spacing: 272px
- Protected-corridor width: 200px
- Transition span: 72px
- Handle diameter: 44px
- Usable handle-center span: 28px

No density formula, solver-budget change, tolerance change, candidate-sample change, ordering change, projection change, or new fixture feasibility was introduced.

PR #1173’s stress behavior remains intact:

- `transitionDensityProjection()`: 41 blocked branches; primary 123 / `(0, 0, 123)`; fallback 328 / `(9, 237, 82)`; terminal typed `no-candidates`.
- `paginationProjection()`: 48 blocked branches; primary 348 / `(0, 0, 348)`; fallback 928 / `(15, 681, 232)`; terminal handle `state-limit` at 32,768 states.

Representative ordinary, routing-only dense, milestone-bearing, reversed, and rotated projections remain byte-identical in coordinates, route primitives, handles, audit results, dimensions, diagnostics, and deterministic ordering. The normalized parity snapshot SHA-256 is `21ce482159d8cce29b7e17a0583c8badb26da8c72067417fdf209f9864e72fb5`.

An `rg` audit confirms direct production references to legacy horizontal constants are confined to the authoritative constructor and compatibility boundary.

### Verification

Final head: `d2d7800e0f952eb982c1441f13acffabb5bc3220`

- CI run 5000 passed: lint, 147 Vitest files / 1,254 tests, 42 Playwright tests, and secret scanning.
- Build and publish GHCR image run 452 passed: typecheck, full CI tests, local image build, and image smoke test. Publishing was intentionally skipped for the pull-request event.
- Diagram visual review run 217 passed.
- Focused diagnostic regressions passed:
  `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js -t 'preserves baseline diagnostic serialization|summarizes the nonuniform hops that constrained handle candidates'`
- `npm run lint -- --quiet`, `npm run typecheck`, `npm run build`, formatting, `git diff --check`, skipped-test auditing, and secret scanning passed.
- The final Codex sandbox lacked the Playwright browser and hit unchanged local 30-second performance-test timeouts; the resulting commit subsequently passed the complete latest-head hosted CI and browser workflows listed above.

Adaptive per-hop demand and expansion remain intentionally deferred to P9.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67c28a0d40832f853e8c63552327e9)