### PR TITLE
Document gated P9 horizontal geometry result

### DIFF
--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -1163,3 +1163,30 @@ that derives routing-node lane order _jointly_ across all ranks a branch's geome
 scoped more narrowly, or a larger budget. This checked-in test's fixed evidence (14 blocked branch
 IDs, 5×55=275 routing-only nodes, ~59.251px feasible lane spacing) is the baseline that
 rearchitecture work should aim to eliminate.
+
+### P9 activation-gate result (2026-07-28)
+
+P9 does **not** activate adaptive horizontal geometry. The P8 test-only diagnostic seam can already
+inject an explicit nonuniform `horizontalGeometry` into the same discovery materialization,
+handle-placement, and route-audit path used by production. However, the checked-in evidence does not
+demonstrate a pure topology-demand threshold that constructively bounds all three independent
+rejection classes (fixed geometry, corridor bounds, and nonincident-route clearance), followed by
+handle feasibility and the unchanged route audit, for both extreme fixtures. Candidate samples that
+reach only the fallback corridor bound and `nearestRejectedCandidate` remain descriptive rather than
+causal evidence.
+
+Accordingly, production continues to select
+`BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY`: every hop is 272 px, rank centers are 109 through 1741,
+and the SVG width is 1850 px. There is no adaptive supported-demand domain or expansion limit to
+claim in this gated result; demand immediately beyond the currently demonstrated baseline-supported
+fixture set continues through the existing bounded solver and fails with its existing typed
+`no-candidates` or 32,768-state `state-limit` result. In particular, the explicit-baseline
+characterization retains the signatures in the table above for `transitionDensityProjection()` and
+`paginationProjection()`.
+
+This negative gate is deliberately narrower than a proof that adaptive geometry cannot work. A
+future activation still needs an order-independent pre-search demand function, a finite supported
+input domain and width limit, successful full-pipeline results for both extreme fixtures, and
+byte-identical parity for every graph that remains at baseline geometry. Until those facts are
+checked in, widening selected hops would be a partially justified production behavior change and is
+therefore unsafe.

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -1786,7 +1786,11 @@ describe("test-only lifecycle layout diagnostics", () => {
         projectionFactory(),
         permuteProjection(projectionFactory, (values) => [...values].reverse()),
         permuteProjection(projectionFactory, rotate),
-      ].map((p) => testOnlyDiagnoseLifecycleLayoutAttempt(p, 1850));
+      ].map((p) =>
+        testOnlyDiagnoseLifecycleLayoutAttempt(p, 1850, {
+          horizontalGeometry: BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
+        }),
+      );
       expect(JSON.stringify(diagnostics[1])).toBe(
         JSON.stringify(diagnostics[0]),
       );
@@ -1817,7 +1821,9 @@ describe("test-only lifecycle layout diagnostics", () => {
 
     let terminalError;
     try {
-      layoutLifecycleRoutingGraph(paginationProjection(), 1850);
+      layoutLifecycleRoutingGraph(paginationProjection(), 1850, {
+        horizontalGeometry: BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
+      });
     } catch (error) {
       terminalError = error;
     }


### PR DESCRIPTION
### Motivation

- Implement the P9 objective to explore a deterministic adaptive per-hop horizontal geometry while ensuring production remains safe and unchanged unless a bounded, order-independent rule is proven. 
- Use a focused test-only harness and the existing P8 geometry seam to evaluate the two extreme fan-in fixtures and gate any production activation on strict, full-pipeline evidence.

### Description

- Make the transition/pagination fan-in characterization explicitly use `BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY` in the test harness so the baseline signatures remain byte-identical and independent of any future default (changes to `test/web-tracker-lifecycle-diagram-layout.test.js`).
- Add a documented P9 activation-gate negative result to `docs/design/lifecycle-diagram-layout-algorithm.md` that records why adaptive production expansion is not enabled, restates the baseline geometry (272px hop spacing, centers 109..1741, SVG width 1850), and enumerates the remaining requirements for a safe activation.
- Preserve production behavior and all consumers of P8 horizontal geometry; no production codepath changes to `src/web/tracker/lifecycleDiagramLayout.js` or other layout/audit budgets, samples, or tolerances were enabled.
- Keep the changes narrowly scoped to tests and documentation and add an `rg` audit confirming the shared P8 geometry remains the sole production source of horizontal coordinates.

### Testing

- Ran `npm run lint -- --quiet` (PASS), `npm run typecheck` (PASS), and `npm run build` (PASS).
- Ran `npx prettier --check` on modified files and `git diff --check` and `git diff | ./scripts/scan-secrets.py` (all PASS) and verified no `it.test.skip` occurrences with `rg -n '(it|test)\.skip\(' test` (PASS).
- Ran `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js` which completed 96/98 tests and produced two timeouts on existing 30s, performance-sensitive cases due to exploratory Vitest processes contending for CPU (environmental interference); the focused characterization change was rerun alone without an assertion failure.
- Did not complete the broader runs (`npx vitest run` for the full lifecycle-diagram suites, Playwright `test/playwright/*`, or `npm run test:ci`) during this session and therefore did not claim full CI/Playwright validation in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6831316e1c832f8cbdb8d9378313ba)