### PR TITLE
Make browser CSV persistence lossless: preserve raw compact cells and export only explicit lifecycle events

### DIFF
--- a/docs/backup-restore-guide.md
+++ b/docs/backup-restore-guide.md
@@ -6,15 +6,15 @@ private tracker data on the server.
 
 ## Formats
 
-- **Compact application CSV**: human-editable, spreadsheet-shaped, one-row-per-application compatibility format. Use it for Google Sheets interchange and manual review; it preserves documented compact metadata but is not the complete backup format.
-- **Supplemental lifecycle CSV**: event-rich CSV keyed by `application_id`. Use it with compact CSV when a spreadsheet workflow needs lifecycle events, action metadata, source artifacts, due dates, and multiline details.
+- **Compact application CSV**: human-editable, spreadsheet-shaped, one-row-per-application compatibility format. It preserves unchanged raw labels and timestamp text through a private metadata envelope, but is not the complete backup format.
+- **Consolidated lifecycle CSV**: explicit user-authored/imported events keyed by stable `event_id` and `application_id`. Runtime compact-derived and inferred events are intentionally excluded. Legacy lifecycle CSVs remain importable.
 - **JSON**: canonical full-fidelity backup bundle for complete browser restores. It includes applications, contacts, outreach messages, lifecycle events, interviews, offers, artifacts, reminders, and settings. Use it for routine backups, before clearing data, or when moving browsers.
 - **NDJSON**: line-oriented full-fidelity stream with stable record types and version metadata. Use it when you want per-record diffs, streaming-friendly storage, or easier manual inspection; restore it from the browser UI import panel.
 
 ## When to use each format
 
 - Use compact CSV when the goal is spreadsheet compatibility.
-- Use supplemental lifecycle CSV alongside compact CSV when the spreadsheet workflow needs event metadata; `application_id` is the relationship source of truth.
+- Use lifecycle CSV alongside compact CSV as the supported two-sheet workflow. Preserve an existing row's `event_id`; give every new event a new unique ID. Blank legacy IDs are generated on canonical export. Date-only deadlines remain dates and offset datetimes remain instants.
 - Use JSON for routine complete backups and full-fidelity browser restores.
 - Use NDJSON for complete backups that should be easy to diff or process one
   record per line, and for full-fidelity browser restores.

--- a/docs/spreadsheet-replacement.md
+++ b/docs/spreadsheet-replacement.md
@@ -1,14 +1,26 @@
 # Replacing the Google Sheets application tracker
 
-jobbot3000 can import the compact CSV tracker into the browser-first IndexedDB data model and export durable backups. Compact CSV is the spreadsheet-compatible one-row-per-application format, supplemental lifecycle CSV carries event metadata keyed by `application_id`, and JSON/NDJSON are full-fidelity backup/restore formats. Use only fake/test data in the repository; keep real application records in private browser backups.
+jobbot3000 supports a two-sheet Google Sheets workflow: one compact, one-row-per-application CSV plus one consolidated explicit lifecycle-events CSV. JSON/NDJSON remain the full-fidelity browser backup formats, including runtime-derived records. Use only fake/test data in the repository; real exports contain private job-search data and must never be committed.
 
 ## Supported compact CSV columns
 
 The importer expects this deterministic header order when exporting back to CSV:
 
 ```text
-application_id,company,role_title,status,applied_at,posting_url,application_url,posting_id,application_channel,work_model,location_display,compensation_min_usd,compensation_max_usd,resume_artifact,resume_url,cover_letter_submitted,cover_letter_artifact,cover_letter_url,job_description_snapshot_url,linkedin_snapshot_screenshot_url,linkedin_snapshot_pdf_url,fit_score_100,outreach_status,outreach_target_name,outreach_channel,outreach_sent_at,outreach_message_text,follow_up_date,interview_stage,outcome,notes,schema_version
+application_id,company,role_title,status,applied_at,posting_url,application_url,posting_id,application_channel,origin,work_model,location_display,compensation_min_usd,compensation_max_usd,resume_artifact,resume_url,cover_letter_submitted,cover_letter_artifact,cover_letter_url,job_description_snapshot_url,linkedin_snapshot_screenshot_url,linkedin_snapshot_pdf_url,fit_score_100,outreach_status,outreach_target_name,outreach_channel,outreach_sent_at,outreach_message_text,follow_up_date,interview_stage,outcome,notes,schema_version
 ```
+
+Legacy compact files without `origin` remain importable. A blank legacy origin means unknown (`other_unknown` internally), not automatically application-submitted; existing referral aliases remain referrals. Arbitrary labels such as work models, interview stages, and outreach channels are retained exactly for unchanged cells even where the browser model uses canonical enums. Exact timestamps, offsets, punctuation, and multiline messages are retained by a versioned, single-line `Spreadsheet metadata:` envelope that is never included in the exported notes cell. A browser edit replaces the preserved value only for the changed cell.
+
+## Canonical lifecycle CSV columns
+
+```text
+event_id,application_id,company,role_title,event_type,raw_event_type,previous_status,occurred_at,occurred_at_precision,inferred,supersedes_event_id,stage,channel,actor,source_artifact,requires_user_action,action_status,due_at,due_at_precision,no_ai_required,details
+```
+
+Lifecycle export contains only explicit user-created or imported events. Compact-derived and reconciliation/migration-inferred events remain available to runtime metrics, timelines, and diagrams but are intentionally excluded. Legacy 19-column and 14-column per-application files remain importable and can be consolidated into this one lifecycle sheet.
+
+`event_id` is stable identity. Keep it unchanged when editing an existing row, and assign a new unique ID to every new event. Blank IDs in legacy files are generated deterministically and appear on the first canonical export. Duplicate IDs are rejected rather than overwritten. Date-only values remain `YYYY-MM-DD`; datetimes remain instants with their supplied offset. A blank occurrence remains blank even when the event has a deadline.
 
 ## Export from Google Sheets
 
@@ -44,16 +56,16 @@ After import, spot-check a few rows in the application tracker:
 - outreach target, channel, sent date, and message text;
 - lifecycle events for applied, outreach sent, interview stage, offer, and final outcome.
 
-The importer preserves compact fields that do not have a first-class normalized field as a `Spreadsheet metadata:` line in application notes, so values such as posting IDs, fit scores, and application URLs are not silently dropped.
+The importer preserves every original compact cell alongside the canonical value captured immediately after import. Unchanged cells therefore round-trip losslessly, while edits to normalized browser state export their new canonical values.
 
 ## Export a backup
 
 Use the export flow after every meaningful update:
 
 - **Compact CSV** for spreadsheet compatibility and manual review.
-- **Lifecycle CSV** when you need event rows, source artifacts, action status, due dates, and multiline details tied back to applications by `application_id`.
-- **JSON** for complete browser backup/restore; this is the preferred everyday backup.
-- **NDJSON** for equivalent full-fidelity backup/restore with one typed record per line.
+- **Lifecycle CSV** for the consolidated explicit event sheet, with stable `event_id`, source artifacts, actions, precision-aware dates, and multiline details.
+- **JSON** for complete browser backup/restore, including internal derived and inferred records; this is the preferred everyday backup.
+- **NDJSON** for the equivalent full browser backup with one typed record per line.
 
 Store backups somewhere private and encrypted. The files may include application history, contacts, outreach messages, links to private artifacts, private URLs, company names, and notes. Do not commit real backups, bake them into Docker images, or paste them into public issues.
 

--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -50,6 +50,11 @@ export const browserApplicationOccurredAtPrecisionSchema = z.enum([
   "date",
   "unknown",
 ]);
+export const browserApplicationLifecycleProvenanceSchema = z.enum([
+  "explicit",
+  "compact_derived",
+  "inferred",
+]);
 
 const isoDateTimeSchema = z.string().datetime({ offset: true });
 const isoDateSchema = z
@@ -118,6 +123,7 @@ export const browserApplicationLifecycleEventSchema = z
     previousStatus: browserApplicationLifecycleStatusSchema.optional(),
     occurredAtPrecision: browserApplicationOccurredAtPrecisionSchema,
     inferred: z.boolean(),
+    provenance: browserApplicationLifecycleProvenanceSchema.optional(),
     supersedesEventId: optionalTrimmedStringSchema,
     stageLabel: optionalTrimmedStringSchema,
     channel: optionalTrimmedStringSchema,
@@ -125,7 +131,8 @@ export const browserApplicationLifecycleEventSchema = z
     sourceArtifact: optionalTrimmedStringSchema,
     requiresUserAction: z.boolean().optional(),
     actionStatus: optionalTrimmedStringSchema,
-    dueAt: isoDateTimeSchema.optional(),
+    dueAt: stableDateOrDateTimeSchema.optional(),
+    dueAtPrecision: browserApplicationOccurredAtPrecisionSchema.optional(),
     noAiRequired: z.boolean().optional(),
     details: optionalTrimmedStringSchema,
     createdAt: isoDateTimeSchema,
@@ -141,6 +148,26 @@ export const browserApplicationLifecycleEventSchema = z
         path: ["occurredAt"],
       });
     }
+    if (
+      event.dueAtPrecision === "instant" &&
+      event.dueAt !== undefined &&
+      !isoDateTimeSchema.safeParse(event.dueAt).success
+    )
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "instant dueAt must be an ISO datetime with offset",
+        path: ["dueAt"],
+      });
+    if (
+      event.dueAtPrecision === "date" &&
+      event.dueAt !== undefined &&
+      !isoDateSchema.safeParse(event.dueAt).success
+    )
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "date dueAt must be YYYY-MM-DD",
+        path: ["dueAt"],
+      });
     if (
       event.occurredAtPrecision === "date" &&
       !isoDateSchema.safeParse(event.occurredAt).success
@@ -351,7 +378,7 @@ export const browserApplicationV1LifecycleEventSchema = z
     sourceArtifact: optionalTrimmedStringSchema,
     requiresUserAction: z.boolean().optional(),
     actionStatus: optionalTrimmedStringSchema,
-    dueAt: isoDateTimeSchema.optional(),
+    dueAt: stableDateOrDateTimeSchema.optional(),
     noAiRequired: z.boolean().optional(),
     details: optionalTrimmedStringSchema,
     createdAt: isoDateTimeSchema,

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -3,6 +3,7 @@ import { upgradeBrowserExportToV2 } from "../storage/browserDataMigration.js";
 import { classifyLifecycleEventType } from "../tracker/lifecycleClassification.js";
 
 export const LIFECYCLE_CSV_COLUMNS = [
+  "event_id",
   "application_id",
   "company",
   "role_title",
@@ -20,6 +21,7 @@ export const LIFECYCLE_CSV_COLUMNS = [
   "requires_user_action",
   "action_status",
   "due_at",
+  "due_at_precision",
   "no_ai_required",
   "details",
 ];
@@ -370,8 +372,64 @@ const parseDate = (
   }
   return date.toISOString();
 };
-const hasTimeComponent = (value) =>
-  /(?:T|\s)\d{1,2}:\d{2}/.test(compact(value));
+const precisionValue = (value) => {
+  const text = compact(value);
+  if (!text) return "unknown";
+  return /^\d{4}-\d{2}-\d{2}$/.test(text) ? "date" : "instant";
+};
+const parseLifecycleDate = (value, precision, field, rowNumber, errors) => {
+  const text = compact(value);
+  const derived = precisionValue(text);
+  const supplied = compact(precision);
+  if (supplied && !["instant", "date", "unknown"].includes(supplied))
+    errors.push({
+      rowNumber,
+      field: `${field}_precision`,
+      code: "invalid_precision",
+    });
+  if (supplied && supplied !== derived)
+    errors.push({
+      rowNumber,
+      field: `${field}_precision`,
+      code: "precision_mismatch",
+      message: `${field}_precision does not match ${field}.`,
+    });
+  if (!text) return { value: undefined, precision: "unknown" };
+  if (derived === "date") {
+    const date = new Date(`${text}T00:00:00.000Z`);
+    if (
+      Number.isNaN(date.getTime()) ||
+      date.toISOString().slice(0, 10) !== text
+    ) {
+      pushMalformedDateError(errors, field, rowNumber);
+      return { value: undefined, precision: "unknown" };
+    }
+  } else if (!isValidIsoOffsetDateTime(text)) {
+    pushMalformedDateError(errors, field, rowNumber);
+    return { value: undefined, precision: "unknown" };
+  }
+  return { value: text, precision: derived };
+};
+const fnv1a = (text, seed) => {
+  let hash = seed >>> 0;
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+};
+const generatedLifecycleId = (row) => {
+  const fingerprint = JSON.stringify(
+    LIFECYCLE_CSV_COLUMNS.filter(
+      (column) => !["event_id", "company", "role_title"].includes(column),
+    ).map((column) => String(row[column] ?? "")),
+  );
+  const hashes = [
+    fnv1a(fingerprint, 0x811c9dc5),
+    fnv1a(fingerprint, 0x9e3779b9),
+  ].join("");
+  return `event_${slug(row.application_id)}_${hashes}`;
+};
 
 const parseBoolean = (value, field, rowNumber, errors) => {
   const text = normalizeKey(value);
@@ -445,6 +503,19 @@ const metadataFromRow = (row) =>
       )
       .filter(([, value]) => value),
   );
+export const createSpreadsheetMetadataEnvelope = (rawRow, canonicalRow) => ({
+  ...metadataFromRow(rawRow),
+  spreadsheet_metadata_version: 2,
+  raw_row: Object.fromEntries(
+    COMPACT_CSV_COLUMNS.map((column) => [column, String(rawRow[column] ?? "")]),
+  ),
+  canonical_row: Object.fromEntries(
+    COMPACT_CSV_COLUMNS.map((column) => [
+      column,
+      String(canonicalRow[column] ?? ""),
+    ]),
+  ),
+});
 const appendMetadataToNotes = (notes, metadata) => {
   const entries = Object.keys(metadata).sort();
   if (entries.length === 0) return compact(notes) || undefined;
@@ -534,7 +605,8 @@ const preservedOutcome = (metadata, currentOutcome) => {
 export const detectSpreadsheetImportFormat = (text) => {
   const headers = csvHeaders(text);
   const headerSet = new Set(headers);
-  const hasAll = (...columns) => columns.every((column) => headerSet.has(column));
+  const hasAll = (...columns) =>
+    columns.every((column) => headerSet.has(column));
 
   if (hasAll("application_id", "event_type", "occurred_at"))
     return "lifecycle_csv";
@@ -574,6 +646,8 @@ export const lifecycleRowsToBrowserApplicationExport = (
   const interviews = [];
   const reminders = [];
   const warnings = [];
+  const seenIds = new Map();
+  const seenLegacyRows = new Map();
   rows.forEach((sourceRow, index) => {
     const rowNumber = index + 2;
     const row = { ...blankLifecycleRow(), ...sourceRow };
@@ -591,19 +665,25 @@ export const lifecycleRowsToBrowserApplicationExport = (
       });
       return;
     }
-    const rawEventType = compact(row.event_type);
+    const rawEventType = compact(row.raw_event_type) || compact(row.event_type);
     const eventType = normalizeLabelKey(rawEventType) || "lifecycle_event";
-    const occurredAt = parseDate(
+    const occurred = parseLifecycleDate(
       row.occurred_at,
+      row.occurred_at_precision,
       "occurred_at",
       rowNumber,
       errors,
     );
-    const dueAt = parseDate(row.due_at, "due_at", rowNumber, errors);
-    const eventOccurredAt = occurredAt ?? dueAt ?? "1970-01-01T00:00:00.000Z";
-    const occurredAtHasTime = hasTimeComponent(row.occurred_at);
-    const dueAtHasTime = hasTimeComponent(row.due_at);
-    const suppliedPrecision = compact(row.occurred_at_precision) || undefined;
+    const due = parseLifecycleDate(
+      row.due_at,
+      row.due_at_precision,
+      "due_at",
+      rowNumber,
+      errors,
+    );
+    const occurredAt = occurred.value;
+    const dueAt = due.value;
+    const eventOccurredAt = occurredAt ?? "1970-01-01T00:00:00.000Z";
     const stageLabel = compact(row.stage) || undefined;
     const knownLifecycleStatus = lifecycleStatusForEvent(eventType);
     if (
@@ -623,15 +703,29 @@ export const lifecycleRowsToBrowserApplicationExport = (
       mapStatus({ status: "", interview_stage: stageLabel ?? "", outcome: "" });
     const sourceArtifact = compact(row.source_artifact) || undefined;
     const details = compact(row.details) || undefined;
-    const id = stableId(
-      "event",
-      applicationId,
-      eventType,
-      eventOccurredAt,
-      dueAt ?? "",
-      sourceArtifact ?? "",
-      details ?? "",
-    );
+    const suppliedId = compact(row.event_id);
+    const id = suppliedId || generatedLifecycleId(row);
+    if (seenIds.has(id))
+      errors.push({
+        rowNumber,
+        field: "event_id",
+        code: suppliedId ? "duplicate_event_id" : "event_id_collision",
+        value: id,
+      });
+    seenIds.set(id, rowNumber);
+    if (!suppliedId) {
+      const fingerprint = JSON.stringify(row);
+      if (seenLegacyRows.has(fingerprint))
+        errors.push({
+          rowNumber,
+          field: "event_id",
+          code: "duplicate_event_without_event_id",
+          value: id,
+        });
+      seenLegacyRows.set(fingerprint, rowNumber);
+    }
+    const inferred =
+      parseBoolean(row.inferred, "inferred", rowNumber, errors) ?? false;
     lifecycleEvents.push({
       id,
       applicationId,
@@ -654,11 +748,10 @@ export const lifecycleRowsToBrowserApplicationExport = (
       ),
       actionStatus: compact(row.action_status) || undefined,
       dueAt,
-      occurredAtPrecision: suppliedPrecision,
-      occurredAtHasTime,
-      dueAtHasTime,
-      inferred:
-        parseBoolean(row.inferred, "inferred", rowNumber, errors) ?? false,
+      occurredAtPrecision: occurred.precision,
+      dueAtPrecision: due.precision,
+      inferred,
+      provenance: inferred ? "inferred" : "explicit",
       supersedesEventId: compact(row.supersedes_event_id) || undefined,
       noAiRequired: parseBoolean(
         row.no_ai_required,
@@ -671,15 +764,9 @@ export const lifecycleRowsToBrowserApplicationExport = (
     });
     if (eventType === "next_tracking_step" && dueAt)
       reminders.push({
-        id: stableId(
-          "reminder",
-          applicationId,
-          eventType,
-          dueAt,
-          details ?? "",
-        ),
+        id: stableId("reminder", id),
         applicationId,
-        dueAt,
+        dueAt: due.precision === "date" ? `${dueAt}T23:59:59.999Z` : dueAt,
         summary: details || stageLabel || "Next tracking step",
         notes: details,
         createdAt: exportedAt,
@@ -688,22 +775,17 @@ export const lifecycleRowsToBrowserApplicationExport = (
     const classification = classifyLifecycleEventType(eventType);
     const interviewStartsAt =
       classification.interviewOutcome === "completed"
-        ? occurredAtHasTime
+        ? occurred.precision === "instant"
           ? occurredAt
-          : dueAtHasTime
+          : due.precision === "instant"
             ? dueAt
             : undefined
-        : dueAtHasTime
+        : due.precision === "instant"
           ? dueAt
           : undefined;
     if (classification.interviewStage && interviewStartsAt)
       interviews.push({
-        id: stableId(
-          "interview",
-          applicationId,
-          classification.interviewStage,
-          interviewStartsAt,
-        ),
+        id: stableId("interview", id),
         applicationId,
         contactIds: [],
         stage: classification.interviewStage,
@@ -725,14 +807,7 @@ export const lifecycleRowsToBrowserApplicationExport = (
     artifacts: [],
     reminders,
   };
-  for (const store of ["lifecycleEvents", "interviews", "reminders"]) {
-    const seen = new Set();
-    bundle[store] = bundle[store].filter(({ id }) => {
-      if (seen.has(id)) return false;
-      seen.add(id);
-      return true;
-    });
-  }
+  if (errors.length > 0) return { bundle, errors, warnings };
   const incomingIds = {
     lifecycleEvents: new Set(bundle.lifecycleEvents.map(({ id }) => id)),
     interviews: new Set(bundle.interviews.map(({ id }) => id)),
@@ -866,13 +941,38 @@ export const rowsToBrowserApplicationExport = (
       ...row,
       fit_score_100: fitScore ?? row.fit_score_100,
     });
+    const explicitOrigin = compact(row.origin);
+    if (
+      explicitOrigin &&
+      ![
+        "application_submitted",
+        "recruiter_company_outreach",
+        "candidate_outreach",
+        "referral",
+        "other_unknown",
+      ].includes(explicitOrigin)
+    )
+      errors.push({
+        rowNumber,
+        field: "origin",
+        code: "unsupported_origin",
+        value: row.origin,
+        message: "origin is not a supported value.",
+      });
+    const origin = explicitOrigin
+      ? explicitOrigin
+      : ["referral", "employee_referral"].includes(
+            normalizeKey(row.application_channel),
+          )
+        ? "referral"
+        : "other_unknown";
     applications.push({
       id,
       company: compact(row.company) || "Unknown company",
       role: compact(row.role_title) || "Unknown role",
       status: mapStatus(row),
       source: compact(row.application_channel) || undefined,
-      origin: compact(row.origin) || undefined,
+      origin,
       postingUrl,
       location: compact(row.location_display) || undefined,
       remote: normalizeKey(row.work_model).includes("remote")
@@ -915,7 +1015,8 @@ export const rowsToBrowserApplicationExport = (
         updatedAt: exportedAt,
       });
     if (
-      OUTREACH_SENT_STATUSES.has(normalizeKey(row.outreach_status)) &&
+      OUTREACH_SENT_STATUSES.has(normalizeKey(row.outreach_status)) ||
+      outreachSentAt ||
       compact(row.outreach_message_text)
     ) {
       outreachMessages.push({
@@ -932,7 +1033,7 @@ export const rowsToBrowserApplicationExport = (
         )
           ? normalizeKey(row.outreach_channel)
           : "other",
-        body: compact(row.outreach_message_text),
+        body: compact(row.outreach_message_text) || undefined,
         sentAt: outreachSentAt,
         createdAt: outreachSentAt ?? timestamp,
         updatedAt: exportedAt,
@@ -948,6 +1049,7 @@ export const rowsToBrowserApplicationExport = (
         eventType: "application_submitted",
         occurredAtPrecision: "instant",
         inferred: false,
+        provenance: "compact_derived",
         createdAt: exportedAt,
       });
     if (outreachSentAt)
@@ -960,6 +1062,7 @@ export const rowsToBrowserApplicationExport = (
         eventType: "candidate_outreach",
         occurredAtPrecision: "instant",
         inferred: false,
+        provenance: "compact_derived",
         createdAt: exportedAt,
       });
     const stageLabel = normalizeLabelKey(row.interview_stage);
@@ -981,6 +1084,7 @@ export const rowsToBrowserApplicationExport = (
               : stage,
         occurredAtPrecision: "instant",
         inferred: false,
+        provenance: "compact_derived",
         createdAt: exportedAt,
       });
       interviews.push({
@@ -1015,6 +1119,7 @@ export const rowsToBrowserApplicationExport = (
           eventType: "employer_rejected",
           occurredAtPrecision: "instant",
           inferred: false,
+          provenance: "compact_derived",
           createdAt: exportedAt,
         });
     }
@@ -1044,6 +1149,7 @@ export const rowsToBrowserApplicationExport = (
                   : "status_changed",
         occurredAtPrecision: "instant",
         inferred: false,
+        provenance: "compact_derived",
         createdAt: exportedAt,
       });
     if (outcome === "offer")
@@ -1092,13 +1198,32 @@ export const rowsToBrowserApplicationExport = (
       code: "schema_validation_failed",
       message: parsed.error.message,
     });
+  if (parsed.success) {
+    const canonicalById = new Map(
+      browserApplicationExportToCanonicalRows(bundle).map((row) => [
+        row.application_id,
+        row,
+      ]),
+    );
+    bundle.applications = bundle.applications.map((application) => {
+      const rawRow = {
+        ...blankRow(),
+        ...rows.find((row) => compact(row.application_id) === application.id),
+      };
+      const { notes } = readMetadataFromNotes(application.notes);
+      const envelope = createSpreadsheetMetadataEnvelope(
+        rawRow,
+        canonicalById.get(application.id) ?? blankRow(),
+      );
+      return { ...application, notes: appendMetadataToNotes(notes, envelope) };
+    });
+  }
   return { bundle, errors, warnings };
 };
 
 export const csvToBrowserApplicationExport = (csvText, options) =>
   rowsToBrowserApplicationExport(parseCsv(csvText), options);
 
-const dateOnly = (value) => (value ? String(value).slice(0, 10) : "");
 const dateTime = (value) => (value ? String(value) : "");
 const compareCodePoints = (left, right) => {
   const leftText = String(left);
@@ -1117,8 +1242,15 @@ const compareIsoDateTimes = (left, right) => {
   if (leftValid !== rightValid) return leftValid ? 1 : -1;
   return compareCodePoints(leftText, rightText);
 };
-const firstBy = (records, predicate) => records.find(predicate) ?? {};
-export const browserApplicationExportToRows = (bundle) => {
+const latestBy = (records, predicate, fields = ["createdAt", "id"]) =>
+  records.filter(predicate).sort((a, b) => {
+    for (const field of fields) {
+      const compared = compareIsoDateTimes(a[field], b[field]);
+      if (compared) return -compared;
+    }
+    return 0;
+  })[0] ?? {};
+export const browserApplicationExportToCanonicalRows = (bundle) => {
   const parsed = upgradeBrowserExportToV2(bundle).data;
   return [...parsed.applications]
     .sort((a, b) => a.id.localeCompare(b.id))
@@ -1128,33 +1260,34 @@ export const browserApplicationExportToRows = (bundle) => {
       const artifacts = parsed.artifacts.filter(
         (artifact) => artifact.applicationId === application.id,
       );
-      const outreach = firstBy(
+      const outreach = latestBy(
         parsed.outreachMessages,
         (message) => message.applicationId === application.id,
+        ["sentAt", "createdAt", "id"],
       );
       const interview =
-        firstBy(
+        latestBy(
           parsed.interviews,
           (record) => record.applicationId === application.id,
         ) ?? {};
-      const interviewStageEvent = firstBy(
+      const interviewStageEvent = latestBy(
         parsed.lifecycleEvents,
         (event) =>
           event.applicationId === application.id &&
           INTERVIEW_STAGES.has(event.status),
       );
-      const outcomeEvent = firstBy(
+      const outcomeEvent = latestBy(
         parsed.lifecycleEvents,
         (event) =>
           event.applicationId === application.id && OUTCOMES.has(event.status),
       );
-      const offer = firstBy(
+      const offer = latestBy(
         parsed.offers,
         (record) => record.applicationId === application.id,
       );
       const contact = outreach.contactId
-        ? firstBy(parsed.contacts, ({ id }) => id === outreach.contactId)
-        : firstBy(
+        ? latestBy(parsed.contacts, ({ id }) => id === outreach.contactId)
+        : latestBy(
             parsed.contacts,
             ({ applicationId }) => applicationId === application.id,
           );
@@ -1163,27 +1296,27 @@ export const browserApplicationExportToRows = (bundle) => {
         company: application.company,
         role_title: application.role,
         status: application.status,
-        applied_at: dateOnly(application.appliedAt),
+        applied_at: dateTime(application.appliedAt),
         posting_url: application.postingUrl ?? "",
         application_channel: application.source ?? "",
         origin: application.origin ?? "",
         work_model: application.remote ? "remote" : (metadata.work_model ?? ""),
         location_display: application.location ?? "",
-        follow_up_date: dateOnly(application.followUpDate),
+        follow_up_date: dateTime(application.followUpDate),
         notes,
         schema_version: metadata.schema_version ?? "1",
       });
-      const resume = firstBy(artifacts, ({ kind }) => kind === "resume");
-      const cover = firstBy(artifacts, ({ kind }) => kind === "cover_letter");
-      const job = firstBy(
+      const resume = latestBy(artifacts, ({ kind }) => kind === "resume");
+      const cover = latestBy(artifacts, ({ kind }) => kind === "cover_letter");
+      const job = latestBy(
         artifacts,
         ({ name }) => name === "Job description snapshot",
       );
-      const screenshot = firstBy(
+      const screenshot = latestBy(
         artifacts,
         ({ name }) => name === "LinkedIn snapshot screenshot",
       );
-      const pdf = firstBy(
+      const pdf = latestBy(
         artifacts,
         ({ name }) => name === "LinkedIn snapshot PDF",
       );
@@ -1216,6 +1349,34 @@ export const browserApplicationExportToRows = (bundle) => {
       return row;
     });
 };
+export const applyPreservedCompactCells = (row, metadata) => {
+  if (
+    metadata.spreadsheet_metadata_version !== 2 ||
+    !metadata.raw_row ||
+    !metadata.canonical_row
+  )
+    return row;
+  return Object.fromEntries(
+    COMPACT_CSV_COLUMNS.map((column) => [
+      column,
+      String(row[column] ?? "") === String(metadata.canonical_row[column] ?? "")
+        ? String(metadata.raw_row[column] ?? "")
+        : String(row[column] ?? ""),
+    ]),
+  );
+};
+export const browserApplicationExportToRows = (bundle) => {
+  const parsed = upgradeBrowserExportToV2(bundle).data;
+  const metadataById = new Map(
+    parsed.applications.map((application) => [
+      application.id,
+      readMetadataFromNotes(application.notes).metadata,
+    ]),
+  );
+  return browserApplicationExportToCanonicalRows(parsed).map((row) =>
+    applyPreservedCompactCells(row, metadataById.get(row.application_id) ?? {}),
+  );
+};
 export const exportCompactCsv = (bundle) =>
   serializeCsv(browserApplicationExportToRows(bundle));
 export const browserApplicationExportToLifecycleRows = (bundle) => {
@@ -1224,6 +1385,7 @@ export const browserApplicationExportToLifecycleRows = (bundle) => {
     parsed.applications.map((application) => [application.id, application]),
   );
   return [...parsed.lifecycleEvents]
+    .filter((event) => event.provenance === "explicit")
     .sort((a, b) => {
       for (const compared of [
         compareCodePoints(a.applicationId, b.applicationId),
@@ -1240,6 +1402,7 @@ export const browserApplicationExportToLifecycleRows = (bundle) => {
       const application = applicationsById.get(event.applicationId) ?? {};
       return {
         ...blankLifecycleRow(),
+        event_id: event.id,
         application_id: event.applicationId,
         company: application.company ?? "",
         role_title: application.role ?? "",
@@ -1248,7 +1411,7 @@ export const browserApplicationExportToLifecycleRows = (bundle) => {
         previous_status: event.previousStatus ?? "",
         occurred_at: event.occurredAt ?? "",
         occurred_at_precision: event.occurredAtPrecision ?? "",
-        inferred: event.inferred === undefined ? "" : String(event.inferred),
+        inferred: "false",
         supersedes_event_id: event.supersedesEventId ?? "",
         stage: event.stageLabel ?? event.status ?? "",
         channel: event.channel ?? "",
@@ -1260,6 +1423,8 @@ export const browserApplicationExportToLifecycleRows = (bundle) => {
             : String(event.requiresUserAction),
         action_status: event.actionStatus ?? "",
         due_at: event.dueAt ?? "",
+        due_at_precision:
+          event.dueAtPrecision ?? (event.dueAt ? "instant" : "unknown"),
         no_ai_required:
           event.noAiRequired === undefined ? "" : String(event.noAiRequired),
         details: event.details ?? event.note ?? "",
@@ -1303,7 +1468,10 @@ const restoreLifecyclePrecisionFlags = (bundle, sourceEvents) => {
 };
 const upgradeBackupBundlePreservingLifecyclePrecision = (bundle) => {
   const upgraded = upgradeBrowserExportToV2(bundle).data;
-  return restoreLifecyclePrecisionFlags(upgraded, bundle?.lifecycleEvents ?? []);
+  return restoreLifecyclePrecisionFlags(
+    upgraded,
+    bundle?.lifecycleEvents ?? [],
+  );
 };
 const canonicalizeBackupBundle = (bundle) => {
   const parsed = upgradeBackupBundlePreservingLifecyclePrecision(bundle);
@@ -1603,6 +1771,13 @@ export const previewSupplementalLifecycleCsvImport = async (
     existing,
   );
   const incomingStores = ["lifecycleEvents", "interviews", "reminders"];
+  const rowNumberByEventId = new Map(
+    rows.map((row, index) => [
+      compact(row.event_id) ||
+        generatedLifecycleId({ ...blankLifecycleRow(), ...row }),
+      index + 2,
+    ]),
+  );
   const conflicts = [];
   for (const store of incomingStores) {
     const seen = new Map();
@@ -1612,7 +1787,7 @@ export const previewSupplementalLifecycleCsvImport = async (
       if (previous) {
         if (!lifecycleRecordsEqual(previous, record))
           conflicts.push({
-            rowNumber: null,
+            rowNumber: rowNumberByEventId.get(record.id) ?? null,
             field: "id",
             code: "duplicate_in_file",
             value: record.id,
@@ -1627,7 +1802,10 @@ export const previewSupplementalLifecycleCsvImport = async (
       );
       if (existingRecord && !lifecycleRecordsEqual(existingRecord, record))
         conflicts.push({
-          rowNumber: null,
+          rowNumber:
+            store === "lifecycleEvents"
+              ? (rowNumberByEventId.get(record.id) ?? null)
+              : null,
           field: "id",
           code: "duplicate_existing",
           value: record.id,

--- a/src/web/storage/browserDataMigration.js
+++ b/src/web/storage/browserDataMigration.js
@@ -73,6 +73,12 @@ const slug = (v) =>
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_+|_+$/g, "") || "record";
 const stableId = (...parts) => parts.map(slug).join("_");
+const compactDerivedEventIds = (appId) => [
+  stableId("event", appId, "application"),
+  stableId("event", appId, "outreach"),
+  stableId("event", appId, "stage"),
+  stableId("event", appId, "outcome"),
+];
 const norm = (v) =>
   String(v ?? "")
     .trim()
@@ -122,7 +128,19 @@ const normalizeEvent = (event, warnings) => {
     occurredAt: occurredAtFor(event, precision),
     occurredAtPrecision: precision,
     inferred: Boolean(event.inferred),
+    provenance:
+      event.provenance ??
+      (event.inferred ||
+      event.source === "reconciliation" ||
+      event.source === "browser_migration"
+        ? "inferred"
+        : event.source === "csv_import" &&
+            compactDerivedEventIds(event.applicationId).includes(event.id)
+          ? "compact_derived"
+          : "explicit"),
   };
+  if (out.dueAt && !out.dueAtPrecision)
+    out.dueAtPrecision = isoDate.test(out.dueAt) ? "date" : "instant";
   if (!out.eventType)
     out.eventType = STATUS_EVENT.get(out.status) ?? "status_changed";
   if (!out.rawEventType) delete out.rawEventType;
@@ -205,6 +223,9 @@ export const upgradeBrowserExportToV2 = (input, options = {}) => {
   const source = clone(input);
   const version = source?.schemaVersion;
   if (source?.schemaVersion === 2) {
+    source.lifecycleEvents = (source.lifecycleEvents ?? []).map((event) =>
+      normalizeEvent(event, warnings),
+    );
     const data = browserApplicationExportSchema.parse(source);
     return { data, warnings };
   }
@@ -239,6 +260,7 @@ export const upgradeBrowserExportToV2 = (input, options = {}) => {
         occurredAt: isoDate.test(evidence.at) ? evidence.at : evidence.at,
         occurredAtPrecision: isoDate.test(evidence.at) ? "date" : "instant",
         inferred: true,
+        provenance: "inferred",
         source: "browser_migration",
         createdAt: migrationCreatedAt,
       });
@@ -272,6 +294,7 @@ export const upgradeBrowserExportToV2 = (input, options = {}) => {
           occurredAt: anchor,
           occurredAtPrecision: "unknown",
           inferred: true,
+          provenance: "inferred",
           source: "browser_migration",
           createdAt: migrationCreatedAt,
         });

--- a/src/web/tracker/lifecycleReconciliation.js
+++ b/src/web/tracker/lifecycleReconciliation.js
@@ -83,6 +83,7 @@ const event = (
     (String(occurredAt).includes("T") ? "instant" : "unknown"),
   inferred: true,
   source: "reconciliation",
+  provenance: "inferred",
   createdAt: "1970-01-01T00:00:00.000Z",
   ...extra,
 });

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -994,6 +994,7 @@ function bindDetail(app) {
           status: v.status,
           occurredAt:
             v.origin === "application_submitted" ? v.appliedAt : operationTime,
+          provenance: "explicit",
           occurredAtPrecision:
             v.origin === "application_submitted" ? "date" : "instant",
           inferred: false,
@@ -1009,6 +1010,7 @@ function bindDetail(app) {
           status: current.status,
           occurredAt:
             v.origin === "application_submitted" ? v.appliedAt : operationTime,
+          provenance: "explicit",
           occurredAtPrecision:
             v.origin === "application_submitted" ? "date" : "instant",
           inferred: false,
@@ -1024,6 +1026,7 @@ function bindDetail(app) {
           eventType: statusEventType(current.status, v.status),
           status: v.status,
           occurredAt: operationTime,
+          provenance: "explicit",
           occurredAtPrecision: "instant",
           inferred: false,
           source: "manual",
@@ -1094,6 +1097,7 @@ function bindDetail(app) {
                   : "candidate_outreach",
               status: nextStatus,
               occurredAt: operationTime,
+              provenance: "explicit",
               occurredAtPrecision: "instant",
               inferred: false,
               source: "manual",
@@ -1123,6 +1127,7 @@ function bindDetail(app) {
               eventType: "assessment_take_home",
               status: latestApp().status,
               occurredAt: operationTime,
+              provenance: "explicit",
               occurredAtPrecision: "instant",
               inferred: false,
               source: "manual",
@@ -1183,6 +1188,7 @@ function bindDetail(app) {
                   : "status_changed",
               status: nextStatus,
               occurredAt: operationTime,
+              provenance: "explicit",
               occurredAtPrecision: "instant",
               inferred: false,
               source: "manual",
@@ -1236,6 +1242,7 @@ function bindDetail(app) {
               eventType,
               status: v.status === "accepted" ? "accepted" : "offer",
               occurredAt: operationTime,
+              provenance: "explicit",
               occurredAtPrecision: "instant",
               inferred: false,
               source: "manual",

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -612,7 +612,7 @@ describe("spreadsheet import/export", () => {
           application_id: "app_applied_stage_rejected",
           status: "Applied",
           interview_stage: "Application rejected",
-          outcome: "rejected",
+          outcome: "",
         }),
       ]),
     );
@@ -719,12 +719,7 @@ describe("spreadsheet import/export", () => {
     )) {
       expect(exportedRowsById.get(row.application_id)).toMatchObject({
         status: row.status,
-        interview_stage:
-          row.status === "Interviewing"
-            ? "Not started"
-            : row.status === "recruiter_screen"
-              ? "recruiter_screen"
-              : row.interview_stage,
+        interview_stage: row.interview_stage,
         outcome: row.outcome,
       });
     }
@@ -1198,9 +1193,9 @@ describe("spreadsheet import/export", () => {
         ({ applicationId, eventType }) =>
           applicationId === "app_roundtrip_alpha" && eventType,
       ),
-    ).toHaveLength(5);
+    ).toHaveLength(4);
     expect(restored.interviews).toHaveLength(1);
-    expect(restored.reminders).toHaveLength(0);
+    expect(restored.reminders).toHaveLength(1);
     expect(restored.artifacts).toHaveLength(0);
     repo.close();
   });
@@ -1276,12 +1271,8 @@ describe("spreadsheet import/export", () => {
       '"Reply included comma, quote ""here"", and newline\nSecond line."',
     );
     const rows = parseCsv(csv);
-    expect(rows.map((row) => row.application_id)).toEqual([
-      "app_a",
-      "app_b",
-      "app_b",
-    ]);
-    expect(rows[2]).toMatchObject({
+    expect(rows.map((row) => row.application_id)).toEqual(["app_a", "app_b"]);
+    expect(rows[1]).toMatchObject({
       source_artifact: "https://example.test/artifact/reply?x=1&y=2",
       requires_user_action: "false",
       no_ai_required: "true",
@@ -1428,7 +1419,7 @@ describe("spreadsheet import/export", () => {
       restored.lifecycleEvents.filter(
         ({ eventType, id, occurredAt }) =>
           eventType !== "migration_status_snapshot" &&
-          id.startsWith("event_app_status_only_") &&
+          id.startsWith("event_status_only_") &&
           occurredAt === "2026-03-02T00:00:00.000Z",
       ),
     ).toHaveLength(statuses.length);
@@ -1515,11 +1506,10 @@ describe("spreadsheet import/export", () => {
         code: "malformed_date",
       }),
     ]);
-    expect(bundle.lifecycleEvents).toEqual([
-      expect.objectContaining({
-        occurredAt: "1970-01-01T00:00:00.000Z",
-      }),
-    ]);
+    expect(bundle.lifecycleEvents[0]).toMatchObject({
+      occurredAt: "1970-01-01T00:00:00.000Z",
+      occurredAtPrecision: "unknown",
+    });
   });
 
   it("restores older JSON and NDJSON backups that omit lifecycle metadata stores", () => {
@@ -1647,10 +1637,9 @@ describe("spreadsheet import/export", () => {
     await Promise.all(
       fixtureNames.map(async (fixtureName) => {
         await expect(
-          readFile(
-            `test/fixtures/tracker-import/${fixtureName}`,
-            "utf8",
-          ).then(detectSpreadsheetImportFormat),
+          readFile(`test/fixtures/tracker-import/${fixtureName}`, "utf8").then(
+            detectSpreadsheetImportFormat,
+          ),
         ).resolves.toBe("lifecycle_csv");
       }),
     );
@@ -2015,7 +2004,7 @@ describe("spreadsheet import/export", () => {
     repo.close();
   });
 
-  it("deduplicates identical supplemental lifecycle rows before applying", async () => {
+  it("rejects identical supplemental lifecycle rows without event ids", async () => {
     const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
     await importCompactCsv(
       serializeCsv([
@@ -2044,12 +2033,11 @@ describe("spreadsheet import/export", () => {
       lifecycleCsv,
       repo,
     );
-    expect(preview.errors).toEqual([]);
-    expect(preview.conflicts).toEqual([]);
-    expect(preview.bundle.lifecycleEvents).toHaveLength(1);
+    expect(preview.errors.map(({ code }) => code)).toContain(
+      "duplicate_event_without_event_id",
+    );
     const result = await importSupplementalLifecycleCsv(lifecycleCsv, repo);
-    expect(result.imported).toBe(true);
-    expect((await repo.exportAllData()).lifecycleEvents).toHaveLength(2);
+    expect(result.imported).toBe(false);
     repo.close();
   });
 
@@ -2110,9 +2098,10 @@ describe("spreadsheet import/export", () => {
     expect(dateOnlyPreview.errors).toEqual([]);
     expect(dateOnlyPreview.bundle.lifecycleEvents).toEqual([
       expect.objectContaining({
-        occurredAt: "2026-01-08",
-        occurredAtPrecision: "date",
-        dueAt: "2026-01-08T00:00:00.000Z",
+        occurredAt: "1970-01-01",
+        occurredAtPrecision: "unknown",
+        dueAt: "2026-01-08",
+        dueAtPrecision: "date",
       }),
     ]);
     expect(dateOnlyPreview.bundle.interviews).toEqual([]);
@@ -2449,8 +2438,119 @@ describe("spreadsheet import/export", () => {
       Object.fromEntries(
         childStores.map((store) => [store, exportedAgain[store].length]),
       ),
-    ).toEqual({ ...childCounts, lifecycleEvents: childCounts.lifecycleEvents + 1 });
+    ).toEqual({
+      ...childCounts,
+      lifecycleEvents: childCounts.lifecycleEvents + 1,
+    });
 
     repo.close();
+  });
+
+  it("preserves arbitrary compact cells through the versioned metadata envelope", () => {
+    const csv = serializeCsv([
+      {
+        application_id: "app_lossless_example",
+        company: "Example Systems",
+        role_title: "Platform Engineer",
+        status: "Interviewing",
+        applied_at: "2026-07-31T13:14:15-07:00",
+        application_channel: "Direct",
+        origin: "recruiter_company_outreach",
+        work_model: "Remote/Hybrid",
+        outreach_target_name: "Example Recruiter",
+        outreach_channel: "LinkedIn InMail",
+        outreach_sent_at: "2026-08-01T09:08:07.654-07:00",
+        outreach_message_text: 'Hello, "team".\nSecond line.',
+        interview_stage: "DevOps interview",
+        schema_version: "9-custom",
+      },
+    ]);
+    const { bundle, errors } = csvToBrowserApplicationExport(csv, {
+      exportedAt: "2026-08-02T00:00:00.000Z",
+    });
+    expect(errors).toEqual([]);
+    expect(bundle.applications[0]).toMatchObject({
+      origin: "recruiter_company_outreach",
+      remote: true,
+    });
+    expect(bundle.outreachMessages[0]).toMatchObject({
+      channel: "other",
+      body: 'Hello, "team".\nSecond line.',
+    });
+    const metadataLine = bundle.applications[0].notes
+      .split("\n")
+      .find((line) => line.startsWith("Spreadsheet metadata:"));
+    expect(metadataLine).toContain('"spreadsheet_metadata_version":2');
+    const exported = parseCsv(exportCompactCsv(bundle))[0];
+    expect(exported).toMatchObject({
+      applied_at: "2026-07-31T13:14:15-07:00",
+      origin: "recruiter_company_outreach",
+      work_model: "Remote/Hybrid",
+      outreach_channel: "LinkedIn InMail",
+      outreach_sent_at: "2026-08-01T09:08:07.654-07:00",
+      outreach_message_text: 'Hello, "team".\nSecond line.',
+      interview_stage: "DevOps interview",
+    });
+    expect(exported.notes).toBe("");
+  });
+
+  it("preserves explicit lifecycle identity and precision while filtering provenance", () => {
+    const exportedAt = "2026-08-02T00:00:00.000Z";
+    const base = {
+      applicationId: "app_events_example",
+      status: "recruiter_screen",
+      occurredAt: "2026-08-03",
+      occurredAtPrecision: "date",
+      source: "csv_import",
+      eventType: "recruiter_screen",
+      inferred: false,
+      createdAt: exportedAt,
+    };
+    const csv = exportLifecycleCsv({
+      schemaVersion: 2,
+      exportedAt,
+      applications: [
+        {
+          id: "app_events_example",
+          company: "Example Events",
+          role: "Engineer",
+          status: "recruiter_screen",
+          origin: "other_unknown",
+          createdAt: exportedAt,
+          updatedAt: exportedAt,
+        },
+      ],
+      contacts: [],
+      outreachMessages: [],
+      interviews: [],
+      offers: [],
+      artifacts: [],
+      reminders: [],
+      lifecycleEvents: [
+        {
+          ...base,
+          id: "explicit_one",
+          provenance: "explicit",
+          dueAt: "2026-08-04",
+          dueAtPrecision: "date",
+        },
+        { ...base, id: "explicit_two", provenance: "explicit" },
+        { ...base, id: "derived_one", provenance: "compact_derived" },
+        { ...base, id: "inferred_one", provenance: "inferred", inferred: true },
+      ],
+    });
+    const rows = parseCsv(csv);
+    expect(new Set(rows.map(({ event_id }) => event_id))).toEqual(
+      new Set(["explicit_one", "explicit_two"]),
+    );
+    expect(
+      rows.find(({ event_id }) => event_id === "explicit_one"),
+    ).toMatchObject({
+      occurred_at: "2026-08-03",
+      occurred_at_precision: "date",
+      due_at: "2026-08-04",
+      due_at_precision: "date",
+      inferred: "false",
+    });
   });
 });

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -1281,12 +1281,12 @@ describe("tracker dashboard metrics", () => {
     );
     expect(lifecycle.interviews).toEqual([
       expect.objectContaining({
-        id: "interview_app_reg_epsilon_005_recruiter_screen_2026_02_15t18_00_00_000z",
+        id: expect.stringMatching(/^interview_event_app_reg_epsilon_005_/),
         stage: "recruiter_screen",
         startsAt: "2026-02-15T18:00:00.000Z",
       }),
       expect.objectContaining({
-        id: "interview_app_reg_epsilon_005_technical_screen_2026_02_18t20_00_00_000z",
+        id: expect.stringMatching(/^interview_event_app_reg_epsilon_005_/),
         stage: "technical_screen",
         startsAt: "2026-02-18T20:00:00.000Z",
       }),


### PR DESCRIPTION
### Motivation

- Fix lossy compact CSV import/export and lifecycle export behavior that changed spreadsheet cells, truncated timestamps, coerced arbitrary labels, and mixed inferred/derived events into lifecycle exports.
- Preserve exact raw spreadsheet cells while keeping normalized browser state usable for metrics and UI, and produce a consolidated explicit lifecycle CSV with stable event identity and date precision.

### Description

- Added a versioned spreadsheet metadata envelope (version 2) storing `raw_row` and `canonical_row` for every imported compact row and preserved legacy flat metadata fallbacks; metadata is stored on a single notes line and not included in exported `notes`. (`src/web/import-export/spreadsheet.js`)
- Split compact export into canonical-row generation and a preserved-cell overlay, applying per-column raw overrides only when the live canonical cell equals the imported canonical cell. Implemented helpers `browserApplicationExportToCanonicalRows`, `createSpreadsheetMetadataEnvelope`, and `applyPreservedCompactCells`. (`src/web/import-export/spreadsheet.js`)
- Preserve full timestamp strings for `applied_at`, `follow_up_date`, and `outreach_sent_at` in canonical exports; date-only inputs remain date-only through the envelope. Added parsing/precision helpers for lifecycle import/export to retain date vs. instant semantics. (`src/web/import-export/spreadsheet.js`) 
- Make outreach message creation more permissive: create outbound messages when a body, sent timestamp, or an outbound sent/replied status is present; preserve multiline messages. (`src/web/import-export/spreadsheet.js`)
- Added explicit `origin` handling: accept legacy missing/blank origins, map known referral aliases to `referral`, treat other blanks as `other_unknown`, and reject unsupported nonblank origins with a field-level error. (`src/web/import-export/spreadsheet.js`)
- Added lifecycle provenance (`explicit`, `compact_derived`, `inferred`) to the domain schema and migration path, and ensured provenance is normalized for legacy imports and inferred migration/reconciliation events. (`src/domain/browserApplication.js`, `src/web/storage/browserDataMigration.js`)
- Implemented deterministic stable lifecycle IDs for legacy rows using a two-seed FNV-1a fingerprint and preserved supplied `event_id` values; added collision and duplicate-row validation with row-numbered errors. Derived reminder/interview IDs from event IDs. (`src/web/import-export/spreadsheet.js`)
- Export lifecycle CSV with the canonical header including `event_id` and `due_at_precision`, and include only events whose effective provenance is `explicit`. (`src/web/import-export/spreadsheet.js`)
- Preserve date-only lifecycle values without converting them to midnight instants, derive reminder actionable instants deterministically for date-only dueAt, and validate supplied precision columns. (`src/web/import-export/spreadsheet.js`, `src/domain/browserApplication.js`)
- Updated tracker code to tag manual lifecycle mutations and reconciliation/migration events with provenance `explicit`/`inferred` so runtime-created events carry provenance. (`src/web/tracker/tracker.js`, `src/web/tracker/lifecycleReconciliation.js`)
- Added and adjusted tests to exercise the lossless compact-envelope behavior, lifecycle provenance and identity, date-precision rules, deterministic ordering, and round-trip idempotence with sanitized example fixtures. (`test/web-spreadsheet-import-export.test.js`, `test/web-tracker-metrics.test.js`)
- Updated docs `docs/spreadsheet-replacement.md` and `docs/backup-restore-guide.md` to state the exact compact and canonical lifecycle headers, two-sheet workflow, explicit-only lifecycle export, precision rules, provenance, and metadata-envelope behavior.

Files changed (high level):
- src/web/import-export/spreadsheet.js (major changes)
- src/domain/browserApplication.js (schema: provenance, dueAtPrecision)
- src/web/storage/browserDataMigration.js (normalize provenance and precision)
- src/web/tracker/tracker.js (tag manual events provenance)
- src/web/tracker/lifecycleReconciliation.js (tag reconciliation events provenance)
- test/web-spreadsheet-import-export.test.js (added/adjusted fixtures and assertions)
- test/web-tracker-metrics.test.js (adjusted expectations for generated ids)
- docs/spreadsheet-replacement.md, docs/backup-restore-guide.md (documentation updates)

### Testing

- Ran Prettier and ESLint (`npx prettier --check ...`, `npm run lint -- --quiet`) and TypeScript checks (`npm run typecheck`); formatting/lint errors fixed where applicable. Results: OK.
- Ran unit tests and focused suites:
  - `npx vitest run test/web-spreadsheet-import-export.test.js test/web-storage-browser-data-migration.test.js test/web-tracker-metrics.test.js test/web-tracker-lifecycle-projection.test.js` — All focused tests passed (127 tests total) after iterative fixes.
  - `npm run test:ci` — executed; directly affected suites passed in this environment, but an unrelated long-running layout test in the full CI (`test/web-tracker-lifecycle-diagram-layout.test.js`) can time out on constrained runners; this pre-existing flaky/long test is outside the scope of CSV persistence changes.
- Verified no committed fixtures contain the production-only terms described (Fivetran/Muon/Reducto) beyond existing regression references; all added fixtures use sanitized `example.test` URLs and fake names.

Notes and residual risks
- The changes strictly preserve raw spreadsheet cells in the metadata envelope while keeping canonical normalized values authoritative for runtime behavior; reviewers should validate the single-line JSON metadata escaping approach meets any UI rendering constraints.
- The two-seed FNV-1a fingerprint implementation is deterministic; ensure compatibility expectations with external tooling that might have relied on the old slug identity.
- Full `test:ci` in CI may expose unrelated long-running layout tests; those were observed to be flaky/time-consuming and pre-existed these changes.

Verification commands run (representative):
- `npx prettier --write src/web/import-export/spreadsheet.js src/domain/browserApplication.js src/web/storage/browserDataMigration.js src/web/tracker/tracker.js src/web/tracker/lifecycleReconciliation.js test/web-spreadsheet-import-export.test.js docs/spreadsheet-replacement.md docs/backup-restore-guide.md`
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npx vitest run test/web-spreadsheet-import-export.test.js test/web-storage-browser-data-migration.test.js test/web-tracker-metrics.test.js test/web-tracker-lifecycle-projection.test.js`
- `npm run test:ci` (note: long-running layout suite may time out in constrained environments)

If you want, I can open a PR branch (codex/lossless-csv) and prepare a focused review checklist and changelog entry for maintainers to review the metadata-envelope and lifecycle provenance changes in detail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a16a0c4c8832fac130fb45b993505)