### PR TITLE
docs: reconcile lifecycle-diagram follow-up status with PRs #1173/#1176/#1183

### DIFF
--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -238,7 +238,9 @@ falling back to plain `nodeSort`/`linkSort`; see
 below for how that was resolved (a purely topological, pre-search order — not a second D3 re-run —
 scoped to never touch the dock of an intermediate, rank 1–5 real milestone node; origin (rank 0) and
 endpoint (rank 6) docks remain intentionally eligible for reordering), and its scope note for why
-this still doesn't reach the two corridor-width-bound extreme fan-in fixtures.
+this still doesn't reach the two extreme fan-in fixtures. The later PR #1173 diagnostic refinement
+shows that their overloaded `clearanceMargin === -1` sentinel does not establish corridor width as
+the primary-sweep cause; see the authoritative status below.
 
 ## Attempted and reverted: barycenter-based `nodeSort`/`linkSort`
 
@@ -361,7 +363,8 @@ construction). But even with real-node positions provably untouched:
   32,768 states when run as a single full search under the routing-only-restricted joint order —
   essentially _at_ the ceiling, the same "exhausted the entire budget, not just short of it" signature
   the barycenter attempt and the raised-budget diagnostic (see
-  ["Outstanding follow-up work" item 1](#outstanding-follow-up-work-as-of-this-writing)) both produced.
+  [historical investigation retained in the final-status section](#outstanding-follow-up-work-authoritative-final-status))
+  both produced.
 - `tracker-lifecycle-diagram-v2.json` (the real dense production fixture) went from 3 blocked branches
   at the handle phase under the current baseline to **12** blocked branches under the joint order (a
   regression, not an improvement), and a full search exhausted the handle-state budget at 32,965 of
@@ -495,15 +498,15 @@ correction to the doc's own prior instrumentation recommendation: the precedence
 above, not the indegree-dead-end counter, is what actually discriminates the safe fix from the
 unsafe construction for these fixtures.
 
-**Scope note:** this does not change, and is not expected to change, the two genuinely infeasible
+**Historical scope note (pre-PR #1173 diagnostics):** this did not change, and was not expected to
+change, the two genuinely infeasible
 extreme fan-in fixtures (`transitionDensityProjection()` and the historical 60-app/89-branch
 pagination fixture — see "Still infeasible for a root cause neither tolerance can reach" below).
-Their rejection evidence (`clearanceMargin === -1`, the `COLLISION_MARGIN` sentinel for a
-fixed-geometry/outside-corridor rejection) is bound by `RANK_CORRIDOR_HALF_WIDTH`, a fixed constant
-driving a static X-extent corridor check that does not depend on branch order, `nodeSort`/`linkSort`,
-or `rankOrder` in any way. No ordering fix — including this one — can relax a fixed-width geometric
-ceiling; both fixtures remain infeasible, as confirmed by re-running the full suite after this fix
-(their tests still characterize the identical infeasibility signature).
+At that time, their `clearanceMargin === -1` evidence was described as a fixed-geometry/outside-
+corridor rejection bound by `RANK_CORRIDOR_HALF_WIDTH`, independent of branch order. PR #1173 later
+showed that the sentinel conflates fixed-geometry and corridor-bound rejection classes and that the
+primary sweep is rejected by nonincident-route clearance. The ordering conclusion still holds, but
+the fixed-width causal claim does not; see the authoritative per-sweep evidence below.
 
 ## Follow-up (shipped): bounded tolerances for route crossings and handle clearance
 
@@ -629,9 +632,9 @@ below.** The spec is no longer `test.skip`'d; both fixture iterations of this pa
 pass on desktop, previous-event, and touch/mobile. `tracker-lifecycle-diagram-routing-v2.json`'s
 exact-zero-collision expectation (`maxCrossings = 0`) is unaffected.
 
-**Still infeasible for a root cause neither tolerance can reach — two fixtures with a different,
-more extreme fan-in shape**, confirmed directly (not assumed) by inspecting the exact rejection
-evidence rather than just observing the failure:
+**Historical pre-PR #1173 interpretation of two still-failing extreme fan-in fixtures.** The
+failure observations below remain useful, but the claimed root cause was based on the overloaded
+sentinel and is superseded by the authoritative per-sweep diagnostics later in this document:
 
 - `transitionDensityProjection()` (50 branches funnelled through a single shared milestone) fails
   fast and deterministically with a genuine `no-candidates` invariant (not a budget exhaustion) — 41
@@ -641,17 +644,17 @@ evidence rather than just observing the failure:
   `nonincidentRouteClearance` one). `HANDLE_CLEARANCE_TOLERANCE` only widens the
   `nonincidentRouteClearance` acceptance window — it cannot help a branch that never reaches that
   check because every sampled point (both primary and fallback t-values) already falls outside the
-  standard rank corridor or intersects fixed node/label geometry. With 50 branches genuinely
-  converging on one milestone, the corridor width itself is the binding constraint, not route
-  clearance.
+  standard rank corridor or intersects fixed node/label geometry. This was the pre-PR #1173
+  interpretation; the later per-sweep diagnostics show that it cannot establish corridor width as
+  the binding primary-sweep constraint.
 - The 60-application/89-branch fixture originally used by
   `test/web-tracker-lifecycle-diagram.test.js`'s
   `"paginates more than 50 endpoint-conditioned flow rows without losing reachability"` has the same
   structural signature: 48 branches rejected with `no-candidates` on the first candidate (confirmed
   via `testOnlyDiagnoseLifecycleLayoutAttempt`), the identical fan-through-few-milestones shape.
 
-Neither fixture's underlying infeasibility is fixed — the corridor-width limitation above is real
-and unaddressed. What changed is how the test suite handles it: both tests' actual _contracts_
+Neither fixture's underlying infeasibility is fixed. What changed is how the test suite handles it:
+both tests' actual _contracts_
 (shared/cumulative/bounded/shuffle-stable handle budget across multiple candidate callbacks; and
 pagination across >50 unique flows) are now exercised against layout-feasible fixtures instead —
 the real `tracker-lifecycle-diagram-v2.json` dense fixture (discovery alone needs 45 candidate
@@ -660,12 +663,11 @@ evaluations to solve it, exercising the shared-budget contract thoroughly) and a
 `it.skip`'d any longer. `transitionDensityProjection()`'s own infeasibility remains actively
 characterized (not deleted) in
 `"resolves un-phased dense fan-in fast, without exponential blowup"`, which asserts the exact
-`no-candidates`/`clearanceMargin === -1` signature above. Making the underlying fixtures themselves
-succeed needs a genuinely different lever than either tolerance shipped here — e.g. widening the
-rank corridor itself for ranks with enough incident branches to need it, or a placement strategy
-that doesn't depend on every branch finding a legal point within a fixed-width corridor at all —
-tracked as further follow-up, not attempted here. Retrying with a larger
-`HANDLE_CLEARANCE_TOLERANCE` value alone will not help; the evidence above rules that out directly.
+`no-candidates`/`clearanceMargin === -1` signature above. PR #1173 subsequently established that
+this overloaded sentinel alone does not select a geometry lever: primary rejection is
+nonincident-route clearance, while corridor-bound samples occur only in fallback. Retrying with a
+larger `HANDLE_CLEARANCE_TOLERANCE` value alone will not help; the evidence above rules that out
+directly.
 
 ## Follow-up (shipped): unified route-crossing classifier
 
@@ -855,9 +857,27 @@ edge count (its pairwise crossing check is `O(edges-within-rank^2)`).
   now succeeds end-to-end via the bounded route-crossing/handle-clearance tolerances (see "Follow-up
   (shipped)" below), so treat it as a live, passing fixture, not an infeasible one.
 
-## Outstanding follow-up work (as of this writing)
+## Outstanding follow-up work (authoritative final status)
 
-### Fixed-corridor diagnostic refinement (2026-07-27)
+The lifecycle test-recovery project is complete. PRs
+[#1173](https://github.com/futuroptimist/jobbot3000/pull/1173),
+[#1176](https://github.com/futuroptimist/jobbot3000/pull/1176), and
+[#1183](https://github.com/futuroptimist/jobbot3000/pull/1183) refined the diagnostics, shipped the
+immutable horizontal-geometry seam, and closed its activation gate with a negative result. Zero
+Vitest tests and zero Playwright tests remain skipped. The extreme fixtures retain their bounded,
+typed failures, while ordinary supported fixtures remain green.
+
+There is no outstanding implementation phase or test debt here. In particular, adaptive geometry
+is **not** an active implementation recommendation, and neither widening
+`RANK_CORRIDOR_HALF_WIDTH`, increasing rank spacing or budgets, changing order, nor weakening
+tolerances is an established next fix. Future work should be reopened only if real data demonstrates
+the need, or if a new constructive joint route-and-handle placement design can account together for
+fixed geometry, corridor bounds, nonincident-route clearance, global handle overlap, and final audit
+acceptance. That would be a new design project, not "P10," another spacing experiment, or unfinished
+test recovery. Later historical sections preserve investigation evidence but do not supersede this
+status.
+
+### Horizontal diagnostic refinement (2026-07-27)
 
 The `clearanceMargin === -1` sentinel was too coarse to justify a production geometry change by
 itself. It is the value retained for both fixed-node/label collisions and transition-corridor-bound
@@ -903,10 +923,10 @@ defaults still select the single baseline instance. Consequently, production geo
 supported-density boundary described above are unchanged: the two extreme fan-in fixtures retain
 their exact deterministic failures and diagnostics.
 
-P9 remains responsible for defining and validating adaptive per-hop demand and expansion. P8 does
-not calculate density demand, alter rank spacing, change candidate samples or budgets, or make
-either extreme fixture feasible. Any P9 expansion rule still needs the constructive proof (or
-exhaustive bounded test) described above before it can replace the baseline constructor inputs.
+P8 did not calculate density demand, alter rank spacing, change candidate samples or budgets, or
+make either extreme fixture feasible. P9 then tested whether an adaptive per-hop rule could pass the
+activation gate and produced the gated negative result below; it did not leave an expansion rule to
+implement.
 
 ### P9 adaptive-geometry activation gate (gated negative, 2026-07-28)
 
@@ -918,8 +938,9 @@ diagnostics under normal, reversed, and deterministic rotated input order. It al
 same deeply frozen geometry identity reaches the graph, dimensions, and route model. This closes a
 test-harness gap in P8; it does not establish an adaptive rule.
 
-Production activation remains gated off. In particular, the available topology counts do not yet
-provide a bounded, monotone mapping to spacing that constructively accounts for all three distinct
+Production activation remains gated off. P9 established no bounded, monotone topology-to-spacing
+rule. In particular, the available topology counts did not provide a mapping that constructively
+accounts for all three distinct
 rejection classes (fixed geometry, transition-corridor bounds, and nonincident-route clearance),
 followed by globally nonoverlapping handles and an acceptable route audit. A diagnostic trial with
 uniform 320 px spacing on `transitionDensityProjection()` did not finish even the unchanged bounded
@@ -936,18 +957,20 @@ typed paths rather than starting a geometry retry/search. The preserved evidence
 | `transitionDensityProjection()` | not established                          |    272 / 272 px on all hops | 72 px transition; 28 px usable handle-center span | terminal `no-candidates`; 41 blocked branches  | not reached |
 | `paginationProjection()`        | not established                          |    272 / 272 px on all hops | 72 px transition; 28 px usable handle-center span | terminal `state-limit` at 32,768 handle states | not reached |
 
-The exact per-sweep rejection tuples in the preceding table remain the authoritative per-hop
+The exact per-sweep rejection tuples in the earlier diagnostic table remain the authoritative
+per-hop
 horizontal evidence and are now explicitly evaluated with
 `BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY`. No fixture name, ID, wall clock, retry, new tolerance,
-candidate sample, solver budget, or audit exemption is used. A future activation still needs a
+candidate sample, solver budget, or audit exemption is used. Any future design would still need a
 finite topology-demand domain, a deterministic maximum SVG width, complete success for both stress
 fixtures, and parity for baseline fixtures before changing the production default.
 
-This is the authoritative, current list — cross-check against the code before trusting it, since
-skip states and test names can drift. `grep -rn "it\.skip(\|test\.skip(" test/` finds all of them.
+The numbered material below is retained as historical investigation and closure evidence. It is not
+a current work list and does not override the final status above.
 
-1. **Make the base D3-Sankey layout `rankOrder`-aware** (a.k.a. "Option 2" above) — **partially
-   resolved; see "Root-causing the routing-node joint-order destabilization" above.** Four attempts
+1. **Historical investigation: make the base D3-Sankey layout `rankOrder`-aware** (a.k.a. "Option
+   2" above) — **resolved within the test-recovery project; see "Root-causing the routing-node
+   joint-order destabilization" above.** Four attempts
    were made in total (see [what didn't work alone](#what-didnt-work-alone),
    [attempted and reverted: barycenter](#attempted-and-reverted-barycenter-based-nodesortlinksort),
    the
@@ -970,14 +993,16 @@ skip states and test names can drift. `grep -rn "it\.skip(\|test\.skip(" test/` 
    applies at an eligible routing-only hop, and byte-identical
    real-node dock precedence to the unconstrained default (see that section for the full evidence).
 
-   **This does not close the corridor-width/constructive-placement gap** the two genuinely-infeasible
-   extreme fan-in fixtures hit (`transitionDensityProjection()` and the 60-application/89-branch
-   pagination fixture — see "Still infeasible for a root cause neither tolerance can reach" above),
-   and was not expected to: their rejection evidence (`clearanceMargin === -1`, the fixed-geometry
-   corridor sentinel) is bound by `RANK_CORRIDOR_HALF_WIDTH`, a static X-extent constant independent
-   of branch order entirely. Confirmed directly: both fixtures' tests still characterize the
-   identical infeasibility signature after this fix. It is also not accurately described as the fix
-   for every item below: item 2's remaining tests were resolved instead by the bounded tolerances
+   **Historical interpretation, superseded by PR #1173 diagnostics:** this did not make the two
+   genuinely infeasible extreme fan-in fixtures (`transitionDensityProjection()` and the
+   60-application/89-branch pagination fixture described above) feasible. The old text treated
+   `clearanceMargin === -1` as a fixed-corridor sentinel bound by
+   `RANK_CORRIDOR_HALF_WIDTH`; the refined diagnostic shows that this value conflates fixed-geometry
+   and corridor-bound rejections. The primary sweeps are entirely nonincident-route-clearance
+   rejections, so fallback-only corridor samples do not establish primary causality. Both fixtures'
+   tests still characterize the identical bounded failure signature. This ordering work is also not
+   accurately described as the fix for every item below: item 2's remaining tests were resolved
+   instead by the bounded tolerances
    (not by this), and item 3's remaining Playwright skip was a separate audit-methodology
    disagreement this work does not touch either. Re-confirmed independently by a still-earlier
    session that built the seeded-replay pipeline above, before the route-crossing/handle-clearance
@@ -989,10 +1014,9 @@ skip states and test names can drift. `grep -rn "it\.skip(\|test\.skip(" test/` 
    tried before hitting the normal budget. This rules out "the search just needs to be more
    efficient" for a no-tolerance, budget-only approach. (`tracker-lifecycle-diagram-v2.json`'s own
    layout problem was separately resolved afterward by the bounded tolerances in "Follow-up
-   (shipped)" below — a different, already-shipped mechanism, not this item.) The remaining,
-   still-open piece of this item is a genuinely different lever for the two corridor-bound
-   fixtures specifically — e.g. widening the rank corridor itself for ranks with enough incident
-   branches to need it — not another ordering change.
+   (shipped)" below — a different, already-shipped mechanism, not this item.) This did not leave a
+   corridor-widening or ordering task open; the conditional threshold for any new design project is
+   stated at the start of this section.
 
 2. **0 unit tests remain `it.skip`ed** (were 4). `HANDLE_CLEARANCE_TOLERANCE` and
    `toleratedRouteCrossingCount` (see "Follow-up (shipped): bounded tolerances..." above) fixed
@@ -1112,8 +1136,8 @@ below), so there was no seed for final to replay. That gap was closed afterward 
 separate, later-shipped bounded tolerances (`HANDLE_CLEARANCE_TOLERANCE` /
 `toleratedRouteCrossingCount`; see "Follow-up (shipped)" below) — not by this seeding
 mechanism itself. `tracker-lifecycle-diagram-v2.json` succeeds end-to-end today; see
-[Outstanding follow-up work](#outstanding-follow-up-work-as-of-this-writing) item 1 below
-for the two fixtures still genuinely infeasible under the full pipeline.
+the [authoritative final status](#outstanding-follow-up-work-authoritative-final-status) for the two
+fixtures that retain bounded typed failures under the full pipeline.
 
 ## Checked-in reproduction: dense routing-only handle infeasibility is structural, not a budget gap (historical -- fixed for this fixture)
 
@@ -1128,10 +1152,9 @@ milestone-convergence case (real milestone nodes, e.g. `tracker-lifecycle-diagra
 **not** fixed by this `rankOrder`-based mechanism — see the investigation section above for why the
 same approach does not extend there. `tracker-lifecycle-diagram-v2.json` was instead fixed by a
 separate, later-shipped mechanism (the bounded tolerances in "Follow-up (shipped)" below), so it has
-no remaining scope here; see
-[Outstanding follow-up work item 1](#outstanding-follow-up-work-as-of-this-writing) for the two
-different, genuinely still-infeasible extreme fixed-corridor fixtures this section's approach would
-need to target instead.
+no remaining scope here. The two different extreme fixtures retain bounded typed failures, but the
+[authoritative final status](#outstanding-follow-up-work-authoritative-final-status) does not assign
+this historical approach to them as active work.
 
 `test/web-tracker-lifecycle-diagram-layout.test.js`'s `"characterizes dense routing-only handle
 infeasibility deterministically"` (in the `"test-only lifecycle layout diagnostics"` describe
@@ -1190,11 +1213,10 @@ the binding constraint; the binding constraint is that no legal handle placement
 branches under the current per-rank lane/routing-node geometry, on the _first_ candidate, before any
 search even begins.
 
-**What actually closes this gap:** the same conclusion [Outstanding follow-up work item
-1](#outstanding-follow-up-work-as-of-this-writing) already reaches — a constructive/greedy strategy
-that derives routing-node lane order _jointly_ across all ranks a branch's geometry touches
-(effectively [Option 2](#deferred-making-the-base-d3-sankey-layout-rankorder-aware), the deferred
-`rankOrder`-aware base-layout rework), not a scoped patch to port spacing, a clearance exemption
-scoped more narrowly, or a larger budget. This checked-in test's fixed evidence (14 blocked branch
-IDs, 5×55=275 routing-only nodes, ~59.251px feasible lane spacing) is the baseline that
-rearchitecture work should aim to eliminate.
+**Historical conclusion for this now-fixed fixture:** this evidence motivated a constructive/greedy
+strategy deriving routing-node lane order jointly across all ranks a branch's geometry touches,
+rather than a scoped port-spacing patch, clearance exemption, or larger budget. The subsequently
+shipped joint-order mechanism fixed this fixture. Its historical evidence (14 blocked branch IDs,
+5×55=275 routing-only nodes, ~59.251px feasible lane spacing) does not establish the cause or next
+fix for the two different extreme fixtures; PR #1173's refined diagnostics and the
+[authoritative final status](#outstanding-follow-up-work-authoritative-final-status) govern those.


### PR DESCRIPTION
### Motivation

- Reconcile stale follow-up language in `docs/design/lifecycle-diagram-layout-algorithm.md` so the design doc reflects the diagnostic refinement and gated result surfaced in PRs #1173, #1176, and #1183 without changing any implementation, tests, or behavior.

### Description

- Clarify and label pre-#1173 claims as historical, and explicitly correct passages that treated the overloaded `clearanceMargin === -1` sentinel as proof that a fixed `RANK_CORRIDOR_HALF_WIDTH` geometry was the primary-sweep cause.
- Preserve and surface the authoritative per-sweep evidence (primary 123 / `(0, 0, 123)` with fallback 328 / `(9, 237, 82)` for `transitionDensityProjection()`; primary 348 / `(0, 0, 348)` with fallback 928 / `(15, 681, 232)` for `paginationProjection()`), while making clear that fallback-only corridor-bound samples do not establish primary causality.
- Add an explicit authoritative final status (links to PRs #1173, #1176, #1183) that records P8 as the shipped immutable horizontal-geometry seam, P9 as a gated negative activation (no adaptive rule left to implement), and that lifecycle test-recovery is complete with zero Vitest and Playwright skips; also state that adaptive geometry is not an active recommendation and that any future work must be a new constructive design project.
- Keep all historical diagnostic data, rejection tuples, fixture counts, and the investigation narrative intact but annotated so it cannot be mistaken for the current, authoritative status; no production code, tests, budgets, tolerances, samples, or audit rules were changed.

### Testing

- Ran the focused verification commands: `rg -n 'clearanceMargin === -1|RANK_CORRIDOR_HALF_WIDTH|corridor-width|widening the rank corridor|remaining, still-open|P8|P9|P10|Outstanding follow-up' docs/design/lifecycle-diagram-layout-algorithm.md` (matches updated occurrences), `npx prettier --check docs/design/lifecycle-diagram-layout-algorithm.md` (passed), `npm run lint -- --quiet` (passed), `npm run typecheck` (passed), `git diff --check` / `git diff --stat` (only `docs/design/lifecycle-diagram-layout-algorithm.md` changed), and `git diff | ./scripts/scan-secrets.py` (no secrets detected).
- Confirmed the exact per-sweep rejection tuples and counts remain present with `rg`/`git show` checks for the tuples `123 /`, `328 /`, `348 /`, and `928 /` (preserved); all formatting and lint checks passed as part of the commit preflight.
- `npm run test:ci` was started briefly during verification but its environment attempted to install Playwright Chromium/system deps and was stopped because this is a documentation-only change; the change is intentionally docs-only and does not modify runtime behavior or tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6848914674832fb1ffcbd4f58b1af7)