### PR TITLE
Run typecheck in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,14 @@ name: CI
 on:
   push:
     paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - '**/*.mdx'
+      - "docs/**"
+      - "**/*.md"
+      - "**/*.mdx"
   pull_request:
     paths-ignore:
-      - 'docs/**'
-      - '**/*.md'
-      - '**/*.mdx'
+      - "docs/**"
+      - "**/*.md"
+      - "**/*.mdx"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -69,6 +69,8 @@ jobs:
       - run: npm ci
         if: steps.doc_changes.outputs.doc_only != 'true'
       - run: npm run lint
+        if: steps.doc_changes.outputs.doc_only != 'true'
+      - run: npm run typecheck
         if: steps.doc_changes.outputs.doc_only != 'true'
       - run: npm run test:ci
         if: steps.doc_changes.outputs.doc_only != 'true'


### PR DESCRIPTION
## Summary
- add the repository typecheck to the main CI workflow
- keep CI aligned with the documented contributor checks

## Validation
- npm run lint -- --quiet
- npm run typecheck