### PR TITLE
Make Claude validator paths portable

### DIFF
--- a/.github/scripts/claude-validate.sh
+++ b/.github/scripts/claude-validate.sh
@@ -53,7 +53,7 @@ run_in_network_sandbox() {
       node_mount_args=(--ro-bind-try "$node_prefix" "$node_prefix")
       ;;
   esac
-  script_path="$(realpath -e -- "$0")"
+  script_path="$(realpath "$0")"
   sandbox_workspace="/workspace"
   sandbox_wrapper="/usr/local/bin/jobbot-claude-validate"
   # Invariant: PR-controlled validation must never receive the host root or
@@ -186,7 +186,7 @@ case "$op" in
       *) echo "node-check accepts only JavaScript source files." >&2; exit 64 ;;
     esac
     [ -f "$candidate" ] || { echo "Path is not a regular file." >&2; exit 66; }
-    resolved="$(realpath -e -- "$candidate")"
+    resolved="$(realpath "$candidate")"
     case "$resolved" in
       "$workspace"/*) ;;
       *) echo "Path escapes GITHUB_WORKSPACE." >&2; exit 66 ;;

--- a/test/claude-validate.test.js
+++ b/test/claude-validate.test.js
@@ -5,6 +5,7 @@ import {
   mkdtempSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -303,7 +304,7 @@ exit 0
     );
     expect(bindTuples).toContainEqual({
       op: "--bind",
-      source: dir,
+      source: realpathSync(dir),
       target: "/workspace",
     });
     expect(joined).toContain("--tmpfs\n/run");
@@ -324,7 +325,7 @@ exit 0
         tuple.target === wrapperBind.target;
       const isExpectedWorkspaceBind =
         tuple.op === "--bind" &&
-        tuple.source === dir &&
+        tuple.source === realpathSync(dir) &&
         tuple.target === "/workspace";
       const paths = [tuple.source, tuple.target];
       expect(paths).not.toContain("/run");


### PR DESCRIPTION
## Summary
- use portable realpath invocation in the validation wrapper
- account for macOS canonical temporary-directory paths in the contract test

## Validation
- npx vitest run test/claude-validate.test.js
- npm run lint -- --quiet
- npm run typecheck