### PR TITLE
Preserve assessment due-date precision

### DIFF
--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -1118,6 +1118,7 @@ function bindDetail(app) {
     const form = e.target;
     await submitWithRecovery(form, async (v) => {
       const operationTime = now();
+      const dueAt = optionalBlankToUndefined(v.dueAt);
       await repo.commitLifecycleMutation({
         records: {
           lifecycleEvents: [
@@ -1132,7 +1133,8 @@ function bindDetail(app) {
               source: "manual",
               provenance: "explicit",
               actionStatus: v.actionStatus,
-              dueAt: isoDate(v.dueAt),
+              dueAt,
+              dueAtPrecision: dueAt ? "date" : undefined,
               details: optionalBlankToUndefined(v.details),
               createdAt: operationTime,
             },

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import { expect, test } from "@playwright/test";
 
+import { parseCsv } from "../../src/web/import-export/spreadsheet.js";
 import { startWebServer } from "../../src/web/server.js";
 
 const csvFixture = [
@@ -984,6 +985,69 @@ test.describe("browser application tracker", () => {
     await expect((await download).suggestedFilename()).toBe(
       "jobbot3000-backup.json",
     );
+  });
+
+  test("preserves assessment due-date precision in lifecycle CSV export", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await importFixture(page, "fake-applications.csv", csvFixture);
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Example Labs" }).click();
+
+    let assessmentForm = page.locator("[data-assessment-form]");
+    await assessmentForm
+      .locator('[name="actionStatus"]')
+      .selectOption("started");
+    await assessmentForm.locator('[name="dueAt"]').fill("2026-08-31");
+    await assessmentForm
+      .locator('[name="details"]')
+      .fill("Distinctive fake dated assessment");
+    await assessmentForm
+      .getByRole("button", { name: "Log assessment" })
+      .click();
+
+    assessmentForm = page.locator("[data-assessment-form]");
+    await assessmentForm
+      .locator('[name="actionStatus"]')
+      .selectOption("pending");
+    await assessmentForm
+      .locator('[name="details"]')
+      .fill("Distinctive fake undated assessment");
+    await assessmentForm
+      .getByRole("button", { name: "Log assessment" })
+      .click();
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Export lifecycle CSV" }).click();
+    const download = await downloadPromise;
+    const csv = await readFile(await download.path(), "utf8");
+    const rows = parseCsv(csv);
+    const dated = rows.find(
+      (row) => row.details === "Distinctive fake dated assessment",
+    );
+    const undated = rows.find(
+      (row) => row.details === "Distinctive fake undated assessment",
+    );
+
+    expect(dated).toMatchObject({
+      event_type: "assessment_take_home",
+      due_at: "2026-08-31",
+      due_at_precision: "date",
+      occurred_at_precision: "instant",
+      inferred: "false",
+    });
+    expect(dated.due_at).not.toBe("2026-08-31T00:00:00.000Z");
+    expect(undated).toMatchObject({
+      event_type: "assessment_take_home",
+      due_at: "",
+      due_at_precision: "",
+      occurred_at_precision: "instant",
+      inferred: "false",
+    });
   });
 
   test("retains IndexedDB data across reload, exports backup, and clears local data", async ({


### PR DESCRIPTION
### Motivation

- The assessment form handler converted a browser `YYYY-MM-DD` date through `isoDate()`, producing a midnight ISO timestamp and dropping the `dueAtPrecision` metadata required by the lifecycle CSV contract introduced in PR #1212.

### Description

- Stop converting nonblank assessment deadlines through `Date`/`isoDate()` and instead use the `optionalBlankToUndefined()` convention so a nonblank value is persisted exactly as `"YYYY-MM-DD"`. 
- Record `dueAtPrecision: "date"` only when a nonblank `dueAt` exists, and leave both `dueAt` and `dueAtPrecision` undefined when blank; all other event fields remain unchanged. 
- Added an end-to-end Playwright regression `preserves assessment due-date precision in lifecycle CSV export` exercising the UI flow and verifying the exported lifecycle CSV preserves `due_at` as `2026-08-31` with `due_at_precision=date` and that a blank submission exports blank cells.
- Files changed: `src/web/tracker/tracker.js` and `test/playwright/browser-tracker.spec.js`.

### Testing

- Formatting and linting: ran `npx prettier --check src/web/tracker/tracker.js test/playwright/browser-tracker.spec.js` and `npm run lint -- --quiet`, both succeeded. 
- Typecheck: ran `npm run typecheck`, which succeeded. 
- Unit/CI subset: ran `npx vitest run test/web-spreadsheet-import-export.test.js test/web-tracker-lifecycle-persistence.test.js` and observed both files' tests passed. 
- Playwright regression: ran `npx playwright test test/playwright/browser-tracker.spec.js --grep "preserves assessment due-date precision"` (installed browsers and host deps as prompted) and the single new Playwright test passed. 
- Full test run: `npm test -- --run` reported 1,331 tests passed and one unrelated lifecycle-diagram layout test timed out; `npm run test:ci` exposed the same unrelated timeout in a long layout test. 

Notes: the change is intentionally limited to the assessment submit handler and the Playwright regression; `isoDate()` was not modified and interview/application forms were left intact. I committed the change as `Preserve assessment due date precision` and verified pre-commit hooks (lint/typecheck) passed; creating a PR was not performed from this environment because the GitHub CLI/auth was not configured here. If you want, I can open the PR once a remote/branch is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b7205bcb8832fbcffaf9fa24a3303)