### PR TITLE
Persist the lifecycle diagram projection cache in IndexedDB (Phase 5c)

### DIFF
--- a/docs/browser-first-architecture.md
+++ b/docs/browser-first-architecture.md
@@ -33,6 +33,10 @@ Browser
   ├─ Web Worker: off-main-thread compute for expensive, purely derived work (e.g. the lifecycle
   │  diagram's layout search) -- holds no data of its own and persists nothing; every message is
   │  request/response over data already owned by the main thread
+  ├─ IndexedDB (derived/cached): content-hash-keyed projection cache for the lifecycle diagram --
+  │  unlike the Worker above, this component does persist data, but only ever a pure function of
+  │  data already in IndexedDB (applications + lifecycle events), so the "clearing storage deletes
+  │  your data" warning below doesn't apply to it
   └─ Downloads/uploads: explicit user backup and restore files
 
 Container / static host
@@ -52,9 +56,17 @@ for compatibility while the browser repository is built behind a clearly named a
 | App data                        | Application rows, contacts, outreach messages, lifecycle events, interviews, offers, notes, reminders | Private IndexedDB object stores                                           |
 | Optional public assets          | Logo, help text, sample empty-state content, generated documentation                                  | Static assets served by the container                                     |
 | Private user-imported artifacts | Spreadsheet imports, resumes, cover letters, take-home files, screenshots, PDFs                       | IndexedDB Blob records or user-managed files referenced by local metadata |
+| Derived/cached data             | Lifecycle diagram projection cache (timeline + per-bucket projections)                                | IndexedDB, content-hash keyed, regenerable from app data                  |
 
 Private imported artifacts must not be copied into the repo, bundled into production images, or
 uploaded to server endpoints unless a future feature makes that transfer explicit and opt-in.
+
+Derived/cached data is a pure, regenerable function of app data (specifically applications +
+lifecycle events for the lifecycle diagram cache) and carries no independent user intent -- it is
+deliberately excluded from `exportAllData()`/`importAllData()` (backups shouldn't ship a stale
+cache alongside the source data that regenerates it), though `clearAllData()` does wipe it, since
+"clear all data" wiping everything is the reasonable user expectation. Losing it is never data
+loss: the next render recomputes and repopulates it from IndexedDB app data.
 
 ## Minimal normalized browser model
 

--- a/src/web/storage/indexedDbRepository.js
+++ b/src/web/storage/indexedDbRepository.js
@@ -17,7 +17,7 @@ import {
 } from "./browserDataMigration.js";
 
 export const DATABASE_NAME = "jobbot3000";
-export const INDEXEDDB_DATABASE_VERSION = 2;
+export const INDEXEDDB_DATABASE_VERSION = 3;
 export const DATABASE_VERSION = INDEXEDDB_DATABASE_VERSION;
 
 export const STORE_NAMES = [
@@ -31,6 +31,14 @@ export const STORE_NAMES = [
   "reminders",
   "settings",
 ];
+
+// Deliberately NOT in STORE_NAMES -- that constant is the allowlist driving
+// backup export/import and clearAllData's main sweep. This store holds only
+// derived, regenerable lifecycle-diagram projection data (Phase 5c), never
+// user-facing domain data, so it must stay unreachable from export/import by
+// construction (a db.transaction() can only touch stores named in it).
+// clearAllData() does still wipe it directly, as user-hygiene -- see there.
+const PROJECTION_CACHE_STORE_NAME = "lifecycleProjectionCache";
 
 const STORE_SCHEMAS = {
   applications: browserApplicationSchema,
@@ -293,6 +301,12 @@ export const migrations = {
           fail(error);
         }
       };
+    }
+  },
+  3(db) {
+    const projectionCache = createStore(db, PROJECTION_CACHE_STORE_NAME);
+    if (projectionCache) {
+      ensureIndex(projectionCache, "by_hash", "hash");
     }
   },
 };
@@ -834,14 +848,108 @@ export const createIndexedDbRepository = async (options = {}) => {
     },
     async clearAllData() {
       return safe(async () => {
-        const tx = db.transaction(STORE_NAMES, "readwrite");
+        // lifecycleProjectionCache is deliberately outside STORE_NAMES (see
+        // its own comment) so it's never reachable from export/import, but
+        // "clear all data" wiping everything is the reasonable user
+        // expectation -- leaving orphaned cache rows behind after a full
+        // wipe would just be permanently unreachable garbage.
+        const tx = db.transaction(
+          [...STORE_NAMES, PROJECTION_CACHE_STORE_NAME],
+          "readwrite",
+        );
         const done = transactionDone(tx);
         for (const storeName of STORE_NAMES) tx.objectStore(storeName).clear();
+        tx.objectStore(PROJECTION_CACHE_STORE_NAME).clear();
         await done;
       });
     },
     listRecords(storeName) {
       return safe(() => getAll(db, storeName));
+    },
+    // The four methods below bypass parseRecord/STORE_SCHEMAS entirely --
+    // lifecycleProjectionCache records are internal cache artifacts (never
+    // imported/exported/user-facing), not domain data, so Zod validation
+    // doesn't apply the way it does to every other store's writes.
+    async getCachedLifecycleTimeline(hash) {
+      return safe(async () => {
+        const tx = db.transaction(PROJECTION_CACHE_STORE_NAME, "readonly");
+        const done = transactionDone(tx);
+        const record = await requestToPromise(
+          tx.objectStore(PROJECTION_CACHE_STORE_NAME).get(`${hash}:timeline`),
+        );
+        await done;
+        return record?.value ?? null;
+      });
+    },
+    async putCachedLifecycleTimeline(hash, value) {
+      return safe(async () => {
+        const tx = db.transaction(PROJECTION_CACHE_STORE_NAME, "readwrite");
+        const done = transactionDone(tx);
+        tx.objectStore(PROJECTION_CACHE_STORE_NAME).put({
+          id: `${hash}:timeline`,
+          hash,
+          kind: "timeline",
+          bucketId: null,
+          value,
+          cachedAt: new Date().toISOString(),
+        });
+        await done;
+      });
+    },
+    async getCachedLifecycleProjection(hash, bucketId) {
+      return safe(async () => {
+        const tx = db.transaction(PROJECTION_CACHE_STORE_NAME, "readonly");
+        const done = transactionDone(tx);
+        const record = await requestToPromise(
+          tx
+            .objectStore(PROJECTION_CACHE_STORE_NAME)
+            .get(`${hash}:${bucketId}`),
+        );
+        await done;
+        return record?.value ?? null;
+      });
+    },
+    async putCachedLifecycleProjection(hash, bucketId, value) {
+      return safe(async () => {
+        const tx = db.transaction(PROJECTION_CACHE_STORE_NAME, "readwrite");
+        const done = transactionDone(tx);
+        tx.objectStore(PROJECTION_CACHE_STORE_NAME).put({
+          id: `${hash}:${bucketId}`,
+          hash,
+          kind: "projection",
+          bucketId,
+          value,
+          cachedAt: new Date().toISOString(),
+        });
+        await done;
+      });
+    },
+    // Deletes every cached record whose hash doesn't match currentHash. A
+    // full cursor scan (not a by_hash index range query) is intentional and
+    // cheap -- this runs immediately whenever a new hash is established, so
+    // the store's steady-state size is bounded to ~1-4 records regardless
+    // of how long the tracker has been in use.
+    async evictStaleLifecycleProjectionCache(currentHash) {
+      return safe(async () => {
+        const tx = db.transaction(PROJECTION_CACHE_STORE_NAME, "readwrite");
+        const done = transactionDone(tx);
+        await new Promise((resolve, reject) => {
+          const request = tx
+            .objectStore(PROJECTION_CACHE_STORE_NAME)
+            .openCursor();
+          request.onsuccess = () => {
+            const cursor = request.result;
+            if (!cursor) {
+              resolve();
+              return;
+            }
+            if (cursor.value.hash !== currentHash) cursor.delete();
+            cursor.continue();
+          };
+          request.onerror = () => reject(request.error);
+        });
+        await done;
+      });
     },
     upsertApplication(record) {
       return safe(() => putRecord(db, "applications", record));

--- a/src/web/tracker/lifecycleProjectionCache.js
+++ b/src/web/tracker/lifecycleProjectionCache.js
@@ -16,6 +16,10 @@ import {
 const FNV_PRIME = 16777619;
 const FNV_SEED_A = 2166136261;
 const FNV_SEED_B = 84696351;
+// Bump whenever timeline/projection semantics or their persisted shape changes.
+// This prevents a deployment from reading entries produced by incompatible
+// projection code while the user's source data remains unchanged.
+const PROJECTION_CACHE_VERSION = 1;
 
 function fnv1a(input, seed) {
   let hash = seed >>> 0;
@@ -62,7 +66,11 @@ export function contentHashForBundle(bundle) {
   const serialized = JSON.stringify(
     canonicalize({ applications, lifecycleEvents }),
   );
-  return `${fnv1a(serialized, FNV_SEED_A)}${fnv1a(serialized, FNV_SEED_B)}`;
+  return [
+    `v${PROJECTION_CACHE_VERSION}`,
+    fnv1a(serialized, FNV_SEED_A),
+    fnv1a(serialized, FNV_SEED_B),
+  ].join(":");
 }
 
 // Cache reads/writes are best-effort -- a failure here must never break
@@ -80,6 +88,7 @@ export async function getOrComputeTimeline(
   store,
   bundle,
   computeTimeline = buildLifecycleTimeline,
+  shouldPersist = () => true,
 ) {
   const hash = contentHashForBundle(bundle);
   let cached = null;
@@ -93,10 +102,14 @@ export async function getOrComputeTimeline(
   // Fire-and-forget from the caller's perspective -- render must never wait
   // on the *write*, only the *read* above. Returned so tests can await it
   // deterministically instead of polling on a timing-dependent write.
-  const persisted = Promise.all([
-    store.putCachedLifecycleTimeline(hash, timeline).catch(reportCacheError),
-    store.evictStaleLifecycleProjectionCache(hash).catch(reportCacheError),
-  ]);
+  const persisted = shouldPersist()
+    ? Promise.all([
+        store
+          .putCachedLifecycleTimeline(hash, timeline)
+          .catch(reportCacheError),
+        store.evictStaleLifecycleProjectionCache(hash).catch(reportCacheError),
+      ])
+    : Promise.resolve();
   return { timeline, hash, persisted };
 }
 
@@ -106,6 +119,7 @@ export async function getOrComputeProjection(
   hash,
   bucketId,
   computeProjection = projectLifecycleAt,
+  shouldPersist = () => true,
 ) {
   let cached = null;
   try {
@@ -115,9 +129,11 @@ export async function getOrComputeProjection(
   }
   if (cached) return { projection: cached, persisted: Promise.resolve() };
   const projection = computeProjection(bundle, bucketId);
-  const persisted = store
-    .putCachedLifecycleProjection(hash, bucketId, projection)
-    .catch(reportCacheError);
+  const persisted = shouldPersist()
+    ? store
+        .putCachedLifecycleProjection(hash, bucketId, projection)
+        .catch(reportCacheError)
+    : Promise.resolve();
   return { projection, persisted };
 }
 
@@ -143,6 +159,7 @@ export function scheduleAdjacentBucketPrecompute(
     cancelIdle = window.cancelIdleCallback ?? window.clearTimeout,
   } = {},
 ) {
+  let active = true;
   const index = timeline.buckets.findIndex((bucket) => bucket.id === bucketId);
   const neighborIds = [
     timeline.buckets[index - 1]?.id,
@@ -153,16 +170,22 @@ export function scheduleAdjacentBucketPrecompute(
   const handle = requestIdle(async () => {
     // A real edit can land between scheduling and this callback firing --
     // abandon rather than precompute against data that's already stale.
-    if (contentHashForBundle(getBundle()) !== hash) return;
+    if (!active || contentHashForBundle(getBundle()) !== hash) return;
     for (const neighborId of neighborIds) {
       const projection = projectLifecycleAt(getBundle(), neighborId);
       // Re-check before EACH write, not just once for the whole batch -- an
       // edit can land between computing one neighbor and the next.
-      if (contentHashForBundle(getBundle()) !== hash) return;
-      store
+      if (!active || contentHashForBundle(getBundle()) !== hash) return;
+      // Await each write so cancellation can stop the next one. If a clear is
+      // initiated while this transaction is in flight, IndexedDB orders the
+      // later clear after it and `active` prevents any post-clear write.
+      await store
         .putCachedLifecycleProjection(hash, neighborId, projection)
         .catch(reportCacheError);
     }
   });
-  return () => cancelIdle(handle);
+  return () => {
+    active = false;
+    cancelIdle(handle);
+  };
 }

--- a/src/web/tracker/lifecycleProjectionCache.js
+++ b/src/web/tracker/lifecycleProjectionCache.js
@@ -1,0 +1,168 @@
+import {
+  buildLifecycleTimeline,
+  projectLifecycleAt,
+} from "./lifecycleProjection.js";
+
+/* global window */
+
+// Two independent FNV-1a passes (different seeds) concatenated into one key
+// -- same cost class as one hash, much larger collision space than a single
+// 32-bit hash. No cryptographic property is needed: this only protects a
+// same-origin, single-user local cache from serving one user's own stale
+// data to themselves. Constants match the FNV-1a style already used in
+// lifecycleReconciliation.js's hashPart (offset basis 2166136261, prime
+// 16777619 are the standard 32-bit FNV-1a values); the second seed is just a
+// different starting value so the two passes diverge.
+const FNV_PRIME = 16777619;
+const FNV_SEED_A = 2166136261;
+const FNV_SEED_B = 84696351;
+
+function fnv1a(input, seed) {
+  let hash = seed >>> 0;
+  for (let index = 0; index < input.length; index += 1) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, FNV_PRIME) >>> 0;
+  }
+  return hash.toString(36);
+}
+
+const codeCompare = (a, b) =>
+  String(a) < String(b) ? -1 : String(a) > String(b) ? 1 : 0;
+
+// Recursive key sort, applied on top of the row-level id sort below -- cheap
+// defense-in-depth against any non-deterministic key insertion order within
+// a single record (e.g. optional-field presence) silently hashing the same
+// logical data two different ways and defeating every cache hit.
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, canonicalize(value[key])]),
+    );
+  }
+  return value;
+}
+
+// Only depends on applications + lifecycleEvents -- deliberately narrower
+// than the bundle as a whole, so this cache (unlike the in-memory
+// object-identity WeakMap cache in lifecycleProjection.js) survives both a
+// page reload AND a same-session write to an unrelated store (contacts,
+// outreach messages, reminders, artifacts), none of which the diagram reads.
+// getAll() doesn't guarantee stable cross-call row ordering, so rows are
+// sorted by id (both stores have keyPath: "id", unique) before serializing.
+export function contentHashForBundle(bundle) {
+  const applications = [...(bundle.applications ?? [])].sort((a, b) =>
+    codeCompare(a.id, b.id),
+  );
+  const lifecycleEvents = [...(bundle.lifecycleEvents ?? [])].sort((a, b) =>
+    codeCompare(a.id, b.id),
+  );
+  const serialized = JSON.stringify(
+    canonicalize({ applications, lifecycleEvents }),
+  );
+  return `${fnv1a(serialized, FNV_SEED_A)}${fnv1a(serialized, FNV_SEED_B)}`;
+}
+
+// Cache reads/writes are best-effort -- a failure here must never break
+// rendering, only forfeit the optimization for this one call.
+function reportCacheError(error) {
+  console.error("Lifecycle projection cache operation failed", error);
+}
+
+// `store` is the small repo.* adapter tracker.js wires up (getCached*/
+// putCached*/evictStale*, delegating to indexedDbRepository.js). Injecting
+// the real compute function as a default param (rather than spying on the
+// lifecycleProjection.js export) keeps this module's tests independent of
+// ESM live-binding/spy semantics.
+export async function getOrComputeTimeline(
+  store,
+  bundle,
+  computeTimeline = buildLifecycleTimeline,
+) {
+  const hash = contentHashForBundle(bundle);
+  let cached = null;
+  try {
+    cached = await store.getCachedLifecycleTimeline(hash);
+  } catch (error) {
+    reportCacheError(error);
+  }
+  if (cached) return { timeline: cached, hash, persisted: Promise.resolve() };
+  const timeline = computeTimeline(bundle);
+  // Fire-and-forget from the caller's perspective -- render must never wait
+  // on the *write*, only the *read* above. Returned so tests can await it
+  // deterministically instead of polling on a timing-dependent write.
+  const persisted = Promise.all([
+    store.putCachedLifecycleTimeline(hash, timeline).catch(reportCacheError),
+    store.evictStaleLifecycleProjectionCache(hash).catch(reportCacheError),
+  ]);
+  return { timeline, hash, persisted };
+}
+
+export async function getOrComputeProjection(
+  store,
+  bundle,
+  hash,
+  bucketId,
+  computeProjection = projectLifecycleAt,
+) {
+  let cached = null;
+  try {
+    cached = await store.getCachedLifecycleProjection(hash, bucketId);
+  } catch (error) {
+    reportCacheError(error);
+  }
+  if (cached) return { projection: cached, persisted: Promise.resolve() };
+  const projection = computeProjection(bundle, bucketId);
+  const persisted = store
+    .putCachedLifecycleProjection(hash, bucketId, projection)
+    .catch(reportCacheError);
+  return { projection, persisted };
+}
+
+// Schedules idle-time precompute of the buckets immediately adjacent (by
+// index) to whichever bucket is currently selected -- not the whole
+// timeline, which could be hundreds of buckets for a timestamp-diverse
+// dataset. Returns a cancel function; callers should invoke any
+// previously-returned cancel before scheduling a new one, so rapid
+// scrubbing doesn't pile up stacked idle callbacks.
+export function scheduleAdjacentBucketPrecompute(
+  store,
+  getBundle,
+  timeline,
+  hash,
+  bucketId,
+  {
+    requestIdle = window.requestIdleCallback ??
+      ((callback) =>
+        window.setTimeout(
+          () => callback({ didTimeout: true, timeRemaining: () => 0 }),
+          200,
+        )),
+    cancelIdle = window.cancelIdleCallback ?? window.clearTimeout,
+  } = {},
+) {
+  const index = timeline.buckets.findIndex((bucket) => bucket.id === bucketId);
+  const neighborIds = [
+    timeline.buckets[index - 1]?.id,
+    timeline.buckets[index + 1]?.id,
+  ].filter(Boolean);
+  if (neighborIds.length === 0) return () => {};
+
+  const handle = requestIdle(async () => {
+    // A real edit can land between scheduling and this callback firing --
+    // abandon rather than precompute against data that's already stale.
+    if (contentHashForBundle(getBundle()) !== hash) return;
+    for (const neighborId of neighborIds) {
+      const projection = projectLifecycleAt(getBundle(), neighborId);
+      // Re-check before EACH write, not just once for the whole batch -- an
+      // edit can land between computing one neighbor and the next.
+      if (contentHashForBundle(getBundle()) !== hash) return;
+      store
+        .putCachedLifecycleProjection(hash, neighborId, projection)
+        .catch(reportCacheError);
+    }
+  });
+  return () => cancelIdle(handle);
+}

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -688,7 +688,13 @@ async function renderDiagram() {
     });
   }
 
-  const { timeline, hash } = await getOrComputeTimeline(repo, bundle);
+  const isCurrentRender = () => myGeneration === state.diagramRenderGeneration;
+  const { timeline, hash } = await getOrComputeTimeline(
+    repo,
+    bundle,
+    buildLifecycleTimeline,
+    isCurrentRender,
+  );
   if (myGeneration !== state.diagramRenderGeneration) return;
 
   const valid = new Set(timeline.buckets.map((bucket) => bucket.id));
@@ -706,6 +712,8 @@ async function renderDiagram() {
     bundle,
     hash,
     selectedBucketId,
+    undefined,
+    isCurrentRender,
   );
   if (myGeneration !== state.diagramRenderGeneration) return;
 
@@ -1595,6 +1603,12 @@ function init() {
       "Clear all local tracker data from this browser? This cannot be undone unless you have a backup.",
     );
     if (ok) {
+      // Invalidate async cache readers before clearing and cancel idle cache
+      // writers. An already-started IndexedDB write precedes the clear
+      // transaction; cancellation prevents another write from following it.
+      state.diagramRenderGeneration += 1;
+      state.diagramPrecomputeCancel?.();
+      state.diagramPrecomputeCancel = null;
       await repo.clear();
       const result = $("[data-settings-result]");
       if (result) result.textContent = "Local IndexedDB tracker data cleared.";

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -27,10 +27,12 @@ import {
 import { createIndexedDbRepository } from "../storage/indexedDbRepository.js";
 import { planLifecycleReconciliation } from "./lifecycleReconciliation.js";
 import { createLifecycleDiagramView } from "./lifecycleDiagram.js";
+import { buildLifecycleTimeline } from "./lifecycleProjection.js";
 import {
-  buildLifecycleTimeline,
-  projectLifecycleAt,
-} from "./lifecycleProjection.js";
+  getOrComputeTimeline,
+  getOrComputeProjection,
+  scheduleAdjacentBucketPrecompute,
+} from "./lifecycleProjectionCache.js";
 
 /* canonical CSV/backup helpers are shared with spreadsheet import/export tests. */
 const ARRAY_STORES = [
@@ -119,6 +121,16 @@ const repo = {
   exportAll: async () => (await getRepository()).exportAllData(),
   commitLifecycleMutation: async (mutation) =>
     (await getRepository()).commitLifecycleMutation(mutation),
+  getCachedLifecycleTimeline: async (hash) =>
+    (await getRepository()).getCachedLifecycleTimeline(hash),
+  putCachedLifecycleTimeline: async (hash, value) =>
+    (await getRepository()).putCachedLifecycleTimeline(hash, value),
+  getCachedLifecycleProjection: async (hash, bucketId) =>
+    (await getRepository()).getCachedLifecycleProjection(hash, bucketId),
+  putCachedLifecycleProjection: async (hash, bucketId, value) =>
+    (await getRepository()).putCachedLifecycleProjection(hash, bucketId, value),
+  evictStaleLifecycleProjectionCache: async (currentHash) =>
+    (await getRepository()).evictStaleLifecycleProjectionCache(currentHash),
 };
 async function batchImport(recordsByStore) {
   return (await getRepository()).importPartialData(recordsByStore);
@@ -136,6 +148,17 @@ const state = {
   diagramBucketId: "current",
   diagramView: null,
   diagramHistoricalBaseline: null,
+  // Bumped at the top of every renderDiagram() call. Closes a race the
+  // Worker-offload deferral inside lifecycleDiagram.js's own renderGeneration
+  // can't reach: renderDiagram() itself is now async (awaits the persisted
+  // projection cache), so a newer call can be triggered before an earlier
+  // one's cache lookup resolves. Every state.* write and the final
+  // view.update() call are gated on this still matching.
+  diagramRenderGeneration: 0,
+  // Cancels any still-pending adjacent-bucket precompute so rapid scrubbing
+  // doesn't pile up stacked idle callbacks -- mirrors the cancelPendingRender
+  // discipline lifecycleDiagram.js already uses for its own deferred work.
+  diagramPrecomputeCancel: null,
 };
 function weekBucket(value) {
   const d = day(value);
@@ -315,7 +338,11 @@ async function refresh() {
   state.apps = [...state.bundle.applications].sort((a, b) =>
     String(b.appliedAt || "").localeCompare(a.appliedAt || ""),
   );
-  renderAll();
+  // Awaited so refresh()'s own callers (13+ mutation sites) keep the
+  // pre-existing implicit contract: once refresh() resolves, the visible
+  // diagram, if any, already reflects the fresh bundle. renderDiagram() is
+  // now async (it awaits the persisted projection cache).
+  await renderAll();
 }
 function showInitializationError(error) {
   const target = $("[data-import-result]") || $("main") || document.body;
@@ -367,13 +394,13 @@ async function refreshWithRetry() {
     scheduleRetry();
   }
 }
-function route(v) {
+async function route(v) {
   $$(".tracker-view").forEach((x) => (x.hidden = x.dataset.view !== v));
   $$(".tracker-nav button").forEach((b) =>
     b.setAttribute("aria-current", b.dataset.route === v ? "page" : "false"),
   );
   if (v === "applications") $('[data-filter="query"]').focus();
-  if (v === "diagram") renderDiagram();
+  if (v === "diagram") await renderDiagram();
 }
 function renderNav() {
   const names = [
@@ -631,26 +658,21 @@ function lifecycleTimelineFingerprint(timeline) {
     )
     .join("|");
 }
-function renderDiagram() {
+async function renderDiagram() {
   const root = $("[data-lifecycle-diagram]");
   if (!root || !state.bundle) return;
-  const timeline = buildLifecycleTimeline(state.bundle);
-  const valid = new Set(timeline.buckets.map((bucket) => bucket.id));
-  let selectedBucketId = state.diagramBucketId || "current";
-  let fallbackAnnounced = false;
-  if (!valid.has(selectedBucketId)) {
-    selectedBucketId = "current";
-    state.diagramBucketId = "current";
-    state.diagramHistoricalBaseline = null;
-    fallbackAnnounced = true;
-  }
-  const snapshot = projectLifecycleAt(state.bundle, selectedBucketId);
-  const timelineFingerprint = lifecycleTimelineFingerprint(timeline);
-  if (selectedBucketId === "current") state.diagramHistoricalBaseline = null;
-  const newerAvailable =
-    selectedBucketId !== "current" &&
-    Boolean(state.diagramHistoricalBaseline) &&
-    state.diagramHistoricalBaseline !== timelineFingerprint;
+  const bundle = state.bundle;
+  // Bumped before any await below -- renderDiagram() is no longer
+  // synchronous end-to-end (it awaits the persisted projection cache), so a
+  // newer call can now be triggered before an earlier one's cache lookup
+  // resolves. Every state.* write and the final view.update() call below
+  // are gated on this still matching by the time each await resolves, so a
+  // superseded call can't clobber a newer one's already-correct state.
+  const myGeneration = ++state.diagramRenderGeneration;
+
+  // Constructed synchronously, before any await, so two overlapping first
+  // calls can't both see !state.diagramView and construct two views (the
+  // second would leave the first's DOM orphaned inside root).
   if (!state.diagramView) {
     state.diagramView = createLifecycleDiagramView(root, {
       onBucketChange(bucketId) {
@@ -665,7 +687,36 @@ function renderDiagram() {
       },
     });
   }
-  state.diagramView.update({
+
+  const { timeline, hash } = await getOrComputeTimeline(repo, bundle);
+  if (myGeneration !== state.diagramRenderGeneration) return;
+
+  const valid = new Set(timeline.buckets.map((bucket) => bucket.id));
+  let selectedBucketId = state.diagramBucketId || "current";
+  let fallbackAnnounced = false;
+  if (!valid.has(selectedBucketId)) {
+    selectedBucketId = "current";
+    state.diagramBucketId = "current";
+    state.diagramHistoricalBaseline = null;
+    fallbackAnnounced = true;
+  }
+
+  const { projection: snapshot } = await getOrComputeProjection(
+    repo,
+    bundle,
+    hash,
+    selectedBucketId,
+  );
+  if (myGeneration !== state.diagramRenderGeneration) return;
+
+  const timelineFingerprint = lifecycleTimelineFingerprint(timeline);
+  if (selectedBucketId === "current") state.diagramHistoricalBaseline = null;
+  const newerAvailable =
+    selectedBucketId !== "current" &&
+    Boolean(state.diagramHistoricalBaseline) &&
+    state.diagramHistoricalBaseline !== timelineFingerprint;
+
+  await state.diagramView.update({
     timeline,
     snapshot,
     selectedBucketId,
@@ -676,10 +727,22 @@ function renderDiagram() {
       "Missing historical point; returned to Current.",
     );
   }
+
+  // Fire-and-forget and unconditional -- a superseded *render* doesn't mean
+  // the cache warm-up is invalid work. Cancel any prior pending precompute
+  // first so rapid scrubbing doesn't pile up stacked idle callbacks.
+  state.diagramPrecomputeCancel?.();
+  state.diagramPrecomputeCancel = scheduleAdjacentBucketPrecompute(
+    repo,
+    () => state.bundle,
+    timeline,
+    hash,
+    selectedBucketId,
+  );
 }
-function renderAll() {
+async function renderAll() {
   renderDashboard();
-  if (!$('[data-view="diagram"]')?.hidden) renderDiagram();
+  if (!$('[data-view="diagram"]')?.hidden) await renderDiagram();
   renderList();
   renderFollowups();
   renderOutreach();

--- a/test/playwright/lifecycle-diagram.spec.js
+++ b/test/playwright/lifecycle-diagram.spec.js
@@ -780,6 +780,7 @@ test.describe("Application Lifecycle Diagram", () => {
     await page
       .getByRole("button", { name: "Previous event", exact: true })
       .click();
+    await waitForDiagramIdle(page);
     const historicalAriaValue = await range.getAttribute("aria-valuetext");
     expect(historicalAriaValue).toBeTruthy();
     await expect(diagram).toContainText("Historical");

--- a/test/web-storage-indexeddb-repository.test.js
+++ b/test/web-storage-indexeddb-repository.test.js
@@ -9,6 +9,7 @@ import {
   openJobbotDatabase,
   migrations,
 } from "../src/web/storage/indexedDbRepository.js";
+import { BROWSER_BACKUP_SCHEMA_VERSION } from "../src/web/storage/browserDataMigration.js";
 
 const now = "2026-01-02T03:04:05.000Z";
 const later = "2026-01-03T03:04:05.000Z";
@@ -114,6 +115,7 @@ describe("IndexedDB repository", () => {
       "contacts",
       "interviews",
       "lifecycleEvents",
+      "lifecycleProjectionCache",
       "offers",
       "outreachMessages",
       "reminders",
@@ -121,6 +123,13 @@ describe("IndexedDB repository", () => {
     ]) {
       expect(db.objectStoreNames.contains(storeName)).toBe(true);
     }
+    expect(
+      Array.from(
+        db
+          .transaction("lifecycleProjectionCache")
+          .objectStore("lifecycleProjectionCache").indexNames,
+      ),
+    ).toContain("by_hash");
 
     const tx = db.transaction([
       "applications",
@@ -193,6 +202,37 @@ describe("IndexedDB repository", () => {
     expect(v2Spy).toHaveBeenCalledTimes(1);
   });
 
+  it("adds the lifecycleProjectionCache store and by_hash index at v3", async () => {
+    const originalV3 = migrations[3];
+    const v3Spy = vi.fn(originalV3);
+
+    const db = await openJobbotDatabase({ indexedDb: indexedDB, version: 2 });
+    db.close();
+
+    migrations[3] = v3Spy;
+    try {
+      const upgraded = await openJobbotDatabase({
+        indexedDb: indexedDB,
+        version: 3,
+      });
+      expect(
+        upgraded.objectStoreNames.contains("lifecycleProjectionCache"),
+      ).toBe(true);
+      expect(
+        Array.from(
+          upgraded
+            .transaction("lifecycleProjectionCache")
+            .objectStore("lifecycleProjectionCache").indexNames,
+        ),
+      ).toContain("by_hash");
+      upgraded.close();
+    } finally {
+      migrations[3] = originalV3;
+    }
+
+    expect(v3Spy).toHaveBeenCalledTimes(1);
+  });
+
   it("writes, reads, exports, clears, and restores application tracker data", async () => {
     const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
 
@@ -230,6 +270,34 @@ describe("IndexedDB repository", () => {
     expect(await repo.getApplication(application.id)).toMatchObject({
       role: "Staff Software Engineer",
     });
+
+    repo.close();
+  });
+
+  // eslint-disable-next-line max-len
+  it("keeps lifecycleProjectionCache out of export/import but wipes it on clearAllData", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await repo.createApplication(application);
+    await repo.putCachedLifecycleTimeline("hash1", { buckets: [] });
+    await repo.putCachedLifecycleProjection("hash1", "current", {
+      includedApplications: 1,
+    });
+
+    const exported = await repo.exportAllData();
+    expect(Object.keys(exported)).not.toContain("lifecycleProjectionCache");
+
+    // A round-trip through import must not require/touch the new store.
+    await repo.importAllData(exported, { dryRun: true });
+    expect(await repo.getCachedLifecycleTimeline("hash1")).toEqual({
+      buckets: [],
+    });
+
+    await repo.clearAllData();
+    expect(await repo.getApplication(application.id)).toBeNull();
+    expect(await repo.getCachedLifecycleTimeline("hash1")).toBeNull();
+    expect(
+      await repo.getCachedLifecycleProjection("hash1", "current"),
+    ).toBeNull();
 
     repo.close();
   });
@@ -506,7 +574,11 @@ describe("IndexedDB repository", () => {
 
     const dryRun = await repo.importAllData(
       {
-        schemaVersion: DATABASE_VERSION,
+        // The JSON backup format's own schema version, not the IndexedDB
+        // database's -- these were both 2 before Phase 5c's version bump to
+        // 3, which is what exposed this as an accidental coupling rather
+        // than an intentional dependency between the two.
+        schemaVersion: BROWSER_BACKUP_SCHEMA_VERSION,
         exportedAt: now,
         applications: [importedApplication],
         contacts: [

--- a/test/web-tracker-lifecycle-projection-cache.test.js
+++ b/test/web-tracker-lifecycle-projection-cache.test.js
@@ -71,6 +71,12 @@ describe("lifecycleProjectionCache", () => {
     store.close();
   });
 
+  it("uses a versioned, unambiguous content-hash encoding", () => {
+    expect(contentHashForBundle(threeEventBundle())).toMatch(
+      /^v\d+:[0-9a-z]+:[0-9a-z]+$/,
+    );
+  });
+
   it("a miss computes and persists", async () => {
     const store = await createIndexedDbRepository({ indexedDb: indexedDB });
     const b = threeEventBundle();
@@ -231,5 +237,45 @@ describe("lifecycleProjectionCache", () => {
       ).toBeNull();
     }
     store.close();
+  });
+
+  it("cancels an in-flight precompute before it can queue another write", async () => {
+    const b = threeEventBundle();
+    const timeline = buildLifecycleTimeline(b);
+    const hash = contentHashForBundle(b);
+    const bucketId = timeline.buckets[1].id;
+    let capturedCallback;
+    let releaseFirstWrite;
+    const firstWrite = new Promise((resolve) => {
+      releaseFirstWrite = resolve;
+    });
+    const store = {
+      putCachedLifecycleProjection: vi
+        .fn()
+        .mockImplementationOnce(() => firstWrite)
+        .mockResolvedValue(undefined),
+    };
+    const cancel = scheduleAdjacentBucketPrecompute(
+      store,
+      () => b,
+      timeline,
+      hash,
+      bucketId,
+      {
+        requestIdle: (callback) => {
+          capturedCallback = callback;
+          return "handle";
+        },
+        cancelIdle: () => {},
+      },
+    );
+
+    const running = capturedCallback();
+    expect(store.putCachedLifecycleProjection).toHaveBeenCalledTimes(1);
+    cancel();
+    releaseFirstWrite();
+    await running;
+
+    expect(store.putCachedLifecycleProjection).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/web-tracker-lifecycle-projection-cache.test.js
+++ b/test/web-tracker-lifecycle-projection-cache.test.js
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { indexedDB } from "fake-indexeddb";
+
+import {
+  DATABASE_NAME,
+  createIndexedDbRepository,
+} from "../src/web/storage/indexedDbRepository.js";
+import { buildLifecycleTimeline } from "../src/web/tracker/lifecycleProjection.js";
+import {
+  contentHashForBundle,
+  getOrComputeTimeline,
+  scheduleAdjacentBucketPrecompute,
+} from "../src/web/tracker/lifecycleProjectionCache.js";
+
+const app = (id, extra = {}) => ({
+  id,
+  company: `Company ${id}`,
+  role: "Engineer",
+  status: "applied",
+  origin: "application_submitted",
+  appliedAt: "2026-01-01",
+  ...extra,
+});
+const ev = (id, applicationId, eventType, occurredAt, extra = {}) => ({
+  id,
+  applicationId,
+  eventType,
+  occurredAt,
+  occurredAtPrecision: occurredAt.includes("T") ? "instant" : "date",
+  inferred: false,
+  createdAt: occurredAt,
+  ...extra,
+});
+const bundle = (applications, lifecycleEvents, extra = {}) => ({
+  applications,
+  lifecycleEvents,
+  ...extra,
+});
+const threeEventBundle = () =>
+  bundle(
+    [app("a")],
+    [
+      ev("o", "a", "application_submitted", "2026-01-01"),
+      ev("t", "a", "technical_interview", "2026-01-02"),
+      ev("r", "a", "offer_received", "2026-01-03"),
+    ],
+  );
+
+const deleteDatabase = () =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(DATABASE_NAME);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => resolve();
+  });
+afterEach(deleteDatabase);
+
+describe("lifecycleProjectionCache", () => {
+  it("a cache hit avoids recomputation", async () => {
+    const store = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const b = threeEventBundle();
+    const computeTimeline = vi.fn(buildLifecycleTimeline);
+
+    const first = await getOrComputeTimeline(store, b, computeTimeline);
+    await first.persisted;
+    const second = await getOrComputeTimeline(store, b, computeTimeline);
+
+    expect(computeTimeline).toHaveBeenCalledTimes(1);
+    expect(second.hash).toBe(first.hash);
+    expect(second.timeline).toEqual(first.timeline);
+    store.close();
+  });
+
+  it("a miss computes and persists", async () => {
+    const store = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const b = threeEventBundle();
+    const computeTimeline = vi.fn(buildLifecycleTimeline);
+
+    const { timeline, hash, persisted } = await getOrComputeTimeline(
+      store,
+      b,
+      computeTimeline,
+    );
+    expect(computeTimeline).toHaveBeenCalledTimes(1);
+    await persisted;
+
+    expect(await store.getCachedLifecycleTimeline(hash)).toEqual(timeline);
+    store.close();
+  });
+
+  // eslint-disable-next-line max-len
+  it("a content change produces a different hash, a correct miss, and evicts the old hash's entries", async () => {
+    const store = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const a = threeEventBundle();
+    const { hash: hashA, persisted: persistedA } = await getOrComputeTimeline(
+      store,
+      a,
+    );
+    await persistedA;
+    expect(await store.getCachedLifecycleTimeline(hashA)).not.toBeNull();
+
+    const b = bundle(
+      [app("a"), app("b")],
+      [
+        ...a.lifecycleEvents,
+        ev("o2", "b", "application_submitted", "2026-01-04"),
+      ],
+    );
+    const { hash: hashB, persisted: persistedB } = await getOrComputeTimeline(
+      store,
+      b,
+    );
+    await persistedB;
+
+    expect(hashB).not.toBe(hashA);
+    expect(await store.getCachedLifecycleTimeline(hashA)).toBeNull();
+    expect(await store.getCachedLifecycleTimeline(hashB)).not.toBeNull();
+    store.close();
+  });
+
+  // eslint-disable-next-line max-len
+  it("an unrelated-store mutation with unchanged applications/lifecycleEvents is a cache hit -- the core value-add over the pre-existing in-memory cache", async () => {
+    const store = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const { applications, lifecycleEvents } = threeEventBundle();
+    const a = bundle(applications, lifecycleEvents, { contacts: [] });
+    const computeTimeline = vi.fn(buildLifecycleTimeline);
+
+    const first = await getOrComputeTimeline(store, a, computeTimeline);
+    await first.persisted;
+
+    // A NEW bundle object (as refresh() produces after every write), same
+    // applications/lifecycleEvents, but a different unrelated store --
+    // simulates adding a contact elsewhere in the tracker. The in-memory
+    // WeakMap cache in lifecycleProjection.js would treat this as a full
+    // miss (new object identity); this cache must not.
+    const b = bundle(applications, lifecycleEvents, {
+      contacts: [{ id: "c1" }],
+    });
+    expect(b).not.toBe(a);
+    const second = await getOrComputeTimeline(store, b, computeTimeline);
+
+    expect(computeTimeline).toHaveBeenCalledTimes(1);
+    expect(second.hash).toBe(first.hash);
+    store.close();
+  });
+
+  // eslint-disable-next-line max-len
+  it("scheduleAdjacentBucketPrecompute populates only the immediately adjacent buckets", async () => {
+    const store = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const b = threeEventBundle();
+    const timeline = buildLifecycleTimeline(b);
+    const hash = contentHashForBundle(b);
+    expect(timeline.buckets.length).toBeGreaterThanOrEqual(3);
+    const bucketIndex = 1;
+    const bucketId = timeline.buckets[bucketIndex].id;
+    const neighborIds = [
+      timeline.buckets[bucketIndex - 1].id,
+      timeline.buckets[bucketIndex + 1].id,
+    ];
+
+    let capturedCallback;
+    scheduleAdjacentBucketPrecompute(store, () => b, timeline, hash, bucketId, {
+      requestIdle: (callback) => {
+        capturedCallback = callback;
+        return "handle";
+      },
+      cancelIdle: () => {},
+    });
+    await capturedCallback();
+
+    for (const neighborId of neighborIds) {
+      expect(
+        await store.getCachedLifecycleProjection(hash, neighborId),
+      ).not.toBeNull();
+    }
+    const otherIds = timeline.buckets
+      .map((bkt) => bkt.id)
+      .filter((id) => id !== bucketId && !neighborIds.includes(id));
+    for (const otherId of otherIds) {
+      expect(
+        await store.getCachedLifecycleProjection(hash, otherId),
+      ).toBeNull();
+    }
+    store.close();
+  });
+
+  // eslint-disable-next-line max-len
+  it("abandons a stale precompute when the content hash changes before the idle callback fires", async () => {
+    const store = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const a = threeEventBundle();
+    const timeline = buildLifecycleTimeline(a);
+    const hash = contentHashForBundle(a);
+    expect(timeline.buckets.length).toBeGreaterThanOrEqual(3);
+    const bucketIndex = 1;
+    const bucketId = timeline.buckets[bucketIndex].id;
+    const neighborIds = [
+      timeline.buckets[bucketIndex - 1].id,
+      timeline.buckets[bucketIndex + 1].id,
+    ];
+
+    let currentBundle = a;
+    let capturedCallback;
+    scheduleAdjacentBucketPrecompute(
+      store,
+      () => currentBundle,
+      timeline,
+      hash,
+      bucketId,
+      {
+        requestIdle: (callback) => {
+          capturedCallback = callback;
+          return "handle";
+        },
+        cancelIdle: () => {},
+      },
+    );
+
+    // A real edit lands before the idle callback fires.
+    currentBundle = bundle(
+      [...a.applications, app("b")],
+      [
+        ...a.lifecycleEvents,
+        ev("o2", "b", "application_submitted", "2026-01-04"),
+      ],
+    );
+    await capturedCallback();
+
+    for (const neighborId of neighborIds) {
+      expect(
+        await store.getCachedLifecycleProjection(hash, neighborId),
+      ).toBeNull();
+    }
+    store.close();
+  });
+});


### PR DESCRIPTION
## Summary
- Third and last risk-split PR for Phase 5 of the diagram-performance roadmap (#1197, closed by #1204): after 5a (#1204, busy indicator) and 5b (#1205, Worker-offloaded layout search), this adds a persisted, content-hash-keyed IndexedDB cache for the projection layer plus eager background precompute of adjacent buckets on idle.
- The existing in-memory cache (`lifecycleProjection.js`, Phase 1/2) is a `WeakMap` keyed on `state.bundle`'s **object identity**. `state.bundle` is reassigned via `refresh()` after every write — 13+ call sites, including writes to stores the diagram doesn't even read (contacts, outreach messages, reminders, artifacts). Since identity-keying can't distinguish "the data I care about changed" from "some unrelated store changed," the in-memory cache is invalidated more often than it needs to be, and provides zero benefit across a page reload. A content-hash key over `applications` + `lifecycleEvents` only survives both.

## Design
- New IndexedDB store `lifecycleProjectionCache` (`INDEXEDDB_DATABASE_VERSION` bumped 2 → 3), one record per `(hash, "timeline"|bucketId)` pair. Deliberately excluded from `STORE_NAMES` — structurally unreachable from `exportAllData()`/`importAllData()` (backups shouldn't ship a stale cache alongside the source data it regenerates from) — but `clearAllData()` still wipes it directly, since "clear all data" wiping everything is the reasonable user expectation.
- `contentHashForBundle()`: two independent FNV-1a passes (different seeds), reusing the constants already used in `lifecycleReconciliation.js`. No cryptographic property is needed (same-origin, single-user local cache). Canonical serialization (row-level sort by `id`, recursive key sort) guards against non-deterministic `getAll()` ordering defeating cache hits.
- New `src/web/tracker/lifecycleProjectionCache.js`: `getOrComputeTimeline`/`getOrComputeProjection` (cache-aside, real compute functions injected as default params for testability), `scheduleAdjacentBucketPrecompute` (idle-time precompute of only the immediately-adjacent buckets, not the whole timeline — double staleness check so an edit mid-flight is correctly abandoned).
- `tracker.js`: `renderDiagram()`/`renderAll()`/`route()` become `async`. A new `state.diagramRenderGeneration` counter gates every `state.*` write and the final `view.update()` call against a superseded call resuming after a newer one already ran — this closes a race Phase 5b's own Worker-response generation counter (inside `lifecycleDiagram.js`) can't reach, since this phase's async gap (awaiting the IndexedDB cache) is one layer higher.
- Eviction: whenever a new hash is established, fire-and-forget cursor-scan deletion of all records under the previous hash — self-healing against races (a stray orphaned record from a bad interleaving gets caught by the next mutation's sweep).

## Test plan
- [x] New `test/web-tracker-lifecycle-projection-cache.test.js` against `fake-indexeddb` (6 tests): cache hit avoids recomputation, miss computes+persists, content change → different hash + old-hash eviction, the core regression (an unrelated-store mutation with unchanged `applications`/`lifecycleEvents` is a cache hit — the value-add over the pre-existing in-memory cache), adjacent-bucket precompute populates only prev/next, a stale precompute is correctly abandoned. All verified via revert-and-confirm-fail.
- [x] `test/web-storage-indexeddb-repository.test.js`: migration test for `migrations[3]`, and a test that `lifecycleProjectionCache` stays out of export/import but is wiped by `clearAllData()`.
- [x] `npm run typecheck`, `eslint`, `prettier --check` — clean.
- [x] Full targeted `vitest` suites (projection cache, storage, projection, diagram, persistence, diagram-performance, layout, reconciliation, metrics, build-metadata, spreadsheet import/export) — all pass. One pre-existing, unrelated failure in `test/web-tracker-lifecycle-diagram-layout.test.js` reproduces identically on `main` at the pre-PR commit.
- [x] `npx playwright test lifecycle-diagram browser-tracker` — 35/35 passing, including a real race this PR's async `renderDiagram` surfaced: a test read `aria-valuetext` immediately after a click without waiting for the now-async render to settle. Fixed with the same `waitForDiagramIdle` helper Phase 5b introduced.
- [x] Manual verification against a running dev server with real browser IndexedDB: cache populates on first render (timeline + selected-bucket + one adjacent-neighbor row), survives a hard reload with the same hash and same rows, an unrelated real UI mutation (adding an outreach message) correctly re-hashes and evicts (outreach messages turn out to also record a `candidate_outreach` lifecycle event in this app's domain model, so this was a genuine content change — the eviction sweep left exactly 3 rows under the new hash, none orphaned), scrubbing to a bucket the eager precompute had already warmed was an immediate cache hit, and no console errors throughout.
- [x] `docs/browser-first-architecture.md` updated with a "Derived/cached data" row and a parallel note near the Worker bullet Phase 5b added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)