### PR TITLE
Cache lifecycle diagram projections and debounce the scrubber

### DIFF
--- a/docs/design/lifecycle-diagram-scrubber-performance-roadmap.md
+++ b/docs/design/lifecycle-diagram-scrubber-performance-roadmap.md
@@ -1,0 +1,100 @@
+# Lifecycle diagram scrubber performance: investigation and roadmap
+
+## Status
+
+Phase 1 implemented (this PR). Phases 2–5 are planned but not yet built — see the
+`diagram-performance`-labeled issues on `futuroptimist/jobbot3000` for tracking, and the
+umbrella issue for the full roadmap. This doc is a second source of context for that roadmap in
+case the issues/PR discussion threads are ever lost.
+
+## Problem
+
+On the Tracker page's Diagram tab, dragging the "Lifecycle point" scrubber causes noticeable
+main-thread jank that worsens as more history accumulates.
+
+## Root cause
+
+Investigation of `src/web/tracker/lifecycleProjection.js`, `src/web/tracker/lifecycleDiagram.js`,
+and `src/web/tracker/lifecycleDiagramLayout.js` found:
+
+- Every scrub tick fully re-sorts/re-parses the entire application + event history **twice** —
+  `buildLifecycleTimeline` and `projectLifecycleAt` each independently call `prepare(bundle)`,
+  which maps and sorts every application and every lifecycle event from scratch.
+- Each call then replays every included application's full event history from scratch inside
+  `projectApp` (no incremental state tracking between buckets).
+- The Sankey/lane/handle-collision layout search in `lifecycleDiagramLayout.js` (bounded by a
+  32768-state budget and an explicit 30s render-latency contract) reruns from zero on every
+  tick, even though adjacent scrub positions often share the same or nearly the same population
+  of applications/branches.
+- `renderSvg()` tears down the entire SVG (`scroll.textContent = ""`) and rebuilds every
+  `rect`/`path`/`circle` node from scratch on every render.
+- All of the above runs synchronously on the main thread — no Web Worker,
+  `requestIdleCallback`, or `requestAnimationFrame` usage anywhere in `src/web/tracker/`.
+- The scrubber's native `input` event was completely undebounced, so dragging fired this whole
+  pipeline once per pixel of movement.
+- No derived/cached data exists in IndexedDB (see `src/web/storage/indexedDbRepository.js`) —
+  only raw event/application stores. Everything is recomputed in memory every time, and before
+  this change, nothing was memoized at all (`grep` for `memoiz|cache|useMemo|WeakMap` across the
+  three files above returned nothing).
+
+`src/web/tracker/lifecycleDiagramLayout.js` has a documented history
+([`lifecycle-diagram-layout-algorithm.md`](lifecycle-diagram-layout-algorithm.md)) of reverted,
+subtly-buggy attempts at ordering/search changes that looked correct under manual review but
+broke production fixtures. Because of that, this work is deliberately split into 5 separate PRs
+sequenced by risk, rather than one large change.
+
+## Roadmap
+
+1. **Phase 1 — In-memory compute caching + debounce (this PR).** Pure data-layer + one
+   event-handler change. Never touches the layout file or DOM rendering shape.
+   - Added a per-bundle `WeakMap` cache in `lifecycleProjection.js` memoizing `prepare(bundle)`,
+     `buildLifecycleTimeline(bundle)`, and `projectLifecycleAt(bundle, bucketId)`. Cache key is
+     bundle object identity — safe because `state.bundle` in `tracker.js` is always replaced
+     wholesale on `refresh()`, never mutated in place.
+   - Debounced the scrubber's `input` listener in `lifecycleDiagram.js` (reused the existing
+     `makeDebounce` helper, 80ms) — discrete prev/next/current buttons stay instant since they
+     never went through that listener.
+   - Closed a latent in-place-mutation foot-gun in `tracker.js`
+     (`state.apps = state.bundle.applications.sort(...)` sorted in place; now copies first) so
+     "bundles are immutable once assigned" is an airtight invariant, not one that held by
+     ordering luck.
+   - Accepted side effect: a same-bundle/same-bucket re-render (e.g. re-navigating to the
+     Diagram tab) now returns the identical cached projection object, so
+     `lifecycleDiagram.js`'s `update()` treats it as a no-op and preserves table pagination
+     instead of resetting it. This is more correct than the prior always-reset behavior and is
+     pinned by a test.
+
+2. **Phase 2 — Incremental per-app event replay + expanded scrub-tick perf coverage + busy
+   indicator.** Restructures `projectApp`'s replay in `lifecycleProjection.js` to update state
+   incrementally instead of replaying all events per bucket from scratch. Highest
+   data-_correctness_ risk in the roadmap: `projectApp` is a dense state machine
+   (terminal/reopen handling, milestone regression detection, assessment in-progress tracking,
+   ~15 warning codes) covered by ~30 edge-case tests — any incremental formulation must produce
+   byte-identical output to full replay for every bucket, every time.
+
+3. **Phase 3 — Diff-based SVG updates + skip negligible elements.** Rewrites `renderSvg()`'s
+   teardown/rebuild into a keyed diff against the previous render, and skips constructing
+   negligible/zero-width nodes, paths, and hit-handles. Risk is DOM-shape/accessibility
+   regression (stale listeners, lost focus during a diff), not layout math.
+
+4. **Phase 4 — Seeded layout reuse across scrub ticks + two-tier drag-quality rendering.**
+   Extends the existing "seeded replay" two-pass technique (see
+   [`lifecycle-diagram-handle-search-seeding-plan.md`](lifecycle-diagram-handle-search-seeding-plan.md),
+   currently used only within a single layout call) across scrub ticks, and adds a
+   cheaper/approximate layout while actively dragging with a full-quality layout once the drag
+   settles. Highest layout-_correctness_ risk phase — must validate against the dense-fixture
+   tests and the 30s render-latency contract; may need to split further.
+
+5. **Phase 5 — Web Worker offload + persisted IndexedDB snapshot store + eager background
+   precompute.** Largest architectural departure: introduces the first derived/cached IndexedDB
+   store in a codebase whose data contract
+   ([`../browser-first-architecture.md`](../browser-first-architecture.md)) currently describes
+   only raw stores, plus Worker-lifecycle and structured-clone handling for the layout search.
+   Ordered last because it depends on stable incremental replay (Phase 2) and layout reuse
+   (Phase 4).
+
+## Tracking
+
+All work is tracked under the `diagram-performance` label on
+`futuroptimist/jobbot3000`, with one issue per phase plus an umbrella tracking issue linking
+them. Each phase's PR references and closes its corresponding issue.

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -1005,10 +1005,16 @@ export function createLifecycleDiagramView(root, options = {}) {
   prev.addEventListener("click", () => changeToIndex(Number(range.value) - 1));
   next.addEventListener("click", () => changeToIndex(Number(range.value) + 1));
   current.addEventListener("click", () => onBucketChange("current"));
-  const debouncedRangeChange = makeDebounce(() =>
-    changeToIndex(Number(range.value)),
+  // Capture range.value at input-event time and pass it through the
+  // debounce closure rather than re-reading range.value when the debounced
+  // callback fires: render() (e.g. from a ResizeObserver tick or a
+  // background refresh landing mid-drag) resets range.value to the
+  // currently *selected* bucket, which would otherwise make a pending
+  // debounced change silently revert to the pre-drag position.
+  const debouncedRangeChange = makeDebounce((value) =>
+    changeToIndex(Number(value)),
   );
-  range.addEventListener("input", debouncedRangeChange);
+  range.addEventListener("input", () => debouncedRangeChange(range.value));
   const sanitizedRootWidth = () => {
     const width = Math.floor(Number(root.clientWidth));
     return Number.isFinite(width) && width > 0 ? width : 0;

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -1002,19 +1002,34 @@ export function createLifecycleDiagramView(root, options = {}) {
     const bucket = timeline.buckets[index];
     if (bucket) onBucketChange(bucket.id);
   };
-  prev.addEventListener("click", () => changeToIndex(Number(range.value) - 1));
-  next.addEventListener("click", () => changeToIndex(Number(range.value) + 1));
-  current.addEventListener("click", () => onBucketChange("current"));
-  // Capture range.value at input-event time and pass it through the
-  // debounce closure rather than re-reading range.value when the debounced
-  // callback fires: render() (e.g. from a ResizeObserver tick or a
-  // background refresh landing mid-drag) resets range.value to the
-  // currently *selected* bucket, which would otherwise make a pending
-  // debounced change silently revert to the pre-drag position.
-  const debouncedRangeChange = makeDebounce((value) =>
-    changeToIndex(Number(value)),
-  );
-  range.addEventListener("input", () => debouncedRangeChange(range.value));
+  // Resolve the bucket *id* from the timeline at input-event time and
+  // debounce that id, rather than debouncing a raw index and resolving it
+  // against `timeline` later: `update()` can reassign `timeline` (e.g. a
+  // background refresh inserting a bucket) before the 80ms timer fires,
+  // which would otherwise shift what an unresolved index points to and
+  // silently select a different bucket than the one the user dragged to.
+  const debouncedRangeChange = makeDebounce((bucketId) => {
+    if (bucketId) onBucketChange(bucketId);
+  });
+  // A newer explicit prev/next/current action always wins over an older
+  // pending drag — without this, clicking a discrete control while a scrub
+  // debounce is still pending would let the stale drag overwrite the newer
+  // selection once its timer caught up.
+  prev.addEventListener("click", () => {
+    debouncedRangeChange.clear();
+    changeToIndex(Number(range.value) - 1);
+  });
+  next.addEventListener("click", () => {
+    debouncedRangeChange.clear();
+    changeToIndex(Number(range.value) + 1);
+  });
+  current.addEventListener("click", () => {
+    debouncedRangeChange.clear();
+    onBucketChange("current");
+  });
+  range.addEventListener("input", () => {
+    debouncedRangeChange(timeline.buckets[Number(range.value)]?.id);
+  });
   const sanitizedRootWidth = () => {
     const width = Math.floor(Number(root.clientWidth));
     return Number.isFinite(width) && width > 0 ? width : 0;

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -1005,7 +1005,10 @@ export function createLifecycleDiagramView(root, options = {}) {
   prev.addEventListener("click", () => changeToIndex(Number(range.value) - 1));
   next.addEventListener("click", () => changeToIndex(Number(range.value) + 1));
   current.addEventListener("click", () => onBucketChange("current"));
-  range.addEventListener("input", () => changeToIndex(Number(range.value)));
+  const debouncedRangeChange = makeDebounce(() =>
+    changeToIndex(Number(range.value)),
+  );
+  range.addEventListener("input", debouncedRangeChange);
   const sanitizedRootWidth = () => {
     const width = Math.floor(Number(root.clientWidth));
     return Number.isFinite(width) && width > 0 ? width : 0;
@@ -1068,6 +1071,7 @@ export function createLifecycleDiagramView(root, options = {}) {
       if (windowResizeHandler)
         window.removeEventListener("resize", windowResizeHandler);
       debouncedResize.clear();
+      debouncedRangeChange.clear();
       announce.clear();
       root.textContent = "";
     },

--- a/src/web/tracker/lifecycleProjection.js
+++ b/src/web/tracker/lifecycleProjection.js
@@ -10,6 +10,22 @@ const deepFreeze = (value) => {
   return Object.freeze(value);
 };
 
+// `bundle` objects are always replaced wholesale (never mutated in place) by
+// callers — see src/web/tracker/tracker.js's refresh(), which reassigns
+// state.bundle from a fresh IndexedDB export. That invariant is what makes a
+// WeakMap keyed on bundle identity a safe cache: mutating a bundle's arrays
+// in place instead of assigning a new bundle object will silently serve
+// stale cached results.
+const bundleCache = new WeakMap();
+const cacheFor = (bundle) => {
+  let entry = bundleCache.get(bundle);
+  if (!entry) {
+    entry = { prepared: null, timeline: null, projections: new Map() };
+    bundleCache.set(bundle, entry);
+  }
+  return entry;
+};
+
 const ORIGINS = [
   ["application_submitted", "Application submitted"],
   ["recruiter_company_outreach", "Recruiter/company reached out"],
@@ -190,6 +206,14 @@ const makeWarning = (code, applicationId, extra = {}) => ({
 });
 
 const prepare = (bundle) => {
+  const entry = cacheFor(bundle);
+  if (entry.prepared) return entry.prepared;
+  const prepared = prepareUncached(bundle);
+  entry.prepared = prepared;
+  return prepared;
+};
+
+const prepareUncached = (bundle) => {
   const warnings = [];
   const apps = (bundle.applications ?? [])
     .map((app, index) => ({ ...app, id: appId(app, index) }))
@@ -230,8 +254,10 @@ const prepare = (bundle) => {
       );
   }
   return {
-    apps,
-    events: events.filter((event) => knownApps.has(event.applicationId)),
+    apps: Object.freeze(apps),
+    events: Object.freeze(
+      events.filter((event) => knownApps.has(event.applicationId)),
+    ),
     warnings,
   };
 };
@@ -544,6 +570,15 @@ const warningCounts = (warnings) =>
   );
 
 export function projectLifecycleAt(bundle = {}, bucketId = "current") {
+  const entry = cacheFor(bundle);
+  const cached = entry.projections.get(bucketId);
+  if (cached) return cached;
+  const projection = projectLifecycleAtUncached(bundle, bucketId);
+  entry.projections.set(bucketId, projection);
+  return projection;
+}
+
+function projectLifecycleAtUncached(bundle, bucketId) {
   const { apps, events, warnings: globalWarnings } = prepare(bundle);
   const selectedEvents = bucketEvents(events, bucketId);
   const eventAppIds = new Set(
@@ -629,6 +664,14 @@ function buildBucketMetadata(bucketId, events) {
 }
 
 export function buildLifecycleTimeline(bundle = {}) {
+  const entry = cacheFor(bundle);
+  if (entry.timeline) return entry.timeline;
+  const timeline = buildLifecycleTimelineUncached(bundle);
+  entry.timeline = timeline;
+  return timeline;
+}
+
+function buildLifecycleTimelineUncached(bundle) {
   const { apps, events, warnings } = prepare(bundle);
   const datedKeys = [
     ...new Set(

--- a/src/web/tracker/lifecycleProjection.js
+++ b/src/web/tracker/lifecycleProjection.js
@@ -26,6 +26,28 @@ const cacheFor = (bundle) => {
   return entry;
 };
 
+// Bounds memory for long-lived tracker tabs that scrub across many distinct
+// buckets: each cached projection holds paths/nodes/links for every included
+// application, so retaining one per visited bucket without a cap would grow
+// roughly with visited buckets × applications. `entry.projections` is kept
+// as a Map in least-recently-used order (see getCachedProjection/
+// cacheProjection below) so the coldest bucket is evicted first.
+const MAX_CACHED_PROJECTIONS_PER_BUNDLE = 50;
+const getCachedProjection = (entry, bucketId) => {
+  const cached = entry.projections.get(bucketId);
+  if (cached === undefined) return undefined;
+  entry.projections.delete(bucketId);
+  entry.projections.set(bucketId, cached);
+  return cached;
+};
+const cacheProjection = (entry, bucketId, projection) => {
+  entry.projections.set(bucketId, projection);
+  if (entry.projections.size > MAX_CACHED_PROJECTIONS_PER_BUNDLE) {
+    const oldestKey = entry.projections.keys().next().value;
+    entry.projections.delete(oldestKey);
+  }
+};
+
 const ORIGINS = [
   ["application_submitted", "Application submitted"],
   ["recruiter_company_outreach", "Recruiter/company reached out"],
@@ -258,7 +280,7 @@ const prepareUncached = (bundle) => {
     events: Object.freeze(
       events.filter((event) => knownApps.has(event.applicationId)),
     ),
-    warnings,
+    warnings: Object.freeze(warnings),
   };
 };
 
@@ -571,10 +593,10 @@ const warningCounts = (warnings) =>
 
 export function projectLifecycleAt(bundle = {}, bucketId = "current") {
   const entry = cacheFor(bundle);
-  const cached = entry.projections.get(bucketId);
+  const cached = getCachedProjection(entry, bucketId);
   if (cached) return cached;
   const projection = projectLifecycleAtUncached(bundle, bucketId);
-  entry.projections.set(bucketId, projection);
+  cacheProjection(entry, bucketId, projection);
   return projection;
 }
 

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -312,7 +312,7 @@ async function reconcileLifecycle() {
 async function refresh() {
   await reconcileLifecycle();
   state.bundle = await repo.exportAll();
-  state.apps = state.bundle.applications.sort((a, b) =>
+  state.apps = [...state.bundle.applications].sort((a, b) =>
     String(b.appliedAt || "").localeCompare(a.appliedAt || ""),
   );
   renderAll();

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -586,10 +586,16 @@ function renderFollowups() {
   $$("[data-done]").forEach(
     (b) =>
       (b.onclick = async () => {
+        // Build a fresh copy rather than mutating the application object
+        // found in state.apps in place: it's the same reference held by
+        // state.bundle.applications, and lifecycleProjection.js's cache
+        // keys on state.bundle's identity — mutating a shared record in
+        // place without reassigning state.bundle would serve stale cached
+        // diagram data until the refresh() below reassigns it.
         const a = state.apps.find((x) => x.id === b.dataset.done);
-        delete a.followUpDate;
-        a.updatedAt = now();
-        await repo.put("applications", a);
+        const updated = { ...a, updatedAt: now() };
+        delete updated.followUpDate;
+        await repo.put("applications", updated);
         refresh();
       }),
   );
@@ -597,9 +603,12 @@ function renderFollowups() {
     (b) =>
       (b.onclick = async () => {
         const a = state.apps.find((x) => x.id === b.dataset.snooze);
-        a.followUpDate = new Date(Date.now() + 7 * 864e5).toISOString();
-        a.updatedAt = now();
-        await repo.put("applications", a);
+        const updated = {
+          ...a,
+          followUpDate: new Date(Date.now() + 7 * 864e5).toISOString(),
+          updatedAt: now(),
+        };
+        await repo.put("applications", updated);
         refresh();
       }),
   );

--- a/test/web-tracker-lifecycle-diagram-performance.test.js
+++ b/test/web-tracker-lifecycle-diagram-performance.test.js
@@ -191,4 +191,34 @@ describe("lifecycle diagram large-data rendering", () => {
           /NaN|Infinity/u,
         );
   });
+
+  it("caches repeated scrub-bucket visits far cheaper than first-visit cost", () => {
+    // This is the regression guard for the scrubber-jank fix: it doesn't
+    // just check that a single call is fast (the test above), it checks
+    // that *revisiting* a bucket while scrubbing back and forth is a cache
+    // hit rather than a full recompute.
+    const bundleData = largeBundle();
+    const timeline = buildLifecycleTimeline(bundleData);
+    const bucketIds = timeline.buckets
+      .map((entry) => entry.id)
+      .filter((id) => id !== "unknown-date" && id !== "current");
+    expect(bucketIds.length).toBeGreaterThan(0);
+
+    const firstVisitStart = performance.now();
+    for (const bucketId of bucketIds) projectLifecycleAt(bundleData, bucketId);
+    const firstVisitDuration = performance.now() - firstVisitStart;
+
+    const revisitStart = performance.now();
+    for (const bucketId of [...bucketIds].reverse())
+      projectLifecycleAt(bundleData, bucketId);
+    const revisitDuration = performance.now() - revisitStart;
+
+    expect(revisitDuration).toBeLessThan(
+      Math.max(firstVisitDuration / 4, 5),
+    );
+
+    const repeatedTimelineStart = performance.now();
+    for (let i = 0; i < 50; i += 1) buildLifecycleTimeline(bundleData);
+    expect(performance.now() - repeatedTimelineStart).toBeLessThan(50);
+  });
 });

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -512,6 +512,77 @@ describe("lifecycle diagram view", () => {
     );
   });
 
+  it("selects the bucket dragged to even if a timeline replacement shifts its index", () => {
+    vi.useFakeTimers();
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t1", "a", "recruiter_screen", "2026-01-02"),
+        ev("t2", "a", "technical_interview", "2026-01-03"),
+      ],
+    );
+    const onBucketChange = vi.fn();
+    const { root, view, timeline } = render(b, "current", onBucketChange);
+    const range = root.querySelector("input[type='range']");
+    const targetIndex = 2;
+    const targetBucketId = timeline.buckets[targetIndex].id;
+    range.value = String(targetIndex);
+    range.dispatchEvent(new window.Event("input", { bubbles: true }));
+
+    // A timeline replacement (e.g. a background refresh discovering an
+    // earlier event) inserts a bucket before the target, shifting what
+    // index `targetIndex` now points to.
+    const withEarlierEvent = bundle(
+      [app("a")],
+      [
+        ev("earlier", "a", "application_submitted", "2025-12-31"),
+        ...b.lifecycleEvents,
+      ],
+    );
+    const nextTimeline = buildLifecycleTimeline(withEarlierEvent);
+    expect(nextTimeline.buckets[targetIndex].id).not.toBe(targetBucketId);
+    view.update({
+      timeline: nextTimeline,
+      snapshot: projectLifecycleAt(withEarlierEvent, "current"),
+      selectedBucketId: "current",
+    });
+
+    vi.advanceTimersByTime(80);
+    expect(onBucketChange).toHaveBeenCalledTimes(1);
+    expect(onBucketChange).toHaveBeenCalledWith(targetBucketId);
+  });
+
+  it("lets a newer discrete prev/next/current action win over an older pending scrub", () => {
+    vi.useFakeTimers();
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t1", "a", "recruiter_screen", "2026-01-02"),
+        ev("t2", "a", "technical_interview", "2026-01-03"),
+      ],
+    );
+    const onBucketChange = vi.fn();
+    const firstBucketId = buildLifecycleTimeline(b).buckets[0].id;
+    const { root, timeline } = render(b, firstBucketId, onBucketChange);
+    const range = root.querySelector("input[type='range']");
+    range.value = "1";
+    range.dispatchEvent(new window.Event("input", { bubbles: true }));
+
+    const nextButton = [...root.querySelectorAll("button")].find(
+      (button) => button.textContent === "Next event",
+    );
+    nextButton.click();
+    expect(onBucketChange).toHaveBeenCalledTimes(1);
+    expect(onBucketChange).toHaveBeenCalledWith(timeline.buckets[2].id);
+
+    // The pending drag-to-bucket-1 debounce must have been cancelled by the
+    // newer click, not fire 80ms later and silently overwrite it.
+    vi.advanceTimersByTime(80);
+    expect(onBucketChange).toHaveBeenCalledTimes(1);
+  });
+
   it("does not mutate P4 projection and has equivalent selectable rows", () => {
     const b = bundle(
       [app("a")],

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -421,6 +421,7 @@ describe("lifecycle diagram view", () => {
   });
 
   it("synchronizes range controls and keeps user text inert", () => {
+    vi.useFakeTimers();
     const b = bundle(
       [app("bad")],
       [ev("x", "bad", "application_submitted", "2026-01-01")],
@@ -430,11 +431,49 @@ describe("lifecycle diagram view", () => {
     const range = root.querySelector("input[type='range']");
     range.value = "0";
     range.dispatchEvent(new window.Event("input", { bubbles: true }));
+    vi.advanceTimersByTime(80);
     expect(onBucketChange).toHaveBeenCalledWith(timeline.buckets[0].id);
     expect(root.querySelector("img")).toBeNull();
     expect([
       ...root.querySelectorAll("svg a, foreignObject, script"),
     ]).toHaveLength(0);
+  });
+
+  it("debounces the range scrubber so dragging fires one update with the final value", () => {
+    vi.useFakeTimers();
+    const b = bundle(
+      [app("bad")],
+      [ev("x", "bad", "application_submitted", "2026-01-01")],
+    );
+    const onBucketChange = vi.fn();
+    const { root, timeline } = render(b, "current", onBucketChange);
+    const range = root.querySelector("input[type='range']");
+    for (let i = 0; i < timeline.buckets.length; i += 1) {
+      range.value = String(i);
+      range.dispatchEvent(new window.Event("input", { bubbles: true }));
+    }
+    expect(onBucketChange).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(80);
+    expect(onBucketChange).toHaveBeenCalledTimes(1);
+    expect(onBucketChange).toHaveBeenCalledWith(
+      timeline.buckets[timeline.buckets.length - 1].id,
+    );
+  });
+
+  it("stops a pending debounced scrub update once the view is destroyed", () => {
+    vi.useFakeTimers();
+    const b = bundle(
+      [app("bad")],
+      [ev("x", "bad", "application_submitted", "2026-01-01")],
+    );
+    const onBucketChange = vi.fn();
+    const { root, view } = render(b, "current", onBucketChange);
+    const range = root.querySelector("input[type='range']");
+    range.value = "0";
+    range.dispatchEvent(new window.Event("input", { bubbles: true }));
+    view.destroy();
+    vi.advanceTimersByTime(80);
+    expect(onBucketChange).not.toHaveBeenCalled();
   });
 
   it("does not mutate P4 projection and has equivalent selectable rows", () => {
@@ -893,6 +932,48 @@ describe("lifecycle diagram P6 pagination and hardening", () => {
     });
     expect(root.querySelector("[data-event-range]").textContent).toMatch(
       /^Events (0–0|1–)/u,
+    );
+  });
+
+  it("preserves table pagination across a no-op re-render of the same bundle/bucket", () => {
+    const applications = [app("many")];
+    const lifecycleEvents = Array.from({ length: 125 }, (_, index) =>
+      ev(
+        `many-${String(index).padStart(3, "0")}`,
+        "many",
+        index ? "employer_response_received" : "application_submitted",
+        `2026-03-${String((index % 28) + 1).padStart(2, "0")}T00:00:00.000Z`,
+      ),
+    );
+    const b = bundle(applications, lifecycleEvents);
+    const { root, view, timeline } = render(b);
+    root.querySelector("[aria-label='Next event page']").click();
+    expect(root.querySelector("[data-event-range]").textContent).toBe(
+      "Events 51–100 of 125",
+    );
+
+    // Same bundle object + same bucket id: projectLifecycleAt is memoized and
+    // returns the identical cached reference, so this is a no-op re-render
+    // (e.g. re-navigating to the Diagram tab) rather than a real data change.
+    view.update({
+      timeline,
+      snapshot: projectLifecycleAt(b, "current"),
+      selectedBucketId: "current",
+    });
+    expect(root.querySelector("[data-event-range]").textContent).toBe(
+      "Events 51–100 of 125",
+    );
+
+    // A genuinely new bundle object for the same bucket id is a real data
+    // change (cache miss) and still resets pagination as before.
+    const changed = bundle(applications, lifecycleEvents.slice(0, 124));
+    view.update({
+      timeline,
+      snapshot: projectLifecycleAt(changed, "current"),
+      selectedBucketId: "current",
+    });
+    expect(root.querySelector("[data-event-range]").textContent).toBe(
+      "Events 1–50 of 124",
     );
   });
 

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -476,6 +476,42 @@ describe("lifecycle diagram view", () => {
     expect(onBucketChange).not.toHaveBeenCalled();
   });
 
+  it("keeps the dragged-to bucket if a render lands mid-debounce (e.g. resize/refresh)", () => {
+    vi.useFakeTimers();
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t1", "a", "recruiter_screen", "2026-01-02"),
+        ev("t2", "a", "technical_interview", "2026-01-03"),
+      ],
+    );
+    const onBucketChange = vi.fn();
+    const { root, view, timeline, snapshot } = render(
+      b,
+      "current",
+      onBucketChange,
+    );
+    const range = root.querySelector("input[type='range']");
+    const targetIndex = timeline.buckets.length - 2;
+    range.value = String(targetIndex);
+    range.dispatchEvent(new window.Event("input", { bubbles: true }));
+
+    // An unrelated render lands mid-debounce-window (e.g. a ResizeObserver
+    // tick or a background refresh that didn't change the selected bucket).
+    // render() resets range.value to the currently *selected* bucket
+    // ("current" here, since onBucketChange hasn't fired yet) — the pending
+    // debounced change must not be lost to that reset.
+    view.update({ timeline, snapshot, selectedBucketId: "current" });
+    expect(range.value).not.toBe(String(targetIndex));
+
+    vi.advanceTimersByTime(80);
+    expect(onBucketChange).toHaveBeenCalledTimes(1);
+    expect(onBucketChange).toHaveBeenCalledWith(
+      timeline.buckets[targetIndex].id,
+    );
+  });
+
   it("does not mutate P4 projection and has equivalent selectable rows", () => {
     const b = bundle(
       [app("a")],

--- a/test/web-tracker-lifecycle-projection.test.js
+++ b/test/web-tracker-lifecycle-projection.test.js
@@ -135,6 +135,48 @@ describe("lifecycle projection", () => {
     );
   });
 
+  it("evicts the least-recently-used cached projection past the per-bundle cap", () => {
+    // Guards the bounded-cache fix: without an eviction policy, scrubbing
+    // across many distinct buckets in one long-lived tab would retain a
+    // fully-materialized projection per bucket forever.
+    const dayEvents = Array.from({ length: 60 }, (_, i) => {
+      const date = new Date(Date.UTC(2026, 0, 1));
+      date.setUTCDate(date.getUTCDate() + i + 1);
+      return ev(
+        `e${i}`,
+        "a",
+        "employer_response_received",
+        date.toISOString().slice(0, 10),
+      );
+    });
+    const b = bundle(
+      [app("a")],
+      [ev("o", "a", "application_submitted", "2026-01-01"), ...dayEvents],
+    );
+    const timeline = buildLifecycleTimeline(b);
+    const datedBucketIds = timeline.buckets
+      .map((entry) => entry.id)
+      .filter((id) => id !== "unknown-date" && id !== "current");
+    expect(datedBucketIds.length).toBeGreaterThan(50);
+
+    const firstBucketId = datedBucketIds[0];
+    const firstProjection = projectLifecycleAt(b, firstBucketId);
+
+    // Visiting enough other distinct buckets pushes the first one out of the
+    // bounded LRU cache.
+    for (const bucketId of datedBucketIds.slice(1))
+      projectLifecycleAt(b, bucketId);
+
+    const revisited = projectLifecycleAt(b, firstBucketId);
+    expect(revisited).not.toBe(firstProjection);
+    expect(revisited).toEqual(firstProjection);
+
+    // A recently visited bucket is still a cache hit.
+    const lastBucketId = datedBucketIds.at(-1);
+    const lastProjection = projectLifecycleAt(b, lastBucketId);
+    expect(projectLifecycleAt(b, lastBucketId)).toBe(lastProjection);
+  });
+
   it("keeps serving the cached projection if a bundle is mutated in place", () => {
     // Bundles must be treated as immutable once passed in: callers are
     // expected to always pass a *new* bundle object after any data change

--- a/test/web-tracker-lifecycle-projection.test.js
+++ b/test/web-tracker-lifecycle-projection.test.js
@@ -98,6 +98,67 @@ describe("lifecycle projection", () => {
     expectInvariants(projection);
   });
 
+  it("memoizes buildLifecycleTimeline and projectLifecycleAt per bundle reference", () => {
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+
+    expect(buildLifecycleTimeline(b)).toBe(buildLifecycleTimeline(b));
+
+    const timeline = buildLifecycleTimeline(b);
+    const bucketA = timeline.buckets[1].id;
+    const bucketB = timeline.buckets[2].id;
+    expect(bucketA).not.toBe(bucketB);
+    expect(projectLifecycleAt(b, bucketA)).toBe(projectLifecycleAt(b, bucketA));
+    expect(projectLifecycleAt(b, bucketA)).not.toBe(
+      projectLifecycleAt(b, bucketB),
+    );
+
+    // A value-equal but reference-distinct bundle must not share the cache —
+    // caching is by object identity, not by deep equality.
+    const bEqual = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+    expect(projectLifecycleAt(bEqual, bucketA)).not.toBe(
+      projectLifecycleAt(b, bucketA),
+    );
+    expect(projectLifecycleAt(bEqual, bucketA)).toEqual(
+      projectLifecycleAt(b, bucketA),
+    );
+  });
+
+  it("keeps serving the cached projection if a bundle is mutated in place", () => {
+    // Bundles must be treated as immutable once passed in: callers are
+    // expected to always pass a *new* bundle object after any data change
+    // (see src/web/tracker/tracker.js's refresh(), which always reassigns
+    // state.bundle). This test pins that contract rather than leaving it
+    // implicit — mutating a bundle in place and reusing the same reference
+    // intentionally continues to serve the stale cached result.
+    const b = bundle(
+      [app("a")],
+      [ev("o", "a", "application_submitted", "2026-01-01")],
+    );
+    const before = projectLifecycleAt(b, "current");
+    expect(before.includedApplications).toBe(1);
+
+    b.lifecycleEvents.push(
+      ev("o2", "z", "application_submitted", "2026-01-02"),
+    );
+    b.applications.push(app("z"));
+
+    const after = projectLifecycleAt(b, "current");
+    expect(after).toBe(before);
+    expect(after.includedApplications).toBe(1);
+  });
+
   it("projects every origin and endpoint exactly once", () => {
     const origins = LIFECYCLE_DIAGRAM_TAXONOMY.origins.map((x) => x.id);
     const terminalEvents = [


### PR DESCRIPTION
## Summary

Phase 1 of the diagram-performance roadmap (see #1198 and
`docs/design/lifecycle-diagram-scrubber-performance-roadmap.md`).

On the Tracker page's Diagram tab, dragging the "Lifecycle point" scrubber causes noticeable
main-thread jank that worsens as more history accumulates. Investigation found:

- Every scrub tick fully re-sorted/re-parsed the entire application + event history **twice** —
  `buildLifecycleTimeline` and `projectLifecycleAt` (`src/web/tracker/lifecycleProjection.js`)
  each independently called `prepare(bundle)`.
- Each call then replayed every included application's full event history from scratch.
- The scrubber's native `input` event was completely undebounced, firing this whole pipeline
  once per pixel of drag.
- Nothing was memoized anywhere in the module.

This PR is deliberately scoped to pure data-layer caching + scrubber-input handling — it never
touches `src/web/tracker/lifecycleDiagramLayout.js`, which has a documented history
(`docs/design/lifecycle-diagram-layout-algorithm.md`) of reverted, subtly-buggy ordering/search
changes. Riskier algorithmic work (incremental replay, layout reuse, Worker offload, persisted
IndexedDB caching) is sequenced into later phases — see the roadmap doc and the
`diagram-performance`-labeled issues (#1194–#1198).

## Changes

**c04f8fb — Cache lifecycle diagram projections and debounce the scrubber**
- Added a per-bundle `WeakMap` cache in `lifecycleProjection.js` memoizing `prepare(bundle)`,
  `buildLifecycleTimeline(bundle)`, and `projectLifecycleAt(bundle, bucketId)`. Cache key is
  bundle object identity — `state.bundle` in `tracker.js` is always replaced wholesale on
  `refresh()`, never mutated in place (see the b27f830 fix below for the one place that wasn't
  true yet).
- Debounced the scrubber's `input` listener in `lifecycleDiagram.js` (80ms, via the existing
  `makeDebounce` helper).
- Accepted and pinned a side effect: a same-bundle/same-bucket re-render (e.g. re-navigating to
  the Diagram tab) now returns the identical cached projection object, so `update()` treats it as
  a no-op and preserves table pagination instead of resetting it — more correct than the prior
  always-reset behavior.
- Added `docs/design/lifecycle-diagram-scrubber-performance-roadmap.md` documenting the full
  investigation and 5-phase roadmap.

**5ba2fd8 — Address review feedback: debounce race, unbounded cache, frozen warnings**
- Fixed a real bug Copilot/Codex review caught: the debounced callback re-read `range.value` when
  it fired, but `render()` (e.g. a `ResizeObserver` tick, or a background refresh landing
  mid-drag) resets `range.value` to the currently selected bucket in the interim, which could
  silently revert a pending drag. Captured the value at input-event time instead.
- Bounded the per-bundle projection cache with LRU eviction (cap 50) so a long-lived tab
  scrubbing across many distinct buckets doesn't retain every visited projection indefinitely.
- Froze the cached `warnings` array for consistency with the already-frozen `apps`/`events`.

**0d8cea7 — Resolve scrubber bucket id at input time, not at debounce-fire time**
- A follow-up review found the previous debounce fix was still incomplete: `changeToIndex(index)`
  resolves against the *current* `timeline` closure variable, which `update()` can reassign
  before the 80ms timer fires (e.g. a background refresh inserting a bucket) — a stale numeric
  index could then resolve to the wrong bucket. Fixed by resolving the bucket **id** from the
  timeline at input-event time and debouncing the id itself.
- Fixed a related race: `prev`/`next`/`current` now clear any pending scrub debounce before
  acting, so a newer discrete navigation can't later be silently overwritten by an older pending
  drag.

**b27f830 — Stop mutating shared application records in follow-up quick actions**
- `renderFollowups()`'s "Mark done" and "Snooze" handlers found an application via
  `state.apps.find(...)` and mutated it directly before persisting. `state.apps` is only a
  shallow copy of `state.bundle.applications`, so that mutated the exact object still referenced
  by `state.bundle.applications` — a real (if narrow-window) violation of the bundle-immutability
  invariant the cache relies on. Both handlers now build a fresh copy via spread before
  persisting, matching the pattern the detail-form save handler already used.

Closes #1193.

## Test plan

- [x] `npx vitest run test/web-tracker-lifecycle-diagram.test.js test/web-tracker-lifecycle-projection.test.js test/web-tracker-lifecycle-diagram-performance.test.js` — 67 tests pass (34 + 31 + 2), including memoization reference-identity tests, LRU-eviction, debounce/race regression tests (each verified to fail against the pre-fix code and pass with the fix), a pagination-preservation test, and a repeated-scrub-tick perf assertion.
- [x] `npx vitest run test/web-tracker-metrics.test.js test/web-spreadsheet-import-export.test.js` — pass (cover other `tracker.js` exports touched by the b27f830 fix).
- [x] `npm run typecheck` and `eslint` — clean on every commit (pre-commit hook enforced).
- [x] Manually verified in a running dev server against real IndexedDB data (200–300 seeded applications/1350–1600 events): the Diagram tab renders correctly, and dispatching 20 rapid synthetic scrubber-drag events collapses into a single debounced update with the correct final bucket, no console errors.
- Note on `test/web-tracker-lifecycle-diagram-layout.test.js`'s "separates primary and fallback evidence for fan-in fixtures": this test is flaky/environment-dependent — it fails locally on this machine on both this branch *and* unmodified `main` (confirmed via `git stash`), but CI on this PR's latest head passed it along with the rest of the suite (see the `build` check). Not a regression from this PR; unrelated to the files it touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
