### PR TITLE
Add two-tier drag-quality layout for the lifecycle diagram scrubber

### DIFF
--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -83,6 +83,20 @@ const PAGE_SIZE = 50;
 // without changing any ordering/search logic itself.
 const DRAG_QUALITY_TRANSITION_LANE_STATE_LIMIT = 50000;
 const DRAG_QUALITY_HANDLE_STATE_LIMIT = 8192;
+// Structured lifecycle-layout-search failure causes (see
+// lifecycleDiagramLayout.js) -- a deterministic budget/state-limit or
+// infeasible-ordering rejection, always carried as error.cause.type. An
+// unexpected/programming error (a genuine bug, not a search limit) never
+// sets a cause matching this set -- see the "hard or unexpected
+// materialization invariant" comment in lifecycleDiagramLayout.js, which
+// propagates with no cause at all specifically so it isn't misclassified
+// as ordinary infeasibility.
+const LIFECYCLE_LAYOUT_FAILURE_CAUSE_TYPES = new Set([
+  "lifecycle-transition-lane-order",
+  "lifecycle-handle-placement",
+  "lifecycle-routing-anchor-allocation",
+  "lifecycle-authoritative-rank-order",
+]);
 const unique = (items) => [...new Set(items.filter(Boolean))].sort(compare);
 const pageSlice = (items, page) => {
   const maxPage = Math.max(0, Math.ceil(items.length / PAGE_SIZE) - 1);
@@ -167,6 +181,14 @@ export function createLifecycleDiagramView(root, options = {}) {
   // (bucket navigation, resize, selection, keyboard stepping), which always
   // use the full-quality layout. See renderSvg()'s qualityTier option below.
   let dragActive = false;
+  // The bucket id resolved at the most recent drag-tick "input" event,
+  // reset on each new pointerdown. Release must resolve against this
+  // captured id, never a raw index against range.value -- update() can
+  // replace `timeline` between the last tick and release (e.g. a
+  // background refresh inserting a bucket), which would shift what that
+  // index now points to. See the debouncedRangeChange comment below for
+  // the identical hazard/fix already applied to the debounced path itself.
+  let lastDragTickBucketId = null;
   // Keyed-diff state for renderSvg(): svg/branchG/handleG are created once
   // and reused across renders instead of being torn down every call. Node
   // ids (`origin:x`, `milestone:x`, `endpoint:x`) and branch ids
@@ -603,14 +625,22 @@ export function createLifecycleDiagramView(root, options = {}) {
         root.clientWidth,
         layoutOptions,
       ));
-    } catch {
-      // A draft-tier failure (budget exceeded) doesn't mean the bucket is
+    } catch (error) {
+      // A known layout-search failure (budget exceeded, infeasible
+      // ordering, etc.) during a draft-tier tick doesn't mean the bucket is
       // actually unlayoutable -- full quality would likely have succeeded
       // given more budget. Skip this tick's render and keep whatever was
       // already on screen rather than flashing the fallback message; a
       // full-quality render is guaranteed on drag release (see releaseDrag
       // below), which will show the real fallback if it also fails there.
-      if (dragActive) return;
+      // An *unexpected* error (no structured cause -- a genuine bug, not a
+      // search limit) must never be silently swallowed just because a drag
+      // happens to be in progress.
+      if (
+        dragActive &&
+        LIFECYCLE_LAYOUT_FAILURE_CAUSE_TYPES.has(error?.cause?.type)
+      )
+        return;
       showDiagramFallback("Unable to lay out lifecycle diagram.");
       return;
     }
@@ -1265,7 +1295,9 @@ export function createLifecycleDiagramView(root, options = {}) {
     onBucketChange("current");
   });
   range.addEventListener("input", () => {
-    debouncedRangeChange(timeline.buckets[Number(range.value)]?.id);
+    const bucketId = timeline.buckets[Number(range.value)]?.id;
+    lastDragTickBucketId = bucketId ?? null;
+    debouncedRangeChange(bucketId);
   });
   // Draft-quality rendering (see renderSvg()'s qualityTier option) is only
   // used between a pointerdown and its matching release on the scrubber
@@ -1274,6 +1306,7 @@ export function createLifecycleDiagramView(root, options = {}) {
   // always renders full quality, same as today.
   range.addEventListener("pointerdown", () => {
     dragActive = true;
+    lastDragTickBucketId = null;
   });
   const releaseDrag = () => {
     if (!dragActive) return;
@@ -1282,8 +1315,15 @@ export function createLifecycleDiagramView(root, options = {}) {
     // synchronously" pattern prev/next/current already use -- guarantees
     // the frame left on screen after release is always full quality, never
     // whatever draft-tier layout the last drag tick happened to produce.
+    // Resolves the bucket *id* captured at the last input tick rather than
+    // changeToIndex(range.value)'s raw index, for the same reason the
+    // "input" listener above resolves an id up front instead of debouncing
+    // a raw index. No captured id (pointerdown/pointerup with no drag
+    // movement in between) means nothing changed -- no bucket change to
+    // apply.
     debouncedRangeChange.clear();
-    changeToIndex(Number(range.value));
+    if (lastDragTickBucketId) onBucketChange(lastDragTickBucketId);
+    lastDragTickBucketId = null;
   };
   // Range inputs get implicit pointer capture while dragging in evergreen
   // browsers, so pointerup fires on `range` itself even if the pointer moved

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -75,6 +75,14 @@ const bucketValueText = (bucket) => {
 const isUnknownPrecision = (precision) =>
   ["unknown", "legacy-placeholder", "legacy_placeholder"].includes(precision);
 const PAGE_SIZE = 50;
+// Draft-tier layout budgets used only while actively dragging the scrubber
+// (see renderSvg()'s qualityTier option) -- roughly a quarter of
+// lifecycleDiagramLayout.js's full-quality defaults (200000/32768). A
+// smaller budget both bounds per-tick latency and makes
+// toleratedRouteCrossingCount's existing budget-pressure curve relax sooner,
+// without changing any ordering/search logic itself.
+const DRAG_QUALITY_TRANSITION_LANE_STATE_LIMIT = 50000;
+const DRAG_QUALITY_HANDLE_STATE_LIMIT = 8192;
 const unique = (items) => [...new Set(items.filter(Boolean))].sort(compare);
 const pageSlice = (items, page) => {
   const maxPage = Math.max(0, Math.ceil(items.length / PAGE_SIZE) - 1);
@@ -153,6 +161,12 @@ export function createLifecycleDiagramView(root, options = {}) {
   let applicationPage = 0;
   let displayBranches = [];
   let lastLayoutWidth = null;
+  // True only between a pointerdown and the matching pointerup/pointercancel
+  // on the scrubber range input -- distinguishes an active drag (cheap,
+  // approximate layout is acceptable) from every other trigger of a render
+  // (bucket navigation, resize, selection, keyboard stepping), which always
+  // use the full-quality layout. See renderSvg()'s qualityTier option below.
+  let dragActive = false;
   // Keyed-diff state for renderSvg(): svg/branchG/handleG are created once
   // and reused across renders instead of being torn down every call. Node
   // ids (`origin:x`, `milestone:x`, `endpoint:x`) and branch ids
@@ -565,15 +579,38 @@ export function createLifecycleDiagramView(root, options = {}) {
     }
     let graph;
     let dimensions;
+    const layoutOptions = {
+      ...(options.horizontalGeometry
+        ? { horizontalGeometry: options.horizontalGeometry }
+        : {}),
+      // Draft tier still runs full handle placement and route-crossing
+      // auditing (unlike the test-only transitionLanePhaseOnly shortcut) --
+      // it only skips discovery's seed-replay half of the pipeline and uses
+      // smaller state budgets, so its output is always independently
+      // validated by the same acceptance logic full quality uses.
+      ...(dragActive
+        ? {
+            qualityTier: "draft",
+            transitionLaneStateLimit: DRAG_QUALITY_TRANSITION_LANE_STATE_LIMIT,
+            handleStateLimit: DRAG_QUALITY_HANDLE_STATE_LIMIT,
+            skipHandleFallbackSweep: true,
+          }
+        : {}),
+    };
     try {
       ({ graph, dimensions } = layoutLifecycleRoutingGraph(
         projection,
         root.clientWidth,
-        options.horizontalGeometry
-          ? { horizontalGeometry: options.horizontalGeometry }
-          : undefined,
+        layoutOptions,
       ));
     } catch {
+      // A draft-tier failure (budget exceeded) doesn't mean the bucket is
+      // actually unlayoutable -- full quality would likely have succeeded
+      // given more budget. Skip this tick's render and keep whatever was
+      // already on screen rather than flashing the fallback message; a
+      // full-quality render is guaranteed on drag release (see releaseDrag
+      // below), which will show the real fallback if it also fails there.
+      if (dragActive) return;
       showDiagramFallback("Unable to lay out lifecycle diagram.");
       return;
     }
@@ -1230,6 +1267,30 @@ export function createLifecycleDiagramView(root, options = {}) {
   range.addEventListener("input", () => {
     debouncedRangeChange(timeline.buckets[Number(range.value)]?.id);
   });
+  // Draft-quality rendering (see renderSvg()'s qualityTier option) is only
+  // used between a pointerdown and its matching release on the scrubber
+  // itself -- keyboard-driven arrow-key stepping produces "input" events
+  // with no preceding pointerdown, so it's unaffected by construction and
+  // always renders full quality, same as today.
+  range.addEventListener("pointerdown", () => {
+    dragActive = true;
+  });
+  const releaseDrag = () => {
+    if (!dragActive) return;
+    dragActive = false;
+    // Same "cancel the pending debounce, then do the authoritative thing
+    // synchronously" pattern prev/next/current already use -- guarantees
+    // the frame left on screen after release is always full quality, never
+    // whatever draft-tier layout the last drag tick happened to produce.
+    debouncedRangeChange.clear();
+    changeToIndex(Number(range.value));
+  };
+  // Range inputs get implicit pointer capture while dragging in evergreen
+  // browsers, so pointerup fires on `range` itself even if the pointer moved
+  // off it before release; pointercancel is a safety net for capture loss
+  // (e.g. an OS-level interruption mid-drag).
+  range.addEventListener("pointerup", releaseDrag);
+  range.addEventListener("pointercancel", releaseDrag);
   const sanitizedRootWidth = () => {
     const width = Math.floor(Number(root.clientWidth));
     return Number.isFinite(width) && width > 0 ? width : 0;

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -3120,7 +3120,10 @@ function layoutLifecycleRoutingGraphPass(
   // shared 32768-state budget after a bounded number of full generation
   // passes — independent of machine speed — instead of retrying expensive
   // work indefinitely.
-  const handleBudget = { statesVisited: 0, stateLimit: 32768 };
+  const handleBudget = {
+    statesVisited: 0,
+    stateLimit: options.handleStateLimit ?? 32768,
+  };
   // See createLaneGeometryFailureCache() above for why a typed cache (rather
   // than a plain membership Set) is required: on a cache hit the callback
   // must still restore lastRoutingAnchorFailure/lastHandleFailure to
@@ -3234,6 +3237,7 @@ function layoutLifecycleRoutingGraphPass(
         sharedBudget: handleBudget,
         seedHandles: options.seedHandles,
         horizontalGeometry,
+        skipHandleFallbackSweep: options.skipHandleFallbackSweep ?? false,
       },
     );
     lastHandleRouteEdgeCount = handleCheck.routeEdgeCount ?? null;
@@ -3648,6 +3652,17 @@ export function layoutLifecycleRoutingGraph(
     options.transitionLanePhaseOnly ||
     (isLifecycleLayoutTestEnvironment() && options.testOnlyBaseNodeOrderByRank)
   )
+    return layoutLifecycleRoutingGraphPass(projection, availableWidth, options);
+
+  // Draft quality tier (see options.qualityTier below): a single fresh pass,
+  // no seed-replay, smaller state budgets. Used while the scrubber is being
+  // actively dragged, where a cheaper-but-still-fully-validated layout is
+  // preferable to the full two-pass search's latency, and the result is
+  // discarded on the very next tick or on drag release anyway -- unlike
+  // transitionLanePhaseOnly above, this still runs full handle placement and
+  // route-crossing auditing (candidateCallback's normal path), it just skips
+  // discovery's replay-seeding half of the pipeline.
+  if (options.qualityTier === "draft")
     return layoutLifecycleRoutingGraphPass(projection, availableWidth, options);
 
   let discoveredRankOrder = null;
@@ -4834,6 +4849,7 @@ const tryAssignBranchHandles = (
     sharedBudget = null,
     seedHandles = null,
     horizontalGeometry = BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
+    skipHandleFallbackSweep = false,
   } = {},
 ) => {
   const nodeBoxes = visibleNodes.map((node) => ({
@@ -5296,7 +5312,7 @@ const tryAssignBranchHandles = (
       }
     };
     sweepCorridor("primary", HANDLE_CANDIDATE_T_VALUES);
-    if (!candidates.length) {
+    if (!candidates.length && !skipHandleFallbackSweep) {
       sweepCorridor("fallback", HANDLE_FALLBACK_CANDIDATE_T_VALUES);
     }
     // Only fall back to a degraded (small negative clearance) candidate

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -3513,6 +3513,98 @@ describe("seeded-replay production layout (routing fixture)", () => {
   });
 });
 
+describe("draft quality tier (Phase 4a drag-quality rendering)", () => {
+  it("skips the two-pass discovery+final wrapper for qualityTier: draft", () => {
+    const { graph: full } = layoutLifecycleRoutingGraph(projection(), 1850);
+    expect(full.transitionLaneSolverStats.layoutAttemptCount).toBe(2);
+
+    const { graph: draft } = layoutLifecycleRoutingGraph(projection(), 1850, {
+      qualityTier: "draft",
+    });
+    // layoutAttemptCount/layoutAttempts are only ever attached by the
+    // two-pass wrapper (see layoutLifecycleRoutingGraph's discovery+final
+    // path); a single fresh layoutLifecycleRoutingGraphPass() call -- the
+    // same shortcut transitionLanePhaseOnly already takes for test
+    // diagnostics -- never sets them.
+    expect(draft.transitionLaneSolverStats.layoutAttemptCount).toBeUndefined();
+    expect(draft.transitionLaneSolverStats.layoutAttempts).toBeUndefined();
+    // Draft tier still runs full handle placement and route-crossing
+    // auditing, unlike transitionLanePhaseOnly -- it must still produce a
+    // real, valid handle for every branch.
+    expect(draft.acceptedHandles?.size).toBe(draft.branches.length);
+  });
+
+  it("qualityTier unset and qualityTier: full both take the two-pass path", () => {
+    const { graph: unset } = layoutLifecycleRoutingGraph(projection(), 1850);
+    const { graph: full } = layoutLifecycleRoutingGraph(projection(), 1850, {
+      qualityTier: "full",
+    });
+    expect(full.transitionLaneSolverStats.layoutAttemptCount).toBe(2);
+    expect([...full.transitionLaneRankOrder.entries()]).toEqual([
+      ...unset.transitionLaneRankOrder.entries(),
+    ]);
+  });
+
+  it("honors a caller-supplied handleStateLimit", () => {
+    // The routing fixture succeeds comfortably under the default 32768
+    // handle-state budget (see the "seeded-replay production layout"
+    // describe block above). A budget of 1 state must fail deterministically
+    // on the very first candidate instead of silently using the default.
+    let thrown;
+    try {
+      layoutLifecycleRoutingGraph(projection(), 1850, {
+        qualityTier: "draft",
+        handleStateLimit: 1,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown?.cause).toMatchObject({
+      type: "lifecycle-transition-lane-order",
+      phase: "handle",
+      reason: "state-limit",
+      stateLimit: 1,
+    });
+  });
+
+  it("honors skipHandleFallbackSweep by never engaging the fallback sweep", () => {
+    // transitionDensityProjection()'s 50-branch fan-in has no fully-clear
+    // primary-sweep candidate for any branch, so every branch's fallback
+    // sweep engages by default (see "uses deterministic state bounds
+    // without unchecked candidate fallback" above) -- the ideal fixture to
+    // prove the fallback sweep can be declined entirely.
+    let thrownWithFallback;
+    try {
+      layoutLifecycleRoutingGraph(transitionDensityProjection(), 1850, {
+        horizontalGeometry: BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
+      });
+    } catch (error) {
+      thrownWithFallback = error;
+    }
+    expect(
+      thrownWithFallback?.cause?.horizontalConstraints?.sweeps?.fallback
+        ?.attempts,
+    ).toBeGreaterThan(0);
+
+    let thrownSkipped;
+    try {
+      layoutLifecycleRoutingGraph(transitionDensityProjection(), 1850, {
+        horizontalGeometry: BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
+        qualityTier: "draft",
+        skipHandleFallbackSweep: true,
+      });
+    } catch (error) {
+      thrownSkipped = error;
+    }
+    expect(
+      thrownSkipped?.cause?.horizontalConstraints?.sweeps?.fallback?.attempts,
+    ).toBe(0);
+    expect(
+      thrownSkipped?.cause?.horizontalConstraints?.sweeps?.primary?.attempts,
+    ).toBeGreaterThan(0);
+  });
+});
+
 describe("shared route-crossing classifier", () => {
   // src/web/tracker/lifecycleRouteGeometry.js -- the pure classifier both
   // auditLifecycleRouteGeometry (here) and the Playwright collision audit

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -553,6 +553,48 @@ describe("lifecycle diagram view", () => {
     expect(onBucketChange).toHaveBeenCalledWith(targetBucketId);
   });
 
+  it("releases the drag to the bucket id captured at the last tick, not a shifted index", () => {
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t1", "a", "recruiter_screen", "2026-01-02"),
+        ev("t2", "a", "technical_interview", "2026-01-03"),
+      ],
+    );
+    const onBucketChange = vi.fn();
+    const { root, view, timeline } = render(b, "current", onBucketChange);
+    const range = root.querySelector("input[type='range']");
+    const targetIndex = 2;
+    const targetBucketId = timeline.buckets[targetIndex].id;
+    range.dispatchEvent(new window.Event("pointerdown", { bubbles: true }));
+    range.value = String(targetIndex);
+    range.dispatchEvent(new window.Event("input", { bubbles: true }));
+
+    // A timeline replacement lands between the last drag tick and release
+    // (e.g. a background refresh discovering an earlier event), inserting a
+    // bucket before the target and shifting what index `targetIndex` now
+    // points to.
+    const withEarlierEvent = bundle(
+      [app("a")],
+      [
+        ev("earlier", "a", "application_submitted", "2025-12-31"),
+        ...b.lifecycleEvents,
+      ],
+    );
+    const nextTimeline = buildLifecycleTimeline(withEarlierEvent);
+    expect(nextTimeline.buckets[targetIndex].id).not.toBe(targetBucketId);
+    view.update({
+      timeline: nextTimeline,
+      snapshot: projectLifecycleAt(withEarlierEvent, "current"),
+      selectedBucketId: "current",
+    });
+
+    range.dispatchEvent(new window.Event("pointerup", { bubbles: true }));
+    expect(onBucketChange).toHaveBeenCalledTimes(1);
+    expect(onBucketChange).toHaveBeenCalledWith(targetBucketId);
+  });
+
   it("lets a newer discrete prev/next/current action win over an older pending scrub", () => {
     vi.useFakeTimers();
     const b = bundle(
@@ -671,7 +713,8 @@ describe("lifecycle diagram view", () => {
     }
   });
 
-  it("keeps the previously rendered frame when a draft-tier layout throws mid-drag", () => {
+  // eslint-disable-next-line max-len
+  it("keeps the previously rendered frame when a known layout-search failure throws mid-drag", () => {
     const b = bundle(
       [app("a")],
       [
@@ -687,7 +730,16 @@ describe("lifecycle diagram view", () => {
     const layoutSpy = vi
       .spyOn(lifecycleLayout, "layoutLifecycleRoutingGraph")
       .mockImplementation(() => {
-        throw new Error("forced draft-tier failure");
+        // A real budget-exceeded failure always carries a structured
+        // cause.type (see lifecycleDiagramLayout.js's
+        // throwHandleStateLimitExceeded) -- only these known types are
+        // swallowed mid-drag, never a plain/unexpected error.
+        const error = new Error("forced draft-tier failure");
+        error.cause = Object.freeze({
+          type: "lifecycle-transition-lane-order",
+          reason: "state-limit",
+        });
+        throw error;
       });
     try {
       // The last bucket still includes the application (an earlier bucket
@@ -704,6 +756,40 @@ describe("lifecycle diagram view", () => {
       // "too slow right now", not "genuinely unlayoutable".
       expect(root.querySelector("svg")).toBe(svgBefore);
       expect(root.textContent).not.toContain(
+        "Unable to lay out lifecycle diagram.",
+      );
+    } finally {
+      layoutSpy.mockRestore();
+    }
+  });
+
+  it("still shows the fallback for an unexpected (uncaused) error during a drag tick", () => {
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+    const { root, view, timeline } = render(b, "current");
+    const range = root.querySelector("input[type='range']");
+    range.dispatchEvent(new window.Event("pointerdown", { bubbles: true }));
+    const layoutSpy = vi
+      .spyOn(lifecycleLayout, "layoutLifecycleRoutingGraph")
+      .mockImplementation(() => {
+        // No error.cause at all -- a genuine bug (e.g. a TypeError), not a
+        // structured layout-search rejection. Must never be silently
+        // swallowed just because a drag happens to be in progress.
+        throw new Error("forced unexpected failure");
+      });
+    try {
+      const targetId = timeline.buckets.at(-1).id;
+      view.update({
+        timeline,
+        snapshot: projectLifecycleAt(b, targetId),
+        selectedBucketId: targetId,
+      });
+      expect(root.textContent).toContain(
         "Unable to lay out lifecycle diagram.",
       );
     } finally {

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -583,6 +583,216 @@ describe("lifecycle diagram view", () => {
     expect(onBucketChange).toHaveBeenCalledTimes(1);
   });
 
+  it("uses the draft quality tier for renders triggered while dragging the scrubber", () => {
+    vi.useFakeTimers();
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+    // Mirrors tracker.js's production wiring: onBucketChange re-projects and
+    // calls view.update(), which is what actually triggers renderSvg().
+    let view;
+    const onBucketChange = vi.fn((bucketId) => {
+      view.update({
+        timeline: buildLifecycleTimeline(b),
+        snapshot: projectLifecycleAt(b, bucketId),
+        selectedBucketId: bucketId,
+      });
+    });
+    const rendered = render(b, "current", onBucketChange);
+    view = rendered.view;
+    const { root, timeline } = rendered;
+    const layoutSpy = vi.spyOn(lifecycleLayout, "layoutLifecycleRoutingGraph");
+    try {
+      const range = root.querySelector("input[type='range']");
+      // The last bucket is the one guaranteed to still include the
+      // application (an earlier bucket can predate its origin event
+      // entirely, hitting the unrelated "No lifecycle data yet" empty-state
+      // return before layoutLifecycleRoutingGraph is ever called).
+      const targetIndex = timeline.buckets.length - 1;
+      range.dispatchEvent(new window.Event("pointerdown", { bubbles: true }));
+      range.value = String(targetIndex);
+      range.dispatchEvent(new window.Event("input", { bubbles: true }));
+      vi.advanceTimersByTime(80);
+      expect(onBucketChange).toHaveBeenCalledWith(
+        timeline.buckets[targetIndex].id,
+      );
+      const dragTickCall = layoutSpy.mock.calls.at(-1);
+      expect(dragTickCall[2]).toMatchObject({ qualityTier: "draft" });
+    } finally {
+      layoutSpy.mockRestore();
+    }
+  });
+
+  it("releasing the drag forces one full-quality render and cancels any pending debounce", () => {
+    vi.useFakeTimers();
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+    let view;
+    const onBucketChange = vi.fn((bucketId) => {
+      view.update({
+        timeline: buildLifecycleTimeline(b),
+        snapshot: projectLifecycleAt(b, bucketId),
+        selectedBucketId: bucketId,
+      });
+    });
+    const rendered = render(b, "current", onBucketChange);
+    view = rendered.view;
+    const { root, timeline } = rendered;
+    const layoutSpy = vi.spyOn(lifecycleLayout, "layoutLifecycleRoutingGraph");
+    try {
+      const range = root.querySelector("input[type='range']");
+      const targetIndex = timeline.buckets.length - 1;
+      range.dispatchEvent(new window.Event("pointerdown", { bubbles: true }));
+      range.value = String(targetIndex);
+      range.dispatchEvent(new window.Event("input", { bubbles: true }));
+      // Released before the 80ms debounce ever fires.
+      range.dispatchEvent(new window.Event("pointerup", { bubbles: true }));
+      expect(onBucketChange).toHaveBeenCalledTimes(1);
+      expect(onBucketChange).toHaveBeenCalledWith(
+        timeline.buckets[targetIndex].id,
+      );
+      const settleCall = layoutSpy.mock.calls.at(-1);
+      expect(settleCall[2]?.qualityTier).not.toBe("draft");
+      // The pending debounce must have been cancelled by release, not fire
+      // 80ms later and cause a second, redundant onBucketChange.
+      vi.advanceTimersByTime(80);
+      expect(onBucketChange).toHaveBeenCalledTimes(1);
+    } finally {
+      layoutSpy.mockRestore();
+    }
+  });
+
+  it("keeps the previously rendered frame when a draft-tier layout throws mid-drag", () => {
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+    const { root, view, timeline } = render(b, "current");
+    const svgBefore = root.querySelector("svg");
+    expect(svgBefore).not.toBeNull();
+    const range = root.querySelector("input[type='range']");
+    range.dispatchEvent(new window.Event("pointerdown", { bubbles: true }));
+    const layoutSpy = vi
+      .spyOn(lifecycleLayout, "layoutLifecycleRoutingGraph")
+      .mockImplementation(() => {
+        throw new Error("forced draft-tier failure");
+      });
+    try {
+      // The last bucket still includes the application (an earlier bucket
+      // can predate its origin event entirely, hitting the unrelated empty-
+      // state return before layoutLifecycleRoutingGraph is ever called).
+      const targetId = timeline.buckets.at(-1).id;
+      view.update({
+        timeline,
+        snapshot: projectLifecycleAt(b, targetId),
+        selectedBucketId: targetId,
+      });
+      // No fallback message, no DOM teardown -- the exact same <svg> element
+      // is still on screen, untouched, since a draft-tier failure means
+      // "too slow right now", not "genuinely unlayoutable".
+      expect(root.querySelector("svg")).toBe(svgBefore);
+      expect(root.textContent).not.toContain(
+        "Unable to lay out lifecycle diagram.",
+      );
+    } finally {
+      layoutSpy.mockRestore();
+    }
+  });
+
+  // eslint-disable-next-line max-len
+  it("still shows the fallback message when the full-quality settle render fails on release", () => {
+    vi.useFakeTimers();
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+    let view;
+    const onBucketChange = vi.fn((bucketId) => {
+      view.update({
+        timeline: buildLifecycleTimeline(b),
+        snapshot: projectLifecycleAt(b, bucketId),
+        selectedBucketId: bucketId,
+      });
+    });
+    const rendered = render(b, "current", onBucketChange);
+    view = rendered.view;
+    const { root, timeline } = rendered;
+    const range = root.querySelector("input[type='range']");
+    range.dispatchEvent(new window.Event("pointerdown", { bubbles: true }));
+    range.value = String(timeline.buckets.length - 1);
+    range.dispatchEvent(new window.Event("input", { bubbles: true }));
+    const layoutSpy = vi
+      .spyOn(lifecycleLayout, "layoutLifecycleRoutingGraph")
+      .mockImplementation(() => {
+        throw new Error("forced full-quality failure on release");
+      });
+    try {
+      // dragActive is cleared before this settle render runs, so a failure
+      // here must fall through to the real fallback, not be silently
+      // swallowed the way a draft-tier failure is.
+      range.dispatchEvent(new window.Event("pointerup", { bubbles: true }));
+      expect(root.textContent).toContain(
+        "Unable to lay out lifecycle diagram.",
+      );
+    } finally {
+      layoutSpy.mockRestore();
+    }
+  });
+
+  it("never uses draft tier for keyboard-driven range input (no preceding pointerdown)", () => {
+    vi.useFakeTimers();
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+    let view;
+    const onBucketChange = vi.fn((bucketId) => {
+      view.update({
+        timeline: buildLifecycleTimeline(b),
+        snapshot: projectLifecycleAt(b, bucketId),
+        selectedBucketId: bucketId,
+      });
+    });
+    const rendered = render(b, "current", onBucketChange);
+    view = rendered.view;
+    const { root, timeline } = rendered;
+    const layoutSpy = vi.spyOn(lifecycleLayout, "layoutLifecycleRoutingGraph");
+    try {
+      const range = root.querySelector("input[type='range']");
+      const targetIndex = timeline.buckets.length - 1;
+      // Simulates a focused range input's native arrow-key stepping: an
+      // "input" event fires with no preceding pointerdown.
+      range.value = String(targetIndex);
+      range.dispatchEvent(new window.Event("input", { bubbles: true }));
+      vi.advanceTimersByTime(80);
+      expect(onBucketChange).toHaveBeenCalledWith(
+        timeline.buckets[targetIndex].id,
+      );
+      const call = layoutSpy.mock.calls.at(-1);
+      expect(call[2]?.qualityTier).not.toBe("draft");
+    } finally {
+      layoutSpy.mockRestore();
+    }
+  });
+
   it("does not mutate P4 projection and has equivalent selectable rows", () => {
     const b = bundle(
       [app("a")],


### PR DESCRIPTION
## Summary

Phase 4a of the diagram-performance roadmap (see `docs/design/lifecycle-diagram-scrubber-performance-roadmap.md`; this phase is issue #1196). Phases 1-3 (PRs #1199/#1200/#1201) made the data layer and rendering fast; the remaining dominant per-tick cost while actively dragging the scrubber is `layoutLifecycleRoutingGraph()`'s full two-pass (discovery+final) search, which reruns from scratch on every tick regardless of drag state.

- Added `options.qualityTier` to `layoutLifecycleRoutingGraph()`. `"draft"` takes a single fresh `layoutLifecycleRoutingGraphPass()` call (the same shortcut `transitionLanePhaseOnly` already takes for test diagnostics) instead of the two-pass discovery+final wrapper. Unlike `transitionLanePhaseOnly`, draft tier still runs full handle placement and route-crossing auditing — it never touches ordering/tie-break logic, only search-budget size, so its output is always independently validated the same way full quality is. Default (`qualityTier` unset/`"full"`) is byte-identical to today's behavior.
- Parameterized the previously-hardcoded 32768 handle-state budget via a new `options.handleStateLimit`, and added `options.skipHandleFallbackSweep` to decline the already-conditional expensive fallback candidate sweep.
- Added drag-state wiring in `lifecycleDiagram.js`: `pointerdown`/`pointerup`/`pointercancel` listeners on the scrubber set/clear a `dragActive` flag, which gates `qualityTier: "draft"` plus smaller budgets on `renderSvg()`'s layout call. Release cancels any pending debounce and forces one synchronous full-quality render — reusing the same "cancel then do the authoritative thing" pattern the prev/next/current buttons already use — so the frame left on screen after release is always full quality, never a draft-tier approximation.
- A draft-tier layout failure (budget exceeded) skips that tick's render and keeps the previously-rendered frame, since it means "too slow right now," not "genuinely unlayoutable." A full-quality failure (including on release) still shows the real fallback message, unchanged from today.
- Keyboard-driven arrow-key stepping never sets `dragActive` (no preceding `pointerdown`), so it always renders full quality, unchanged.

**Why this is lower-risk than it might look:** `docs/design/lifecycle-diagram-layout-algorithm.md` documents three attempts (two fully reverted, one that took a second investigation to root-cause) where changes to the DFS's *ordering* computation looked correct under manual review and still broke production fixtures. This PR deliberately never touches ordering/tie-break logic — it only threads smaller state-budget numbers and skips an already-conditional expensive step through options that are either brand new or (in one case) already existed but hardcoded.

**Deliberately out of scope:** cross-bucket layout seeding (the other half of issue #1196) is deferred to a follow-up PR (4b). It touches the highest-risk ordering/DFS code in this file and benefits from this PR's drag-state signal to scope when it's even attempted, so it's being built and reviewed separately rather than bundled here.

## Tests

- `test/web-tracker-lifecycle-diagram-layout.test.js`: new `qualityTier: "draft"` single-pass-shortcut test, `handleStateLimit`/`skipHandleFallbackSweep` honored tests, and a regression guard that `qualityTier` unset/`"full"` still takes the two-pass path — all ~98 pre-existing tests in this file remain unmodified.
- `test/web-tracker-lifecycle-diagram.test.js`: new drag-state category — drag ticks use draft tier, release forces exactly one full-quality render and cancels the pending debounce, a draft-tier throw mid-drag leaves the previous frame untouched (no fallback, no DOM teardown), a full-tier throw on release still shows the fallback, and keyboard-driven input never uses draft tier. Every new regression was verified to actually catch what it claims by reverting the corresponding implementation piece and confirming the test fails.

## Verification

- `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js test/web-tracker-lifecycle-diagram.test.js test/web-tracker-lifecycle-diagram-performance.test.js test/web-tracker-lifecycle-projection.test.js` — all pass except one pre-existing, unrelated local-environment flake (a documented dense-layout off-by-one, reproduced identically with this PR's changes stashed out).
- `npm run typecheck`, `eslint`, `prettier --check` — clean.
- Full Playwright suite (`npx playwright test`) — 42/42 pass, including the full `lifecycle-diagram.spec.js` file.
- Manual verification against a 200-application dataset in a real running dev server: dragged the scrubber via real pointer/input events, confirmed no console errors, confirmed the settled frame after release is byte-identical to a direct (non-drag) navigation to the same bucket, confirmed prev/next/current buttons and keyboard arrow-stepping are visually unaffected. Instrumented per-tick timing directly (draft ~126ms vs full ~145ms on this dataset, `renderTables`/`renderDetails` negligible) to confirm no regression or runaway cost; instrumentation was reverted before committing.

Closes nothing yet — issue #1196 stays open until the follow-up 4b PR (cross-bucket seeding) also lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)