### PR TITLE
Make two-CSV persistence lossless and deterministic

### DIFF
--- a/docs/backup-restore-guide.md
+++ b/docs/backup-restore-guide.md
@@ -7,7 +7,7 @@ private tracker data on the server.
 ## Formats
 
 - **Compact application CSV**: human-editable, spreadsheet-shaped, one-row-per-application compatibility format. Use it for Google Sheets interchange and manual review; it preserves documented compact metadata but is not the complete backup format.
-- **Supplemental lifecycle CSV**: event-rich CSV keyed by `application_id`. Use it with compact CSV when a spreadsheet workflow needs lifecycle events, action metadata, source artifacts, due dates, and multiline details.
+- **Supplemental lifecycle CSV**: explicit event CSV keyed by stable `event_id` and `application_id`. Use it with compact CSV as the supported two-sheet spreadsheet workflow. Runtime compact-derived and inferred events are excluded; JSON/NDJSON retain them.
 - **JSON**: canonical full-fidelity backup bundle for complete browser restores. It includes applications, contacts, outreach messages, lifecycle events, interviews, offers, artifacts, reminders, and settings. Use it for routine backups, before clearing data, or when moving browsers.
 - **NDJSON**: line-oriented full-fidelity stream with stable record types and version metadata. Use it when you want per-record diffs, streaming-friendly storage, or easier manual inspection; restore it from the browser UI import panel.
 
@@ -15,6 +15,7 @@ private tracker data on the server.
 
 - Use compact CSV when the goal is spreadsheet compatibility.
 - Use supplemental lifecycle CSV alongside compact CSV when the spreadsheet workflow needs event metadata; `application_id` is the relationship source of truth.
+- Keep an existing lifecycle row's `event_id` unchanged; give every new event a new unique ID. Legacy blank IDs are generated on canonical export. Date-only values remain dates rather than midnight instants.
 - Use JSON for routine complete backups and full-fidelity browser restores.
 - Use NDJSON for complete backups that should be easy to diff or process one
   record per line, and for full-fidelity browser restores.

--- a/docs/spreadsheet-replacement.md
+++ b/docs/spreadsheet-replacement.md
@@ -7,8 +7,33 @@ jobbot3000 can import the compact CSV tracker into the browser-first IndexedDB d
 The importer expects this deterministic header order when exporting back to CSV:
 
 ```text
-application_id,company,role_title,status,applied_at,posting_url,application_url,posting_id,application_channel,work_model,location_display,compensation_min_usd,compensation_max_usd,resume_artifact,resume_url,cover_letter_submitted,cover_letter_artifact,cover_letter_url,job_description_snapshot_url,linkedin_snapshot_screenshot_url,linkedin_snapshot_pdf_url,fit_score_100,outreach_status,outreach_target_name,outreach_channel,outreach_sent_at,outreach_message_text,follow_up_date,interview_stage,outcome,notes,schema_version
+application_id,company,role_title,status,applied_at,posting_url,application_url,posting_id,application_channel,origin,work_model,location_display,compensation_min_usd,compensation_max_usd,resume_artifact,resume_url,cover_letter_submitted,cover_letter_artifact,cover_letter_url,job_description_snapshot_url,linkedin_snapshot_screenshot_url,linkedin_snapshot_pdf_url,fit_score_100,outreach_status,outreach_target_name,outreach_channel,outreach_sent_at,outreach_message_text,follow_up_date,interview_stage,outcome,notes,schema_version
 ```
+
+Legacy compact files without `origin` remain importable. A blank legacy origin means
+`other_unknown` internally (or `referral` for an existing referral channel alias), not an inferred
+application submission. Arbitrary spreadsheet labels and exact date/date-time spelling are kept in
+a versioned, single-line metadata envelope. Unedited cells therefore round-trip exactly; a tracker
+edit replaces only the changed cell with its current canonical value.
+
+## Supported lifecycle CSV columns
+
+Canonical lifecycle export uses this exact header:
+
+```text
+event_id,application_id,company,role_title,event_type,raw_event_type,previous_status,occurred_at,occurred_at_precision,inferred,supersedes_event_id,stage,channel,actor,source_artifact,requires_user_action,action_status,due_at,due_at_precision,no_ai_required,details
+```
+
+Compact CSV plus lifecycle CSV is the supported two-sheet Google Sheets workflow. Lifecycle export
+contains only explicit user-authored or imported events; compact-derived projections, reconciliation
+events, and migration snapshots remain available at runtime but are intentionally excluded. Legacy
+19-column and per-application 14-column files remain importable and can be consolidated.
+
+`event_id` is stable row identity. Keep it unchanged while editing an event and assign a new unique
+ID to each new event. Blank legacy IDs are generated deterministically and appear in the first
+canonical export. Date-only values remain `YYYY-MM-DD`; instants retain their ISO datetime and
+offset. A date-only deadline schedules a reminder at end-of-day UTC without changing the event's
+stored date, and it does not create an interview.
 
 ## Export from Google Sheets
 
@@ -51,9 +76,9 @@ The importer preserves compact fields that do not have a first-class normalized 
 Use the export flow after every meaningful update:
 
 - **Compact CSV** for spreadsheet compatibility and manual review.
-- **Lifecycle CSV** when you need event rows, source artifacts, action status, due dates, and multiline details tied back to applications by `application_id`.
-- **JSON** for complete browser backup/restore; this is the preferred everyday backup.
-- **NDJSON** for equivalent full-fidelity backup/restore with one typed record per line.
+- **Lifecycle CSV** for explicit event rows, source artifacts, action status, due dates, and multiline details tied back to applications by `application_id`.
+- **JSON** for a complete browser backup, including internal derived records; this is the preferred everyday backup.
+- **NDJSON** for the equivalent full-fidelity backup, including internal derived records, with one typed record per line.
 
 Store backups somewhere private and encrypted. The files may include application history, contacts, outreach messages, links to private artifacts, private URLs, company names, and notes. Do not commit real backups, bake them into Docker images, or paste them into public issues.
 

--- a/src/domain/browserApplication.js
+++ b/src/domain/browserApplication.js
@@ -50,6 +50,11 @@ export const browserApplicationOccurredAtPrecisionSchema = z.enum([
   "date",
   "unknown",
 ]);
+export const browserApplicationLifecycleProvenanceSchema = z.enum([
+  "explicit",
+  "compact_derived",
+  "inferred",
+]);
 
 const isoDateTimeSchema = z.string().datetime({ offset: true });
 const isoDateSchema = z
@@ -118,6 +123,7 @@ export const browserApplicationLifecycleEventSchema = z
     previousStatus: browserApplicationLifecycleStatusSchema.optional(),
     occurredAtPrecision: browserApplicationOccurredAtPrecisionSchema,
     inferred: z.boolean(),
+    provenance: browserApplicationLifecycleProvenanceSchema.optional(),
     supersedesEventId: optionalTrimmedStringSchema,
     stageLabel: optionalTrimmedStringSchema,
     channel: optionalTrimmedStringSchema,
@@ -125,7 +131,8 @@ export const browserApplicationLifecycleEventSchema = z
     sourceArtifact: optionalTrimmedStringSchema,
     requiresUserAction: z.boolean().optional(),
     actionStatus: optionalTrimmedStringSchema,
-    dueAt: isoDateTimeSchema.optional(),
+    dueAt: stableDateOrDateTimeSchema.optional(),
+    dueAtPrecision: browserApplicationOccurredAtPrecisionSchema.optional(),
     noAiRequired: z.boolean().optional(),
     details: optionalTrimmedStringSchema,
     createdAt: isoDateTimeSchema,
@@ -151,6 +158,26 @@ export const browserApplicationLifecycleEventSchema = z
         path: ["occurredAt"],
       });
     }
+    if (
+      event.dueAt &&
+      event.dueAtPrecision === "instant" &&
+      !isoDateTimeSchema.safeParse(event.dueAt).success
+    )
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "instant dueAt must be an ISO datetime with offset",
+        path: ["dueAt"],
+      });
+    if (
+      event.dueAt &&
+      event.dueAtPrecision === "date" &&
+      !isoDateSchema.safeParse(event.dueAt).success
+    )
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "date dueAt must be YYYY-MM-DD",
+        path: ["dueAt"],
+      });
   });
 
 export const browserApplicationInterviewSchema = z.object({

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -724,6 +724,20 @@ export const lifecycleRowsToBrowserApplicationExport = (
     const normalizedBehaviorType =
       normalizeLabelKey(behaviorType) || "lifecycle_event";
     const canonicalType = canonicalLifecycleEventType(row.event_type);
+    if (
+      !lifecycleStatusForEvent(normalizedBehaviorType) &&
+      !lifecycleStatusForEvent(canonicalType) &&
+      !["lifecycle_event", "next_tracking_step"].includes(
+        normalizedBehaviorType,
+      )
+    )
+      warnings.push({
+        rowNumber,
+        field: "event_type",
+        code: "unsupported_event_type",
+        value: behaviorType || normalizedBehaviorType,
+        message: "Imported as a generic lifecycle event.",
+      });
     const occurredAt = compact(row.occurred_at) || "1970-01-01T00:00:00.000Z";
     const dueAt = compact(row.due_at) || undefined;
     const explicitId = compact(row.event_id);
@@ -1767,7 +1781,8 @@ export const importCompactCsv = async (
   };
 };
 
-// Precision flags are intentionally ignored only for conflict comparison.
+// Import provenance and precision flags are intentionally ignored only for
+// conflict comparison.
 // Supplemental imports still replace the existing same-id lifecycle record with
 // the incoming record, so re-importing upgrades legacy flagless records.
 const lifecycleComparableRecord = (record) =>
@@ -1777,6 +1792,7 @@ const lifecycleComparableRecord = (record) =>
         ![
           "createdAt",
           "updatedAt",
+          "source",
           "occurredAtHasTime",
           "dueAtHasTime",
         ].includes(key),
@@ -1827,7 +1843,11 @@ export const previewSupplementalLifecycleCsvImport = async (
       const existingRecord = (existing[store] ?? []).find(
         ({ id }) => id === record.id,
       );
-      if (existingRecord && !lifecycleRecordsEqual(existingRecord, record))
+      if (
+        store !== "lifecycleEvents" &&
+        existingRecord &&
+        !lifecycleRecordsEqual(existingRecord, record)
+      )
         conflicts.push({
           rowNumber:
             store === "lifecycleEvents"

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -3,6 +3,7 @@ import { upgradeBrowserExportToV2 } from "../storage/browserDataMigration.js";
 import { classifyLifecycleEventType } from "../tracker/lifecycleClassification.js";
 
 export const LIFECYCLE_CSV_COLUMNS = [
+  "event_id",
   "application_id",
   "company",
   "role_title",
@@ -20,6 +21,7 @@ export const LIFECYCLE_CSV_COLUMNS = [
   "requires_user_action",
   "action_status",
   "due_at",
+  "due_at_precision",
   "no_ai_required",
   "details",
 ];
@@ -73,6 +75,14 @@ const KNOWN_STATUSES = new Set([
   "closed_archived",
 ]);
 const OUTREACH_SENT_STATUSES = new Set(["sent", "replied"]);
+const VALID_ORIGINS = new Set([
+  "application_submitted",
+  "recruiter_company_outreach",
+  "candidate_outreach",
+  "referral",
+  "other_unknown",
+]);
+const REFERRAL_ALIASES = new Set(["referral", "employee_referral"]);
 const INTERVIEW_STAGES = new Map([
   ["recruiter_screen", "recruiter_screen"],
   ["phone_screen", "recruiter_screen"],
@@ -370,9 +380,6 @@ const parseDate = (
   }
   return date.toISOString();
 };
-const hasTimeComponent = (value) =>
-  /(?:T|\s)\d{1,2}:\d{2}/.test(compact(value));
-
 const parseBoolean = (value, field, rowNumber, errors) => {
   const text = normalizeKey(value);
   if (!text) return undefined;
@@ -445,6 +452,23 @@ const metadataFromRow = (row) =>
       )
       .filter(([, value]) => value),
   );
+export const createSpreadsheetMetadataEnvelope = (
+  rawRow,
+  canonicalRow,
+  compatibility = metadataFromRow(rawRow),
+) => ({
+  ...compatibility,
+  spreadsheet_metadata_version: 2,
+  raw_row: Object.fromEntries(
+    COMPACT_CSV_COLUMNS.map((column) => [column, String(rawRow[column] ?? "")]),
+  ),
+  canonical_row: Object.fromEntries(
+    COMPACT_CSV_COLUMNS.map((column) => [
+      column,
+      String(canonicalRow[column] ?? ""),
+    ]),
+  ),
+});
 const appendMetadataToNotes = (notes, metadata) => {
   const entries = Object.keys(metadata).sort();
   if (entries.length === 0) return compact(notes) || undefined;
@@ -473,6 +497,23 @@ const readMetadataFromNotes = (notes) => {
   } catch {
     return { notes: compact(notes), metadata: {} };
   }
+};
+export const applyPreservedCompactCells = (canonicalRow, metadata) => {
+  if (
+    metadata?.spreadsheet_metadata_version !== 2 ||
+    !metadata.raw_row ||
+    !metadata.canonical_row
+  )
+    return canonicalRow;
+  return Object.fromEntries(
+    COMPACT_CSV_COLUMNS.map((column) => [
+      column,
+      String(canonicalRow[column] ?? "") ===
+      String(metadata.canonical_row[column] ?? "")
+        ? String(metadata.raw_row[column] ?? "")
+        : String(canonicalRow[column] ?? ""),
+    ]),
+  );
 };
 const mapStatus = (row) => {
   const status = normalizeLabelKey(row.status);
@@ -534,7 +575,8 @@ const preservedOutcome = (metadata, currentOutcome) => {
 export const detectSpreadsheetImportFormat = (text) => {
   const headers = csvHeaders(text);
   const headerSet = new Set(headers);
-  const hasAll = (...columns) => columns.every((column) => headerSet.has(column));
+  const hasAll = (...columns) =>
+    columns.every((column) => headerSet.has(column));
 
   if (hasAll("application_id", "event_type", "occurred_at"))
     return "lifecycle_csv";
@@ -559,6 +601,74 @@ const lifecycleStatusForStage = (stageLabel) => {
   const status = normalizeLabelKey(stageLabel);
   return KNOWN_STATUSES.has(status) ? status : undefined;
 };
+const canonicalLifecycleEventType = (eventType) => {
+  const value = normalizeLabelKey(eventType);
+  if (
+    [
+      "application_submitted",
+      "recruiter_company_outreach",
+      "candidate_outreach",
+      "referral",
+      "other_unknown",
+      "employer_response_received",
+      "recruiter_screen",
+      "assessment_take_home",
+      "technical_interview",
+      "onsite_final_loop",
+      "offer_received",
+      "offer_negotiating",
+      "employer_rejected",
+      "candidate_withdrew",
+      "offer_declined",
+      "offer_expired_rescinded",
+      "offer_accepted",
+      "closed_archived",
+      "application_reopened",
+      "status_changed",
+      "migration_status_snapshot",
+    ].includes(value)
+  )
+    return value;
+  if (value === "hiring_manager_reply") return "employer_response_received";
+  if (value === "next_tracking_step") return "status_changed";
+  if (value.includes("assessment") || value.startsWith("take_home"))
+    return "assessment_take_home";
+  if (value.startsWith("recruiter_screen")) return "recruiter_screen";
+  if (value.startsWith("technical_") || value.startsWith("devops_interview"))
+    return "technical_interview";
+  if (value.startsWith("onsite_") || value.startsWith("final_interview"))
+    return "onsite_final_loop";
+  return STATUS_LABELS.get(value) === "rejected"
+    ? "employer_rejected"
+    : value === "applied"
+      ? "application_submitted"
+      : "status_changed";
+};
+
+const precisionForCsvValue = (value) => {
+  const text = compact(value);
+  if (!text) return "unknown";
+  if (/^\d{4}-\d{2}-\d{2}$/.test(text)) return "date";
+  return isValidIsoOffsetDateTime(text) ? "instant" : undefined;
+};
+const fnv1a32 = (text, seed) => {
+  let hash = seed >>> 0;
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+};
+const generatedLifecycleId = (row) => {
+  const values = LIFECYCLE_CSV_COLUMNS.filter(
+    (column) => !["event_id", "company", "role_title"].includes(column),
+  ).map((column) => String(row[column] ?? ""));
+  const fingerprint = JSON.stringify(values);
+  return `event_${slug(row.application_id)}_${fnv1a32(fingerprint, 0x811c9dc5)}${fnv1a32(
+    fingerprint,
+    0x9e3779b9,
+  )}`;
+};
 
 export const lifecycleRowsToBrowserApplicationExport = (
   rows,
@@ -566,19 +676,19 @@ export const lifecycleRowsToBrowserApplicationExport = (
   { exportedAt = nowIso() } = {},
 ) => {
   const errors = [];
+  const warnings = [];
   const existingApplications = existing?.applications ?? [];
-  const existingApplicationIds = new Set(
-    existingApplications.map(({ id }) => id),
-  );
+  const applicationIds = new Set(existingApplications.map(({ id }) => id));
   const lifecycleEvents = [];
   const interviews = [];
   const reminders = [];
-  const warnings = [];
+  const seenIds = new Map();
+
   rows.forEach((sourceRow, index) => {
     const rowNumber = index + 2;
     const row = { ...blankLifecycleRow(), ...sourceRow };
     const applicationId = compact(row.application_id);
-    if (!applicationId || !existingApplicationIds.has(applicationId)) {
+    if (!applicationId || !applicationIds.has(applicationId)) {
       errors.push({
         rowNumber,
         field: "application_id",
@@ -591,61 +701,78 @@ export const lifecycleRowsToBrowserApplicationExport = (
       });
       return;
     }
-    const rawEventType = compact(row.event_type);
-    const eventType = normalizeLabelKey(rawEventType) || "lifecycle_event";
-    const occurredAt = parseDate(
-      row.occurred_at,
-      "occurred_at",
-      rowNumber,
-      errors,
+    const occurredPrecision = precisionForCsvValue(row.occurred_at);
+    const duePrecision = precisionForCsvValue(row.due_at);
+    for (const [field, precision, supplied] of [
+      ["occurred_at", occurredPrecision, compact(row.occurred_at_precision)],
+      ["due_at", duePrecision, compact(row.due_at_precision)],
+    ]) {
+      if (precision === undefined)
+        pushMalformedDateError(errors, field, rowNumber);
+      else if (supplied && supplied !== precision)
+        errors.push({
+          rowNumber,
+          field: `${field}_precision`,
+          code: "precision_mismatch",
+          message: `${field}_precision does not agree with ${field}.`,
+        });
+    }
+    if (occurredPrecision === undefined || duePrecision === undefined) return;
+    const inferred =
+      parseBoolean(row.inferred, "inferred", rowNumber, errors) ?? false;
+    const behaviorType = compact(row.raw_event_type) || compact(row.event_type);
+    const normalizedBehaviorType =
+      normalizeLabelKey(behaviorType) || "lifecycle_event";
+    const canonicalType = canonicalLifecycleEventType(row.event_type);
+    const occurredAt = compact(row.occurred_at) || "1970-01-01T00:00:00.000Z";
+    const dueAt = compact(row.due_at) || undefined;
+    const explicitId = compact(row.event_id);
+    const id = explicitId || generatedLifecycleId(row);
+    const rowFingerprint = JSON.stringify(
+      LIFECYCLE_CSV_COLUMNS.map((column) => String(row[column] ?? "")),
     );
-    const dueAt = parseDate(row.due_at, "due_at", rowNumber, errors);
-    const eventOccurredAt = occurredAt ?? dueAt ?? "1970-01-01T00:00:00.000Z";
-    const occurredAtHasTime = hasTimeComponent(row.occurred_at);
-    const dueAtHasTime = hasTimeComponent(row.due_at);
-    const suppliedPrecision = compact(row.occurred_at_precision) || undefined;
-    const stageLabel = compact(row.stage) || undefined;
-    const knownLifecycleStatus = lifecycleStatusForEvent(eventType);
-    if (
-      !knownLifecycleStatus &&
-      !["lifecycle_event", "next_tracking_step"].includes(eventType)
-    )
-      warnings.push({
+    if (seenIds.has(id)) {
+      const previous = seenIds.get(id);
+      errors.push({
         rowNumber,
-        field: "event_type",
-        code: "unsupported_event_type",
-        value: rawEventType || eventType,
-        message: "Imported as a generic lifecycle event.",
+        field: "event_id",
+        code: explicitId
+          ? "duplicate_event_id"
+          : previous === rowFingerprint
+            ? "duplicate_event_without_event_id"
+            : "event_id_collision",
+        value: id,
+        message: `Lifecycle event identity ${id} is duplicated.`,
       });
+      return;
+    }
+    seenIds.set(id, rowFingerprint);
+    const stageLabel = compact(row.stage) || undefined;
     const status =
-      knownLifecycleStatus ??
+      lifecycleStatusForEvent(normalizedBehaviorType) ??
+      lifecycleStatusForEvent(canonicalType) ??
       lifecycleStatusForStage(stageLabel) ??
       mapStatus({ status: "", interview_stage: stageLabel ?? "", outcome: "" });
-    const sourceArtifact = compact(row.source_artifact) || undefined;
     const details = compact(row.details) || undefined;
-    const id = stableId(
-      "event",
-      applicationId,
-      eventType,
-      eventOccurredAt,
-      dueAt ?? "",
-      sourceArtifact ?? "",
-      details ?? "",
-    );
     lifecycleEvents.push({
       id,
       applicationId,
       status,
-      occurredAt: eventOccurredAt,
+      occurredAt,
       source: "csv_import",
+      provenance: inferred ? "inferred" : "explicit",
       note: details,
-      eventType,
-      rawEventType: compact(row.raw_event_type) || undefined,
+      eventType: canonicalType,
+      rawEventType:
+        compact(row.raw_event_type) ||
+        (normalizedBehaviorType !== canonicalType
+          ? normalizedBehaviorType
+          : undefined),
       previousStatus: compact(row.previous_status) || undefined,
       stageLabel,
       channel: compact(row.channel) || undefined,
       actor: compact(row.actor) || undefined,
-      sourceArtifact,
+      sourceArtifact: compact(row.source_artifact) || undefined,
       requiresUserAction: parseBoolean(
         row.requires_user_action,
         "requires_user_action",
@@ -654,11 +781,9 @@ export const lifecycleRowsToBrowserApplicationExport = (
       ),
       actionStatus: compact(row.action_status) || undefined,
       dueAt,
-      occurredAtPrecision: suppliedPrecision,
-      occurredAtHasTime,
-      dueAtHasTime,
-      inferred:
-        parseBoolean(row.inferred, "inferred", rowNumber, errors) ?? false,
+      dueAtPrecision: duePrecision,
+      occurredAtPrecision: occurredPrecision,
+      inferred,
       supersedesEventId: compact(row.supersedes_event_id) || undefined,
       noAiRequired: parseBoolean(
         row.no_ai_required,
@@ -669,41 +794,31 @@ export const lifecycleRowsToBrowserApplicationExport = (
       details,
       createdAt: exportedAt,
     });
-    if (eventType === "next_tracking_step" && dueAt)
+    if (normalizedBehaviorType === "next_tracking_step" && dueAt) {
+      const reminderDueAt =
+        duePrecision === "date" ? `${dueAt}T23:59:59.000Z` : dueAt;
       reminders.push({
-        id: stableId(
-          "reminder",
-          applicationId,
-          eventType,
-          dueAt,
-          details ?? "",
-        ),
+        id: stableId("reminder", id),
         applicationId,
-        dueAt,
+        dueAt: reminderDueAt,
         summary: details || stageLabel || "Next tracking step",
         notes: details,
         createdAt: exportedAt,
         updatedAt: exportedAt,
       });
-    const classification = classifyLifecycleEventType(eventType);
+    }
+    const classification = classifyLifecycleEventType(normalizedBehaviorType);
     const interviewStartsAt =
       classification.interviewOutcome === "completed"
-        ? occurredAtHasTime
+        ? occurredPrecision === "instant"
           ? occurredAt
-          : dueAtHasTime
-            ? dueAt
-            : undefined
-        : dueAtHasTime
+          : undefined
+        : duePrecision === "instant"
           ? dueAt
           : undefined;
     if (classification.interviewStage && interviewStartsAt)
       interviews.push({
-        id: stableId(
-          "interview",
-          applicationId,
-          classification.interviewStage,
-          interviewStartsAt,
-        ),
+        id: stableId("interview", id),
         applicationId,
         contactIds: [],
         stage: classification.interviewStage,
@@ -714,9 +829,12 @@ export const lifecycleRowsToBrowserApplicationExport = (
       });
   });
   const bundle = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     exportedAt,
-    applications: existingApplications,
+    applications: existingApplications.map((application) => ({
+      ...application,
+      origin: application.origin ?? "other_unknown",
+    })),
     contacts: [],
     outreachMessages: [],
     lifecycleEvents,
@@ -725,36 +843,22 @@ export const lifecycleRowsToBrowserApplicationExport = (
     artifacts: [],
     reminders,
   };
-  for (const store of ["lifecycleEvents", "interviews", "reminders"]) {
-    const seen = new Set();
-    bundle[store] = bundle[store].filter(({ id }) => {
-      if (seen.has(id)) return false;
-      seen.add(id);
-      return true;
-    });
+  let canonicalBundle = bundle;
+  try {
+    canonicalBundle = upgradeBrowserExportToV2(bundle, {
+      migrationCreatedAt: exportedAt,
+    }).data;
+  } catch {
+    // The structured schema error below is more useful to import previews.
   }
-  const incomingIds = {
-    lifecycleEvents: new Set(bundle.lifecycleEvents.map(({ id }) => id)),
-    interviews: new Set(bundle.interviews.map(({ id }) => id)),
-    reminders: new Set(bundle.reminders.map(({ id }) => id)),
-  };
-  const upgraded = upgradeBrowserExportToV2(bundle, {
-    migrationCreatedAt: exportedAt,
-  });
-  const canonicalBundle = {
-    ...bundle,
-    ...upgraded.data,
-    lifecycleEvents: upgraded.data.lifecycleEvents.filter(({ id }) =>
-      incomingIds.lifecycleEvents.has(id),
-    ),
-    interviews: upgraded.data.interviews.filter(({ id }) =>
-      incomingIds.interviews.has(id),
-    ),
-    reminders: upgraded.data.reminders.filter(({ id }) =>
-      incomingIds.reminders.has(id),
-    ),
-  };
-  warnings.push(...upgraded.warnings);
+  const parsed = browserApplicationExportSchema.safeParse(canonicalBundle);
+  if (!parsed.success)
+    errors.push({
+      rowNumber: null,
+      field: "bundle",
+      code: "schema_validation_failed",
+      message: parsed.error.message,
+    });
   return { bundle: canonicalBundle, errors, warnings };
 };
 
@@ -818,6 +922,15 @@ export const rowsToBrowserApplicationExport = (
       rowNumber,
       errors,
     );
+    const suppliedOrigin = compact(row.origin);
+    if (suppliedOrigin && !VALID_ORIGINS.has(suppliedOrigin))
+      errors.push({
+        rowNumber,
+        field: "origin",
+        code: "unsupported_origin",
+        value: suppliedOrigin,
+        message: "origin is not a supported value.",
+      });
     const postingUrl = validUrl(
       row.posting_url,
       "posting_url",
@@ -872,7 +985,11 @@ export const rowsToBrowserApplicationExport = (
       role: compact(row.role_title) || "Unknown role",
       status: mapStatus(row),
       source: compact(row.application_channel) || undefined,
-      origin: compact(row.origin) || undefined,
+      origin:
+        (VALID_ORIGINS.has(suppliedOrigin) && suppliedOrigin) ||
+        (REFERRAL_ALIASES.has(normalizeLabelKey(row.application_channel))
+          ? "referral"
+          : "other_unknown"),
       postingUrl,
       location: compact(row.location_display) || undefined,
       remote: normalizeKey(row.work_model).includes("remote")
@@ -915,8 +1032,9 @@ export const rowsToBrowserApplicationExport = (
         updatedAt: exportedAt,
       });
     if (
-      OUTREACH_SENT_STATUSES.has(normalizeKey(row.outreach_status)) &&
-      compact(row.outreach_message_text)
+      compact(row.outreach_message_text) ||
+      outreachSentAt ||
+      OUTREACH_SENT_STATUSES.has(normalizeKey(row.outreach_status))
     ) {
       outreachMessages.push({
         id: stableId(
@@ -932,7 +1050,7 @@ export const rowsToBrowserApplicationExport = (
         )
           ? normalizeKey(row.outreach_channel)
           : "other",
-        body: compact(row.outreach_message_text),
+        body: compact(row.outreach_message_text) || undefined,
         sentAt: outreachSentAt,
         createdAt: outreachSentAt ?? timestamp,
         updatedAt: exportedAt,
@@ -948,6 +1066,7 @@ export const rowsToBrowserApplicationExport = (
         eventType: "application_submitted",
         occurredAtPrecision: "instant",
         inferred: false,
+        provenance: "compact_derived",
         createdAt: exportedAt,
       });
     if (outreachSentAt)
@@ -960,6 +1079,7 @@ export const rowsToBrowserApplicationExport = (
         eventType: "candidate_outreach",
         occurredAtPrecision: "instant",
         inferred: false,
+        provenance: "compact_derived",
         createdAt: exportedAt,
       });
     const stageLabel = normalizeLabelKey(row.interview_stage);
@@ -981,6 +1101,7 @@ export const rowsToBrowserApplicationExport = (
               : stage,
         occurredAtPrecision: "instant",
         inferred: false,
+        provenance: "compact_derived",
         createdAt: exportedAt,
       });
       interviews.push({
@@ -1015,6 +1136,7 @@ export const rowsToBrowserApplicationExport = (
           eventType: "employer_rejected",
           occurredAtPrecision: "instant",
           inferred: false,
+          provenance: "compact_derived",
           createdAt: exportedAt,
         });
     }
@@ -1044,6 +1166,7 @@ export const rowsToBrowserApplicationExport = (
                   : "status_changed",
         occurredAtPrecision: "instant",
         inferred: false,
+        provenance: "compact_derived",
         createdAt: exportedAt,
       });
     if (outcome === "offer")
@@ -1076,6 +1199,21 @@ export const rowsToBrowserApplicationExport = (
     });
     Object.assign(bundle, upgraded.data);
     warnings.push(...upgraded.warnings);
+    const canonicalRows = browserApplicationExportToCanonicalRows(bundle);
+    bundle.applications = bundle.applications.map((application, index) => {
+      const rawRow = { ...blankRow(), ...(rows[index] ?? {}) };
+      const canonicalRow = canonicalRows.find(
+        (row) => row.application_id === application.id,
+      );
+      const { notes } = readMetadataFromNotes(application.notes);
+      return {
+        ...application,
+        notes: appendMetadataToNotes(
+          notes,
+          createSpreadsheetMetadataEnvelope(rawRow, canonicalRow ?? blankRow()),
+        ),
+      };
+    });
   } catch (error) {
     errors.push({
       rowNumber: null,
@@ -1098,7 +1236,6 @@ export const rowsToBrowserApplicationExport = (
 export const csvToBrowserApplicationExport = (csvText, options) =>
   rowsToBrowserApplicationExport(parseCsv(csvText), options);
 
-const dateOnly = (value) => (value ? String(value).slice(0, 10) : "");
 const dateTime = (value) => (value ? String(value) : "");
 const compareCodePoints = (left, right) => {
   const leftText = String(left);
@@ -1117,8 +1254,10 @@ const compareIsoDateTimes = (left, right) => {
   if (leftValid !== rightValid) return leftValid ? 1 : -1;
   return compareCodePoints(leftText, rightText);
 };
-const firstBy = (records, predicate) => records.find(predicate) ?? {};
-export const browserApplicationExportToRows = (bundle) => {
+const firstBy = (records, predicate) =>
+  [...records].sort((a, b) => compareCodePoints(a.id, b.id)).find(predicate) ??
+  {};
+export const browserApplicationExportToCanonicalRows = (bundle) => {
   const parsed = upgradeBrowserExportToV2(bundle).data;
   return [...parsed.applications]
     .sort((a, b) => a.id.localeCompare(b.id))
@@ -1128,10 +1267,19 @@ export const browserApplicationExportToRows = (bundle) => {
       const artifacts = parsed.artifacts.filter(
         (artifact) => artifact.applicationId === application.id,
       );
-      const outreach = firstBy(
-        parsed.outreachMessages,
-        (message) => message.applicationId === application.id,
-      );
+      const outreach =
+        [...parsed.outreachMessages]
+          .filter(
+            (message) =>
+              message.applicationId === application.id &&
+              message.direction === "outbound",
+          )
+          .sort(
+            (a, b) =>
+              compareIsoDateTimes(b.sentAt, a.sentAt) ||
+              compareIsoDateTimes(b.createdAt, a.createdAt) ||
+              compareCodePoints(b.id, a.id),
+          )[0] ?? {};
       const interview =
         firstBy(
           parsed.interviews,
@@ -1163,13 +1311,13 @@ export const browserApplicationExportToRows = (bundle) => {
         company: application.company,
         role_title: application.role,
         status: application.status,
-        applied_at: dateOnly(application.appliedAt),
+        applied_at: dateTime(application.appliedAt),
         posting_url: application.postingUrl ?? "",
         application_channel: application.source ?? "",
         origin: application.origin ?? "",
         work_model: application.remote ? "remote" : (metadata.work_model ?? ""),
         location_display: application.location ?? "",
-        follow_up_date: dateOnly(application.followUpDate),
+        follow_up_date: dateTime(application.followUpDate),
         notes,
         schema_version: metadata.schema_version ?? "1",
       });
@@ -1216,14 +1364,52 @@ export const browserApplicationExportToRows = (bundle) => {
       return row;
     });
 };
+export const browserApplicationExportToRows = (bundle) =>
+  browserApplicationExportToCanonicalRows(bundle).map((row) => {
+    const application = bundle.applications.find(
+      ({ id }) => id === row.application_id,
+    );
+    const { metadata } = readMetadataFromNotes(application?.notes);
+    return applyPreservedCompactCells(row, metadata);
+  });
 export const exportCompactCsv = (bundle) =>
   serializeCsv(browserApplicationExportToRows(bundle));
+const effectiveLifecycleProvenance = (event) => {
+  if (event.provenance) return event.provenance;
+  if (
+    event.inferred ||
+    event.source === "reconciliation" ||
+    event.source === "browser_migration"
+  )
+    return "inferred";
+  if (
+    event.source === "csv_import" &&
+    [
+      "applied",
+      "outreach_sent",
+      "recruiter_screen",
+      "technical_screen",
+      "onsite_loop",
+      "offer",
+      "accepted",
+      "rejected",
+      "withdrawn",
+      "closed_archived",
+      "application_rejected",
+    ].some(
+      (suffix) => event.id === stableId("event", event.applicationId, suffix),
+    )
+  )
+    return "compact_derived";
+  return "explicit";
+};
 export const browserApplicationExportToLifecycleRows = (bundle) => {
   const parsed = upgradeBrowserExportToV2(bundle).data;
   const applicationsById = new Map(
     parsed.applications.map((application) => [application.id, application]),
   );
   return [...parsed.lifecycleEvents]
+    .filter((event) => effectiveLifecycleProvenance(event) === "explicit")
     .sort((a, b) => {
       for (const compared of [
         compareCodePoints(a.applicationId, b.applicationId),
@@ -1240,15 +1426,20 @@ export const browserApplicationExportToLifecycleRows = (bundle) => {
       const application = applicationsById.get(event.applicationId) ?? {};
       return {
         ...blankLifecycleRow(),
+        event_id: event.id,
         application_id: event.applicationId,
         company: application.company ?? "",
         role_title: application.role ?? "",
         event_type: event.eventType ?? "",
         raw_event_type: event.rawEventType ?? "",
         previous_status: event.previousStatus ?? "",
-        occurred_at: event.occurredAt ?? "",
+        occurred_at:
+          event.occurredAtPrecision === "unknown" &&
+          String(event.occurredAt).startsWith("1970-01-01")
+            ? ""
+            : (event.occurredAt ?? ""),
         occurred_at_precision: event.occurredAtPrecision ?? "",
-        inferred: event.inferred === undefined ? "" : String(event.inferred),
+        inferred: "false",
         supersedes_event_id: event.supersedesEventId ?? "",
         stage: event.stageLabel ?? event.status ?? "",
         channel: event.channel ?? "",
@@ -1260,6 +1451,7 @@ export const browserApplicationExportToLifecycleRows = (bundle) => {
             : String(event.requiresUserAction),
         action_status: event.actionStatus ?? "",
         due_at: event.dueAt ?? "",
+        due_at_precision: event.dueAtPrecision ?? "",
         no_ai_required:
           event.noAiRequired === undefined ? "" : String(event.noAiRequired),
         details: event.details ?? event.note ?? "",
@@ -1303,7 +1495,10 @@ const restoreLifecyclePrecisionFlags = (bundle, sourceEvents) => {
 };
 const upgradeBackupBundlePreservingLifecyclePrecision = (bundle) => {
   const upgraded = upgradeBrowserExportToV2(bundle).data;
-  return restoreLifecyclePrecisionFlags(upgraded, bundle?.lifecycleEvents ?? []);
+  return restoreLifecyclePrecisionFlags(
+    upgraded,
+    bundle?.lifecycleEvents ?? [],
+  );
 };
 const canonicalizeBackupBundle = (bundle) => {
   const parsed = upgradeBackupBundlePreservingLifecyclePrecision(bundle);
@@ -1603,6 +1798,13 @@ export const previewSupplementalLifecycleCsvImport = async (
     existing,
   );
   const incomingStores = ["lifecycleEvents", "interviews", "reminders"];
+  const rowNumberByEventId = new Map(
+    rows.map((row, index) => [
+      compact(row.event_id) ||
+        generatedLifecycleId({ ...blankLifecycleRow(), ...row }),
+      index + 2,
+    ]),
+  );
   const conflicts = [];
   for (const store of incomingStores) {
     const seen = new Map();
@@ -1627,7 +1829,10 @@ export const previewSupplementalLifecycleCsvImport = async (
       );
       if (existingRecord && !lifecycleRecordsEqual(existingRecord, record))
         conflicts.push({
-          rowNumber: null,
+          rowNumber:
+            store === "lifecycleEvents"
+              ? (rowNumberByEventId.get(record.id) ?? null)
+              : null,
           field: "id",
           code: "duplicate_existing",
           value: record.id,

--- a/src/web/storage/browserDataMigration.js
+++ b/src/web/storage/browserDataMigration.js
@@ -73,6 +73,23 @@ const slug = (v) =>
     .replace(/[^a-z0-9]+/g, "_")
     .replace(/^_+|_+$/g, "") || "record";
 const stableId = (...parts) => parts.map(slug).join("_");
+const isLegacyCompactDerivedEvent = (event) =>
+  event.source === "csv_import" &&
+  [
+    "applied",
+    "outreach_sent",
+    "recruiter_screen",
+    "technical_screen",
+    "onsite_loop",
+    "offer",
+    "accepted",
+    "rejected",
+    "withdrawn",
+    "closed_archived",
+    "application_rejected",
+  ].some(
+    (suffix) => event.id === stableId("event", event.applicationId, suffix),
+  );
 const norm = (v) =>
   String(v ?? "")
     .trim()
@@ -122,7 +139,18 @@ const normalizeEvent = (event, warnings) => {
     occurredAt: occurredAtFor(event, precision),
     occurredAtPrecision: precision,
     inferred: Boolean(event.inferred),
+    provenance:
+      event.provenance ??
+      (event.inferred ||
+      event.source === "reconciliation" ||
+      event.source === "browser_migration"
+        ? "inferred"
+        : isLegacyCompactDerivedEvent(event)
+          ? "compact_derived"
+          : "explicit"),
   };
+  if (out.dueAt && !out.dueAtPrecision)
+    out.dueAtPrecision = isoDate.test(out.dueAt) ? "date" : "instant";
   if (!out.eventType)
     out.eventType = STATUS_EVENT.get(out.status) ?? "status_changed";
   if (!out.rawEventType) delete out.rawEventType;
@@ -205,6 +233,9 @@ export const upgradeBrowserExportToV2 = (input, options = {}) => {
   const source = clone(input);
   const version = source?.schemaVersion;
   if (source?.schemaVersion === 2) {
+    source.lifecycleEvents = (source.lifecycleEvents ?? []).map((event) =>
+      normalizeEvent(event, warnings),
+    );
     const data = browserApplicationExportSchema.parse(source);
     return { data, warnings };
   }
@@ -239,6 +270,7 @@ export const upgradeBrowserExportToV2 = (input, options = {}) => {
         occurredAt: isoDate.test(evidence.at) ? evidence.at : evidence.at,
         occurredAtPrecision: isoDate.test(evidence.at) ? "date" : "instant",
         inferred: true,
+        provenance: "inferred",
         source: "browser_migration",
         createdAt: migrationCreatedAt,
       });
@@ -272,6 +304,7 @@ export const upgradeBrowserExportToV2 = (input, options = {}) => {
           occurredAt: anchor,
           occurredAtPrecision: "unknown",
           inferred: true,
+          provenance: "inferred",
           source: "browser_migration",
           createdAt: migrationCreatedAt,
         });

--- a/src/web/tracker/lifecycleReconciliation.js
+++ b/src/web/tracker/lifecycleReconciliation.js
@@ -83,6 +83,7 @@ const event = (
     (String(occurredAt).includes("T") ? "instant" : "unknown"),
   inferred: true,
   source: "reconciliation",
+  provenance: "inferred",
   createdAt: "1970-01-01T00:00:00.000Z",
   ...extra,
 });

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -998,6 +998,7 @@ function bindDetail(app) {
             v.origin === "application_submitted" ? "date" : "instant",
           inferred: false,
           source: "manual",
+          provenance: "explicit",
           createdAt: operationTime,
         });
       } else if (v.origin !== current.origin) {
@@ -1013,6 +1014,7 @@ function bindDetail(app) {
             v.origin === "application_submitted" ? "date" : "instant",
           inferred: false,
           source: "manual",
+          provenance: "explicit",
           supersedesEventId: priorOrigin?.id,
           createdAt: operationTime,
         });
@@ -1027,6 +1029,7 @@ function bindDetail(app) {
           occurredAtPrecision: "instant",
           inferred: false,
           source: "manual",
+          provenance: "explicit",
           createdAt: operationTime,
         });
       }
@@ -1097,6 +1100,7 @@ function bindDetail(app) {
               occurredAtPrecision: "instant",
               inferred: false,
               source: "manual",
+              provenance: "explicit",
               channel: v.channel,
               sourceArtifact: message.id,
               actionStatus: v.direction,
@@ -1126,6 +1130,7 @@ function bindDetail(app) {
               occurredAtPrecision: "instant",
               inferred: false,
               source: "manual",
+              provenance: "explicit",
               actionStatus: v.actionStatus,
               dueAt: isoDate(v.dueAt),
               details: optionalBlankToUndefined(v.details),
@@ -1186,6 +1191,7 @@ function bindDetail(app) {
               occurredAtPrecision: "instant",
               inferred: false,
               source: "manual",
+              provenance: "explicit",
               stageLabel: v.stage,
               actionStatus: v.outcome,
               dueAt: interview.startsAt,
@@ -1239,6 +1245,7 @@ function bindDetail(app) {
               occurredAtPrecision: "instant",
               inferred: false,
               source: "manual",
+              provenance: "explicit",
               sourceArtifact: offer.id,
               actionStatus: v.status,
               createdAt: operationTime,

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -612,7 +612,7 @@ describe("spreadsheet import/export", () => {
           application_id: "app_applied_stage_rejected",
           status: "Applied",
           interview_stage: "Application rejected",
-          outcome: "rejected",
+          outcome: "",
         }),
       ]),
     );
@@ -719,12 +719,7 @@ describe("spreadsheet import/export", () => {
     )) {
       expect(exportedRowsById.get(row.application_id)).toMatchObject({
         status: row.status,
-        interview_stage:
-          row.status === "Interviewing"
-            ? "Not started"
-            : row.status === "recruiter_screen"
-              ? "recruiter_screen"
-              : row.interview_stage,
+        interview_stage: row.interview_stage,
         outcome: row.outcome,
       });
     }
@@ -1198,9 +1193,9 @@ describe("spreadsheet import/export", () => {
         ({ applicationId, eventType }) =>
           applicationId === "app_roundtrip_alpha" && eventType,
       ),
-    ).toHaveLength(5);
+    ).toHaveLength(4);
     expect(restored.interviews).toHaveLength(1);
-    expect(restored.reminders).toHaveLength(0);
+    expect(restored.reminders).toHaveLength(1);
     expect(restored.artifacts).toHaveLength(0);
     repo.close();
   });
@@ -1276,12 +1271,8 @@ describe("spreadsheet import/export", () => {
       '"Reply included comma, quote ""here"", and newline\nSecond line."',
     );
     const rows = parseCsv(csv);
-    expect(rows.map((row) => row.application_id)).toEqual([
-      "app_a",
-      "app_b",
-      "app_b",
-    ]);
-    expect(rows[2]).toMatchObject({
+    expect(rows.map((row) => row.application_id)).toEqual(["app_a", "app_b"]);
+    expect(rows[1]).toMatchObject({
       source_artifact: "https://example.test/artifact/reply?x=1&y=2",
       requires_user_action: "false",
       no_ai_required: "true",
@@ -1431,7 +1422,7 @@ describe("spreadsheet import/export", () => {
           id.startsWith("event_app_status_only_") &&
           occurredAt === "2026-03-02T00:00:00.000Z",
       ),
-    ).toHaveLength(statuses.length);
+    ).toHaveLength(0);
     repo.close();
   });
 
@@ -1515,11 +1506,7 @@ describe("spreadsheet import/export", () => {
         code: "malformed_date",
       }),
     ]);
-    expect(bundle.lifecycleEvents).toEqual([
-      expect.objectContaining({
-        occurredAt: "1970-01-01T00:00:00.000Z",
-      }),
-    ]);
+    expect(bundle.lifecycleEvents).toEqual([]);
   });
 
   it("restores older JSON and NDJSON backups that omit lifecycle metadata stores", () => {
@@ -1647,10 +1634,9 @@ describe("spreadsheet import/export", () => {
     await Promise.all(
       fixtureNames.map(async (fixtureName) => {
         await expect(
-          readFile(
-            `test/fixtures/tracker-import/${fixtureName}`,
-            "utf8",
-          ).then(detectSpreadsheetImportFormat),
+          readFile(`test/fixtures/tracker-import/${fixtureName}`, "utf8").then(
+            detectSpreadsheetImportFormat,
+          ),
         ).resolves.toBe("lifecycle_csv");
       }),
     );
@@ -2044,12 +2030,18 @@ describe("spreadsheet import/export", () => {
       lifecycleCsv,
       repo,
     );
-    expect(preview.errors).toEqual([]);
+    expect(preview.errors).toEqual([
+      expect.objectContaining({
+        rowNumber: 3,
+        field: "event_id",
+        code: "duplicate_event_without_event_id",
+      }),
+    ]);
     expect(preview.conflicts).toEqual([]);
     expect(preview.bundle.lifecycleEvents).toHaveLength(1);
     const result = await importSupplementalLifecycleCsv(lifecycleCsv, repo);
-    expect(result.imported).toBe(true);
-    expect((await repo.exportAllData()).lifecycleEvents).toHaveLength(2);
+    expect(result.imported).toBe(false);
+    expect((await repo.exportAllData()).lifecycleEvents).toHaveLength(1);
     repo.close();
   });
 
@@ -2110,9 +2102,10 @@ describe("spreadsheet import/export", () => {
     expect(dateOnlyPreview.errors).toEqual([]);
     expect(dateOnlyPreview.bundle.lifecycleEvents).toEqual([
       expect.objectContaining({
-        occurredAt: "2026-01-08",
-        occurredAtPrecision: "date",
-        dueAt: "2026-01-08T00:00:00.000Z",
+        occurredAt: "1970-01-01",
+        occurredAtPrecision: "unknown",
+        dueAt: "2026-01-08",
+        dueAtPrecision: "date",
       }),
     ]);
     expect(dateOnlyPreview.bundle.interviews).toEqual([]);
@@ -2449,7 +2442,10 @@ describe("spreadsheet import/export", () => {
       Object.fromEntries(
         childStores.map((store) => [store, exportedAgain[store].length]),
       ),
-    ).toEqual({ ...childCounts, lifecycleEvents: childCounts.lifecycleEvents + 1 });
+    ).toEqual({
+      ...childCounts,
+      lifecycleEvents: childCounts.lifecycleEvents + 1,
+    });
 
     repo.close();
   });

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -1426,6 +1426,91 @@ describe("spreadsheet import/export", () => {
     repo.close();
   });
 
+  it("reimports and edits a manual lifecycle event by stable id", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await importCompactCsv(
+      serializeCsv([
+        {
+          application_id: "app_stable_manual_event",
+          company: "Stable Systems",
+          role_title: "Engineer",
+          applied_at: "2026-03-01",
+          schema_version: "1",
+        },
+      ]),
+      repo,
+      { mode: "replace" },
+    );
+    const existing = await repo.exportAllData();
+    existing.lifecycleEvents.push({
+      id: "event_stable_manual",
+      applicationId: "app_stable_manual_event",
+      status: "applied",
+      occurredAt: "2026-03-02T10:00:00.000Z",
+      source: "manual",
+      provenance: "explicit",
+      eventType: "lifecycle_event",
+      note: "Original details",
+      createdAt: "2026-03-02T10:00:00.000Z",
+    });
+    await repo.importAllData(existing, { allowOverwrite: true });
+
+    const lifecycleCsv = exportLifecycleCsv(await repo.exportAllData());
+    const unchanged = await importSupplementalLifecycleCsv(lifecycleCsv, repo);
+    expect(unchanged.imported).toBe(true);
+    expect(unchanged.preview.conflicts).toEqual([]);
+
+    const rows = parseCsv(lifecycleCsv);
+    rows[0].details = "Edited details";
+    const edited = await importSupplementalLifecycleCsv(
+      serializeCsv(rows, LIFECYCLE_CSV_COLUMNS),
+      repo,
+    );
+    expect(edited.imported).toBe(true);
+    expect(edited.preview.conflicts).toEqual([]);
+    expect(
+      (await repo.exportAllData()).lifecycleEvents.find(
+        ({ id }) => id === "event_stable_manual",
+      ),
+    ).toMatchObject({ note: "Edited details", source: "csv_import" });
+    repo.close();
+  });
+
+  it("warns when importing an unsupported lifecycle event type", () => {
+    const { errors, warnings, bundle } =
+      lifecycleRowsToBrowserApplicationExport(
+        [
+          {
+            application_id: "app_unsupported_event",
+            event_type: "bespoke_vendor_ping",
+            occurred_at: "2026-03-02T10:00:00.000Z",
+          },
+        ],
+        {
+          applications: [
+            {
+              id: "app_unsupported_event",
+              company: "Vendor Systems",
+              role: "Engineer",
+              status: "applied",
+              createdAt: "2026-03-01T00:00:00.000Z",
+              updatedAt: "2026-03-01T00:00:00.000Z",
+            },
+          ],
+        },
+      );
+
+    expect(errors).toEqual([]);
+    expect(warnings).toEqual([
+      expect.objectContaining({
+        rowNumber: 2,
+        code: "unsupported_event_type",
+        value: "bespoke_vendor_ping",
+      }),
+    ]);
+    expect(bundle.lifecycleEvents).toHaveLength(1);
+  });
+
   it("preserves valid ISO offset datetimes without milliseconds", () => {
     const { bundle, errors } = csvToBrowserApplicationExport(
       serializeCsv([

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -1281,12 +1281,10 @@ describe("tracker dashboard metrics", () => {
     );
     expect(lifecycle.interviews).toEqual([
       expect.objectContaining({
-        id: "interview_app_reg_epsilon_005_recruiter_screen_2026_02_15t18_00_00_000z",
         stage: "recruiter_screen",
         startsAt: "2026-02-15T18:00:00.000Z",
       }),
       expect.objectContaining({
-        id: "interview_app_reg_epsilon_005_technical_screen_2026_02_18t20_00_00_000z",
         stage: "technical_screen",
         startsAt: "2026-02-18T20:00:00.000Z",
       }),


### PR DESCRIPTION
### Motivation

- Existing compact CSV import/export lost raw spreadsheet fidelity (timestamps, labels, multiline cells) and mixed derived/inferred lifecycle rows into lifecycle exports, producing lossy round trips.  
- Implement a general preservation overlay so the tracker stores raw CSV cell text and exports exact original cells when the normalized state hasn't been edited.  
- Make lifecycle CSVs explicit-only, stable, and deterministic by adding provenance, robust legacy ID generation, and date/datetime precision preservation.

### Description

- Preserve raw compact cells in a versioned single-line metadata envelope written to application notes as JSON (`spreadsheet_metadata_version: 2`) with `raw_row` and `canonical_row`, and add helpers `createSpreadsheetMetadataEnvelope`, `browserApplicationExportToCanonicalRows`, and `applyPreservedCompactCells`. (changes in `src/web/import-export/spreadsheet.js`)
- Export compact CSV in two phases: produce canonical rows from normalized browser state, then overlay preserved `raw_row` values per-column when the canonical cell equals the stored `canonical_row`; unedited metadata-only fields remain raw. (changes in `src/web/import-export/spreadsheet.js`)
- Add lifecycle provenance and due-date precision to the domain schema and migration path: `provenance` enum (`explicit|compact_derived|inferred`), `dueAtPrecision`, and `dueAt` accepting date or datetime; normalize legacy events deterministically and assign provenance during migration. (changes in `src/domain/browserApplication.js`, `src/web/storage/browserDataMigration.js`)
- Make lifecycle import/export deterministic and explicit-only: accept new canonical lifecycle header (adds `event_id` and `due_at_precision`), generate stable two-seed FNV-1a `event_<slug>_<h1><h2>` IDs for legacy rows without `event_id`, detect collisions and duplicate-ID errors with CSV row numbers, and export only events with effective `provenance === 'explicit'`. (changes in `src/web/import-export/spreadsheet.js`, `src/web/storage/browserDataMigration.js`)
- Preserve date precision semantics: date-only values remain date-only (no midnight coercion), ISO datetimes keep offsets/seconds/fractions, `dueAtPrecision` and `occurredAtPrecision` are emitted and validated on import, and date-only reminders deterministically map to end-of-day UTC for actionable reminders while retaining the date-only event value. (changes in `src/web/import-export/spreadsheet.js`, `src/domain/browserApplication.js`)
- Create compact-derived lifecycle events deterministically (ids, interviews, reminders) but mark them `compact_derived` and exclude them from lifecycle CSV export; inferred/migration/reconciliation events are preserved in JSON/NDJSON but not in the exported lifecycle CSV. (changes in `src/web/import-export/spreadsheet.js`, `src/web/tracker/tracker.js`, `src/web/tracker/lifecycleReconciliation.js`)
- Tests and docs updated: added/adjusted regression expectations and documented exact canonical headers and two-file workflow. (changes in `test/web-spreadsheet-import-export.test.js`, `test/web-tracker-metrics.test.js`, `docs/spreadsheet-replacement.md`, `docs/backup-restore-guide.md`)

Files changed:
- src/web/import-export/spreadsheet.js
- src/domain/browserApplication.js
- src/web/storage/browserDataMigration.js
- src/web/tracker/tracker.js
- src/web/tracker/lifecycleReconciliation.js
- src/web/tracker/metrics.js (reads metadata; no public API change)
- test/web-spreadsheet-import-export.test.js
- test/web-tracker-metrics.test.js
- docs/spreadsheet-replacement.md
- docs/backup-restore-guide.md

### Testing

- Formatting and linting: `npx prettier --check <files>` and `npm run lint -- --quiet` succeeded.  
- Typecheck: `npm run typecheck` succeeded.  
- Focused unit tests: `npx vitest run test/web-spreadsheet-import-export.test.js test/web-storage-browser-data-migration.test.js test/web-tracker-metrics.test.js test/web-tracker-lifecycle-projection.test.js` were executed and passed in the final verification run.  
- Full CI-local smoke: `npm run test:ci` was executed as part of pre-commit/test workflow (completed in the environment used).  

Verification commands run (examples):
- `npx prettier --check src/web/import-export/spreadsheet.js src/domain/browserApplication.js src/web/storage/browserDataMigration.js src/web/tracker/metrics.js src/web/tracker/tracker.js src/web/tracker/lifecycleReconciliation.js test/web-spreadsheet-import-export.test.js test/web-storage-browser-data-migration.test.js docs/spreadsheet-replacement.md docs/backup-restore-guide.md` — OK
- `npm run lint -- --quiet` — OK
- `npm run typecheck` — OK
- `npx vitest run test/web-spreadsheet-import-export.test.js test/web-storage-browser-data-migration.test.js test/web-tracker-metrics.test.js test/web-tracker-lifecycle-projection.test.js` — focused suites OK
- `npm run test:ci` — executed as part of pre-commit; environment run completed.

Notes / follow-ups

- Backward compatibility: legacy compact CSVs without `origin` remain importable; blank legacy origin maps to internal `other_unknown` (or `referral` for recognized referral channel aliases), and legacy lifecycle files without `event_id` or precision columns are accepted and normalized with deterministic generated IDs and precision inference.  
- The implementation keeps JSON/NDJSON backups fully expressive (they still contain inferred and compact-derived records) while the lifecycle CSV export is intentionally filtered to explicit events only.  
- Please review the updated docs for the exact canonical headers before releasing the import flow to users.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7a16f00748832fbc0298fe8a462ed8)