### PR TITLE
Add shared lifecycle horizontal geometry (P8)

### DIFF
--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -19,6 +19,21 @@ of the pipeline each impose their own ordering on branches, and those orderings 
 document maps out those systems, what was fixed, and what's intentionally still deferred, so a
 future investigation doesn't have to re-discover any of this by trial and error.
 
+## Shared horizontal-geometry boundary (P8)
+
+All production consumers of lifecycle X coordinates now receive the same deeply immutable
+`LIFECYCLE_HORIZONTAL_GEOMETRY` value. Its rank-keyed centers and hop-keyed adjacent-transition
+records are the authority for node placement, protected and control spans, route primitives,
+handle corridors, diagnostics, SVG width, rendering, and route auditing. Exported legacy constants
+and helper defaults remain compatibility inputs at the constructor boundary; consumers do not
+reconstruct equivalent geometry from them.
+
+P8 is an architectural seam only. The shipped centers, 272 px spacing, 200 px protected corridor,
+72 px transition span, 44 px handle diameter, 28 px usable handle-center span, supported-density
+boundary, solver behavior, and rendered output remain unchanged. In particular, the two extreme
+fan-in fixtures intentionally retain their existing typed failures and diagnostics. Computing
+per-hop demand and expanding individual hops to accommodate it is deferred to P9.
+
 ## The five ordering systems
 
 The rendered position of every route segment is the product of up to five independent mechanisms.
@@ -499,8 +514,8 @@ unsafe construction for these fixtures.
 extreme fan-in fixtures (`transitionDensityProjection()` and the historical 60-app/89-branch
 pagination fixture — see "Still infeasible for a root cause neither tolerance can reach" below).
 Their rejection evidence (`clearanceMargin === -1`, the `COLLISION_MARGIN` sentinel for a
-fixed-geometry/outside-corridor rejection) is bound by `RANK_CORRIDOR_HALF_WIDTH`, a fixed constant
-driving a static X-extent corridor check that does not depend on branch order, `nodeSort`/`linkSort`,
+fixed-geometry/outside-corridor rejection) is bound by the shared geometry's fixed corridor
+half-width, driving a static X-extent check that does not depend on branch order, `nodeSort`/`linkSort`,
 or `rankOrder` in any way. No ordering fix — including this one — can relax a fixed-width geometric
 ceiling; both fixtures remain infeasible, as confirmed by re-running the full suite after this fix
 (their tests still characterize the identical infeasibility signature).
@@ -886,7 +901,7 @@ descriptive evidence but is not, by itself, causal evidence for every rejected s
 No density-aware production expansion is shipped from this evidence. The experiment rules out the
 tested scalar density-only spacing rule; it does not prove that every bounded geometry-only rule is
 impossible. Increasing
-`RANK_CORRIDOR_HALF_WIDTH` reduces the 72 px between-rank transition span, while increasing rank
+the shared geometry's corridor half-width reduces the 72 px between-rank transition span, while increasing rank
 spacing moves the sampled cubic points but does not by itself establish a bound that clears labels,
 other routes, handle overlap, and the route audit together. A safe formula needs a constructive
 proof (or an exhaustive bounded test over the supported density domain) connecting density to all
@@ -928,7 +943,7 @@ skip states and test names can drift. `grep -rn "it\.skip(\|test\.skip(" test/` 
    extreme fan-in fixtures hit (`transitionDensityProjection()` and the 60-application/89-branch
    pagination fixture — see "Still infeasible for a root cause neither tolerance can reach" above),
    and was not expected to: their rejection evidence (`clearanceMargin === -1`, the fixed-geometry
-   corridor sentinel) is bound by `RANK_CORRIDOR_HALF_WIDTH`, a static X-extent constant independent
+   corridor sentinel) is bound by the shared geometry's static X extent, independent
    of branch order entirely. Confirmed directly: both fixtures' tests still characterize the
    identical infeasibility signature after this fix. It is also not accurately described as the fix
    for every item below: item 2's remaining tests were resolved instead by the bounded tolerances

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -460,8 +460,9 @@ export function createLifecycleDiagramView(root, options = {}) {
     }
     let graph;
     let dimensions;
+    let horizontalGeometry;
     try {
-      ({ graph, dimensions } = layoutLifecycleRoutingGraph(
+      ({ graph, dimensions, horizontalGeometry } = layoutLifecycleRoutingGraph(
         projection,
         root.clientWidth,
       ));
@@ -530,9 +531,12 @@ export function createLifecycleDiagramView(root, options = {}) {
         handles = graph.acceptedHandles;
       } else {
         handles = new Map(
-          assignBranchHandles(branches, segmentsByBranch, visibleNodes).map(
-            (h) => [h.branchId, h],
-          ),
+          assignBranchHandles(
+            branches,
+            segmentsByBranch,
+            visibleNodes,
+            horizontalGeometry,
+          ).map((h) => [h.branchId, h]),
         );
       }
     } catch {
@@ -548,7 +552,7 @@ export function createLifecycleDiagramView(root, options = {}) {
       const segments = segmentsByBranch
         .get(branch.id)
         .sort((a, b) => a.segmentIndex - b.segmentIndex);
-      const pathData = compoundBranchPath(segments);
+      const pathData = compoundBranchPath(segments, horizontalGeometry);
       if (!pathData || /NaN|Infinity/u.test(pathData)) continue;
       const from = TAXONOMY.get(branch.source)?.label ?? branch.source;
       const to = TAXONOMY.get(branch.target)?.label ?? branch.target;
@@ -716,7 +720,7 @@ export function createLifecycleDiagramView(root, options = {}) {
           event.stopPropagation();
           selectNode();
         });
-        const labelBox = labelBoxForNode(node);
+        const labelBox = labelBoxForNode(node, horizontalGeometry);
         const label = svgEl("text", {
           x: labelBox.x + labelBox.width / 2,
           y: labelBox.y + 12,

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -42,13 +42,129 @@ export const MINIMUM_TRANSITION_WIDTH = 72;
 export const LAYOUT_LEFT_MARGIN = 100;
 export const LAYOUT_RIGHT_MARGIN = 100;
 export const MINIMUM_RANK_CENTER_SPACING = 272;
-export const MINIMUM_SVG_WIDTH =
-  LAYOUT_LEFT_MARGIN +
-  LAYOUT_RIGHT_MARGIN +
-  SANKEY_NODE_WIDTH +
-  6 * MINIMUM_RANK_CENTER_SPACING;
 export const BRANCH_STROKE_OPACITY = 0.82;
 export const BRANCH_HANDLE_RADIUS = 22;
+
+const deepFreezePlain = (value) => {
+  if (!value || typeof value !== "object" || Object.isFrozen(value))
+    return value;
+  for (const child of Object.values(value)) deepFreezePlain(child);
+  return Object.freeze(value);
+};
+
+export function createLifecycleHorizontalGeometry({
+  rankCenters = Object.fromEntries(
+    Array.from({ length: 7 }, (_, rank) => [
+      rank,
+      LAYOUT_LEFT_MARGIN +
+        SANKEY_NODE_WIDTH / 2 +
+        rank * MINIMUM_RANK_CENTER_SPACING,
+    ]),
+  ),
+  corridorHalfWidth = RANK_CORRIDOR_HALF_WIDTH,
+  controlOffset = TRANSITION_CONTROL_OFFSET,
+  leftMargin = LAYOUT_LEFT_MARGIN,
+  rightMargin = LAYOUT_RIGHT_MARGIN,
+  nodeWidth = SANKEY_NODE_WIDTH,
+  handleRadius = BRANCH_HANDLE_RADIUS,
+} = {}) {
+  const finite = (name, value) => {
+    if (!Number.isFinite(value))
+      throw new TypeError(
+        `Lifecycle horizontal geometry ${name} must be finite`,
+      );
+    return value;
+  };
+  for (const [name, value] of Object.entries({
+    corridorHalfWidth,
+    controlOffset,
+    leftMargin,
+    rightMargin,
+    nodeWidth,
+    handleRadius,
+  }))
+    finite(name, value);
+  if (
+    [
+      corridorHalfWidth,
+      controlOffset,
+      leftMargin,
+      rightMargin,
+      nodeWidth,
+      handleRadius,
+    ].some((value) => value < 0)
+  )
+    throw new RangeError(
+      "Lifecycle horizontal geometry dimensions must be nonnegative",
+    );
+  const centerByRank = {};
+  for (let rank = 0; rank <= 6; rank += 1) {
+    if (!Object.hasOwn(rankCenters, rank))
+      throw new RangeError(
+        `Lifecycle horizontal geometry is missing rank ${rank}`,
+      );
+    centerByRank[rank] = finite(`rank ${rank} center`, rankCenters[rank]);
+    if (rank > 0 && centerByRank[rank] <= centerByRank[rank - 1])
+      throw new RangeError(
+        "Lifecycle horizontal geometry rank centers must increase",
+      );
+  }
+  if (Object.keys(rankCenters).some((rank) => !/^[0-6]$/u.test(rank)))
+    throw new RangeError(
+      "Lifecycle horizontal geometry has unsupported rank coverage",
+    );
+  const adjacentHopById = {};
+  for (let sourceRank = 0; sourceRank < 6; sourceRank += 1) {
+    const targetRank = sourceRank + 1;
+    const sourceCenter = centerByRank[sourceRank];
+    const targetCenter = centerByRank[targetRank];
+    const exitX = sourceCenter + corridorHalfWidth;
+    const entryX = targetCenter - corridorHalfWidth;
+    const transitionSpan = entryX - exitX;
+    const controlMinX = exitX + controlOffset;
+    const controlMaxX = entryX - controlOffset;
+    if (transitionSpan < MINIMUM_TRANSITION_WIDTH || controlMinX > controlMaxX)
+      throw new RangeError(
+        `Lifecycle horizontal geometry hop ${sourceRank}->${targetRank} is too narrow`,
+      );
+    adjacentHopById[`${sourceRank}->${targetRank}`] = {
+      id: `${sourceRank}->${targetRank}`,
+      sourceRank,
+      targetRank,
+      sourceCenter,
+      targetCenter,
+      rankCenterSpacing: targetCenter - sourceCenter,
+      exitX,
+      entryX,
+      controlMinX,
+      controlMaxX,
+      controlSpan: controlMaxX - controlMinX,
+      protectedMinX: sourceCenter - corridorHalfWidth,
+      protectedMaxX: targetCenter + corridorHalfWidth,
+      protectedCorridorWidth: 2 * corridorHalfWidth,
+      transitionSpan,
+      usableHandleCenterSpan: transitionSpan - 2 * handleRadius,
+    };
+  }
+  const svgWidth =
+    leftMargin + rightMargin + nodeWidth + centerByRank[6] - centerByRank[0];
+  return deepFreezePlain({
+    centerByRank,
+    adjacentHopById,
+    corridorHalfWidth,
+    controlOffset,
+    leftMargin,
+    rightMargin,
+    nodeWidth,
+    handleRadius,
+    handleDiameter: 2 * handleRadius,
+    svgWidth,
+  });
+}
+
+export const LIFECYCLE_HORIZONTAL_GEOMETRY =
+  createLifecycleHorizontalGeometry();
+export const MINIMUM_SVG_WIDTH = LIFECYCLE_HORIZONTAL_GEOMETRY.svgWidth;
 // A handle candidate's clearance from a *nonincident* route (a different
 // branch's line passing nearby) is a softer concern than clearance from
 // fixed geometry (a node/label box) or from another handle: it's the same
@@ -588,12 +704,13 @@ export function calculateLifecycleDiagramLayout(
   projection,
   availableWidth,
   routingGraph,
+  horizontalGeometry = LIFECYCLE_HORIZONTAL_GEOMETRY,
 ) {
   const integerWidth = Math.floor(Number(availableWidth));
   const sanitizedWidth =
     Number.isFinite(integerWidth) && integerWidth > 0
       ? integerWidth
-      : MINIMUM_SVG_WIDTH;
+      : horizontalGeometry.svgWidth;
   const graph = routingGraph ?? buildLifecycleRoutingGraph(projection);
   const rankCounts = new Map();
   for (const node of graph.nodes ?? []) {
@@ -659,7 +776,7 @@ export function calculateLifecycleDiagramLayout(
     densestRoutedRank * PER_LANE_VERTICAL_BUDGET +
     Math.max(0, densestRoutedRank - 1) * ROUTED_NODE_PADDING;
   return {
-    width: Math.max(MINIMUM_SVG_WIDTH, sanitizedWidth),
+    width: Math.max(horizontalGeometry.svgWidth, sanitizedWidth),
     height: Math.max(MINIMUM_SVG_HEIGHT, Math.ceil(densityHeight)),
     nodePadding: ROUTED_NODE_PADDING,
     topMargin: LAYOUT_TOP_MARGIN,
@@ -668,10 +785,25 @@ export function calculateLifecycleDiagramLayout(
   };
 }
 
-export const rankCenterX = (rank) =>
-  LAYOUT_LEFT_MARGIN +
-  SANKEY_NODE_WIDTH / 2 +
-  rank * MINIMUM_RANK_CENTER_SPACING;
+export const rankCenterX = (
+  rank,
+  horizontalGeometry = LIFECYCLE_HORIZONTAL_GEOMETRY,
+) => {
+  const center = horizontalGeometry.centerByRank[rank];
+  if (!Number.isFinite(center))
+    throw new RangeError(`Lifecycle horizontal geometry has no rank ${rank}`);
+  return center;
+};
+
+const adjacentHopGeometry = (sourceRank, targetRank, horizontalGeometry) => {
+  const hop =
+    horizontalGeometry.adjacentHopById[`${sourceRank}->${targetRank}`];
+  if (!hop)
+    throw new RangeError(
+      `Lifecycle horizontal geometry has no hop ${sourceRank}->${targetRank}`,
+    );
+  return hop;
+};
 
 // Layout-wide cache of full-geometry signatures already proven infeasible by
 // layoutLifecycleRoutingGraph's candidateCallback, keyed to the specific
@@ -810,6 +942,8 @@ function layoutLifecycleRoutingGraphPass(
   availableWidth,
   options = {},
 ) {
+  const horizontalGeometry =
+    options.horizontalGeometry ?? LIFECYCLE_HORIZONTAL_GEOMETRY;
   const enableTestDiagnostics = isLifecycleLayoutTestEnvironment();
   const explicitNodeOrderByRank =
     options.authoritativeNodeOrderByRank ??
@@ -877,6 +1011,7 @@ function layoutLifecycleRoutingGraphPass(
     projection,
     availableWidth,
     graph,
+    horizontalGeometry,
   );
   const rankLayers = [...new Set(graph.nodes.map((node) => node.rank))].sort(
     (left, right) => left - right,
@@ -885,7 +1020,7 @@ function layoutLifecycleRoutingGraphPass(
   const layout = sankey()
     .nodeId((d) => d.id)
     .nodeAlign((node) => layerByRank.get(node.rank) ?? 0)
-    .nodeWidth(SANKEY_NODE_WIDTH)
+    .nodeWidth(horizontalGeometry.nodeWidth)
     .nodePadding(ROUTED_NODE_PADDING)
     .nodeSort((left, right) => {
       if (baseNodeOrderByRank && left.rank === right.rank) {
@@ -922,19 +1057,19 @@ function layoutLifecycleRoutingGraphPass(
       );
     })
     .extent([
-      [LAYOUT_LEFT_MARGIN, LAYOUT_TOP_MARGIN],
+      [horizontalGeometry.leftMargin, LAYOUT_TOP_MARGIN],
       [
-        dimensions.width - LAYOUT_RIGHT_MARGIN,
+        dimensions.width - horizontalGeometry.rightMargin,
         dimensions.height - LAYOUT_BOTTOM_MARGIN,
       ],
     ]);
   layout(graph);
   for (const node of graph.nodes) {
-    const center = rankCenterX(node.rank);
+    const center = rankCenterX(node.rank, horizontalGeometry);
     if (node.routing) node.x0 = node.x1 = center;
     else {
-      node.x0 = center - SANKEY_NODE_WIDTH / 2;
-      node.x1 = center + SANKEY_NODE_WIDTH / 2;
+      node.x0 = center - horizontalGeometry.nodeWidth / 2;
+      node.x1 = center + horizontalGeometry.nodeWidth / 2;
     }
   }
   layout.update(graph);
@@ -982,7 +1117,7 @@ function layoutLifecycleRoutingGraphPass(
   const labelBoxes = visibleNodes.map((node) => ({
     kind: "label",
     id: node.id,
-    ...labelBoxForNode(node),
+    ...labelBoxForNode(node, horizontalGeometry),
   }));
   const hitBoxes = visibleNodes.map((node) => ({
     kind: "hit",
@@ -1326,10 +1461,12 @@ function layoutLifecycleRoutingGraphPass(
     const variables = links
       .map((link) => {
         const rank = link.source.rank;
-        const exitX = rankCenterX(rank) + RANK_CORRIDOR_HALF_WIDTH;
-        const entryX = rankCenterX(link.target.rank) - RANK_CORRIDOR_HALF_WIDTH;
-        const controlMinX = exitX + TRANSITION_CONTROL_OFFSET;
-        const controlMaxX = entryX - TRANSITION_CONTROL_OFFSET;
+        const hop = adjacentHopGeometry(
+          rank,
+          link.target.rank,
+          horizontalGeometry,
+        );
+        const { controlMinX, controlMaxX } = hop;
         if (controlMinX > controlMaxX + LANE_Y_EPSILON) {
           throw new Error(
             `Lifecycle transition lane control span invariant violated for ${link.id}`,
@@ -1338,9 +1475,8 @@ function layoutLifecycleRoutingGraphPass(
         // The constant transition lane Y controls the cubic plateau, while
         // clearance is guaranteed across the full source-to-target corridor
         // exercised by the renderer-level obstacle contract.
-        const clearanceMinX = rankCenterX(rank) - RANK_CORRIDOR_HALF_WIDTH;
-        const clearanceMaxX =
-          rankCenterX(link.target.rank) + RANK_CORRIDOR_HALF_WIDTH;
+        const clearanceMinX = hop.protectedMinX;
+        const clearanceMaxX = hop.protectedMaxX;
         const incidentIds = new Set([link.source.id, link.target.id]);
         const sourceDockY = Number.isFinite(link.y0)
           ? link.y0
@@ -2864,7 +3000,7 @@ function layoutLifecycleRoutingGraphPass(
           compareLifecycleIds(a.node.id, b.node.id)
         );
       });
-      const centerX = rankCenterX(rank);
+      const centerX = rankCenterX(rank, horizontalGeometry);
       const assignment = assignMonotone(
         entries,
         (entry, idealY) =>
@@ -3079,7 +3215,11 @@ function layoutLifecycleRoutingGraphPass(
       graph.branches,
       linksByBranch,
       visibleNodes,
-      { sharedBudget: handleBudget, seedHandles: options.seedHandles },
+      {
+        sharedBudget: handleBudget,
+        seedHandles: options.seedHandles,
+        horizontalGeometry,
+      },
     );
     lastHandleRouteEdgeCount = handleCheck.routeEdgeCount ?? null;
     if (handleCheck.ok) {
@@ -3120,6 +3260,7 @@ function layoutLifecycleRoutingGraphPass(
         graph,
         dimensions,
         handles: handleCheck.handles,
+        horizontalGeometry,
       });
       const budgetFraction = Math.max(
         handleBudget.statesVisited / handleBudget.stateLimit,
@@ -3291,7 +3432,7 @@ function layoutLifecycleRoutingGraphPass(
       error.cause?.reason === "no-feasible-topological-order" &&
       lastHandleFailure
     ) {
-      throw handlePlacementError(lastHandleFailure);
+      throw handlePlacementError(lastHandleFailure, horizontalGeometry);
     }
     // Exhaustive search proved every viable candidate failed routing-anchor
     // materialization (no candidate ever reached handle placement): surface
@@ -3332,7 +3473,7 @@ function layoutLifecycleRoutingGraphPass(
   graph.transitionLaneSolverStats = Object.freeze({
     ...transitionLaneSolverStats,
   });
-  return { graph, dimensions };
+  return { graph, dimensions, horizontalGeometry };
 }
 
 const compareOrderKeys = (left, right) => {
@@ -3692,6 +3833,7 @@ export function testOnlyDiagnoseLifecycleLayoutAttempt(
         branchDiagnosticCount: reason.branchDiagnostics?.length ?? 0,
         horizontalConstraints: summarizeHandleCandidateConstraints(
           reason.branchDiagnostics ?? [],
+          options.horizontalGeometry ?? LIFECYCLE_HORIZONTAL_GEOMETRY,
         ),
       },
     };
@@ -3815,21 +3957,26 @@ export function testOnlyDiagnoseLifecycleLayoutAttempt(
 }
 
 const point = (x, y) => `${Number(x).toFixed(3)},${Number(y).toFixed(3)}`;
-export function segmentRoutePrimitives(segment) {
-  const sourceCenter = rankCenterX(segment.source.rank);
-  const targetCenter = rankCenterX(segment.target.rank);
+export function segmentRoutePrimitives(
+  segment,
+  horizontalGeometry = LIFECYCLE_HORIZONTAL_GEOMETRY,
+) {
+  const hop = adjacentHopGeometry(
+    segment.source.rank,
+    segment.target.rank,
+    horizontalGeometry,
+  );
+  const { sourceCenter, targetCenter, exitX, entryX } = hop;
   const sourceY = segment.y0;
   const targetY = segment.y1;
   const sourceDockX = segment.source.routing ? sourceCenter : segment.source.x1;
   const targetDockX = segment.target.routing ? targetCenter : segment.target.x0;
-  const exitX = sourceCenter + RANK_CORRIDOR_HALF_WIDTH;
-  const entryX = targetCenter - RANK_CORRIDOR_HALF_WIDTH;
   const laneY = Number.isFinite(segment.transitionLaneY)
     ? segment.transitionLaneY
     : targetY;
   const p0 = { x: exitX, y: sourceY };
-  const p1 = { x: exitX + TRANSITION_CONTROL_OFFSET, y: laneY };
-  const p2 = { x: entryX - TRANSITION_CONTROL_OFFSET, y: laneY };
+  const p1 = { x: hop.controlMinX, y: laneY };
+  const p2 = { x: hop.controlMaxX, y: laneY };
   const p3 = { x: entryX, y: targetY };
   return [
     {
@@ -3850,8 +3997,14 @@ export function segmentRoutePrimitives(segment) {
   ];
 }
 
-export function adjacentRankSegmentPath(segment) {
-  const [source, cubic, target] = segmentRoutePrimitives(segment);
+export function adjacentRankSegmentPath(
+  segment,
+  horizontalGeometry = LIFECYCLE_HORIZONTAL_GEOMETRY,
+) {
+  const [source, cubic, target] = segmentRoutePrimitives(
+    segment,
+    horizontalGeometry,
+  );
   return [
     `M${point(source.p0.x, source.p0.y)}`,
     `L${point(source.p1.x, source.p1.y)}`,
@@ -3864,8 +4017,13 @@ export function adjacentRankSegmentPath(segment) {
   ].join("");
 }
 
-export function compoundBranchPath(segments) {
-  return segments.map(adjacentRankSegmentPath).join("");
+export function compoundBranchPath(
+  segments,
+  horizontalGeometry = LIFECYCLE_HORIZONTAL_GEOMETRY,
+) {
+  return segments
+    .map((segment) => adjacentRankSegmentPath(segment, horizontalGeometry))
+    .join("");
 }
 
 export function wrapLifecycleLabel(
@@ -3890,17 +4048,30 @@ export function wrapLifecycleLabel(
   );
 }
 
-export function labelBoxForNode(node) {
+export function labelBoxForNode(
+  node,
+  horizontalGeometry = LIFECYCLE_HORIZONTAL_GEOMETRY,
+) {
+  const geometry = horizontalGeometry?.centerByRank
+    ? horizontalGeometry
+    : LIFECYCLE_HORIZONTAL_GEOMETRY;
   const lines = wrapLifecycleLabel(node.label);
   const width = NODE_LABEL_MAX_WIDTH;
   const height = lines.length * 16;
-  const x = Math.max(0, rankCenterX(node.rank) - width / 2);
+  const center = Number.isInteger(node.rank)
+    ? rankCenterX(node.rank, geometry)
+    : (node.x0 + node.x1) / 2;
+  const x = Math.max(0, center - width / 2);
   const y = Math.max(0, node.y0 - height - 12);
   return { x, y, width, height, lines };
 }
 
-export const cubicTransitionPoint = (segment, t) => {
-  const cubic = segmentRoutePrimitives(segment)[1];
+export const cubicTransitionPoint = (
+  segment,
+  t,
+  horizontalGeometry = LIFECYCLE_HORIZONTAL_GEOMETRY,
+) => {
+  const cubic = segmentRoutePrimitives(segment, horizontalGeometry)[1];
   const oneMinus = 1 - t;
   return {
     x:
@@ -3924,7 +4095,11 @@ const quantizePoint = ({ x, y }) => ({
 const segmentKey = (segment) =>
   `${segment.branchId ?? ""}:${segment.segmentIndex ?? ""}:${segment.id ?? ""}`;
 
-export function buildLifecycleRouteModel(graph, dimensions) {
+export function buildLifecycleRouteModel(
+  graph,
+  dimensions,
+  horizontalGeometry = LIFECYCLE_HORIZONTAL_GEOMETRY,
+) {
   const branches = [...(graph.branches ?? [])].sort(compareBranches);
   const segmentsByBranch = new Map();
   const segmentsByTransitionRank = Array.from({ length: 6 }, () => []);
@@ -3972,6 +4147,7 @@ export function buildLifecycleRouteModel(graph, dimensions) {
   return {
     graph,
     dimensions,
+    horizontalGeometry,
     branches,
     segmentsByBranch,
     segmentsByTransitionRank,
@@ -4015,8 +4191,11 @@ export function flattenLifecycleCubic(cubic, depth = 0) {
   );
 }
 
-export const flattenRouteSegment = (segment) =>
-  segmentRoutePrimitives(segment).flatMap((primitive) =>
+export const flattenRouteSegment = (
+  segment,
+  horizontalGeometry = LIFECYCLE_HORIZONTAL_GEOMETRY,
+) =>
+  segmentRoutePrimitives(segment, horizontalGeometry).flatMap((primitive) =>
     primitive.type === "line"
       ? [{ p0: primitive.p0, p1: primitive.p1, primitive }]
       : flattenLifecycleCubic(primitive).map((edge) => ({
@@ -4025,16 +4204,24 @@ export const flattenRouteSegment = (segment) =>
         })),
   );
 
-export const routeEdgesByBranch = (graphOrModel) => {
+export const routeEdgesByBranch = (
+  graphOrModel,
+  horizontalGeometry = graphOrModel?.horizontalGeometry ??
+    LIFECYCLE_HORIZONTAL_GEOMETRY,
+) => {
   const model = graphOrModel?.segmentsByBranch
     ? graphOrModel
-    : buildLifecycleRouteModel(graphOrModel, { width: 0, height: 0 });
+    : buildLifecycleRouteModel(
+        graphOrModel,
+        { width: 0, height: 0 },
+        horizontalGeometry,
+      );
   const edgesByBranch = new Map();
   for (const [branchId, segments] of model.segmentsByBranch) {
     const edges = [];
     for (const segment of segments) {
       edges.push(
-        ...flattenRouteSegment(segment).map((edge) => ({
+        ...flattenRouteSegment(segment, horizontalGeometry).map((edge) => ({
           ...edge,
           branchId,
           segmentId: segmentKey(segment),
@@ -4069,8 +4256,11 @@ export function auditLifecycleRouteGeometry({
   dimensions,
   model,
   handles = [],
+  horizontalGeometry = model?.horizontalGeometry ??
+    LIFECYCLE_HORIZONTAL_GEOMETRY,
 }) {
-  const routeModel = model ?? buildLifecycleRouteModel(graph, dimensions);
+  const routeModel =
+    model ?? buildLifecycleRouteModel(graph, dimensions, horizontalGeometry);
   const fatalFindings = [];
   const forcedCrossings = [];
   const allFindings = [];
@@ -4097,7 +4287,7 @@ export function auditLifecycleRouteGeometry({
       }
       try {
         flatEdges.push(
-          ...flattenRouteSegment(segment).map((edge) => ({
+          ...flattenRouteSegment(segment, horizontalGeometry).map((edge) => ({
             ...edge,
             branchId,
             segment,
@@ -4117,7 +4307,11 @@ export function auditLifecycleRouteGeometry({
       width: node.x1 - node.x0,
       height: node.y1 - node.y0,
     },
-    { kind: "label", id: node.id, ...labelBoxForNode(node) },
+    {
+      kind: "label",
+      id: node.id,
+      ...labelBoxForNode(node, horizontalGeometry),
+    },
     { kind: "hit", ...rendererHitBoxForNode(node) },
   ]);
   for (const edge of flatEdges) {
@@ -4301,6 +4495,8 @@ export function auditLifecycleRouteGeometry({
 }
 
 export function solveLifecycleRouteGeometry(graph, dimensions, options = {}) {
+  const horizontalGeometry =
+    options.horizontalGeometry ?? LIFECYCLE_HORIZONTAL_GEOMETRY;
   const baseline = new Map(
     graph.links.map((link) => [
       link.id,
@@ -4320,7 +4516,7 @@ export function solveLifecycleRouteGeometry(graph, dimensions, options = {}) {
     restore();
     throw new Error("Unable to construct valid lifecycle routes");
   }
-  const model = buildLifecycleRouteModel(graph, dimensions);
+  const model = buildLifecycleRouteModel(graph, dimensions, horizontalGeometry);
   const audit = auditLifecycleRouteGeometry({ model, handles: [] });
   if (audit.fatalFindings.length) {
     restore();
@@ -4334,13 +4530,6 @@ const boxesOverlap = (a, b) =>
   a.x + a.width > b.x &&
   a.y < b.y + b.height &&
   a.y + a.height > b.y;
-
-const deepFreezePlain = (value) => {
-  if (!value || typeof value !== "object" || Object.isFrozen(value))
-    return value;
-  for (const child of Object.values(value)) deepFreezePlain(child);
-  return Object.freeze(value);
-};
 
 export const solveHandleCandidateSets = (
   branches,
@@ -4510,7 +4699,10 @@ export const solveHandleCandidateSets = (
   return { ok: true, selected };
 };
 
-const handlePlacementError = (result) => {
+const handlePlacementError = (
+  result,
+  horizontalGeometry = LIFECYCLE_HORIZONTAL_GEOMETRY,
+) => {
   const branchId = result.blockedBranchIds?.[0] ?? "unknown branch";
   const error = new Error(
     `Lifecycle diagram handle placement invariant violated for ${branchId}`,
@@ -4524,13 +4716,17 @@ const handlePlacementError = (result) => {
     branches: [...(result.branchDiagnostics ?? [])],
     horizontalConstraints: summarizeHandleCandidateConstraints(
       result.branchDiagnostics ?? [],
+      horizontalGeometry,
     ),
     component: result.component ?? null,
   });
   return error;
 };
 
-export function summarizeHandleCandidateConstraints(branchDiagnostics) {
+export function summarizeHandleCandidateConstraints(
+  branchDiagnostics,
+  horizontalGeometry = LIFECYCLE_HORIZONTAL_GEOMETRY,
+) {
   const emptySweep = () => ({
     attempts: 0,
     rejected: {
@@ -4562,8 +4758,7 @@ export function summarizeHandleCandidateConstraints(branchDiagnostics) {
         (nearestBlockerKinds[blockerKind] ?? 0) + 1;
     }
   }
-  const transitionSpan =
-    MINIMUM_RANK_CENTER_SPACING - 2 * RANK_CORRIDOR_HALF_WIDTH;
+  const baselineHop = horizontalGeometry.adjacentHopById["0->1"];
   return {
     attempts,
     rejected,
@@ -4573,11 +4768,11 @@ export function summarizeHandleCandidateConstraints(branchDiagnostics) {
         compareLifecycleIds(left, right),
       ),
     ),
-    rankCenterSpacing: MINIMUM_RANK_CENTER_SPACING,
-    protectedCorridorWidth: 2 * RANK_CORRIDOR_HALF_WIDTH,
-    transitionSpan,
-    handleDiameter: 2 * BRANCH_HANDLE_RADIUS,
-    usableHandleCenterSpan: transitionSpan - 2 * BRANCH_HANDLE_RADIUS,
+    rankCenterSpacing: baselineHop.rankCenterSpacing,
+    protectedCorridorWidth: baselineHop.protectedCorridorWidth,
+    transitionSpan: baselineHop.transitionSpan,
+    handleDiameter: horizontalGeometry.handleDiameter,
+    usableHandleCenterSpan: baselineHop.usableHandleCenterSpan,
   };
 }
 
@@ -4585,7 +4780,11 @@ const tryAssignBranchHandles = (
   branches,
   segmentsByBranch,
   visibleNodes = [],
-  { sharedBudget = null, seedHandles = null } = {},
+  {
+    sharedBudget = null,
+    seedHandles = null,
+    horizontalGeometry = LIFECYCLE_HORIZONTAL_GEOMETRY,
+  } = {},
 ) => {
   const nodeBoxes = visibleNodes.map((node) => ({
     x: node.x0,
@@ -4593,12 +4792,14 @@ const tryAssignBranchHandles = (
     width: node.x1 - node.x0,
     height: node.y1 - node.y0,
   }));
-  const labelBoxes = visibleNodes.map(labelBoxForNode);
+  const labelBoxes = visibleNodes.map((node) =>
+    labelBoxForNode(node, horizontalGeometry),
+  );
   const routeEdges = [];
   for (const [branchId, segments] of segmentsByBranch) {
     for (const segment of segments) {
       routeEdges.push(
-        ...flattenRouteSegment(segment).map((edge) => ({
+        ...flattenRouteSegment(segment, horizontalGeometry).map((edge) => ({
           ...edge,
           branchId,
           segmentId: segmentKey(segment),
@@ -4921,14 +5122,15 @@ const tryAssignBranchHandles = (
         diagnostic.nearestRejectedCandidate = candidate;
       }
     };
-    const sweepCorridor = (sweepName, tValues, corridorHalfWidth) => {
+    const sweepCorridor = (sweepName, tValues) => {
       for (const segment of orderedSegments) {
-        const sourceCenter = rankCenterX(segment.source.rank);
-        const targetCenter = rankCenterX(segment.target.rank);
-        const exitX = sourceCenter + corridorHalfWidth;
-        const entryX = targetCenter - corridorHalfWidth;
+        const { exitX, entryX } = adjacentHopGeometry(
+          segment.source.rank,
+          segment.target.rank,
+          horizontalGeometry,
+        );
         for (const t of tValues) {
-          const { x, y } = cubicTransitionPoint(segment, t);
+          const { x, y } = cubicTransitionPoint(segment, t, horizontalGeometry);
           const box = {
             x: x - BRANCH_HANDLE_RADIUS,
             y: y - BRANCH_HANDLE_RADIUS,
@@ -5024,17 +5226,9 @@ const tryAssignBranchHandles = (
         }
       }
     };
-    sweepCorridor(
-      "primary",
-      HANDLE_CANDIDATE_T_VALUES,
-      RANK_CORRIDOR_HALF_WIDTH,
-    );
+    sweepCorridor("primary", HANDLE_CANDIDATE_T_VALUES);
     if (!candidates.length) {
-      sweepCorridor(
-        "fallback",
-        HANDLE_FALLBACK_CANDIDATE_T_VALUES,
-        RANK_CORRIDOR_HALF_WIDTH,
-      );
+      sweepCorridor("fallback", HANDLE_FALLBACK_CANDIDATE_T_VALUES);
     }
     // Only fall back to a degraded (small negative clearance) candidate
     // when this branch has no fully-clear candidate anywhere across both
@@ -5096,12 +5290,14 @@ export function assignBranchHandles(
   branches,
   segmentsByBranch,
   visibleNodes = [],
+  horizontalGeometry = LIFECYCLE_HORIZONTAL_GEOMETRY,
 ) {
   const result = tryAssignBranchHandles(
     branches,
     segmentsByBranch,
     visibleNodes,
+    { horizontalGeometry },
   );
   if (result.ok) return result.handles;
-  throw handlePlacementError(result);
+  throw handlePlacementError(result, horizontalGeometry);
 }

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -36,12 +36,14 @@ import {
   combinationsOfSize,
   compareBranches,
   compareLifecycleIds,
+  createLifecycleHorizontalGeometry,
   createLaneGeometryFailureCache,
   cubicTransitionPoint,
   edgeCrossing,
   endpointColor,
   isRouteHandleCollision,
   layoutLifecycleRoutingGraph,
+  LIFECYCLE_HORIZONTAL_GEOMETRY,
   labelBoxForNode,
   LANE_Y_EPSILON,
   nodeSort,
@@ -2694,6 +2696,81 @@ describe("lifecycle diagram render-only routing layout", () => {
     expect(
       buildLifecycleRoutingGraph(projection()).links.map((l) => l.id),
     ).toEqual(buildLifecycleRoutingGraph(projection()).links.map((l) => l.id));
+  });
+
+  it("constructs one deterministic, deeply immutable horizontal geometry", () => {
+    const first = createLifecycleHorizontalGeometry();
+    const second = createLifecycleHorizontalGeometry();
+    expect(first).toEqual(second);
+    expect(first).not.toBe(second);
+    expect(Object.isFrozen(first)).toBe(true);
+    expect(Object.isFrozen(first.centerByRank)).toBe(true);
+    expect(Object.isFrozen(first.adjacentHopById)).toBe(true);
+    expect(Object.isFrozen(first.adjacentHopById["0->1"])).toBe(true);
+    expect(() => {
+      first.centerByRank[0] = -1;
+    }).toThrow(TypeError);
+    expect(LIFECYCLE_HORIZONTAL_GEOMETRY).toEqual(first);
+    expect(
+      buildLifecycleRouteModel(
+        { branches: [], links: [], nodes: [] },
+        { width: first.svgWidth, height: 360 },
+        first,
+      ).horizontalGeometry,
+    ).toBe(first);
+    expect(
+      layoutLifecycleRoutingGraph(projection(), 1850).horizontalGeometry,
+    ).toBe(LIFECYCLE_HORIZONTAL_GEOMETRY);
+  });
+
+  it("provides rank and hop lookups with the baseline derived geometry", () => {
+    const geometry = LIFECYCLE_HORIZONTAL_GEOMETRY;
+    const hop = geometry.adjacentHopById["0->1"];
+    expect(geometry.centerByRank[1] - geometry.centerByRank[0]).toBe(272);
+    expect(rankCenterX(1, geometry)).toBe(geometry.centerByRank[1]);
+    expect(hop.rankCenterSpacing).toBe(272);
+    expect(hop.protectedCorridorWidth).toBe(200);
+    expect(hop.transitionSpan).toBe(72);
+    expect(geometry.handleDiameter).toBe(44);
+    expect(hop.usableHandleCenterSpan).toBe(28);
+    expect(hop.exitX).toBe(geometry.centerByRank[0] + 100);
+    expect(hop.entryX).toBe(geometry.centerByRank[1] - 100);
+    expect(hop.controlSpan).toBe(24);
+    expect(geometry.svgWidth).toBe(MINIMUM_SVG_WIDTH);
+  });
+
+  it("validates horizontal geometry rank and hop invariants", () => {
+    const centers = Object.fromEntries(
+      Array.from({ length: 7 }, (_, rank) => [rank, 109 + rank * 272]),
+    );
+    expect(() =>
+      createLifecycleHorizontalGeometry({
+        rankCenters: { ...centers, 2: Number.NaN },
+      }),
+    ).toThrow(/must be finite/u);
+    expect(() => {
+      const missing = { ...centers };
+      delete missing[4];
+      createLifecycleHorizontalGeometry({ rankCenters: missing });
+    }).toThrow(/missing rank 4/u);
+    expect(() =>
+      createLifecycleHorizontalGeometry({
+        rankCenters: { ...centers, 3: centers[2] },
+      }),
+    ).toThrow(/must increase/u);
+    expect(() =>
+      createLifecycleHorizontalGeometry({
+        rankCenters: { ...centers, 7: centers[6] + 272 },
+      }),
+    ).toThrow(/unsupported rank coverage/u);
+    expect(() =>
+      createLifecycleHorizontalGeometry({
+        rankCenters: { ...centers, 1: centers[0] + 271 },
+      }),
+    ).toThrow(/hop 0->1 is too narrow/u);
+    expect(() => rankCenterX(7, LIFECYCLE_HORIZONTAL_GEOMETRY)).toThrow(
+      /no rank 7/u,
+    );
   });
 
   it("sorts origins and endpoints canonically while ranking milestones by endpoint median", () => {


### PR DESCRIPTION
### Motivation

- Introduce a single, immutable horizontal-geometry seam so all consumers use one authoritative X-geometry representation instead of reconstructing values from scattered constants. 
- Preserve existing behavior and diagnostics while making it possible to add per-hop/density-aware spacing in a follow-up (P9). 
- Keep the change minimal and focused on the layout/route/handle call graph so production semantics, solver budgets, candidate sampling, and UI behavior remain unchanged.

### Description

- Add `createLifecycleHorizontalGeometry()` and a frozen baseline `LIFECYCLE_HORIZONTAL_GEOMETRY` that encodes rank centers, adjacent-hop records, exit/entry Xs, control span, protected corridor extents, handle diameter, and `svgWidth`, with validation for finiteness, monotonic centers, hop coverage, and non-negative dimensions (`src/web/tracker/lifecycleDiagramLayout.js`).
- Thread the same `horizontalGeometry` instance through all production consumers: `calculateLifecycleDiagramLayout`, `layoutLifecycleRoutingGraphPass`/`layoutLifecycleRoutingGraph`, `segmentRoutePrimitives`, `compoundBranchPath`, `labelBoxForNode`, `buildLifecycleRouteModel`, `flattenRouteSegment`/`routeEdgesByBranch`, audit/route-audit helpers, `tryAssignBranchHandles`/`assignBranchHandles`, and the renderer (`src/web/tracker/lifecycleDiagramLayout.js`, `src/web/tracker/lifecycleDiagram.js`).
- Replace direct production uses of baseline constants with lookups/derived values from the geometry object while keeping the old constants only as constructor defaults/compatibility exports; expose `MINIMUM_SVG_WIDTH` derived from the geometry for compatibility.
- Add focused tests covering deterministic construction, deep immutability, validation, rank/hop lookup, instance identity, and the preserved baseline derived values (rank spacing 272, protected corridor 200, transition span 72, handle diameter 44, usable handle-center span 28) (`test/web-tracker-lifecycle-diagram-layout.test.js`).
- Update design doc `docs/design/lifecycle-diagram-layout-algorithm.md` to describe the new boundary and explicitly state P8 is behavior-preserving and that adaptive per-hop expansion is deferred to P9.

### Testing

- Ran unit/regression targets and checks; notable results below (environment timings and Playwright browser install are noted):
  - `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js -t 'horizontal geometry'` — passed (focused tests for the new geometry seam passed).
  - `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js` and combined `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js test/web-tracker-lifecycle-diagram.test.js test/web-tracker-lifecycle-diagram-performance.test.js` — large suites passed majority tests; a small number of existing CPU-heavy tests hit the environment 30s timeout in this runner (the same shared-budget test times out on an untouched `origin/main` baseline too), indicating an environment/time budget issue rather than a functional regression; overall parity across the requested fixtures was preserved.
  - Playwright: `npx playwright test test/playwright/lifecycle-diagram.spec.js test/playwright/static-smoke.spec.js` required `npx playwright install` and host libs; after installing Chromium and dependencies, the Playwright run completed with most tests passing (9/11), two long browser-based cases hit the existing 60s timeout in this constrained environment; the route-collision audits that matter for production passed when browsers and host deps were present.
  - Linting: `npm run lint -- --quiet` succeeded after removing generated `dist/` from the check path; type checking `npm run typecheck` succeeded.
  - Build: `npm run build` succeeded and `npx prettier --check <touched files>` passed.
  - CI-equivalent script: `npm run test:ci` executed and ran many tests (242) before the test harness reported a worker RPC timeout on the runner (no assertion failures were introduced by this change).
  - Secrets/format/audit checks: `git diff --check`, `npx prettier --check`, `rg -n '(it|test)\.skip\(' test` and `git diff | ./scripts/scan-secrets.py` were run and showed no skips or secrets in the change.

Parity & diagnostics confirmation

- The baseline geometry reproduces the existing canonical values exactly (272px rank spacing, 200px protected corridor, 72px transition span, 44px handle diameter, 28px usable handle-center span, and 1850px minimum SVG width) and focused tests assert these values.
- The two extreme fan-in fixtures and their diagnostic signatures from prior work were re-verified and remain unchanged: `transitionDensityProjection()` diagnostics remained the same (41 blocked branches; primary 123 / `(0, 0, 123)`; fallback 328 / `(9, 237, 82)`; terminal typed `no-candidates`) and `paginationProjection()` retained its earlier characterization (48 blocked branches; primary 348 / `(0, 0, 348)`; fallback 928 / `(15, 681, 232)`; terminal handle `state-limit` at 32,768 states).
- `rg` audit shows legacy constants (`MINIMUM_RANK_CENTER_SPACING`, `RANK_CORRIDOR_HALF_WIDTH`, `TRANSITION_CONTROL_OFFSET`, `LAYOUT_LEFT_MARGIN`, `LAYOUT_RIGHT_MARGIN`, and the derived `MINIMUM_SVG_WIDTH`) are present only as compatibility exports and constructor defaults in `src/web/tracker/lifecycleDiagramLayout.js` and test/doc references; production consumers now take values from `LIFECYCLE_HORIZONTAL_GEOMETRY` instead of recomputing geometry independently.

Notes and residual risks

- This PR is an architectural seam only and does not implement adaptive per-hop density expansion (deferred to P9).
- A few very long-running tests can time out in constrained CI/workers; those timeouts reproduce on the baseline branch in this environment and are therefore reported as environment/test-time budget limitations rather than regressions caused by this PR.

If reviewers want I can split follow-ups (a) tighten any lingering helper signatures to remove the last fallbacks to legacy constants, and (b) add a small README fragment showing how to construct an alternate `horizontalGeometry` for local experimentation before P9.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67c27bf210832fb333ec0e63318b01)