### PR TITLE
Keep CLI integration stderr assertions stable

### DIFF
--- a/test/web-server-integration.test.js
+++ b/test/web-server-integration.test.js
@@ -88,9 +88,7 @@ describe('web server integration with CLI', () => {
           env: {
             ...process.env,
             JOBBOT_DATA_DIR: sandboxDataDir,
-            NODE_OPTIONS: [process.env.NODE_OPTIONS, '--no-warnings']
-              .filter(Boolean)
-              .join(' '),
+            NODE_OPTIONS: '--no-warnings',
           },
           allowedEnvVars: ['NODE_OPTIONS'],
         },

--- a/test/web-server-integration.test.js
+++ b/test/web-server-integration.test.js
@@ -85,7 +85,14 @@ describe('web server integration with CLI', () => {
     try {
       const server = await startServer({
         commandAdapterOptions: {
-          env: { ...process.env, JOBBOT_DATA_DIR: sandboxDataDir },
+          env: {
+            ...process.env,
+            JOBBOT_DATA_DIR: sandboxDataDir,
+            NODE_OPTIONS: [process.env.NODE_OPTIONS, '--no-warnings']
+              .filter(Boolean)
+              .join(' '),
+          },
+          allowedEnvVars: ['NODE_OPTIONS'],
         },
       });
 


### PR DESCRIPTION
## Summary
- permit the test subprocess to receive the warning-suppression option
- keep Node runtime experimental warnings out of application stderr assertions

## Validation
- npx vitest run test/web-server-integration.test.js
- npm run lint -- --quiet
- npm run typecheck