### PR TITLE
Make the lifecycle diagram's authoritative-node-order cycle non-fatal

### DIFF
--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -980,13 +980,38 @@ This specific signature does not appear anywhere else in this document and is di
 `clearanceMargin === -1` handle-placement/corridor-bound signature the "extreme fixtures" above are
 characterized by — it's a new, previously-uncharacterized way this algorithm's known "not globally
 rank-order-aware" limitation can manifest, this time as an order-consistency cycle rather than a
-handle/lane budget or corridor-clearance exhaustion. Per user decision, recorded here as a
-characterized, accepted limitation (the diagram's fallback UI degrades gracefully -- a message is
-shown, nothing else on the page breaks) rather than pursued as an immediate fix. The exact
-`nodeIds`/full application data that triggered it were not captured (the browser console truncated
-the nested `cause` object and no repro fixture was exported), so there isn't yet enough here to
-build a minimal checked-in regression fixture -- a future investigation would need to start by
-capturing that.
+handle/lane budget or corridor-clearance exhaustion.
+
+**Resolved (2026-08-04), narrowly, without touching the deeper architectural gap.**
+`deriveAuthoritativeLayoutOrders` returns `{ branchOrderByRank, nodeOrderByRank }`. Tracing every
+consumer of its return value found that `nodeOrderByRank` is **never used**: the function's only
+caller (inside the two-pass discovery→final wrapper) forwards only `branchOrderByRank` to the final
+pass; the final pass's actual node order comes from an entirely separate, y0-position-derived map
+(`discoveredNodeOrderByRank`), whose own comment already documents that the topological merge and
+D3's node placement "can legitimately disagree." `branchOrderByRank` — the only consumed output — is
+computed unconditionally, before the per-rank node-order loop even starts, and is structurally
+unaffected by any cycle in that loop. And by the time this check runs, the candidate's geometry has
+already cleared lane materialization, handle placement, and the route-crossing audit
+(`candidateCallback`) — a node-order cycle here doesn't indicate broken geometry, only that this one,
+otherwise-unused computation couldn't resolve a consistent order for diagnostic purposes.
+
+Given that, the fix makes the cycle non-fatal: instead of throwing, the affected rank falls back to
+the same deterministic tie-break (`stableNodeOrder`) already used to seed Kahn's algorithm, and the
+loop continues to the next rank. This is a strict widening of what layout attempts succeed — no
+currently-passing fixture's per-rank loop ever reaches the new fallback branch, so none are affected.
+
+No topology fed through the real transition-lane solver was found, within a bounded search (~40
+hand-constructed variants across three strategies), that reproduces the cycle without also exhausting
+the unrelated handle-state-limit budget first — the two failure modes appear correlated in a way that
+makes this one hard to isolate synthetically via the full pipeline. The regression test instead
+exercises `deriveAuthoritativeLayoutOrders` directly with a hand-constructed minimal
+`graph`/`rankOrderByRank` pair (two rank-1 nodes with disjoint incident branches, where the
+incoming-transition order places one first and the outgoing-transition order places the other first)
+that bypasses the solver entirely — confirmed via revert-and-confirm-fail to throw the identical
+`"Lifecycle authoritative node order disagrees at rank 1"` message the real staging deployment hit,
+before the fix, and to pass afterward. See
+`test/web-tracker-lifecycle-diagram-layout.test.js`'s `"authoritative node order (rank-local
+topological merge)"` describe block.
 
 ### Historical completed-work checklist
 

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -892,7 +892,11 @@ export function createLifecycleDiagramView(root, options = {}) {
     const result = acquireLayoutSync(buildBaseLayoutOptions());
     if (result.status === "skip") return;
     if (result.status === "error") {
-      console.error("Lifecycle diagram layout failed", result.error);
+      console.error(
+        "Lifecycle diagram layout failed",
+        result.error?.message,
+        JSON.stringify(result.error?.cause),
+      );
       showDiagramFallback("Unable to lay out lifecycle diagram.");
       return;
     }
@@ -924,7 +928,11 @@ export function createLifecycleDiagramView(root, options = {}) {
     if (result.status === "stale") return false;
     if (result.status === "skip") return true;
     if (result.status === "error") {
-      console.error("Lifecycle diagram layout failed", result.error);
+      console.error(
+        "Lifecycle diagram layout failed",
+        result.error?.message,
+        JSON.stringify(result.error?.cause),
+      );
       showDiagramFallback("Unable to lay out lifecycle diagram.");
       return true;
     }
@@ -1067,7 +1075,11 @@ export function createLifecycleDiagramView(root, options = {}) {
         );
       }
     } catch (error) {
-      console.error("Lifecycle diagram layout failed", error);
+      console.error(
+        "Lifecycle diagram layout failed",
+        error?.message,
+        JSON.stringify(error?.cause),
+      );
       showDiagramFallback("Unable to lay out lifecycle diagram.");
       return;
     }
@@ -1402,7 +1414,11 @@ export function createLifecycleDiagramView(root, options = {}) {
       // children are never touched.
       reconcileChildOrder(diagramSvg, orderedNodeGroups, handleGroupEl);
     } catch (error) {
-      console.error("Lifecycle diagram layout failed", error);
+      console.error(
+        "Lifecycle diagram layout failed",
+        error?.message,
+        JSON.stringify(error?.cause),
+      );
       showDiagramFallback("Unable to lay out lifecycle diagram.");
       return;
     }

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -894,7 +894,7 @@ export function createLifecycleDiagramView(root, options = {}) {
     if (result.status === "error") {
       console.error(
         "Lifecycle diagram layout failed",
-        result.error?.message,
+        result.error,
         JSON.stringify(result.error?.cause),
       );
       showDiagramFallback("Unable to lay out lifecycle diagram.");
@@ -930,7 +930,7 @@ export function createLifecycleDiagramView(root, options = {}) {
     if (result.status === "error") {
       console.error(
         "Lifecycle diagram layout failed",
-        result.error?.message,
+        result.error,
         JSON.stringify(result.error?.cause),
       );
       showDiagramFallback("Unable to lay out lifecycle diagram.");
@@ -1077,7 +1077,7 @@ export function createLifecycleDiagramView(root, options = {}) {
     } catch (error) {
       console.error(
         "Lifecycle diagram layout failed",
-        error?.message,
+        error,
         JSON.stringify(error?.cause),
       );
       showDiagramFallback("Unable to lay out lifecycle diagram.");
@@ -1416,7 +1416,7 @@ export function createLifecycleDiagramView(root, options = {}) {
     } catch (error) {
       console.error(
         "Lifecycle diagram layout failed",
-        error?.message,
+        error,
         JSON.stringify(error?.cause),
       );
       showDiagramFallback("Unable to lay out lifecycle diagram.");

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -3522,7 +3522,7 @@ const compareOrderKeys = (left, right) => {
   return 0;
 };
 
-const deriveAuthoritativeLayoutOrders = (graph, rankOrderByRank) => {
+export const deriveAuthoritativeLayoutOrders = (graph, rankOrderByRank) => {
   const branchOrderByRank = new Map(
     [...rankOrderByRank].map(([rank, ids]) => [
       rank,
@@ -3623,24 +3623,31 @@ const deriveAuthoritativeLayoutOrders = (graph, rankOrderByRank) => {
           }
         }
       }
-      if (combined.length !== nodes.length) {
-        const error = new Error(
-          `Lifecycle authoritative node order disagrees at rank ${rank}`,
-        );
-        error.cause = Object.freeze({
-          type: "lifecycle-authoritative-rank-order",
-          reason: "order-disagreement",
-          rank,
-          nodeIds: Object.freeze(
-            nodes
-              .filter((node) => indegree.get(node.id) > 0)
-              .map((node) => node.id)
-              .sort(compareLifecycleIds),
-          ),
-        });
-        throw error;
+      if (combined.length === nodes.length) {
+        nodes.splice(0, nodes.length, ...combined);
+      } else {
+        // A genuine cycle: the incoming-context order and outgoing-context
+        // order for this rank's nodes contradict each other (two different
+        // nodes' relative order flips between the rank-1->rank transition's
+        // independently-solved lane order and the rank->rank+1 transition's
+        // -- nothing constrains those two solves to agree, since each
+        // transition's lane order is chosen independently). This was
+        // previously fatal (aborted the whole layout attempt), but this
+        // value is never consumed: the only caller discards
+        // nodeOrderByRank in favor of a y0-position-derived order (see
+        // "discoveredNodeOrderByRank" in layoutLifecycleRoutingGraph, whose
+        // own comment explains the topological merge and D3's node
+        // placement "can legitimately disagree"), and only
+        // branchOrderByRank (computed independently above, before this
+        // loop, and unaffected by this cycle) is used downstream. The
+        // geometry itself has already cleared lane materialization, handle
+        // placement, and the route-crossing audit by this point -- a
+        // node-order cycle here doesn't indicate broken geometry, just
+        // that this specific, otherwise-unused computation couldn't
+        // resolve one. Fall back to the same deterministic tie-break
+        // already used to seed Kahn's algorithm above.
+        nodes.sort(stableNodeOrder);
       }
-      nodes.splice(0, nodes.length, ...combined);
     }
     nodeOrderByRank.set(
       rank,

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -3571,10 +3571,14 @@ describe("authoritative node order (rank-local topological merge)", () => {
       orders = deriveAuthoritativeLayoutOrders(graph, rankOrderByRank);
     }).not.toThrow();
 
-    expect([...orders.nodeOrderByRank.get(1).keys()].sort()).toEqual([
-      "milestone:A",
-      "milestone:B",
-    ]);
+    // Neither id is in the real taxonomy, so stableNodeOrder's routing/
+    // taxonomyOrder tie-breaks both resolve to a tie and it falls through to
+    // compareLifecycleIds -- "milestone:A" sorts before "milestone:B".
+    // Asserting the actual produced indices (not just that both ids are
+    // present) is what makes this a real check of the fallback's tie-break
+    // behavior, not just that it didn't throw.
+    expect(orders.nodeOrderByRank.get(1).get("milestone:A")).toBe(0);
+    expect(orders.nodeOrderByRank.get(1).get("milestone:B")).toBe(1);
     // branchOrderByRank is computed independently, before the per-rank node-
     // order loop, and is unaffected by a node-order cycle at any rank.
     expect(orders.branchOrderByRank.get(0).get("a1")).toBe(0);

--- a/test/web-tracker-lifecycle-diagram-layout.test.js
+++ b/test/web-tracker-lifecycle-diagram-layout.test.js
@@ -40,6 +40,7 @@ import {
   createLaneGeometryFailureCache,
   createLifecycleHorizontalGeometry,
   cubicTransitionPoint,
+  deriveAuthoritativeLayoutOrders,
   edgeCrossing,
   endpointColor,
   isRouteHandleCollision,
@@ -3510,6 +3511,119 @@ describe("seeded-replay production layout (routing fixture)", () => {
     const normal = signatureFor(projectLifecycleAt(routingFixture));
     const reversed = signatureFor(reversedProjection());
     expect(reversed).toEqual(normal);
+  });
+});
+
+// Reproduced on staging with real data (2026-08-04): a rank whose incoming-
+// transition lane order and outgoing-transition lane order flip the relative
+// position of two nodes with disjoint incident branches used to abort the
+// whole layout attempt. See docs/design/lifecycle-diagram-layout-algorithm.md
+// ("New failure signature observed in real production data") for the full
+// investigation. deriveAuthoritativeLayoutOrders is exercised directly here
+// (hand-constructed graph/rankOrderByRank, bypassing the transition-lane
+// solver entirely) because no topology fed through the real solver was found
+// -- within a bounded search -- that reliably reproduces the cycle without
+// also exhausting the handle-state-limit budget first (a separate, already-
+// documented failure mode).
+describe("authoritative node order (rank-local topological merge)", () => {
+  // eslint-disable-next-line max-len
+  it("falls back to a deterministic order instead of throwing on a genuine incoming/outgoing cycle", () => {
+    // Two rank-1 nodes, A and B, with disjoint incident branches. Transition
+    // 0 (rank 0 -> 1) places A's branch before B's; transition 1 (rank 1 ->
+    // 2) places B's branch before A's -- a direct contradiction, since each
+    // transition's lane order is solved independently with nothing tying
+    // the two together.
+    const graph = {
+      nodes: [
+        { id: "milestone:A", rank: 1, routing: false },
+        { id: "milestone:B", rank: 1, routing: false },
+      ],
+      links: [
+        {
+          branchId: "a1",
+          source: { id: "origin:x", rank: 0 },
+          target: { id: "milestone:A", rank: 1 },
+        },
+        {
+          branchId: "b1",
+          source: { id: "origin:y", rank: 0 },
+          target: { id: "milestone:B", rank: 1 },
+        },
+        {
+          branchId: "a2",
+          source: { id: "milestone:A", rank: 1 },
+          target: { id: "endpoint:p", rank: 2 },
+        },
+        {
+          branchId: "b2",
+          source: { id: "milestone:B", rank: 1 },
+          target: { id: "endpoint:q", rank: 2 },
+        },
+      ],
+    };
+    const rankOrderByRank = new Map([
+      [0, ["a1", "b1"]],
+      [1, ["b2", "a2"]],
+    ]);
+
+    let orders;
+    expect(() => {
+      orders = deriveAuthoritativeLayoutOrders(graph, rankOrderByRank);
+    }).not.toThrow();
+
+    expect([...orders.nodeOrderByRank.get(1).keys()].sort()).toEqual([
+      "milestone:A",
+      "milestone:B",
+    ]);
+    // branchOrderByRank is computed independently, before the per-rank node-
+    // order loop, and is unaffected by a node-order cycle at any rank.
+    expect(orders.branchOrderByRank.get(0).get("a1")).toBe(0);
+    expect(orders.branchOrderByRank.get(0).get("b1")).toBe(1);
+    expect(orders.branchOrderByRank.get(1).get("b2")).toBe(0);
+    expect(orders.branchOrderByRank.get(1).get("a2")).toBe(1);
+  });
+
+  it("still produces a consistent order when incoming/outgoing contexts agree", () => {
+    // Same shape as above, but transition 1 keeps A before B too -- no
+    // contradiction, so the topological merge should succeed normally
+    // (regression guard: the fallback path must only engage on a genuine
+    // cycle, not on every multi-node rank).
+    const graph = {
+      nodes: [
+        { id: "milestone:A", rank: 1, routing: false },
+        { id: "milestone:B", rank: 1, routing: false },
+      ],
+      links: [
+        {
+          branchId: "a1",
+          source: { id: "origin:x", rank: 0 },
+          target: { id: "milestone:A", rank: 1 },
+        },
+        {
+          branchId: "b1",
+          source: { id: "origin:y", rank: 0 },
+          target: { id: "milestone:B", rank: 1 },
+        },
+        {
+          branchId: "a2",
+          source: { id: "milestone:A", rank: 1 },
+          target: { id: "endpoint:p", rank: 2 },
+        },
+        {
+          branchId: "b2",
+          source: { id: "milestone:B", rank: 1 },
+          target: { id: "endpoint:q", rank: 2 },
+        },
+      ],
+    };
+    const rankOrderByRank = new Map([
+      [0, ["a1", "b1"]],
+      [1, ["a2", "b2"]],
+    ]);
+
+    const orders = deriveAuthoritativeLayoutOrders(graph, rankOrderByRank);
+    expect(orders.nodeOrderByRank.get(1).get("milestone:A")).toBe(0);
+    expect(orders.nodeOrderByRank.get(1).get("milestone:B")).toBe(1);
   });
 });
 


### PR DESCRIPTION
## Summary

Reproduced on staging with real data: some historical scrub points showed "Unable to lay out lifecycle diagram." instead of the diagram. PR #1207's new diagnostic logging surfaced the cause: `{ type: "lifecycle-authoritative-rank-order", reason: "order-disagreement", rank: 1, nodeIds: [...] }`, thrown from `deriveAuthoritativeLayoutOrders`'s per-rank topological sort — a genuine cycle when a rank's incoming-transition lane order and outgoing-transition lane order flip the relative position of two nodes with disjoint incident branches (each transition is solved independently, with nothing constraining the two to agree).

This is a **new, previously-uncharacterized failure signature**, distinct from the deep, multi-session "extreme fixtures" gap chronicled across PRs #1166-#1170 (`clearanceMargin === -1`, handle-placement/corridor-bound budget exhaustion) — see `docs/design/lifecycle-diagram-layout-algorithm.md`. That gap still needs real architectural rearchitecture and isn't touched here.

**Why this one is safe to fix narrowly:** tracing every consumer of `deriveAuthoritativeLayoutOrders`'s return value found `nodeOrderByRank` (what the cycle-detection was protecting) is **never used downstream**. The final pass gets its actual node order from a separate, y0-position-based derivation instead — its own comment already documents that the topological merge "can legitimately disagree" with it. The only consumed output, `branchOrderByRank`, is computed independently, before the cycle-prone loop even starts, and is structurally unaffected by it. By the time this check runs, the candidate's geometry has already cleared lane materialization, handle placement, and the route-crossing audit — a node-order cycle here doesn't indicate broken geometry, only that this one, otherwise-unused validation couldn't resolve an order.

## Changes
- `deriveAuthoritativeLayoutOrders` (`lifecycleDiagramLayout.js`): the cycle case now falls back to the same deterministic tie-break (`stableNodeOrder`) already used to seed Kahn's algorithm, instead of throwing and aborting the whole layout attempt. Exported (previously internal) so it can be tested directly.
- `lifecycleDiagram.js`: the four layout-failure diagnostic `console.error` sites (added in #1207) now `JSON.stringify` the error cause, so a future failure of *any* kind captures full detail (e.g. `nodeIds`) as copy-pasteable text instead of a console-collapsed object — this is what let us find the exact throw site and design a targeted fix without a full-pipeline repro.
- `docs/design/lifecycle-diagram-layout-algorithm.md` + project memory updated with the resolution.

## Test plan
- [x] New regression test in `test/web-tracker-lifecycle-diagram-layout.test.js` (`"authoritative node order (rank-local topological merge)"`) calls `deriveAuthoritativeLayoutOrders` directly with a hand-constructed minimal `graph`/`rankOrderByRank` (two rank-1 nodes, disjoint incident branches, incoming/outgoing transitions in flipped order) — no topology fed through the real solver was found, within a bounded search (~40 hand-constructed variants across three strategies), that reproduces the cycle without also exhausting the unrelated handle-state-limit budget first, so this bypasses the solver entirely. Verified via revert-and-confirm-fail: throws the *identical* message the real staging failure produced (`"Lifecycle authoritative node order disagrees at rank 1"`) before the fix, passes after. A second test confirms the fallback path doesn't engage when incoming/outgoing contexts agree (no regression on the normal case).
- [x] `npx vitest run test/web-tracker-lifecycle-diagram-layout.test.js test/web-tracker-lifecycle-diagram.test.js test/web-tracker-lifecycle-diagram-performance.test.js` — 185/186 pass; the one failure (`"separates primary and fallback evidence for fan-in fixtures"`) is a confirmed pre-existing, unrelated issue reproducing identically on `main` before this branch.
- [x] `npm run typecheck`, `eslint`, `prettier --check` — clean.
- [x] `npx playwright test lifecycle-diagram` — 8/8 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)