### PR TITLE
Fix CSP style-src violations in the lifecycle diagram legend, log layout failures

### DIFF
--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -729,9 +729,14 @@ export function createLifecycleDiagramView(root, options = {}) {
       legend.append(
         el("span", { className: "diagram-legend-item" }, [
           el("span", {
-            className: "diagram-legend-swatch",
+            // A static per-endpoint-id class, not an inline style -- the
+            // strict production CSP (script-src/style-src 'self', no
+            // 'unsafe-inline') blocks the style attribute entirely. Colors
+            // live in tracker.css's .diagram-legend-swatch--* rules, kept in
+            // sync with ENDPOINT_BRANCH_COLORS by hand. item.id is always a
+            // fixed taxonomy id, never arbitrary data.
+            className: `diagram-legend-swatch diagram-legend-swatch--${item.id}`,
             "aria-hidden": "true",
-            style: `background:${endpointColor(item.id)}`,
           }),
           document.createTextNode(`${item.label} ${item.count}`),
         ]),
@@ -852,7 +857,7 @@ export function createLifecycleDiagramView(root, options = {}) {
             LIFECYCLE_LAYOUT_FAILURE_CAUSE_TYPES.has(retryError?.cause?.type)
           )
             return { status: "skip" };
-          return { status: "error" };
+          return { status: "error", error: retryError };
         }
       }
       if (
@@ -871,7 +876,7 @@ export function createLifecycleDiagramView(root, options = {}) {
         // just because a drag happens to be in progress.
         return { status: "skip" };
       }
-      return { status: "error" };
+      return { status: "error", error };
     }
   };
   const renderSvg = () => {
@@ -887,6 +892,7 @@ export function createLifecycleDiagramView(root, options = {}) {
     const result = acquireLayoutSync(buildBaseLayoutOptions());
     if (result.status === "skip") return;
     if (result.status === "error") {
+      console.error("Lifecycle diagram layout failed", result.error);
       showDiagramFallback("Unable to lay out lifecycle diagram.");
       return;
     }
@@ -918,6 +924,7 @@ export function createLifecycleDiagramView(root, options = {}) {
     if (result.status === "stale") return false;
     if (result.status === "skip") return true;
     if (result.status === "error") {
+      console.error("Lifecycle diagram layout failed", result.error);
       showDiagramFallback("Unable to lay out lifecycle diagram.");
       return true;
     }
@@ -940,15 +947,15 @@ export function createLifecycleDiagramView(root, options = {}) {
         baseLayoutOptions,
       );
       if (myGeneration !== renderGeneration) return { status: "stale" };
-      if (!response.ok) return { status: "error" };
+      if (!response.ok) return { status: "error", error: response.error };
       return {
         status: "ok",
         graph: response.graph,
         dimensions: response.dimensions,
       };
-    } catch {
+    } catch (error) {
       if (myGeneration !== renderGeneration) return { status: "stale" };
-      return { status: "error" };
+      return { status: "error", error };
     } finally {
       outstandingAsyncLayoutCalls -= 1;
     }
@@ -1059,7 +1066,8 @@ export function createLifecycleDiagramView(root, options = {}) {
           ).map((h) => [h.branchId, h]),
         );
       }
-    } catch {
+    } catch (error) {
+      console.error("Lifecycle diagram layout failed", error);
       showDiagramFallback("Unable to lay out lifecycle diagram.");
       return;
     }
@@ -1393,7 +1401,8 @@ export function createLifecycleDiagramView(root, options = {}) {
       // starting right after handleGroupEl so those earlier, static
       // children are never touched.
       reconcileChildOrder(diagramSvg, orderedNodeGroups, handleGroupEl);
-    } catch {
+    } catch (error) {
+      console.error("Lifecycle diagram layout failed", error);
       showDiagramFallback("Unable to lay out lifecycle diagram.");
       return;
     }

--- a/src/web/tracker/tracker.css
+++ b/src/web/tracker/tracker.css
@@ -256,6 +256,43 @@
   height: 0.85rem;
   width: 0.85rem;
 }
+/* One modifier per ENDPOINT_BRANCH_COLORS key (lifecycleDiagramLayout.js) --
+   colors must stay in sync with that map. A static class per fixed taxonomy
+   id (not an inline style) so this satisfies a strict style-src 'self' CSP
+   with no 'unsafe-inline'. */
+.diagram-legend-swatch--awaiting_response {
+  background: #60a5fa;
+}
+.diagram-legend-swatch--interviewing {
+  background: #c084fc;
+}
+.diagram-legend-swatch--assessment_in_progress {
+  background: #facc15;
+}
+.diagram-legend-swatch--offer_negotiating {
+  background: #2dd4bf;
+}
+.diagram-legend-swatch--employer_rejected {
+  background: #fb7185;
+}
+.diagram-legend-swatch--candidate_withdrew {
+  background: #fb923c;
+}
+.diagram-legend-swatch--offer_declined {
+  background: #f472b6;
+}
+.diagram-legend-swatch--offer_expired_rescinded {
+  background: #a3e635;
+}
+.diagram-legend-swatch--offer_accepted {
+  background: #4ade80;
+}
+.diagram-legend-swatch--closed_archived {
+  background: #94a3b8;
+}
+.diagram-legend-swatch--unknown {
+  background: #e2e8f0;
+}
 .diagram-scroll svg {
   display: block;
   min-width: 1850px;

--- a/test/web-tracker-lifecycle-diagram.test.js
+++ b/test/web-tracker-lifecycle-diagram.test.js
@@ -341,6 +341,30 @@ describe("lifecycle diagram view", () => {
     expect(outreachRow.textContent).toContain("0");
   });
 
+  it("colors legend swatches via a class, not an inline style", async () => {
+    // The production static-server CSP has no 'unsafe-inline' for
+    // style-src, so an inline style="..." attribute is silently blocked --
+    // legend swatch color must come from a static per-endpoint-id class
+    // (tracker.css's .diagram-legend-swatch--*) instead.
+    const b = bundle(
+      [app("a2", { origin: "referral", status: "offer" })],
+      [
+        ev("o2", "a2", "referral", "2026-01-01"),
+        ev("t2", "a2", "technical_interview", "2026-01-02T10:00:00.000Z"),
+        ev("offer", "a2", "offer_received", "2026-01-03"),
+      ],
+    );
+    const { root } = await render(b);
+    const swatches = [
+      ...root.querySelectorAll("[data-diagram-legend] .diagram-legend-swatch"),
+    ];
+    expect(swatches.length).toBeGreaterThan(0);
+    for (const swatch of swatches) {
+      expect(swatch.hasAttribute("style")).toBe(false);
+      expect(swatch.className).toMatch(/diagram-legend-swatch--\w+/u);
+    }
+  });
+
   it("keeps semantic tables aggregate-first and preserves semantic button focus", async () => {
     const b = bundle(
       [app("a")],


### PR DESCRIPTION
## Summary

Found on `staging.jobbot3000.tech/tracker` after Phase 5 (#1197) shipped: some historical scrub points showed "Unable to lay out lifecycle diagram." instead of the diagram, and the devtools console showed several Content Security Policy violations.

- **CSP style-src violations (fixed here)**: the legend's endpoint-color swatches (`renderLegend()` in `lifecycleDiagram.js`) set an inline `style="background:..."` attribute, which the strict production CSP (`scripts/static-server.js`: `style-src 'self'`, no `unsafe-inline`) silently blocks. `endpointColor()` maps a small, fixed, build-time-known set (`ENDPOINT_BRANCH_COLORS`, 11 keys in `lifecycleDiagramLayout.js`) to hex colors, so replaced the inline style with a static per-endpoint-id CSS class (`tracker.css`'s new `.diagram-legend-swatch--*` rules) — no dynamic styling needed. Confirmed via grep this was the *only* inline-style usage in the diagram's rendering path (SVG coloring elsewhere already uses `fill`/`stroke` presentation attributes, which `style-src` doesn't restrict).
- **CSP script-src violation (not a bug, left as-is)**: the blocked `static.cloudflareinsights.com/beacon.min.js` load is Cloudflare's own edge-injected Web Analytics beacon — not from this repo. Blocking a third-party tracker is correct behavior for this app's browser-first, no-external-analytics design; not allowlisting it. If the console noise is unwanted, disabling "Web Analytics" injection is a Cloudflare dashboard/zone setting, not a code change.
- **Layout failures (diagnostics only this round)**: `acquireLayoutSync`/`acquireLayoutAsync` in `lifecycleDiagram.js` were catching the underlying `layoutLifecycleRoutingGraph()` error but discarding it entirely — no `console.error` anywhere, so a live "Unable to lay out" failure was undebuggable without a local repro. All four `showDiagramFallback("Unable to lay out lifecycle diagram.")` call sites now log the actual error (including its structured `cause.type` where available, e.g. `"lifecycle-handle-placement"`).

  This class of failure (dense fan-in/fan-out lifecycle topologies exhausting the layout search's handle/lane budget) has a documented history: three independent rearchitecture attempts across PRs #1166–#1170 already tried and were abandoned or found unsafe, and prior investigation concluded a real fix needs the base layout algorithm to become rank-order-aware across all ranks jointly — multi-session-scale rearchitecture, not a scoped patch. Per that history, this PR intentionally does **not** touch `lifecycleDiagramLayout.js`'s search/placement logic. Once these diagnostics are deployed, the console output will show whether the staging failure matches that known signature or is something new, which determines what (if any) further work is warranted.

## Test plan
- [x] New regression test in `test/web-tracker-lifecycle-diagram.test.js` ("colors legend swatches via a class, not an inline style") — verified via revert-and-confirm-fail against the old inline-style implementation.
- [x] `npx vitest run test/web-tracker-lifecycle-diagram.test.js test/web-tracker-lifecycle-diagram-performance.test.js` — 76/76 passing, including confirming the new `console.error` diagnostics fire with useful structured info at every existing layout-failure test case.
- [x] `npm run typecheck`, `eslint`, `prettier --check` — clean.
- [x] `npx playwright test lifecycle-diagram` — 8/8 passing.
- [x] Manual: built the static bundle (`npm run build`), served it locally with the real strict CSP (`node scripts/static-server.js`), added an application via the UI to populate the legend, and confirmed via devtools — zero console messages of any kind (no CSP violations), swatch has class `diagram-legend-swatch--awaiting_response` with no `style` attribute, and its computed background (`rgb(96, 165, 250)`) matches `ENDPOINT_BRANCH_COLORS.awaiting_response` (`#60A5FA`) exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)