### PR TITLE
Rewrite the lifecycle diagram SVG render as a keyed diff

### DIFF
--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -527,6 +527,27 @@ export function createLifecycleDiagramView(root, options = {}) {
       if (!Object.is(a[key], b[key])) return false;
     return true;
   };
+  // `container.append(existingChild)` unconditionally removes and
+  // reinserts the child even when it's already in the correct position --
+  // that's a real DOM mutation, not a no-op, so doing it for every keyed
+  // element on every render would silently defeat the "reuse untouched"
+  // half of the diff contract above. This walks the container's current
+  // children alongside the desired order and only calls insertBefore for
+  // an element that's actually out of place; elements already positioned
+  // correctly are left completely untouched (zero DOM writes, zero
+  // mutation records). `startAfter` lets a reconciled range start partway
+  // through a container that also holds other, non-reconciled children
+  // (diagramSvg's title/desc/branchGroupEl/handleGroupEl before its node
+  // groups).
+  const reconcileChildOrder = (container, desiredElements, startAfter) => {
+    let referenceNode = startAfter
+      ? startAfter.nextSibling
+      : container.firstChild;
+    for (const element of desiredElements) {
+      if (referenceNode === element) referenceNode = referenceNode.nextSibling;
+      else container.insertBefore(element, referenceNode);
+    }
+  };
   const showDiagramFallback = (message) => {
     scroll.textContent = "";
     resetSvgDiffState();
@@ -641,6 +662,8 @@ export function createLifecycleDiagramView(root, options = {}) {
     );
 
     const processedBranchKeys = new Set();
+    const orderedBranchGroups = [];
+    const orderedHandleCircles = [];
     for (const branch of branches) {
       const segments = segmentsByBranch
         .get(branch.id)
@@ -791,8 +814,8 @@ export function createLifecycleDiagramView(root, options = {}) {
         });
         branchSignatureByKey.set(branch.id, signature);
       }
-      branchGroupEl.append(group);
-      if (handleCircle) handleGroupEl.append(handleCircle);
+      orderedBranchGroups.push(group);
+      if (handleCircle) orderedHandleCircles.push(handleCircle);
     }
     for (const [key, stored] of [...branchElementsByKey]) {
       if (processedBranchKeys.has(key)) continue;
@@ -802,9 +825,15 @@ export function createLifecycleDiagramView(root, options = {}) {
       branchSignatureByKey.delete(key);
       currentBranchByKey.delete(key);
     }
+    // Reconcile order only after stale keys are removed, so a removed
+    // element that's still momentarily in the DOM can't cause an
+    // unnecessary extra move while walking the desired sequence.
+    reconcileChildOrder(branchGroupEl, orderedBranchGroups);
+    reconcileChildOrder(handleGroupEl, orderedHandleCircles);
 
     try {
       const processedNodeKeys = new Set();
+      const orderedNodeGroups = [];
       for (const node of visibleNodes) {
         const rawWidth = node.x1 - node.x0;
         const rawHeight = node.y1 - node.y0;
@@ -916,7 +945,7 @@ export function createLifecycleDiagramView(root, options = {}) {
           nodeElementsByKey.set(node.id, { group: g, rect, selected });
           nodeSignatureByKey.set(node.id, signature);
         }
-        diagramSvg.append(g);
+        orderedNodeGroups.push(g);
       }
       for (const [key, stored] of [...nodeElementsByKey]) {
         if (processedNodeKeys.has(key)) continue;
@@ -925,6 +954,11 @@ export function createLifecycleDiagramView(root, options = {}) {
         nodeSignatureByKey.delete(key);
         currentNodeByKey.delete(key);
       }
+      // Node groups are diagramSvg's direct children too, appended after
+      // title/desc/branchGroupEl/handleGroupEl -- reconcile only the range
+      // starting right after handleGroupEl so those earlier, static
+      // children are never touched.
+      reconcileChildOrder(diagramSvg, orderedNodeGroups, handleGroupEl);
     } catch {
       showDiagramFallback("Unable to lay out lifecycle diagram.");
       return;

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -153,6 +153,33 @@ export function createLifecycleDiagramView(root, options = {}) {
   let applicationPage = 0;
   let displayBranches = [];
   let lastLayoutWidth = null;
+  // Keyed-diff state for renderSvg(): svg/branchG/handleG are created once
+  // and reused across renders instead of being torn down every call. Node
+  // ids (`origin:x`, `milestone:x`, `endpoint:x`) and branch ids
+  // (`branch:${semanticLinkId}:endpoint:${endpointId}`) are pure functions
+  // of taxonomy vocabulary (see docs/design/application-lifecycle-diagram.md),
+  // so they're stable/safe diff keys both within one projection's
+  // re-renders and across different bucket projections of the same bundle.
+  let diagramSvg = null;
+  let branchGroupEl = null;
+  let handleGroupEl = null;
+  const nodeElementsByKey = new Map();
+  const nodeSignatureByKey = new Map();
+  const currentNodeByKey = new Map();
+  const branchElementsByKey = new Map();
+  const branchSignatureByKey = new Map();
+  const currentBranchByKey = new Map();
+  const resetSvgDiffState = () => {
+    diagramSvg = null;
+    branchGroupEl = null;
+    handleGroupEl = null;
+    nodeElementsByKey.clear();
+    nodeSignatureByKey.clear();
+    currentNodeByKey.clear();
+    branchElementsByKey.clear();
+    branchSignatureByKey.clear();
+    currentBranchByKey.clear();
+  };
   const ids = {
     title: "lifecycle-diagram-title",
     desc: "lifecycle-diagram-desc",
@@ -338,6 +365,42 @@ export function createLifecycleDiagramView(root, options = {}) {
         .find((button) => button.dataset.diagramSelectId === feature.id)
         ?.focus();
   };
+  const branchLabelFor = (branch) => {
+    const from = TAXONOMY.get(branch.source)?.label ?? branch.source;
+    const to = TAXONOMY.get(branch.target)?.label ?? branch.target;
+    const outcome =
+      LIFECYCLE_DIAGRAM_TAXONOMY.endpoints.find(
+        (endpoint) => endpoint.id === branch.endpointId,
+      )?.label ?? branch.endpointId;
+    return `${from} to ${to}, outcome ${outcome}: ${branch.value}`;
+  };
+  const nodeLabelFor = (node) => `${node.label}: ${node.total}`;
+  // Click/touch/pointer listeners on a reused SVG element are attached
+  // exactly once, at element creation — never re-attached on reuse. To
+  // avoid them going stale (layoutLifecycleRoutingGraph() isn't memoized by
+  // projection identity, so a node/branch can have identical rendered
+  // geometry across two different buckets while its `applicationIds`
+  // membership differs), listeners look up the *current* node/branch by key
+  // at click time via these maps rather than closing over the object
+  // captured when the element was built.
+  const selectBranchByKey = (branchId) => {
+    const branch = currentBranchByKey.get(branchId);
+    if (branch)
+      selectFeature({
+        id: branch.id,
+        label: branchLabelFor(branch),
+        applicationIds: branch.applicationIds,
+      });
+  };
+  const selectNodeByKey = (nodeId) => {
+    const node = currentNodeByKey.get(nodeId);
+    if (node)
+      selectFeature({
+        id: node.id,
+        label: nodeLabelFor(node),
+        applicationIds: node.applicationIds,
+      });
+  };
   const renderDetails = () => {
     const total = projection.includedApplications || 0;
     const warningCounts = projection.warningCounts ?? {};
@@ -441,22 +504,42 @@ export function createLifecycleDiagramView(root, options = {}) {
       );
     }
   };
-  const renderSvg = () => {
+  const branchSignature = (branch, pathData, widthPx, handle) => ({
+    pathData,
+    widthPx,
+    color: branch.color,
+    value: branch.value,
+    handleX: handle?.x ?? null,
+    handleY: handle?.y ?? null,
+    handleR: handle?.radius ?? null,
+  });
+  const nodeSignature = (node) => ({
+    x0: node.x0,
+    y0: node.y0,
+    x1: node.x1,
+    y1: node.y1,
+    label: node.label,
+    total: node.total,
+  });
+  const sameSignature = (a, b) => {
+    if (!a || !b) return false;
+    for (const key of Object.keys(a))
+      if (!Object.is(a[key], b[key])) return false;
+    return true;
+  };
+  const showDiagramFallback = (message) => {
     scroll.textContent = "";
+    resetSvgDiffState();
+    scroll.append(el("p", { className: "muted", textContent: message }));
+  };
+  const renderSvg = () => {
     renderLegend();
     if (!projection.totalApplications) {
-      scroll.append(
-        el("p", { className: "muted", textContent: "No lifecycle data yet." }),
-      );
+      showDiagramFallback("No lifecycle data yet.");
       return;
     }
     if (!projection.nodes.length) {
-      scroll.append(
-        el("p", {
-          className: "muted",
-          textContent: "No diagram nodes are available for this point.",
-        }),
-      );
+      showDiagramFallback("No diagram nodes are available for this point.");
       return;
     }
     let graph;
@@ -470,12 +553,7 @@ export function createLifecycleDiagramView(root, options = {}) {
           : undefined,
       ));
     } catch {
-      scroll.append(
-        el("p", {
-          className: "muted",
-          textContent: "Unable to lay out lifecycle diagram.",
-        }),
-      );
+      showDiagramFallback("Unable to lay out lifecycle diagram.");
       return;
     }
     const { width, height } = dimensions;
@@ -486,22 +564,6 @@ export function createLifecycleDiagramView(root, options = {}) {
       finiteNode(link.target) &&
       Number.isFinite(link.width ?? 0) &&
       link.target.rank === link.source.rank + 1;
-    const svg = svgEl("svg", {
-      role: "img",
-      "aria-labelledby": `${ids.title} ${ids.desc}`,
-      viewBox: `0 0 ${width} ${height}`,
-      width,
-      height,
-      "data-reduced-motion": reduceMotion?.matches ? "true" : "false",
-    });
-    svg.append(svgEl("title", { id: ids.title }));
-    svg.querySelector("title").textContent = "Lifecycle Sankey diagram";
-    svg.append(svgEl("desc", { id: ids.desc }));
-    svg.querySelector("desc").textContent =
-      "Application counts flowing through protected adjacent-rank lifecycle branches. " +
-      "Equivalent tables follow.";
-    const handleG = svgEl("g", { fill: "none" });
-    const branchG = svgEl("g", { fill: "none" });
     const visibleNodes = graph.nodes.filter(
       (n) => !n.routing && n.total > 0 && finiteNode(n),
     );
@@ -543,14 +605,42 @@ export function createLifecycleDiagramView(root, options = {}) {
         );
       }
     } catch {
-      scroll.append(
-        el("p", {
-          className: "muted",
-          textContent: "Unable to lay out lifecycle diagram.",
-        }),
-      );
+      showDiagramFallback("Unable to lay out lifecycle diagram.");
       return;
     }
+
+    // svg/branchGroupEl/handleGroupEl are created once and reused across
+    // renders (a scrub tick, click, or resize no longer tears down and
+    // rebuilds the whole SVG). branchGroupEl must stay appended before
+    // handleGroupEl -- an existing test asserts the visible-link group's
+    // DOM index is less than the link-hit group's.
+    if (!diagramSvg) {
+      scroll.textContent = "";
+      diagramSvg = svgEl("svg", {
+        role: "img",
+        "aria-labelledby": `${ids.title} ${ids.desc}`,
+      });
+      diagramSvg.append(svgEl("title", { id: ids.title }));
+      diagramSvg.querySelector("title").textContent =
+        "Lifecycle Sankey diagram";
+      diagramSvg.append(svgEl("desc", { id: ids.desc }));
+      diagramSvg.querySelector("desc").textContent =
+        "Application counts flowing through protected adjacent-rank lifecycle branches. " +
+        "Equivalent tables follow.";
+      branchGroupEl = svgEl("g", { fill: "none" });
+      handleGroupEl = svgEl("g", { fill: "none" });
+      diagramSvg.append(branchGroupEl, handleGroupEl);
+      scroll.append(diagramSvg);
+    }
+    diagramSvg.setAttribute("viewBox", `0 0 ${width} ${height}`);
+    diagramSvg.setAttribute("width", width);
+    diagramSvg.setAttribute("height", height);
+    diagramSvg.setAttribute(
+      "data-reduced-motion",
+      reduceMotion?.matches ? "true" : "false",
+    );
+
+    const processedBranchKeys = new Set();
     for (const branch of branches) {
       const segments = segmentsByBranch
         .get(branch.id)
@@ -560,209 +650,285 @@ export function createLifecycleDiagramView(root, options = {}) {
         dimensions.horizontalGeometry,
       );
       if (!pathData || /NaN|Infinity/u.test(pathData)) continue;
-      const from = TAXONOMY.get(branch.source)?.label ?? branch.source;
-      const to = TAXONOMY.get(branch.target)?.label ?? branch.target;
-      const outcome =
-        LIFECYCLE_DIAGRAM_TAXONOMY.endpoints.find(
-          (endpoint) => endpoint.id === branch.endpointId,
-        )?.label ?? branch.endpointId;
-      const branchLabel = `${from} to ${to}, outcome ${outcome}: ${branch.value}`;
+      processedBranchKeys.add(branch.id);
+      currentBranchByKey.set(branch.id, branch);
       const selected = selectedFeature?.id === branch.id;
       const widthPx = Math.max(
         3,
         ...segments.map((segment) => renderedBranchStrokeWidth(segment.width)),
       );
-      const selectBranch = () =>
-        selectFeature({
-          id: branch.id,
-          label: branchLabel,
-          applicationIds: branch.applicationIds,
+      const handle = handles.get(branch.id);
+      const signature = branchSignature(branch, pathData, widthPx, handle);
+      const stored = branchElementsByKey.get(branch.id);
+      const previousSignature = branchSignatureByKey.get(branch.id);
+      let group;
+      let handleCircle;
+
+      if (stored && sameSignature(previousSignature, signature)) {
+        group = stored.group;
+        handleCircle = stored.handleCircle;
+        if (stored.selected !== selected) {
+          group.setAttribute("data-selected", selected ? "true" : "false");
+          stored.path.setAttribute(
+            "data-selected",
+            selected ? "true" : "false",
+          );
+          stored.path.setAttribute(
+            "stroke-opacity",
+            selected ? "1" : String(BRANCH_STROKE_OPACITY),
+          );
+          if (selected && !stored.hasHalo) {
+            const halo = svgEl("path", {
+              d: pathData,
+              stroke: "#F8FAFC",
+              "stroke-width": widthPx + 12,
+              "pointer-events": "none",
+              "aria-hidden": "true",
+              "data-diagram-branch-halo": branch.id,
+            });
+            group.insertBefore(halo, group.firstChild);
+            stored.hasHalo = true;
+          } else if (!selected && stored.hasHalo) {
+            group.querySelector("[data-diagram-branch-halo]")?.remove();
+            stored.hasHalo = false;
+          }
+          stored.selected = selected;
+        }
+      } else {
+        if (stored) {
+          stored.group.remove();
+          stored.handleCircle?.remove();
+        }
+        const branchLabel = branchLabelFor(branch);
+        group = svgEl("g", {
+          "data-diagram-branch-group": branch.id,
+          "data-selected": selected ? "true" : "false",
         });
-      const group = svgEl("g", {
-        "data-diagram-branch-group": branch.id,
-        "data-selected": selected ? "true" : "false",
-      });
-      if (selected)
+        let hasHalo = false;
+        if (selected) {
+          group.append(
+            svgEl("path", {
+              d: pathData,
+              stroke: "#F8FAFC",
+              "stroke-width": widthPx + 12,
+              "pointer-events": "none",
+              "aria-hidden": "true",
+              "data-diagram-branch-halo": branch.id,
+            }),
+          );
+          hasHalo = true;
+        }
         group.append(
           svgEl("path", {
             d: pathData,
-            stroke: "#F8FAFC",
-            "stroke-width": widthPx + 12,
+            stroke: "#020617",
+            "stroke-width": widthPx + 6,
             "pointer-events": "none",
             "aria-hidden": "true",
-            "data-diagram-branch-halo": branch.id,
+            "data-diagram-branch-separator": branch.id,
           }),
         );
-      group.append(
-        svgEl("path", {
+        const path = svgEl("path", {
           d: pathData,
-          stroke: "#020617",
-          "stroke-width": widthPx + 6,
-          "pointer-events": "none",
-          "aria-hidden": "true",
-          "data-diagram-branch-separator": branch.id,
-        }),
-      );
-      const path = svgEl("path", {
-        d: pathData,
-        stroke: branch.color,
-        "stroke-width": widthPx,
-        "stroke-opacity": selected ? "1" : String(BRANCH_STROKE_OPACITY),
-        "data-diagram-link": branch.id,
-        "data-diagram-branch": branch.id,
-        "data-semantic-link-id": branch.semanticLinkId,
-        "data-endpoint-id": branch.endpointId,
-        "data-source-node-id": branch.source,
-        "data-target-node-id": branch.target,
-        "data-selected": selected ? "true" : "false",
-        "data-segment-ranks": segments
-          .map((segment) => `${segment.source.rank}-${segment.target.rank}`)
-          .join(","),
-      });
-      path.append(svgEl("title"));
-      path.querySelector("title").textContent = branchLabel;
-      path.addEventListener("click", (event) => {
-        event.stopPropagation();
-        selectBranch();
-      });
-      path.addEventListener("touchend", (event) => {
-        event.preventDefault();
-        event.stopPropagation();
-        selectBranch();
-      });
-      group.append(path);
-      const handle = handles.get(branch.id);
-      if (handle) {
-        const circle = svgEl("circle", {
-          cx: handle.x,
-          cy: handle.y,
-          r: handle.radius,
-          fill: "transparent",
-          "pointer-events": "all",
-          "data-diagram-link-hit": branch.id,
-          "data-diagram-branch-handle": branch.id,
-          "aria-hidden": "true",
-        });
-        circle.addEventListener("click", (event) => {
-          event.stopPropagation();
-          selectBranch();
-        });
-        circle.addEventListener("touchend", (event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          selectBranch();
-        });
-        circle.addEventListener("pointerup", (event) => {
-          event.stopPropagation();
-          selectBranch();
-        });
-        handleG.append(circle);
-      }
-      branchG.append(group);
-    }
-    svg.append(branchG);
-    svg.append(handleG);
-    try {
-      for (const node of visibleNodes) {
-        const nodeLabel = `${node.label}: ${node.total}`;
-        const selected = selectedFeature?.id === node.id;
-        const g = svgEl("g", {
-          "data-diagram-node": node.id,
+          stroke: branch.color,
+          "stroke-width": widthPx,
+          "stroke-opacity": selected ? "1" : String(BRANCH_STROKE_OPACITY),
+          "data-diagram-link": branch.id,
+          "data-diagram-branch": branch.id,
+          "data-semantic-link-id": branch.semanticLinkId,
+          "data-endpoint-id": branch.endpointId,
+          "data-source-node-id": branch.source,
+          "data-target-node-id": branch.target,
           "data-selected": selected ? "true" : "false",
+          "data-segment-ranks": segments
+            .map((segment) => `${segment.source.rank}-${segment.target.rank}`)
+            .join(","),
         });
-        const rect = svgEl("rect", {
-          x: node.x0,
-          y: node.y0,
-          width: Math.max(8, node.x1 - node.x0),
-          height: Math.max(8, node.y1 - node.y0),
-          rx: 4,
-          fill: node.id.startsWith("endpoint:")
-            ? endpointColor(node.id.split(":").at(-1))
-            : "#64748b",
-          stroke: selected ? "#F8FAFC" : "#e2e8f0",
-          "stroke-width": selected ? "4" : "1",
+        path.append(svgEl("title"));
+        path.querySelector("title").textContent = branchLabel;
+        path.addEventListener("click", (event) => {
+          event.stopPropagation();
+          selectBranchByKey(branch.id);
         });
-        g.append(svgEl("title"));
-        g.querySelector("title").textContent = nodeLabel;
-        const selectNode = () =>
-          selectFeature({
-            id: node.id,
-            label: nodeLabel,
-            applicationIds: node.applicationIds,
+        path.addEventListener("touchend", (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          selectBranchByKey(branch.id);
+        });
+        group.append(path);
+        handleCircle = null;
+        if (handle) {
+          handleCircle = svgEl("circle", {
+            cx: handle.x,
+            cy: handle.y,
+            r: handle.radius,
+            fill: "transparent",
+            "pointer-events": "all",
+            "data-diagram-link-hit": branch.id,
+            "data-diagram-branch-handle": branch.id,
+            "aria-hidden": "true",
           });
-        const hitBox = rendererHitBoxForNode(
-          node,
-          dimensions.horizontalGeometry,
-        );
-        const hitRect = svgEl("rect", {
-          x: hitBox.x,
-          y: hitBox.y,
-          width: hitBox.width,
-          height: hitBox.height,
-          fill: "transparent",
-          "pointer-events": "all",
-          "aria-hidden": "true",
-          "data-diagram-node-hit": node.id,
+          handleCircle.addEventListener("click", (event) => {
+            event.stopPropagation();
+            selectBranchByKey(branch.id);
+          });
+          handleCircle.addEventListener("touchend", (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            selectBranchByKey(branch.id);
+          });
+          handleCircle.addEventListener("pointerup", (event) => {
+            event.stopPropagation();
+            selectBranchByKey(branch.id);
+          });
+        }
+        branchElementsByKey.set(branch.id, {
+          group,
+          path,
+          handleCircle,
+          hasHalo,
+          selected,
         });
-        hitRect.addEventListener("click", (event) => {
-          event.stopPropagation();
-          selectNode();
-        });
-        hitRect.addEventListener("touchend", (event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          selectNode();
-        });
-        hitRect.addEventListener("pointerup", (event) => {
-          event.stopPropagation();
-          selectNode();
-        });
-        rect.addEventListener("click", (event) => {
-          event.stopPropagation();
-          selectNode();
-        });
-        rect.addEventListener("touchend", (event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          selectNode();
-        });
-        rect.addEventListener("pointerup", (event) => {
-          event.stopPropagation();
-          selectNode();
-        });
-        const labelBox = labelBoxForNode(node, dimensions.horizontalGeometry);
-        const label = svgEl("text", {
-          x: labelBox.x + labelBox.width / 2,
-          y: labelBox.y + 12,
-          "text-anchor": "middle",
-          fill: "currentColor",
-          "data-diagram-node-label": node.id,
-        });
-        wrapLifecycleLabel(node.label).forEach((line, index) => {
-          const tspan = svgEl("tspan", {
+        branchSignatureByKey.set(branch.id, signature);
+      }
+      branchGroupEl.append(group);
+      if (handleCircle) handleGroupEl.append(handleCircle);
+    }
+    for (const [key, stored] of [...branchElementsByKey]) {
+      if (processedBranchKeys.has(key)) continue;
+      stored.group.remove();
+      stored.handleCircle?.remove();
+      branchElementsByKey.delete(key);
+      branchSignatureByKey.delete(key);
+      currentBranchByKey.delete(key);
+    }
+
+    try {
+      const processedNodeKeys = new Set();
+      for (const node of visibleNodes) {
+        const rawWidth = node.x1 - node.x0;
+        const rawHeight = node.y1 - node.y0;
+        // Symmetric to the branch loop's pathData NaN/Infinity skip above:
+        // degenerate (non-positive) geometry is a layout-bug symptom, not
+        // something to paper over with the minimum-size floor below.
+        if (!(rawWidth > 0) || !(rawHeight > 0)) continue;
+        processedNodeKeys.add(node.id);
+        currentNodeByKey.set(node.id, node);
+        const selected = selectedFeature?.id === node.id;
+        const signature = nodeSignature(node);
+        const stored = nodeElementsByKey.get(node.id);
+        const previousSignature = nodeSignatureByKey.get(node.id);
+        let g;
+
+        if (stored && sameSignature(previousSignature, signature)) {
+          g = stored.group;
+          if (stored.selected !== selected) {
+            stored.rect.setAttribute(
+              "stroke",
+              selected ? "#F8FAFC" : "#e2e8f0",
+            );
+            stored.rect.setAttribute("stroke-width", selected ? "4" : "1");
+            g.setAttribute("data-selected", selected ? "true" : "false");
+            stored.selected = selected;
+          }
+        } else {
+          if (stored) stored.group.remove();
+          const nodeLabel = nodeLabelFor(node);
+          g = svgEl("g", {
+            "data-diagram-node": node.id,
+            "data-selected": selected ? "true" : "false",
+          });
+          const rect = svgEl("rect", {
+            x: node.x0,
+            y: node.y0,
+            width: Math.max(8, rawWidth),
+            height: Math.max(8, rawHeight),
+            rx: 4,
+            fill: node.id.startsWith("endpoint:")
+              ? endpointColor(node.id.split(":").at(-1))
+              : "#64748b",
+            stroke: selected ? "#F8FAFC" : "#e2e8f0",
+            "stroke-width": selected ? "4" : "1",
+          });
+          g.append(svgEl("title"));
+          g.querySelector("title").textContent = nodeLabel;
+          const hitBox = rendererHitBoxForNode(
+            node,
+            dimensions.horizontalGeometry,
+          );
+          const hitRect = svgEl("rect", {
+            x: hitBox.x,
+            y: hitBox.y,
+            width: hitBox.width,
+            height: hitBox.height,
+            fill: "transparent",
+            "pointer-events": "all",
+            "aria-hidden": "true",
+            "data-diagram-node-hit": node.id,
+          });
+          hitRect.addEventListener("click", (event) => {
+            event.stopPropagation();
+            selectNodeByKey(node.id);
+          });
+          hitRect.addEventListener("touchend", (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            selectNodeByKey(node.id);
+          });
+          hitRect.addEventListener("pointerup", (event) => {
+            event.stopPropagation();
+            selectNodeByKey(node.id);
+          });
+          rect.addEventListener("click", (event) => {
+            event.stopPropagation();
+            selectNodeByKey(node.id);
+          });
+          rect.addEventListener("touchend", (event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            selectNodeByKey(node.id);
+          });
+          rect.addEventListener("pointerup", (event) => {
+            event.stopPropagation();
+            selectNodeByKey(node.id);
+          });
+          const labelBox = labelBoxForNode(node, dimensions.horizontalGeometry);
+          const label = svgEl("text", {
             x: labelBox.x + labelBox.width / 2,
-            dy: index ? "1.1em" : "0",
+            y: labelBox.y + 12,
+            "text-anchor": "middle",
+            fill: "currentColor",
+            "data-diagram-node-label": node.id,
           });
-          tspan.textContent = line;
-          label.append(tspan);
-        });
-        label.addEventListener("click", (event) => {
-          event.stopPropagation();
-          selectNode();
-        });
-        g.append(hitRect, rect, label);
-        svg.append(g);
+          wrapLifecycleLabel(node.label).forEach((line, index) => {
+            const tspan = svgEl("tspan", {
+              x: labelBox.x + labelBox.width / 2,
+              dy: index ? "1.1em" : "0",
+            });
+            tspan.textContent = line;
+            label.append(tspan);
+          });
+          label.addEventListener("click", (event) => {
+            event.stopPropagation();
+            selectNodeByKey(node.id);
+          });
+          g.append(hitRect, rect, label);
+          nodeElementsByKey.set(node.id, { group: g, rect, selected });
+          nodeSignatureByKey.set(node.id, signature);
+        }
+        diagramSvg.append(g);
+      }
+      for (const [key, stored] of [...nodeElementsByKey]) {
+        if (processedNodeKeys.has(key)) continue;
+        stored.group.remove();
+        nodeElementsByKey.delete(key);
+        nodeSignatureByKey.delete(key);
+        currentNodeByKey.delete(key);
       }
     } catch {
-      scroll.append(
-        el("p", {
-          className: "muted",
-          textContent: "Unable to lay out lifecycle diagram.",
-        }),
-      );
+      showDiagramFallback("Unable to lay out lifecycle diagram.");
       return;
     }
-    scroll.append(svg);
   };
   const renderTables = () => {
     const activeLabel =

--- a/test/playwright/lifecycle-diagram.spec.js
+++ b/test/playwright/lifecycle-diagram.spec.js
@@ -843,6 +843,11 @@ test.describe("Application Lifecycle Diagram", () => {
   test("renders seeded current/historical states with semantic tables and selection", async ({
     page,
   }) => {
+    // This single test deliberately combines desktop + mobile rendering,
+    // two axe-core audits, timeline transitions, selection, hostile-input,
+    // and persistence checks -- its observed CI runtime approaches the
+    // default 60s limit even though it passes comfortably standalone.
+    test.slow();
     const requests = [];
     page.on("request", (request) => requests.push(request));
     await importFixture(page);

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -822,6 +822,240 @@ describe("lifecycle diagram view", () => {
     view.destroy();
   });
 
+  it("reuses unchanged SVG node/branch elements across a no-op re-render", () => {
+    const b = bundle(
+      [app("a"), app("b")],
+      [
+        ev("o1", "a", "application_submitted", "2026-01-01"),
+        ev("t1", "a", "technical_interview", "2026-01-02"),
+        ev("o2", "b", "application_submitted", "2026-01-01"),
+        ev("t2", "b", "technical_interview", "2026-01-02"),
+      ],
+    );
+    const { root, view, timeline, snapshot } = render(b);
+    const nodeGroup = root.querySelector(
+      "[data-diagram-node='origin:application_submitted']",
+    );
+    const nodeRect = nodeGroup.querySelector(
+      "rect:not([data-diagram-node-hit])",
+    );
+    const branchGroup = root.querySelector("[data-diagram-branch-group]");
+    const branchPath = branchGroup.querySelector("[data-diagram-link]");
+
+    view.update({ timeline, snapshot, selectedBucketId: "current" });
+
+    expect(
+      root.querySelector("[data-diagram-node='origin:application_submitted']"),
+    ).toBe(nodeGroup);
+    expect(
+      root
+        .querySelector("[data-diagram-node='origin:application_submitted']")
+        .querySelector("rect:not([data-diagram-node-hit])"),
+    ).toBe(nodeRect);
+    expect(root.querySelector("[data-diagram-branch-group]")).toBe(branchGroup);
+    expect(
+      root.querySelector("[data-diagram-branch-group] [data-diagram-link]"),
+    ).toBe(branchPath);
+  });
+
+  it("reuses the SVG node group on selection, patching only selection attributes", () => {
+    const b = bundle(
+      [app("a")],
+      [ev("o1", "a", "application_submitted", "2026-01-01")],
+    );
+    const { root } = render(b);
+    const nodeGroup = root.querySelector(
+      "[data-diagram-node='origin:application_submitted']",
+    );
+    const nodeRect = nodeGroup.querySelector(
+      "rect:not([data-diagram-node-hit])",
+    );
+    const hitRect = nodeGroup.querySelector("[data-diagram-node-hit]");
+    expect(nodeGroup.getAttribute("data-selected")).toBe("false");
+    expect(nodeRect.getAttribute("stroke")).toBe("#e2e8f0");
+
+    nodeRect.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+
+    const sameGroup = root.querySelector(
+      "[data-diagram-node='origin:application_submitted']",
+    );
+    expect(sameGroup).toBe(nodeGroup);
+    expect(sameGroup.querySelector("rect:not([data-diagram-node-hit])")).toBe(
+      nodeRect,
+    );
+    expect(sameGroup.querySelector("[data-diagram-node-hit]")).toBe(hitRect);
+    expect(sameGroup.getAttribute("data-selected")).toBe("true");
+    expect(nodeRect.getAttribute("stroke")).toBe("#F8FAFC");
+  });
+
+  it("reuses the SVG branch group on selection, adding/removing only the halo", () => {
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o1", "a", "application_submitted", "2026-01-01"),
+        ev("t1", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+    const { root } = render(b);
+    const branchGroup = root.querySelector("[data-diagram-branch-group]");
+    const branchPath = branchGroup.querySelector("[data-diagram-link]");
+    expect(branchGroup.querySelector("[data-diagram-branch-halo]")).toBeNull();
+
+    branchPath.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+
+    const sameGroup = root.querySelector("[data-diagram-branch-group]");
+    expect(sameGroup).toBe(branchGroup);
+    expect(sameGroup.querySelector("[data-diagram-link]")).toBe(branchPath);
+    expect(sameGroup.getAttribute("data-selected")).toBe("true");
+    expect(
+      sameGroup.querySelector("[data-diagram-branch-halo]"),
+    ).not.toBeNull();
+
+    // Selecting something else (there's no click-to-toggle-off) deselects
+    // the branch, which should remove the halo from the same reused group.
+    root
+      .querySelector(
+        "[data-diagram-node='origin:application_submitted'] rect:not([data-diagram-node-hit])",
+      )
+      .dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    expect(root.querySelector("[data-diagram-branch-group]")).toBe(branchGroup);
+    expect(root.querySelector("[data-diagram-link]")).toBe(branchPath);
+    expect(branchGroup.getAttribute("data-selected")).toBe("false");
+    expect(root.querySelector("[data-diagram-branch-halo]")).toBeNull();
+  });
+
+  it("disconnects SVG elements for nodes that drop out of a later bucket", () => {
+    const b = bundle(
+      [app("a")],
+      [ev("o1", "a", "application_submitted", "2026-01-01")],
+    );
+    const { root, view, timeline } = render(b, "unknown-date");
+    // "unknown-date" has no dated events for this bundle, so the diagram
+    // shows the empty-nodes fallback rather than an origin node.
+    expect(
+      root.querySelector("[data-diagram-node='origin:application_submitted']"),
+    ).toBeNull();
+
+    view.update({
+      timeline,
+      snapshot: projectLifecycleAt(b, "current"),
+      selectedBucketId: "current",
+    });
+    const nodeGroup = root.querySelector(
+      "[data-diagram-node='origin:application_submitted']",
+    );
+    expect(nodeGroup).not.toBeNull();
+    expect(nodeGroup.isConnected).toBe(true);
+
+    view.update({
+      timeline,
+      snapshot: projectLifecycleAt(b, "unknown-date"),
+      selectedBucketId: "unknown-date",
+    });
+    expect(
+      root.querySelector("[data-diagram-node='origin:application_submitted']"),
+    ).toBeNull();
+    expect(nodeGroup.isConnected).toBe(false);
+  });
+
+  it("keeps a reused SVG node's click listener reading current, not stale, data", () => {
+    // The projection layer replays event histories fresh every render (only
+    // Phase 1/2's *bucket-level* results are cached), so a node's rendered
+    // signature (position/size/label/total) can be identical across two
+    // different bundles while the underlying application membership behind
+    // it differs -- e.g. two applications swap origins, leaving the
+    // "referral" node's total unchanged but backed by a different
+    // application. A reused element's listener must reflect the *current*
+    // render's data, not whatever was captured when the element was built.
+    const endEvents = (id) => [
+      ev(`${id}-recruiter`, id, "recruiter_screen", "2026-01-02"),
+      ev(`${id}-rejected`, id, "employer_rejected", "2026-01-03"),
+    ];
+    const before = bundle(
+      [app("a"), app("b")],
+      [
+        ev("a-origin", "a", "referral", "2026-01-01"),
+        ...endEvents("a"),
+        ev("b-origin", "b", "candidate_outreach", "2026-01-01"),
+        ...endEvents("b"),
+      ],
+    );
+    const after = bundle(
+      [app("a"), app("b")],
+      [
+        ev("a-origin", "a", "candidate_outreach", "2026-01-01"),
+        ...endEvents("a"),
+        ev("b-origin", "b", "referral", "2026-01-01"),
+        ...endEvents("b"),
+      ],
+    );
+    const { root, view } = render(before);
+    const referralGroup = root.querySelector(
+      "[data-diagram-node='origin:referral']",
+    );
+    expect(referralGroup).not.toBeNull();
+
+    const afterSnapshot = projectLifecycleAt(after, "current");
+    view.update({
+      timeline: buildLifecycleTimeline(after),
+      snapshot: afterSnapshot,
+      selectedBucketId: "current",
+    });
+    // Same element reused -- proves the signature (position/size/total) was
+    // judged unchanged even though the backing application swapped.
+    expect(root.querySelector("[data-diagram-node='origin:referral']")).toBe(
+      referralGroup,
+    );
+
+    referralGroup
+      .querySelector("rect:not([data-diagram-node-hit])")
+      .dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    expect(
+      [...root.querySelectorAll("[data-affected-applications] li")].map(
+        (item) => item.textContent,
+      ),
+    ).toEqual(["b"]);
+  });
+
+  it("constructs zero new SVG elements when a node selection changes", () => {
+    // Node/branch counts are bounded by the fixed taxonomy (a couple dozen
+    // categories at most), not by application count, so a data-driven
+    // "far fewer elements than a full rebuild" scenario is sensitive to
+    // Sankey re-layout cascades that are hard to predict precisely. A
+    // selection change is a cleaner, fully deterministic proxy: it never
+    // touches geometry, so the diff should construct nothing at all for a
+    // node selection (only attribute patches).
+    const b = bundle(
+      [app("a")],
+      [ev("o1", "a", "application_submitted", "2026-01-01")],
+    );
+    const { root } = render(b);
+    const createSpy = vi.spyOn(document, "createElementNS");
+    const nodeRect = root.querySelector(
+      "[data-diagram-node='origin:application_submitted'] rect:not([data-diagram-node-hit])",
+    );
+    nodeRect.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    expect(createSpy).not.toHaveBeenCalled();
+    createSpy.mockRestore();
+  });
+
+  it("constructs exactly one new SVG element (the halo) when a branch is selected", () => {
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o1", "a", "application_submitted", "2026-01-01"),
+        ev("t1", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+    const { root } = render(b);
+    const createSpy = vi.spyOn(document, "createElementNS");
+    const branchPath = root.querySelector("[data-diagram-link]");
+    branchPath.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+    expect(createSpy).toHaveBeenCalledTimes(1);
+    expect(createSpy).toHaveBeenCalledWith(expect.any(String), "path");
+    createSpy.mockRestore();
+  });
+
   it("renders warning summary from supplied P4 warning codes", () => {
     const root = setup();
     const view = createLifecycleDiagramView(root);

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -1031,12 +1031,15 @@ describe("lifecycle diagram view", () => {
     );
     const { root } = render(b);
     const createSpy = vi.spyOn(document, "createElementNS");
-    const nodeRect = root.querySelector(
-      "[data-diagram-node='origin:application_submitted'] rect:not([data-diagram-node-hit])",
-    );
-    nodeRect.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
-    expect(createSpy).not.toHaveBeenCalled();
-    createSpy.mockRestore();
+    try {
+      const nodeRect = root.querySelector(
+        "[data-diagram-node='origin:application_submitted'] rect:not([data-diagram-node-hit])",
+      );
+      nodeRect.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+      expect(createSpy).not.toHaveBeenCalled();
+    } finally {
+      createSpy.mockRestore();
+    }
   });
 
   it("constructs exactly one new SVG element (the halo) when a branch is selected", () => {
@@ -1049,11 +1052,16 @@ describe("lifecycle diagram view", () => {
     );
     const { root } = render(b);
     const createSpy = vi.spyOn(document, "createElementNS");
-    const branchPath = root.querySelector("[data-diagram-link]");
-    branchPath.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
-    expect(createSpy).toHaveBeenCalledTimes(1);
-    expect(createSpy).toHaveBeenCalledWith(expect.any(String), "path");
-    createSpy.mockRestore();
+    try {
+      const branchPath = root.querySelector("[data-diagram-link]");
+      branchPath.dispatchEvent(
+        new window.MouseEvent("click", { bubbles: true }),
+      );
+      expect(createSpy).toHaveBeenCalledTimes(1);
+      expect(createSpy).toHaveBeenCalledWith(expect.any(String), "path");
+    } finally {
+      createSpy.mockRestore();
+    }
   });
 
   it("renders warning summary from supplied P4 warning codes", () => {

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -1064,6 +1064,165 @@ describe("lifecycle diagram view", () => {
     }
   });
 
+  it("performs zero SVG childList mutations on a no-op re-render", async () => {
+    // container.append(existingChild) unconditionally removes and
+    // reinserts the child even when it's already in the correct position
+    // -- a real mutation, not a no-op -- so this specifically guards
+    // against the diff silently reparenting every keyed element on every
+    // render regardless of whether anything actually changed.
+    const b = bundle(
+      [app("a"), app("b")],
+      [
+        ev("o1", "a", "application_submitted", "2026-01-01"),
+        ev("t1", "a", "technical_interview", "2026-01-02"),
+        ev("o2", "b", "application_submitted", "2026-01-01"),
+        ev("t2", "b", "technical_interview", "2026-01-02"),
+      ],
+    );
+    const { root, view, timeline, snapshot } = render(b);
+    const svg = root.querySelector("svg");
+    const callback = vi.fn();
+    const observer = new window.MutationObserver(callback);
+    observer.observe(svg, { childList: true, subtree: true });
+    try {
+      view.update({ timeline, snapshot, selectedBucketId: "current" });
+      await Promise.resolve();
+      expect(callback).not.toHaveBeenCalled();
+    } finally {
+      observer.disconnect();
+    }
+  });
+
+  it("performs zero SVG childList mutations when only a node selection changes", async () => {
+    const b = bundle(
+      [app("a")],
+      [ev("o1", "a", "application_submitted", "2026-01-01")],
+    );
+    const { root } = render(b);
+    const svg = root.querySelector("svg");
+    const callback = vi.fn();
+    const observer = new window.MutationObserver(callback);
+    observer.observe(svg, { childList: true, subtree: true });
+    try {
+      const nodeRect = root.querySelector(
+        "[data-diagram-node='origin:application_submitted'] rect:not([data-diagram-node-hit])",
+      );
+      nodeRect.dispatchEvent(new window.MouseEvent("click", { bubbles: true }));
+      await Promise.resolve();
+      expect(callback).not.toHaveBeenCalled();
+    } finally {
+      observer.disconnect();
+    }
+  });
+
+  it("mutates only the halo on branch selection, without reparenting groups", async () => {
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o1", "a", "application_submitted", "2026-01-01"),
+        ev("t1", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+    const { root } = render(b);
+    const branchGroup = root.querySelector("[data-diagram-branch-group]");
+    const handleGroupEl = root.querySelector(
+      "[data-diagram-branch-handle]",
+    )?.parentElement;
+    const diagramSvg = root.querySelector("svg");
+
+    // Direct-children-only observers on the three containers whose child
+    // *lists* must stay untouched by a selection-only render (only the
+    // branch's own group may gain/lose its halo child).
+    const svgCallback = vi.fn();
+    const svgObserver = new window.MutationObserver(svgCallback);
+    svgObserver.observe(diagramSvg, { childList: true });
+    const branchGroupElCallback = vi.fn();
+    const branchGroupElObserver = new window.MutationObserver(
+      branchGroupElCallback,
+    );
+    branchGroupElObserver.observe(diagramSvg.querySelector("g"), {
+      childList: true,
+    });
+    const handleGroupCallback = vi.fn();
+    const handleGroupObserver = handleGroupEl
+      ? new window.MutationObserver(handleGroupCallback)
+      : null;
+    handleGroupObserver?.observe(handleGroupEl, { childList: true });
+    const haloParentCallback = vi.fn();
+    const haloParentObserver = new window.MutationObserver(haloParentCallback);
+    haloParentObserver.observe(branchGroup, { childList: true });
+
+    try {
+      const branchPath = root.querySelector("[data-diagram-link]");
+      branchPath.dispatchEvent(
+        new window.MouseEvent("click", { bubbles: true }),
+      );
+      await Promise.resolve();
+      expect(svgCallback).not.toHaveBeenCalled();
+      expect(branchGroupElCallback).not.toHaveBeenCalled();
+      expect(handleGroupCallback).not.toHaveBeenCalled();
+      // Exactly one mutation on the branch's own group: the halo insertion.
+      expect(haloParentCallback).toHaveBeenCalledTimes(1);
+      expect(
+        branchGroup.querySelector("[data-diagram-branch-halo]"),
+      ).not.toBeNull();
+    } finally {
+      svgObserver.disconnect();
+      branchGroupElObserver.disconnect();
+      handleGroupObserver?.disconnect();
+      haloParentObserver.disconnect();
+    }
+  });
+
+  it("reorders SVG node groups to match rank order when a new node is inserted", () => {
+    // "offer_accepted" (endpoint rank 8) exists first; a later render adds
+    // "awaiting_response" (rank 0), which must be inserted *before* it in
+    // DOM order, not appended after -- proving the reconciler performs a
+    // genuine reorder/insert, not just a same-position no-op or an
+    // append-to-end.
+    const before = bundle(
+      [app("a")],
+      [
+        ev("a-o", "a", "application_submitted", "2026-01-01"),
+        ev("a-r", "a", "recruiter_screen", "2026-01-02"),
+        ev("a-off", "a", "offer_accepted", "2026-01-03"),
+      ],
+    );
+    const after = bundle(
+      [app("a"), app("b")],
+      [
+        ev("a-o", "a", "application_submitted", "2026-01-01"),
+        ev("a-r", "a", "recruiter_screen", "2026-01-02"),
+        ev("a-off", "a", "offer_accepted", "2026-01-03"),
+        ev("b-o", "b", "application_submitted", "2026-01-01"),
+      ],
+    );
+    const { root, view } = render(before);
+    const acceptedGroup = root.querySelector(
+      "[data-diagram-node='endpoint:offer_accepted']",
+    );
+    expect(acceptedGroup).not.toBeNull();
+
+    view.update({
+      timeline: buildLifecycleTimeline(after),
+      snapshot: projectLifecycleAt(after, "current"),
+      selectedBucketId: "current",
+    });
+
+    const svg = root.querySelector("svg");
+    const nodeGroups = [...svg.children].filter((child) =>
+      child.hasAttribute("data-diagram-node"),
+    );
+    const acceptedIndex = nodeGroups.indexOf(
+      root.querySelector("[data-diagram-node='endpoint:offer_accepted']"),
+    );
+    const awaitingIndex = nodeGroups.indexOf(
+      root.querySelector("[data-diagram-node='endpoint:awaiting_response']"),
+    );
+    expect(awaitingIndex).toBeGreaterThanOrEqual(0);
+    expect(awaitingIndex).toBeLessThan(acceptedIndex);
+  });
+
   it("renders warning summary from supplied P4 warning codes", () => {
     const root = setup();
     const view = createLifecycleDiagramView(root);


### PR DESCRIPTION
## Summary

Phase 3 of the lifecycle-diagram performance roadmap (see #1198 and `docs/design/lifecycle-diagram-scrubber-performance-roadmap.md`; this phase is #1195).

`renderSvg()` in `src/web/tracker/lifecycleDiagram.js` previously tore down and rebuilt the entire SVG on every render, including selection-only updates where geometry did not change. This PR replaces that behavior with keyed DOM reconciliation while preserving existing structure, accessibility, interactions, focus behavior, and paint order.

Closes #1195.

## Design

Node IDs (`origin:x`, `milestone:x`, `endpoint:x`) and branch IDs (`branch:${semanticLinkId}:endpoint:${endpointId}`) are stable taxonomy-derived diff keys across rerenders and bucket projections.

The `<svg>` root, branch group, and handle group are created once and reused. Each node and branch tracks:

- A geometry/content signature covering position, size, label, color, value, path, and handle geometry as applicable.
- Selection state.

Behavior per key:

- Unchanged geometry/content and selection: reuse the existing subtree without DOM writes.
- Selection-only change: patch selection-dependent attributes in place and add or remove only the branch halo when needed.
- Geometry/content change or key addition/removal: replace, insert, or remove the affected subtree.

`reconcileChildOrder()` preserves deterministic branch, handle, and node paint order while calling `insertBefore()` only for elements that are actually out of position. Correctly positioned keyed elements are not removed and reinserted, so no-op and node-selection rerenders produce zero SVG child-list mutations.

Click, touch, and pointer listeners are attached once and resolve the current node or branch through `currentNodeByKey` and `currentBranchByKey`. This prevents reused elements from retaining stale application membership when rendered geometry remains unchanged across projections.

The existing structural order remains intact: visible branch groups precede hit-handle groups, and node groups remain above them.

The issue’s negligible/zero-width scope was mostly covered by existing filters for zero-total nodes, zero-value links, and invalid paths. This PR adds the missing symmetric node case: non-positive pre-floor width or height is skipped instead of being forced through the minimum-size floor. Real nonzero data is not culled with a new pixel threshold.

No API, storage, schema, migration, or layout-algorithm changes are included.

## Tests

All 34 pre-existing tests in `test/web-tracker-lifecycle-diagram.test.js` remain unmodified. Eleven focused regressions now cover:

- No-op element and subtree reuse.
- Node selection through attribute-only patches.
- Branch selection through halo-only insertion/removal.
- Removal and disconnection across bucket transitions.
- Reused listeners reading current rather than stale application data.
- Zero new SVG construction for node selection.
- Exactly one new SVG element for branch selection.
- Zero SVG child-list mutations on no-op and node-selection rerenders.
- Branch selection mutating only the selected branch group.
- Correct keyed order when an earlier-ranked node is inserted.

The mutation-count regressions were verified to fail against the prior unconditional-append behavior and pass with minimal-order reconciliation.

The comprehensive Playwright lifecycle-diagram scenario is marked slow at test scope because it intentionally combines desktop and mobile rendering, two axe-core audits, timeline transitions, selection, hostile-input, persistence, and request checks. No assertions were removed or weakened, no retries were added, and the global timeout remains unchanged.

## Test plan

- [x] `npx vitest run test/web-tracker-lifecycle-diagram.test.js` — 45 tests pass: 34 pre-existing and 11 new.
- [x] Latest-head push CI, pull-request CI, and GHCR build/smoke workflows pass.
- [x] Full CI passes 147 Vitest files / 1,281 tests and all 42 Playwright tests.
- [x] Diagram visual-review capture passes.
- [x] `npm run lint`, `npm run typecheck`, and Prettier checks pass.
- [x] Manually verified against real IndexedDB data with 200 seeded applications: rendering, node selection, details updates, DOM-reference reuse, and console behavior remain correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)