### PR TITLE
Add cross-bucket layout seeding for the lifecycle diagram scrubber

### DIFF
--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -7,6 +7,7 @@ import {
   buildLifecycleDisplayBranches,
   calculateLifecycleDiagramLayout,
   compareBranches,
+  compareLifecycleIds,
   compoundBranchPath,
   endpointColor,
   layoutLifecycleRoutingGraph,
@@ -97,6 +98,14 @@ const LIFECYCLE_LAYOUT_FAILURE_CAUSE_TYPES = new Set([
   "lifecycle-routing-anchor-allocation",
   "lifecycle-authoritative-rank-order",
 ]);
+// A seed-replay rejection (see lastLayoutSeed below) is an EXPECTED, routine
+// outcome for a cross-bucket seed candidate -- unlike the same-call
+// discovery->final replay this mechanism was originally built for, two
+// different buckets are not guaranteed to agree. Distinguished from every
+// other typed layout failure so only this one triggers an unseeded retry.
+const isSeedReplayFailure = (error) =>
+  error?.cause?.type === "lifecycle-authoritative-rank-order" &&
+  error?.cause?.reason === "seed-replay-failed";
 const unique = (items) => [...new Set(items.filter(Boolean))].sort(compare);
 const pageSlice = (items, page) => {
   const maxPage = Math.max(0, Math.ceil(items.length / PAGE_SIZE) - 1);
@@ -181,6 +190,14 @@ export function createLifecycleDiagramView(root, options = {}) {
   // (bucket navigation, resize, selection, keyboard stepping), which always
   // use the full-quality layout. See renderSvg()'s qualityTier option below.
   let dragActive = false;
+  // Captured from the most recent successful layoutLifecycleRoutingGraph()
+  // call (draft or full quality, whichever produced it) -- an opportunistic
+  // candidate for the next drag tick's seed-replay attempt. Node/branch/link
+  // ids are pure functions of taxonomy vocabulary (stable across different
+  // buckets of the same bundle, not just across two passes of one bucket),
+  // so a seed captured here can be looked up by id against a later bucket's
+  // freshly-built graph even though the two buckets are otherwise unrelated.
+  let lastLayoutSeed = null;
   // The bucket id resolved at the most recent drag-tick "input" event,
   // reset on each new pointerdown. Release must resolve against this
   // captured id, never a raw index against range.value -- update() can
@@ -601,7 +618,7 @@ export function createLifecycleDiagramView(root, options = {}) {
     }
     let graph;
     let dimensions;
-    const layoutOptions = {
+    const baseLayoutOptions = {
       ...(options.horizontalGeometry
         ? { horizontalGeometry: options.horizontalGeometry }
         : {}),
@@ -619,30 +636,100 @@ export function createLifecycleDiagramView(root, options = {}) {
           }
         : {}),
     };
+    // Cross-bucket seed reuse only applies to draft-tier drag ticks -- the
+    // full-quality settle-on-release call always runs unseeded (dragActive
+    // is false by the time it fires), and it already derives its own seed
+    // internally via its two-pass discovery+final wrapper.
+    const seededLayoutOptions =
+      dragActive && lastLayoutSeed
+        ? { ...baseLayoutOptions, ...lastLayoutSeed }
+        : null;
     try {
       ({ graph, dimensions } = layoutLifecycleRoutingGraph(
         projection,
         root.clientWidth,
-        layoutOptions,
+        seededLayoutOptions ?? baseLayoutOptions,
       ));
     } catch (error) {
-      // A known layout-search failure (budget exceeded, infeasible
-      // ordering, etc.) during a draft-tier tick doesn't mean the bucket is
-      // actually unlayoutable -- full quality would likely have succeeded
-      // given more budget. Skip this tick's render and keep whatever was
-      // already on screen rather than flashing the fallback message; a
-      // full-quality render is guaranteed on drag release (see releaseDrag
-      // below), which will show the real fallback if it also fails there.
-      // An *unexpected* error (no structured cause -- a genuine bug, not a
-      // search limit) must never be silently swallowed just because a drag
-      // happens to be in progress.
-      if (
+      if (seededLayoutOptions && isSeedReplayFailure(error)) {
+        // A seed that doesn't apply to this bucket (different composition,
+        // or geometry that's no longer legal under this bucket's own
+        // values) is expected, routine, and cheap to detect -- retry once,
+        // unseeded, before falling into the ordinary layout-failure
+        // handling below.
+        try {
+          ({ graph, dimensions } = layoutLifecycleRoutingGraph(
+            projection,
+            root.clientWidth,
+            baseLayoutOptions,
+          ));
+        } catch (retryError) {
+          if (
+            dragActive &&
+            LIFECYCLE_LAYOUT_FAILURE_CAUSE_TYPES.has(retryError?.cause?.type)
+          )
+            return;
+          showDiagramFallback("Unable to lay out lifecycle diagram.");
+          return;
+        }
+      } else if (
         dragActive &&
         LIFECYCLE_LAYOUT_FAILURE_CAUSE_TYPES.has(error?.cause?.type)
-      )
+      ) {
+        // A known layout-search failure (budget exceeded, infeasible
+        // ordering, etc.) during a draft-tier tick doesn't mean the bucket
+        // is actually unlayoutable -- full quality would likely have
+        // succeeded given more budget. Skip this tick's render and keep
+        // whatever was already on screen rather than flashing the fallback
+        // message; a full-quality render is guaranteed on drag release (see
+        // releaseDrag below), which will show the real fallback if it also
+        // fails there. An *unexpected* error (no structured cause -- a
+        // genuine bug, not a search limit) must never be silently swallowed
+        // just because a drag happens to be in progress.
         return;
-      showDiagramFallback("Unable to lay out lifecycle diagram.");
-      return;
+      } else {
+        showDiagramFallback("Unable to lay out lifecycle diagram.");
+        return;
+      }
+    }
+    // Capture a fresh cross-bucket seed candidate from this successful
+    // layout (draft or full quality -- either populates the same fields on
+    // its own graph) for the next drag tick to opportunistically reuse.
+    {
+      const authoritativeBranchOrderByRank = new Map(
+        [...graph.transitionLaneRankOrder].map(([rank, ids]) => [
+          rank,
+          new Map(ids.map((id, index) => [id, index])),
+        ]),
+      );
+      const nodesByRank = new Map();
+      for (const node of graph.nodes) {
+        if (!nodesByRank.has(node.rank)) nodesByRank.set(node.rank, []);
+        nodesByRank.get(node.rank).push(node);
+      }
+      const authoritativeNodeOrderByRank = new Map();
+      for (const [rank, nodes] of nodesByRank) {
+        const sorted = [...nodes].sort(
+          (a, b) => a.y0 - b.y0 || compareLifecycleIds(a.id, b.id),
+        );
+        authoritativeNodeOrderByRank.set(
+          rank,
+          new Map(sorted.map((node, index) => [node.id, index])),
+        );
+      }
+      lastLayoutSeed = {
+        seedAssignments: new Map(
+          graph.links.map((link) => [link.id, link.transitionLaneY]),
+        ),
+        seedRankOrderByRank: graph.transitionLaneRankOrder,
+        seedHandles: graph.acceptedHandles,
+        seedLinkDocks: new Map(
+          graph.links.map((link) => [link.id, { y0: link.y0, y1: link.y1 }]),
+        ),
+        seedAcceptedRouteCrossingCount: graph.acceptedRouteCrossingCount,
+        authoritativeBranchOrderByRank,
+        authoritativeNodeOrderByRank,
+      };
     }
     const { width, height } = dimensions;
     const finiteNode = (node) =>

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -717,6 +717,19 @@ export function createLifecycleDiagramView(root, options = {}) {
           new Map(sorted.map((node, index) => [node.id, index])),
         );
       }
+      // seedAcceptedRouteCrossingCount is deliberately NOT captured here,
+      // unlike the same-bucket discovery->final replay this mechanism was
+      // originally built for. It's used as the audit's tolerance bound
+      // verbatim rather than derived from *this* attempt's own budget
+      // pressure, which would let a generously-tolerant previous bucket's
+      // bound validate a worse layout than this bucket's own search would
+      // ever accept. Omitting it simply lets candidateCallback fall through
+      // to its normal, already-correct-for-this-bucket budget-pressure
+      // derivation. seedLinkDocks IS still captured -- materializeLaneAssignments
+      // only reproduces the seeded dock for a link's *routing* (invisible,
+      // intermediate) endpoint, never a real node's, so it can't leave a
+      // route ending outside a real node's current boundary; the real
+      // half is always freshly computed from this pass's own geometry.
       lastLayoutSeed = {
         seedAssignments: new Map(
           graph.links.map((link) => [link.id, link.transitionLaneY]),
@@ -726,7 +739,6 @@ export function createLifecycleDiagramView(root, options = {}) {
         seedLinkDocks: new Map(
           graph.links.map((link) => [link.id, { y0: link.y0, y1: link.y1 }]),
         ),
-        seedAcceptedRouteCrossingCount: graph.acceptedRouteCrossingCount,
         authoritativeBranchOrderByRank,
         authoritativeNodeOrderByRank,
       };

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -3091,8 +3091,17 @@ function layoutLifecycleRoutingGraphPass(
       for (const link of graph.links) {
         const dock = options.seedLinkDocks.get(link.id);
         if (!dock) continue;
-        link.y0 = dock.y0;
-        link.y1 = dock.y1;
+        // Only the routing (intermediate, invisible) half of a dock is a
+        // second independent DP solve that can drift a fraction of a pixel
+        // from an otherwise-identical geometry -- reproducing it exactly is
+        // what this option exists for. A real node's own dock half was
+        // just correctly computed above from *this* pass's own node
+        // geometry (loops starting at :2871/:2890); overwriting it here
+        // would silently replace a correct value with whatever the caller's
+        // seed happened to carry, which is only guaranteed consistent with
+        // this pass's geometry when the seed came from an identical graph.
+        if (link.source.routing) link.y0 = dock.y0;
+        if (link.target.routing) link.y1 = dock.y1;
       }
     }
   };

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -3632,6 +3632,12 @@ describe("cross-call seed replay (Phase 4b cross-bucket seeding)", () => {
         new Map(sorted.map((node, index) => [node.id, index])),
       );
     }
+    // seedAcceptedRouteCrossingCount is deliberately NOT captured -- see the
+    // matching comment in lifecycleDiagram.js. It's used as the audit's
+    // tolerance bound verbatim rather than derived from this attempt's own
+    // budget pressure. seedLinkDocks IS captured: materializeLaneAssignments
+    // only reproduces the seeded dock for a link's *routing* endpoint, never
+    // a real node's (see the matching fix in lifecycleDiagramLayout.js).
     return {
       seedAssignments: new Map(
         graph.links.map((link) => [link.id, link.transitionLaneY]),
@@ -3641,7 +3647,6 @@ describe("cross-call seed replay (Phase 4b cross-bucket seeding)", () => {
       seedLinkDocks: new Map(
         graph.links.map((link) => [link.id, { y0: link.y0, y1: link.y1 }]),
       ),
-      seedAcceptedRouteCrossingCount: graph.acceptedRouteCrossingCount,
       authoritativeBranchOrderByRank,
       authoritativeNodeOrderByRank,
     };

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -3605,6 +3605,203 @@ describe("draft quality tier (Phase 4a drag-quality rendering)", () => {
   });
 });
 
+describe("cross-call seed replay (Phase 4b cross-bucket seeding)", () => {
+  // Mirrors exactly what lifecycleDiagram.js's lastLayoutSeed capture does --
+  // kept independent (not imported from the UI file) so this test would
+  // catch a divergence between what the renderer captures and what this
+  // suite verifies actually works.
+  const seedFromGraph = (graph) => {
+    const authoritativeBranchOrderByRank = new Map(
+      [...graph.transitionLaneRankOrder].map(([rank, ids]) => [
+        rank,
+        new Map(ids.map((id, index) => [id, index])),
+      ]),
+    );
+    const nodesByRank = new Map();
+    for (const node of graph.nodes) {
+      if (!nodesByRank.has(node.rank)) nodesByRank.set(node.rank, []);
+      nodesByRank.get(node.rank).push(node);
+    }
+    const authoritativeNodeOrderByRank = new Map();
+    for (const [rank, nodes] of nodesByRank) {
+      const sorted = [...nodes].sort(
+        (a, b) => a.y0 - b.y0 || compareLifecycleIds(a.id, b.id),
+      );
+      authoritativeNodeOrderByRank.set(
+        rank,
+        new Map(sorted.map((node, index) => [node.id, index])),
+      );
+    }
+    return {
+      seedAssignments: new Map(
+        graph.links.map((link) => [link.id, link.transitionLaneY]),
+      ),
+      seedRankOrderByRank: graph.transitionLaneRankOrder,
+      seedHandles: graph.acceptedHandles,
+      seedLinkDocks: new Map(
+        graph.links.map((link) => [link.id, { y0: link.y0, y1: link.y1 }]),
+      ),
+      seedAcceptedRouteCrossingCount: graph.acceptedRouteCrossingCount,
+      authoritativeBranchOrderByRank,
+      authoritativeNodeOrderByRank,
+    };
+  };
+
+  it("replays a self-captured seed cheaply and deterministically under qualityTier: draft", () => {
+    const first = layoutLifecycleRoutingGraph(projection(), 1850, {
+      qualityTier: "draft",
+    });
+    const seed = seedFromGraph(first.graph);
+    const second = layoutLifecycleRoutingGraph(projection(), 1850, {
+      qualityTier: "draft",
+      ...seed,
+    });
+    // Seed replay validates and reuses the seed directly instead of
+    // searching -- exactly one candidateCallback invocation, not a
+    // multi-candidate backtracking search.
+    expect(second.graph.transitionLaneSolverStats.candidateEvaluations).toBe(1);
+    expect([...second.graph.transitionLaneRankOrder]).toEqual([
+      ...first.graph.transitionLaneRankOrder,
+    ]);
+    expect(
+      second.graph.links.map((link) => [link.id, link.transitionLaneY]),
+    ).toEqual(first.graph.links.map((link) => [link.id, link.transitionLaneY]));
+  });
+
+  it("cleanly rejects a seed replayed against a different-topology projection", () => {
+    const seed = seedFromGraph(
+      layoutLifecycleRoutingGraph(projection(), 1850, {
+        qualityTier: "draft",
+      }).graph,
+    );
+    const unrelatedProjection = () => ({
+      nodes: [
+        {
+          id: "origin:candidate_outreach",
+          label: "Outreach",
+          total: 1,
+          applicationIds: ["z"],
+        },
+        {
+          id: "endpoint:offer_accepted",
+          label: "Accepted",
+          total: 1,
+          applicationIds: ["z"],
+        },
+      ],
+      links: [
+        {
+          id: "link:origin:candidate_outreach->endpoint:offer_accepted",
+          source: "origin:candidate_outreach",
+          target: "endpoint:offer_accepted",
+          value: 1,
+          applicationIds: ["z"],
+        },
+      ],
+      paths: [
+        {
+          applicationId: "z",
+          endpoint: "offer_accepted",
+          nodeIds: ["origin:candidate_outreach", "endpoint:offer_accepted"],
+        },
+      ],
+    });
+    let thrown;
+    try {
+      layoutLifecycleRoutingGraph(unrelatedProjection(), 1850, {
+        qualityTier: "draft",
+        ...seed,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown?.cause).toMatchObject({
+      type: "lifecycle-authoritative-rank-order",
+      reason: "seed-replay-failed",
+      detail: "link-id-coverage-mismatch",
+    });
+  });
+
+  it("rejects a seed whose authoritativeBranchOrderByRank contradicts its own rank order", () => {
+    // Composition/values are otherwise identical (same projection replayed
+    // against itself) -- deliberately reversing one rank's authoritative
+    // order isolates exactly the "authoritative-order-mismatch" check from
+    // every other seed-validation reason (coverage, spacing, legality).
+    const graph = layoutLifecycleRoutingGraph(projection(), 1850, {
+      qualityTier: "draft",
+    }).graph;
+    const seed = seedFromGraph(graph);
+    const rank3 = seed.authoritativeBranchOrderByRank.get(3);
+    expect(rank3.size).toBeGreaterThan(1);
+    seed.authoritativeBranchOrderByRank.set(
+      3,
+      new Map(
+        [...rank3.entries()].map(([id], index, entries) => [
+          id,
+          entries.length - 1 - index,
+        ]),
+      ),
+    );
+    let thrown;
+    try {
+      layoutLifecycleRoutingGraph(projection(), 1850, {
+        qualityTier: "draft",
+        ...seed,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown?.cause).toMatchObject({
+      type: "lifecycle-authoritative-rank-order",
+      reason: "seed-replay-failed",
+      detail: "authoritative-order-mismatch",
+      rank: 3,
+    });
+  });
+
+  // eslint-disable-next-line max-len
+  it("omitting authoritativeBranchOrderByRank/authoritativeNodeOrderByRank does not break a matching self-replay", () => {
+    // Regression guard for the capture code itself: the two authoritative
+    // fields must be additive safety, never required for the common case
+    // where they'd agree anyway.
+    const graph = layoutLifecycleRoutingGraph(projection(), 1850, {
+      qualityTier: "draft",
+    }).graph;
+    const seed = seedFromGraph(graph);
+    delete seed.authoritativeBranchOrderByRank;
+    delete seed.authoritativeNodeOrderByRank;
+    let thrown;
+    let result;
+    try {
+      result = layoutLifecycleRoutingGraph(projection(), 1850, {
+        qualityTier: "draft",
+        ...seed,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown).toBeUndefined();
+    expect(result.graph.transitionLaneSolverStats.candidateEvaluations).toBe(1);
+  });
+
+  it("qualityTier unset/full is unaffected by seed options being present", () => {
+    // Full-quality's own two-pass wrapper always derives its own seed from
+    // its own discovery pass -- a caller-supplied cross-bucket seed option
+    // must never leak into or perturb that path.
+    const seed = seedFromGraph(
+      layoutLifecycleRoutingGraph(projection(), 1850, {
+        qualityTier: "draft",
+      }).graph,
+    );
+    const withSeed = layoutLifecycleRoutingGraph(projection(), 1850, seed);
+    const withoutSeed = layoutLifecycleRoutingGraph(projection(), 1850);
+    expect(withSeed.graph.transitionLaneSolverStats.layoutAttemptCount).toBe(2);
+    expect([...withSeed.graph.transitionLaneRankOrder]).toEqual([
+      ...withoutSeed.graph.transitionLaneRankOrder,
+    ]);
+  });
+});
+
 describe("shared route-crossing classifier", () => {
   // src/web/tracker/lifecycleRouteGeometry.js -- the pure classifier both
   // auditLifecycleRouteGeometry (here) and the Playwright collision audit

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -916,6 +916,12 @@ describe("lifecycle diagram view", () => {
       expect(firstTickCall[2].seedRankOrderByRank).toBeInstanceOf(Map);
       expect(firstTickCall[2].seedHandles).toBeInstanceOf(Map);
       expect(firstTickCall[2].seedLinkDocks).toBeInstanceOf(Map);
+      // seedAcceptedRouteCrossingCount is deliberately never captured for
+      // cross-bucket reuse -- see the capture-site comment in
+      // lifecycleDiagram.js.
+      expect(firstTickCall[2]).not.toHaveProperty(
+        "seedAcceptedRouteCrossingCount",
+      );
       expect(firstTickCall[2].authoritativeBranchOrderByRank).toBeInstanceOf(
         Map,
       );

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -879,6 +879,236 @@ describe("lifecycle diagram view", () => {
     }
   });
 
+  it("reuses a captured layout seed for the next drag tick, from any tier", () => {
+    vi.useFakeTimers();
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+    let view;
+    const onBucketChange = vi.fn((bucketId) => {
+      view.update({
+        timeline: buildLifecycleTimeline(b),
+        snapshot: projectLifecycleAt(b, bucketId),
+        selectedBucketId: bucketId,
+      });
+    });
+    const rendered = render(b, "current", onBucketChange);
+    view = rendered.view;
+    const { root, timeline } = rendered;
+    const layoutSpy = vi.spyOn(lifecycleLayout, "layoutLifecycleRoutingGraph");
+    try {
+      const range = root.querySelector("input[type='range']");
+      const targetIndex = timeline.buckets.length - 1;
+      range.dispatchEvent(new window.Event("pointerdown", { bubbles: true }));
+      range.value = String(targetIndex);
+      range.dispatchEvent(new window.Event("input", { bubbles: true }));
+      vi.advanceTimersByTime(80);
+      // The mount's own initial render is full quality (dragActive was
+      // false) and still captures a seed -- the very first drag tick
+      // already has one to reuse.
+      const firstTickCall = layoutSpy.mock.calls.at(-1);
+      expect(firstTickCall[2]).toMatchObject({ qualityTier: "draft" });
+      expect(firstTickCall[2].seedAssignments).toBeInstanceOf(Map);
+      expect(firstTickCall[2].seedRankOrderByRank).toBeInstanceOf(Map);
+      expect(firstTickCall[2].seedHandles).toBeInstanceOf(Map);
+      expect(firstTickCall[2].seedLinkDocks).toBeInstanceOf(Map);
+      expect(firstTickCall[2].authoritativeBranchOrderByRank).toBeInstanceOf(
+        Map,
+      );
+      expect(firstTickCall[2].authoritativeNodeOrderByRank).toBeInstanceOf(Map);
+    } finally {
+      layoutSpy.mockRestore();
+    }
+  });
+
+  it("retries once unseeded when a seed-replay rejection occurs, and still renders", () => {
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+    const { root, view, timeline } = render(b, "current");
+    const range = root.querySelector("input[type='range']");
+    range.dispatchEvent(new window.Event("pointerdown", { bubbles: true }));
+    const originalLayout = lifecycleLayout.layoutLifecycleRoutingGraph;
+    const layoutSpy = vi
+      .spyOn(lifecycleLayout, "layoutLifecycleRoutingGraph")
+      .mockImplementation((proj, width, opts) => {
+        if (opts?.seedAssignments) {
+          const error = new Error("forced seed-replay rejection");
+          error.cause = Object.freeze({
+            type: "lifecycle-authoritative-rank-order",
+            reason: "seed-replay-failed",
+            detail: "link-id-coverage-mismatch",
+          });
+          throw error;
+        }
+        return originalLayout(proj, width, opts);
+      });
+    try {
+      const targetId = timeline.buckets.at(-1).id;
+      view.update({
+        timeline,
+        snapshot: projectLifecycleAt(b, targetId),
+        selectedBucketId: targetId,
+      });
+      expect(layoutSpy).toHaveBeenCalledTimes(2);
+      const [, retryCall] = layoutSpy.mock.calls;
+      for (const key of [
+        "seedAssignments",
+        "seedRankOrderByRank",
+        "seedHandles",
+        "seedLinkDocks",
+        "seedAcceptedRouteCrossingCount",
+        "authoritativeBranchOrderByRank",
+        "authoritativeNodeOrderByRank",
+      ]) {
+        expect(retryCall[2]).not.toHaveProperty(key);
+      }
+      // The unseeded retry succeeded -- the bucket actually rendered, not
+      // the "keep previous frame" fallback.
+      expect(root.querySelector("svg")).toBeTruthy();
+      expect(root.textContent).not.toContain(
+        "Unable to lay out lifecycle diagram.",
+      );
+    } finally {
+      layoutSpy.mockRestore();
+    }
+  });
+
+  it("keeps the previous frame when both the seeded attempt and the unseeded retry fail", () => {
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+    const { root, view, timeline } = render(b, "current");
+    const svgBefore = root.querySelector("svg");
+    const range = root.querySelector("input[type='range']");
+    range.dispatchEvent(new window.Event("pointerdown", { bubbles: true }));
+    const layoutSpy = vi
+      .spyOn(lifecycleLayout, "layoutLifecycleRoutingGraph")
+      .mockImplementation(() => {
+        const error = new Error("forced seed-replay rejection, every call");
+        error.cause = Object.freeze({
+          type: "lifecycle-authoritative-rank-order",
+          reason: "seed-replay-failed",
+          detail: "link-id-coverage-mismatch",
+        });
+        throw error;
+      });
+    try {
+      const targetId = timeline.buckets.at(-1).id;
+      view.update({
+        timeline,
+        snapshot: projectLifecycleAt(b, targetId),
+        selectedBucketId: targetId,
+      });
+      expect(layoutSpy).toHaveBeenCalledTimes(2);
+      // lifecycle-authoritative-rank-order is itself a known layout-failure
+      // cause type, so the retry's own failure still falls into "keep the
+      // previous frame" during a drag, same as any other known failure.
+      expect(root.querySelector("svg")).toBe(svgBefore);
+      expect(root.textContent).not.toContain(
+        "Unable to lay out lifecycle diagram.",
+      );
+    } finally {
+      layoutSpy.mockRestore();
+    }
+  });
+
+  it("never retries an unexpected (uncaused) error even when a seed was attempted", () => {
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+    const { root, view, timeline } = render(b, "current");
+    const range = root.querySelector("input[type='range']");
+    range.dispatchEvent(new window.Event("pointerdown", { bubbles: true }));
+    const layoutSpy = vi
+      .spyOn(lifecycleLayout, "layoutLifecycleRoutingGraph")
+      .mockImplementation(() => {
+        throw new Error("forced unexpected failure");
+      });
+    try {
+      const targetId = timeline.buckets.at(-1).id;
+      view.update({
+        timeline,
+        snapshot: projectLifecycleAt(b, targetId),
+        selectedBucketId: targetId,
+      });
+      expect(layoutSpy).toHaveBeenCalledTimes(1);
+      expect(root.textContent).toContain(
+        "Unable to lay out lifecycle diagram.",
+      );
+    } finally {
+      layoutSpy.mockRestore();
+    }
+  });
+
+  it("never threads seed options into the full-quality settle-on-release call", () => {
+    vi.useFakeTimers();
+    const b = bundle(
+      [app("a")],
+      [
+        ev("o", "a", "application_submitted", "2026-01-01"),
+        ev("t", "a", "technical_interview", "2026-01-02"),
+      ],
+    );
+    let view;
+    const onBucketChange = vi.fn((bucketId) => {
+      view.update({
+        timeline: buildLifecycleTimeline(b),
+        snapshot: projectLifecycleAt(b, bucketId),
+        selectedBucketId: bucketId,
+      });
+    });
+    const rendered = render(b, "current", onBucketChange);
+    view = rendered.view;
+    const { root, timeline } = rendered;
+    const layoutSpy = vi.spyOn(lifecycleLayout, "layoutLifecycleRoutingGraph");
+    try {
+      const range = root.querySelector("input[type='range']");
+      const targetIndex = timeline.buckets.length - 1;
+      range.dispatchEvent(new window.Event("pointerdown", { bubbles: true }));
+      range.value = String(targetIndex);
+      range.dispatchEvent(new window.Event("input", { bubbles: true }));
+      vi.advanceTimersByTime(80);
+      // Confirm a seed really was available and used for the drag tick,
+      // so the release assertion below is meaningful, not vacuous.
+      expect(layoutSpy.mock.calls.at(-1)[2].seedAssignments).toBeInstanceOf(
+        Map,
+      );
+      range.dispatchEvent(new window.Event("pointerup", { bubbles: true }));
+      const settleCall = layoutSpy.mock.calls.at(-1);
+      expect(settleCall[2]?.qualityTier).not.toBe("draft");
+      for (const key of [
+        "seedAssignments",
+        "seedRankOrderByRank",
+        "seedHandles",
+        "seedLinkDocks",
+        "seedAcceptedRouteCrossingCount",
+        "authoritativeBranchOrderByRank",
+        "authoritativeNodeOrderByRank",
+      ]) {
+        expect(settleCall[2]).not.toHaveProperty(key);
+      }
+    } finally {
+      layoutSpy.mockRestore();
+    }
+  });
+
   it("does not mutate P4 projection and has equivalent selectable rows", () => {
     const b = bundle(
       [app("a")],


### PR DESCRIPTION
## Summary

Completes Phase 4 of the lifecycle-diagram performance roadmap from #1196. Phase 4a (#1202) added lower-budget draft rendering while the scrubber is being dragged; this PR adds Phase 4b by opportunistically reusing the previous successful bucket’s layout seed for the next draft-tier drag tick.

The existing seed-validation and replay path remains responsible for accepting or rejecting a candidate. Stable taxonomy-derived node, branch, and link IDs allow a previous bucket’s seed to be mapped onto the current graph, while mismatches produce the existing typed `seed-replay-failed` error and trigger one unseeded retry.

## Implementation

- Adds closure-scoped `lastLayoutSeed` state in `lifecycleDiagram.js`, refreshed after every successful draft- or full-quality layout.
- Captures six cross-bucket seed fields:
  - `seedAssignments`
  - `seedRankOrderByRank`
  - `seedHandles`
  - `seedLinkDocks`
  - `authoritativeBranchOrderByRank`
  - `authoritativeNodeOrderByRank`
- Passes the captured seed only to draft-tier layouts while `dragActive` is true.
- Retries once without seed options when the seeded attempt fails specifically with `lifecycle-authoritative-rank-order` / `seed-replay-failed`.
- Preserves the existing behavior of retaining the previous frame when both draft attempts encounter known layout-search failures.
- Never supplies a cross-bucket seed to the full-quality settle-on-release render.
- Makes a narrow correction in `lifecycleDiagramLayout.js`: seeded dock coordinates are restored only for routing-node endpoints. Real-node docks are always recomputed from the current bucket’s node geometry.
- Deliberately omits `seedAcceptedRouteCrossingCount` from cross-bucket seeds so each bucket derives its crossing allowance from its own current search and budget pressure.

The PR does not change `solveGlobal`, `solveFromComponent`, `nodeSort`, `linkSort`, branch-precedence construction, or the core DFS ordering logic.

## Correctness safeguards

The final implementation incorporates both Codex P2 review findings:

- A previous bucket can no longer overwrite a real node’s freshly computed dock position and render a route outside the current node boundary.
- A previous bucket’s accepted crossing count can no longer become the current bucket’s audit tolerance.

Seed rejection is isolated to the attempted call; no module-level mutable layout state is introduced. Full-quality rendering and the existing same-call discovery-to-final replay path retain their established behavior.

## Tests

- `test/web-tracker-lifecycle-diagram-layout.test.js`
  - Verifies cheap, deterministic self-seed replay under draft quality.
  - Verifies clean rejection for mismatched topology.
  - Verifies authoritative-order mismatch detection.
  - Verifies the authoritative-order fields remain optional for matching self-replay.
  - Verifies caller-supplied cross-bucket seed options do not affect full-quality layout.
- `test/web-tracker-lifecycle-diagram.test.js`
  - Verifies seed capture and reuse from either quality tier.
  - Verifies `seedAcceptedRouteCrossingCount` is not captured.
  - Verifies seeded rejection followed by a successful unseeded retry.
  - Verifies the previous frame is retained when both draft attempts fail with known causes.
  - Verifies unexpected errors do not trigger the retry.
  - Verifies the full-quality settle-on-release call receives no cross-bucket seed options.

Each new regression test was mutation-checked by reverting the corresponding implementation behavior and confirming that the test failed.

## Verification

- Targeted Vitest suites for lifecycle layout, rendering, performance, and projection were run locally; all selected cases passed except one documented pre-existing environment-sensitive dense-layout off-by-one.
- Type checking, ESLint, and Prettier checks were clean.
- Full Playwright suite: 42/42 passed.
- Manual verification against a real 200-application dataset showed a successful seeded drag tick at 17 ms versus 147 ms unseeded, clean fallback when later seeds were incompatible, no console errors, and a settled frame identical to direct non-drag navigation.

No persistence, schema, API, or migration changes are introduced.

Closes #1196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)