### PR TITLE
Record gated P9 horizontal geometry result

### DIFF
--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -908,6 +908,28 @@ not calculate density demand, alter rank spacing, change candidate samples or bu
 either extreme fixture feasible. Any P9 expansion rule still needs the constructive proof (or
 exhaustive bounded test) described above before it can replace the baseline constructor inputs.
 
+#### P9 activation gate result (2026-07-28)
+
+P9 remains gated off. The current production code and characterization evidence do not demonstrate
+a finite, topology-derived demand-to-spacing rule that makes both extreme fixtures pass the complete
+two-pass materialization, handle-placement, and route-audit pipeline while preserving every existing
+budget and ordinary-fixture byte signature. In particular, the per-sweep counts above distinguish
+primary, fallback, fixed-geometry, corridor-bound, and nonincident-route-clearance evidence, but they
+do not establish a smallest feasible spacing for either fixture. Selecting an expansion from those
+counts would therefore infer causality from rejection samples rather than demonstrate a safe bound.
+
+Production consequently continues to construct exactly the baseline P8 geometry: every adjacent
+rank remains 272 px apart and the SVG remains 1,850 px wide. There is no adaptive supported-demand
+domain or expansion-width bound to document because no adaptive rule is activated; input immediately
+beyond the currently supported practical boundary retains the existing deterministic bounded failure
+behavior (`no-candidates` for the 50-way milestone convergence and the 32,768-state handle limit for
+the pagination fixture). The focused characterization test now supplies
+`BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY` explicitly for normal, reversed, and rotated input, guarding
+these signatures against a future change to the production default. A future activation must first
+add explicit nonuniform-geometry successes through the full pipeline, derive a finite monotone demand
+domain from pre-search topology, and prove the maximum width and immediately-out-of-domain failure;
+until then, partial or speculative expansion is intentionally prohibited.
+
 This is the authoritative, current list — cross-check against the code before trusting it, since
 skip states and test names can drift. `grep -rn "it\.skip(\|test\.skip(" test/` finds all of them.
 

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -1786,7 +1786,11 @@ describe("test-only lifecycle layout diagnostics", () => {
         projectionFactory(),
         permuteProjection(projectionFactory, (values) => [...values].reverse()),
         permuteProjection(projectionFactory, rotate),
-      ].map((p) => testOnlyDiagnoseLifecycleLayoutAttempt(p, 1850));
+      ].map((p) =>
+        testOnlyDiagnoseLifecycleLayoutAttempt(p, 1850, {
+          horizontalGeometry: BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
+        }),
+      );
       expect(JSON.stringify(diagnostics[1])).toBe(
         JSON.stringify(diagnostics[0]),
       );
@@ -1817,7 +1821,9 @@ describe("test-only lifecycle layout diagnostics", () => {
 
     let terminalError;
     try {
-      layoutLifecycleRoutingGraph(paginationProjection(), 1850);
+      layoutLifecycleRoutingGraph(paginationProjection(), 1850, {
+        horizontalGeometry: BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
+      });
     } catch (error) {
       terminalError = error;
     }


### PR DESCRIPTION
### Motivation

- The work attempted to add a deterministic, topology-derived adaptive per-hop horizontal geometry but required a safety gate: only activate if a bounded, provable demand→spacing rule passes the full two-pass production pipeline for both extreme fan-in fixtures. 
- Current characterization evidence does not produce a safe bounded rule that meets every activation criterion, so production must keep the immutable P8 geometry until a constructive, deterministic rule is proven.

### Description

- Preserve production behavior by keeping `BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY` as the immutable P8 horizontal geometry and not activating any adaptive expansion rule. 
- Make the baseline geometry explicit in the fan-in characterization and pagination terminal-path checks by passing `horizontalGeometry: BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY` into the focused diagnostic/test harness, ensuring byte-identical baseline signatures remain protected under normal, reversed, and rotated input orders. 
- Document the gated negative result and the evidence/requirements for any future P9 activation in `docs/design/lifecycle-diagram-layout-algorithm.md`, including the per-fixture primary/fallback counts and the retained deterministic failure bounds. 
- No production algorithms, solver budgets, candidate sampling, tolerances, two-pass replay, routing semantics, rendering, or audit rules were changed; horizontal coordinates remain sourced exclusively from the P8 geometry seam.

### Testing

- Ran focused characterization test: `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js -t 'separates primary and fallback evidence for fan-in fixtures'` — passed (1 passed, 97 skipped by filter). 
- Formatting and style: `npx prettier --check test/web-tracker-lifecycle-diagram-layout.test.js docs/design/lifecycle-diagram-layout-algorithm.md` — passed. 
- Lint: `npm run lint -- --quiet` — passed. 
- Typecheck: `npm run typecheck` (`tsc -p tsconfig.json`) — passed. 
- Build: `npm run build` — passed. 
- Repository checks: `npx prettier --check`, `git diff --check`, and `git diff | ./scripts/scan-secrets.py` — passed (no formatting, diff, or secrets issues in the committed delta). 

Note: the edit is intentionally a gated fallback (documentation + protected characterization) rather than an enabled adaptive geometry; broader test matrices (full unfiltered Vitest suites, Playwright E2E, and `npm run test:ci`) were not re-run as part of this focused documentation-and-characterization change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a683116f9ec832f8fa7a52bc4b47f81)