### PR TITLE
Document gated P9 adaptive geometry result and add nonuniform-geometry test harness

### DIFF
--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -908,6 +908,41 @@ not calculate density demand, alter rank spacing, change candidate samples or bu
 either extreme fixture feasible. Any P9 expansion rule still needs the constructive proof (or
 exhaustive bounded test) described above before it can replace the baseline constructor inputs.
 
+### P9 adaptive-geometry activation gate (gated negative, 2026-07-28)
+
+P9 exercised explicit nonuniform rank centers through the same two-pass production entry point,
+materialization, handle placement, route-model construction, and audit used by normal layouts. The
+checked-in harness expands only hop `2->3` (368 px rather than 272 px) on the ordinary routing
+fixture and proves byte-for-byte-equivalent normalized nodes, links, handles, dimensions, and solver
+diagnostics under normal, reversed, and deterministic rotated input order. It also proves that the
+same deeply frozen geometry identity reaches the graph, dimensions, and route model. This closes a
+test-harness gap in P8; it does not establish an adaptive rule.
+
+Production activation remains gated off. In particular, the available topology counts do not yet
+provide a bounded, monotone mapping to spacing that constructively accounts for all three distinct
+rejection classes (fixed geometry, transition-corridor bounds, and nonincident-route clearance),
+followed by globally nonoverlapping handles and an acceptable route audit. A diagnostic trial with
+uniform 320 px spacing on `transitionDensityProjection()` did not finish even the unchanged bounded
+production search within two minutes on the investigation host. That is evidence against treating
+"slightly wider" as a safe rule, but is neither a portable timeout contract nor proof that 320 px
+is infeasible. It is deliberately not part of production behavior or a test assertion.
+
+Consequently every hop still selects the baseline 272 px spacing, the exact supported-demand bound
+is unchanged, and input immediately beyond that existing boundary fails through the same bounded
+typed paths rather than starting a geometry retry/search. The preserved evidence is:
+
+| Fixture                         | Hop demand usable as a safe spacing rule | Baseline / selected spacing | Geometry bound                                    | Solver states                                  | Final audit |
+| ------------------------------- | ---------------------------------------- | --------------------------: | ------------------------------------------------- | ---------------------------------------------- | ----------- |
+| `transitionDensityProjection()` | not established                          |    272 / 272 px on all hops | 72 px transition; 28 px usable handle-center span | terminal `no-candidates`; 41 blocked branches  | not reached |
+| `paginationProjection()`        | not established                          |    272 / 272 px on all hops | 72 px transition; 28 px usable handle-center span | terminal `state-limit` at 32,768 handle states | not reached |
+
+The exact per-sweep rejection tuples in the preceding table remain the authoritative per-hop
+horizontal evidence and are now explicitly evaluated with
+`BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY`. No fixture name, ID, wall clock, retry, new tolerance,
+candidate sample, solver budget, or audit exemption is used. A future activation still needs a
+finite topology-demand domain, a deterministic maximum SVG width, complete success for both stress
+fixtures, and parity for baseline fixtures before changing the production default.
+
 This is the authoritative, current list — cross-check against the code before trusting it, since
 skip states and test names can drift. `grep -rn "it\.skip(\|test\.skip(" test/` finds all of them.
 

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -222,6 +222,84 @@ describe("lifecycle horizontal geometry", () => {
     expect(Object.keys(graph)).not.toContain("horizontalGeometry");
     expect(Object.keys(dimensions)).not.toContain("horizontalGeometry");
   });
+
+  it("exercises explicit nonuniform geometry through the complete production pipeline", () => {
+    const rankCenters = {
+      ...BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY.rankCenters,
+    };
+    for (let rank = 3; rank <= 6; rank += 1) rankCenters[rank] += 96;
+    const horizontalGeometry = createLifecycleHorizontalGeometry({
+      rankCenters,
+    });
+    const rotate = (values) => {
+      const offset = Math.floor(values.length / 3);
+      return [...values.slice(offset), ...values.slice(0, offset)];
+    };
+    const permutations = [
+      (values) => values,
+      (values) => [...values].reverse(),
+      rotate,
+    ];
+    const signatureFor = (permutation) => {
+      const original = projection();
+      const permuted = {
+        ...original,
+        nodes: permutation(original.nodes),
+        links: permutation(original.links),
+        paths: permutation(original.paths),
+      };
+      const { graph, dimensions } = layoutLifecycleRoutingGraph(
+        permuted,
+        1850,
+        { horizontalGeometry },
+      );
+      const visibleNodes = graph.nodes.filter(
+        (node) => !node.routing && node.total > 0,
+      );
+      const linksByBranch = new Map();
+      for (const link of graph.links) {
+        if (!linksByBranch.has(link.branchId))
+          linksByBranch.set(link.branchId, []);
+        linksByBranch.get(link.branchId).push(link);
+      }
+      const handles = assignBranchHandles(
+        graph.branches,
+        linksByBranch,
+        visibleNodes,
+        horizontalGeometry,
+      );
+      const model = buildLifecycleRouteModel(graph, dimensions);
+      const audit = auditLifecycleRouteGeometry({ model, handles });
+      expect(graph.horizontalGeometry).toBe(horizontalGeometry);
+      expect(dimensions.horizontalGeometry).toBe(horizontalGeometry);
+      expect(model.horizontalGeometry).toBe(horizontalGeometry);
+      expect(audit.fatalFindings).toEqual([]);
+      return {
+        dimensions: { width: dimensions.width, height: dimensions.height },
+        nodes: graph.nodes
+          .map(({ id, x0, x1, y0, y1 }) => [id, x0, x1, y0, y1])
+          .sort(([left], [right]) => compareLifecycleIds(left, right)),
+        links: graph.links
+          .map(({ id, y0, y1, transitionLaneY }) => [
+            id,
+            y0,
+            y1,
+            transitionLaneY,
+          ])
+          .sort(([left], [right]) => compareLifecycleIds(left, right)),
+        handles: handles
+          .map(({ branchId, x, y }) => [branchId, x, y])
+          .sort(([left], [right]) => compareLifecycleIds(left, right)),
+        solver: graph.transitionLaneSolverStats,
+      };
+    };
+
+    expect(horizontalGeometry.hops["2->3"].rankCenterSpacing).toBe(368);
+    expect(horizontalGeometry.hops["3->4"].rankCenterSpacing).toBe(272);
+    const signatures = permutations.map(signatureFor);
+    expect(signatures[1]).toEqual(signatures[0]);
+    expect(signatures[2]).toEqual(signatures[0]);
+  });
 });
 const deepFreeze = (value) => {
   if (!value || typeof value !== "object" || Object.isFrozen(value))
@@ -1786,7 +1864,11 @@ describe("test-only lifecycle layout diagnostics", () => {
         projectionFactory(),
         permuteProjection(projectionFactory, (values) => [...values].reverse()),
         permuteProjection(projectionFactory, rotate),
-      ].map((p) => testOnlyDiagnoseLifecycleLayoutAttempt(p, 1850));
+      ].map((p) =>
+        testOnlyDiagnoseLifecycleLayoutAttempt(p, 1850, {
+          horizontalGeometry: BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
+        }),
+      );
       expect(JSON.stringify(diagnostics[1])).toBe(
         JSON.stringify(diagnostics[0]),
       );
@@ -1817,7 +1899,9 @@ describe("test-only lifecycle layout diagnostics", () => {
 
     let terminalError;
     try {
-      layoutLifecycleRoutingGraph(paginationProjection(), 1850);
+      layoutLifecycleRoutingGraph(paginationProjection(), 1850, {
+        horizontalGeometry: BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
+      });
     } catch (error) {
       terminalError = error;
     }

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -253,16 +253,28 @@ describe("lifecycle horizontal geometry", () => {
         1850,
         { horizontalGeometry },
       );
-      const handles = graph.acceptedHandles;
+      const linksByBranch = new Map();
+      for (const link of graph.links) {
+        if (!linksByBranch.has(link.branchId))
+          linksByBranch.set(link.branchId, []);
+        linksByBranch.get(link.branchId).push(link);
+      }
+      const renderedBranches = graph.branches.filter((branch) =>
+        linksByBranch.has(branch.id),
+      );
+      const acceptedHandles = graph.acceptedHandles;
+      expect(acceptedHandles).toBeInstanceOf(Map);
+      expect(
+        renderedBranches.every((branch) => acceptedHandles.has(branch.id)),
+      ).toBe(true);
+      const handles = renderedBranches.map((branch) =>
+        acceptedHandles.get(branch.id),
+      );
       const model = buildLifecycleRouteModel(graph, dimensions);
       const audit = auditLifecycleRouteGeometry({ model, handles });
       expect(graph.horizontalGeometry).toBe(horizontalGeometry);
       expect(dimensions.horizontalGeometry).toBe(horizontalGeometry);
       expect(model.horizontalGeometry).toBe(horizontalGeometry);
-      expect(handles).toBeInstanceOf(Map);
-      expect(graph.branches.every((branch) => handles.has(branch.id))).toBe(
-        true,
-      );
       expect(audit.fatalFindings).toEqual([]);
       return {
         dimensions: { width: dimensions.width, height: dimensions.height },
@@ -277,7 +289,7 @@ describe("lifecycle horizontal geometry", () => {
             transitionLaneY,
           ])
           .sort(([left], [right]) => compareLifecycleIds(left, right)),
-        handles: [...handles.values()]
+        handles: handles
           .map(({ branchId, x, y }) => [branchId, x, y])
           .sort(([left], [right]) => compareLifecycleIds(left, right)),
         solver: graph.transitionLaneSolverStats,
@@ -1231,7 +1243,9 @@ describe("transition lane solver", () => {
     const start = Date.now();
     let thrown;
     try {
-      layoutLifecycleRoutingGraph(transitionDensityProjection(), 1850);
+      layoutLifecycleRoutingGraph(transitionDensityProjection(), 1850, {
+        horizontalGeometry: BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
+      });
     } catch (error) {
       thrown = error;
     }

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -253,26 +253,16 @@ describe("lifecycle horizontal geometry", () => {
         1850,
         { horizontalGeometry },
       );
-      const visibleNodes = graph.nodes.filter(
-        (node) => !node.routing && node.total > 0,
-      );
-      const linksByBranch = new Map();
-      for (const link of graph.links) {
-        if (!linksByBranch.has(link.branchId))
-          linksByBranch.set(link.branchId, []);
-        linksByBranch.get(link.branchId).push(link);
-      }
-      const handles = assignBranchHandles(
-        graph.branches,
-        linksByBranch,
-        visibleNodes,
-        horizontalGeometry,
-      );
+      const handles = graph.acceptedHandles;
       const model = buildLifecycleRouteModel(graph, dimensions);
       const audit = auditLifecycleRouteGeometry({ model, handles });
       expect(graph.horizontalGeometry).toBe(horizontalGeometry);
       expect(dimensions.horizontalGeometry).toBe(horizontalGeometry);
       expect(model.horizontalGeometry).toBe(horizontalGeometry);
+      expect(handles).toBeInstanceOf(Map);
+      expect(graph.branches.every((branch) => handles.has(branch.id))).toBe(
+        true,
+      );
       expect(audit.fatalFindings).toEqual([]);
       return {
         dimensions: { width: dimensions.width, height: dimensions.height },
@@ -287,7 +277,7 @@ describe("lifecycle horizontal geometry", () => {
             transitionLaneY,
           ])
           .sort(([left], [right]) => compareLifecycleIds(left, right)),
-        handles: handles
+        handles: [...handles.values()]
           .map(({ branchId, x, y }) => [branchId, x, y])
           .sort(([left], [right]) => compareLifecycleIds(left, right)),
         solver: graph.transitionLaneSolverStats,


### PR DESCRIPTION
### Motivation

- Evaluate P9's adaptive per-hop horizontal geometry through P8's immutable horizontal-geometry seam without activating an unsafe production rule.
- Preserve all existing solver budgets, candidate samples, tolerances, and the baseline deterministic failure signatures for the two extreme fan-in fixtures while adding a focused harness to collect reproducible evidence.

### Description

- Add a focused test-only harness that exercises an explicit nonuniform geometry (only hop `2->3` expanded from 272px to 368px) through the full two-pass production pipeline (discovery + final), handle placement, route-model construction, and audit; the harness is in `test/web-tracker-lifecycle-diagram-layout.test.js`.
- Wire the test to verify deterministic normalized parity (nodes, links, handles, dimensions, solver diagnostics, and ordering) under normal, reversed, and deterministic rotated input permutations, and ensure the same deeply frozen geometry identity threads through `graph`, `dimensions`, and the route model.
- Make the stress-fixture characterizations explicitly invoke `BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY` so their pre-existing diagnostic signatures remain byte-identical and preserved.
- Document the gated negative result and the investigation evidence (including the uniform-320px diagnostic trial observation) in `docs/design/lifecycle-diagram-layout-algorithm.md`, and record that production remains on the baseline geometry; do not activate any adaptive expansion in production code.
- Keep all other production behavior unchanged; no budgets, tolerances, sampling, two-pass replay semantics, or route-audit rules were modified.

### Testing

- Ran the focused harness: `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js -t "exercises explicit nonuniform geometry"` — PASS (new test passes).
- Single-file test run: `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js` — the suite completed with the new test passing; an existing long-running shared-budget test hit the unchanged 30s Vitest timeout on the host in an earlier run but the new test was fixed and passes independently; observed 97/99 (initial) then later 98/99 skipped/filtered behaviours in local iterations due to harness tuning (no tests were relaxed).
- Focused multi-file Vitest run: `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js test/web-tracker-lifecycle-diagram.test.js test/web-tracker-lifecycle-diagram-performance.test.js` — 126/128 tests passed; two existing performance-sensitive tests timed out on this host (unchanged test timeouts), and the new harness test passed.
- Playwright: `npx playwright test test/playwright/lifecycle-diagram.spec.js test/playwright/static-smoke.spec.js` — 1 static smoke test passed, 10 browser tests could not start because Playwright browsers are not installed in the execution environment (run `npx playwright install` locally/CI to verify these).
- Lint/typecheck/build/format checks: `npm run lint -- --quiet`, `npm run typecheck`, `npm run build`, and `npx prettier --check $(git diff --name-only --diff-filter=ACM origin/main)` — all passed.
- Repo checks: `git diff --check`, `rg -n '(it|test)\.skip\(' test` (no skipped tests), and `git diff | ./scripts/scan-secrets.py` — passed clean.
- Horizontal-coordinate audit: `rg -n 'rankCenterX|rankCenters|horizontalGeometry' src/web/tracker/lifecycleDiagramLayout.js src/web/tracker/lifecycleDiagram.js` — confirmed P8's horizontal-geometry instance remains the authoritative, immutable source of horizontal coordinates and is threaded to all consumers.

Remaining limitations and notes

- No adaptive production geometry was activated because the evidence does not yet provide a deterministic bounded topology-to-spacing rule that satisfies the activation gate for both stress fixtures; the PR intentionally records a gated negative result rather than partially enabling expansion.
- Some long-running, performance-sensitive tests on this host hit the existing 30s vitest timeout; those are pre-existing and unchanged by this PR and may require a longer test timeout or a different environment to run to completion.
- Playwright browser tests require `npx playwright install` in the verification environment and were not executed here due to missing browsers.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a68312a0e10832fa8a59f4d4ee27ccf)