### PR TITLE
Preserve assessment due-date precision in tracker assessment form

### DIFF
--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -1118,6 +1118,7 @@ function bindDetail(app) {
     const form = e.target;
     await submitWithRecovery(form, async (v) => {
       const operationTime = now();
+      const dueAt = optionalBlankToUndefined(v.dueAt);
       await repo.commitLifecycleMutation({
         records: {
           lifecycleEvents: [
@@ -1132,7 +1133,8 @@ function bindDetail(app) {
               source: "manual",
               provenance: "explicit",
               actionStatus: v.actionStatus,
-              dueAt: isoDate(v.dueAt),
+              dueAt,
+              dueAtPrecision: dueAt ? "date" : undefined,
               details: optionalBlankToUndefined(v.details),
               createdAt: operationTime,
             },

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import { expect, test } from "@playwright/test";
 
+import { parseCsv } from "../../src/web/import-export/spreadsheet.js";
 import { startWebServer } from "../../src/web/server.js";
 
 const csvFixture = [
@@ -175,6 +176,69 @@ test.describe("browser application tracker", () => {
       .locator("[data-applications-table] tbody tr")
       .filter({ hasText: "Company Delta" });
     await expect(deltaRow).toContainText("Assessment ×1");
+  });
+
+  test("preserves assessment due-date precision in lifecycle CSV export", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await importFixture(page, "fake-applications.csv", csvFixture);
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Example Labs" }).click();
+
+    const assessmentForm = page.locator("[data-assessment-form]");
+    await assessmentForm
+      .locator('[name="actionStatus"]')
+      .selectOption("pending");
+    await assessmentForm.locator('[name="dueAt"]').fill("2026-08-31");
+    await assessmentForm
+      .locator('[name="details"]')
+      .fill("Distinctive fake assessment deadline");
+    await assessmentForm
+      .getByRole("button", { name: "Log assessment" })
+      .click();
+
+    const blankAssessmentForm = page.locator("[data-assessment-form]");
+    await blankAssessmentForm
+      .locator('[name="actionStatus"]')
+      .selectOption("requested");
+    await blankAssessmentForm
+      .locator('[name="details"]')
+      .fill("Distinctive fake assessment without deadline");
+    await blankAssessmentForm
+      .getByRole("button", { name: "Log assessment" })
+      .click();
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Export lifecycle CSV" }).click();
+    const download = await downloadPromise;
+    const csv = await readFile(await download.path(), "utf8");
+    const rows = parseCsv(csv);
+    const datedRow = rows.find(
+      (row) => row.details === "Distinctive fake assessment deadline",
+    );
+    const blankRow = rows.find(
+      (row) => row.details === "Distinctive fake assessment without deadline",
+    );
+
+    expect(datedRow).toMatchObject({
+      event_type: "assessment_take_home",
+      due_at: "2026-08-31",
+      due_at_precision: "date",
+      occurred_at_precision: "instant",
+      inferred: "false",
+    });
+    expect(datedRow.due_at).not.toBe("2026-08-31T00:00:00.000Z");
+    expect(blankRow).toMatchObject({
+      event_type: "assessment_take_home",
+      due_at: "",
+      due_at_precision: "",
+      occurred_at_precision: "instant",
+      inferred: "false",
+    });
   });
 
   test("does not infer recruiter chips from free-form stage labels", async ({


### PR DESCRIPTION
### Motivation

- A browser `<input type="date">` returns `YYYY-MM-DD`, but the assessment handler previously passed that value through `isoDate()` which produced a midnight ISO instant and omitted `dueAtPrecision`, breaking the lifecycle CSV contract that date-only deadlines must remain date-only.

### Description

- Use the existing `optionalBlankToUndefined()` convention to convert only blank values to `undefined` and otherwise persist the browser-supplied `YYYY-MM-DD` string unchanged in the assessment lifecycle event.
- Add `dueAtPrecision: "date"` when a nonblank `dueAt` is present, and leave both `dueAt` and `dueAtPrecision` undefined for blank inputs, preserving all other event fields and semantics (`eventType`, `occurredAt`, `occurredAtPrecision`, `source`, `provenance`, `inferred`, action-status and details handling).
- Keep shared helper `isoDate()` and interview/application forms unchanged.
- Add a Playwright end-to-end regression `preserves assessment due-date precision in lifecycle CSV export` that logs a dated assessment, logs a blank-deadline assessment, exports the lifecycle CSV, parses it with the repo `parseCsv()` helper, and asserts the exported cells match the expected `YYYY-MM-DD` date, `due_at_precision=date`, and blank cells for the optional case.

### Testing

- `npx prettier --check src/web/tracker/tracker.js test/playwright/browser-tracker.spec.js` — OK (prettier style matched after formatting).
- `npm run lint -- --quiet` — OK (ESLint passed on changed files).
- `npm run typecheck` — OK (TypeScript checks passed).
- `npx vitest run test/web-spreadsheet-import-export.test.js test/web-tracker-lifecycle-persistence.test.js` — OK (these targeted Vitest suites passed; 55 tests ran and passed).
- `npx playwright test test/playwright/browser-tracker.spec.js --grep "preserves assessment due-date precision"` — OK (the new Playwright regression passed after installing Playwright browsers; the script downloaded Chromium and required host deps were installed during verification).
- `npm run test:ci` — Partial: the CI-equivalent suite executed, relevant spreadsheet/import/export and tracker persistence tests passed, but an unrelated long-running lifecycle diagram layout test timed out (one Vitest test failed due to timeout in `test/web-tracker-lifecycle-diagram-layout.test.js`); this is unrelated to the current changes.

Files changed

- `src/web/tracker/tracker.js` — use `optionalBlankToUndefined(v.dueAt)`, persist `dueAt` unchanged, and set `dueAtPrecision: dueAt ? "date" : undefined` in the assessment handler.
- `test/playwright/browser-tracker.spec.js` — add Playwright regression `preserves assessment due-date precision in lifecycle CSV export` that exercises the real UI and verifies CSV export cells for both dated and blank assessment submissions.

Root cause

- The handler converted browser date inputs to a `Date`/ISO instant via `isoDate()`, which turns `YYYY-MM-DD` into `YYYY-MM-DDT00:00:00.000Z` and drops the precision marker; the fix preserves the original `YYYY-MM-DD` and attaches `dueAtPrecision: "date"`.

Verification commands used and primary outcomes

- `npx prettier --check src/web/tracker/tracker.js test/playwright/browser-tracker.spec.js` — passed
- `npm run lint -- --quiet` — passed
- `npm run typecheck` — passed
- `npx vitest run test/web-spreadsheet-import-export.test.js test/web-tracker-lifecycle-persistence.test.js` — passed (55 tests)
- `npx playwright install chromium` — performed to obtain browsers for Playwright tests
- `npx playwright test test/playwright/browser-tracker.spec.js --grep "preserves assessment due-date precision"` — passed (1 Playwright test)
- `npm run test:ci` — ran; the directly related tests passed but an unrelated Vitest timeout occurred in a lifecycle-diagram layout test (one failing test due to timeout)

Residual notes

- The change is intentionally minimal and limited to the assessment submit handler and the Playwright regression; no helpers, lifecycle schema, import behavior, CSV headers, or unrelated UI were modified.
- The unrelated Vitest timeout surfaced during full `test:ci`; it appears to be a long-running layout test and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b72049bbc832f86b91c0e30b8f913)