### PR TITLE
Preserve assessment due-date precision (store date-only as YYYY-MM-DD)

### DIFF
--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -1118,6 +1118,7 @@ function bindDetail(app) {
     const form = e.target;
     await submitWithRecovery(form, async (v) => {
       const operationTime = now();
+      const dueAt = optionalBlankToUndefined(v.dueAt);
       await repo.commitLifecycleMutation({
         records: {
           lifecycleEvents: [
@@ -1132,7 +1133,8 @@ function bindDetail(app) {
               source: "manual",
               provenance: "explicit",
               actionStatus: v.actionStatus,
-              dueAt: isoDate(v.dueAt),
+              dueAt,
+              dueAtPrecision: dueAt ? "date" : undefined,
               details: optionalBlankToUndefined(v.details),
               createdAt: operationTime,
             },

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -5,6 +5,7 @@ import path from "node:path";
 
 import { expect, test } from "@playwright/test";
 
+import { parseCsv } from "../../src/web/import-export/spreadsheet.js";
 import { startWebServer } from "../../src/web/server.js";
 
 const csvFixture = [
@@ -984,6 +985,68 @@ test.describe("browser application tracker", () => {
     await expect((await download).suggestedFilename()).toBe(
       "jobbot3000-backup.json",
     );
+  });
+
+  test("preserves assessment due-date precision in lifecycle CSV export", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await importFixture(page, "fake-applications.csv", csvFixture);
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Example Labs" }).click();
+
+    let assessmentForm = page.locator("[data-assessment-form]");
+    await assessmentForm
+      .locator('[name="actionStatus"]')
+      .selectOption("started");
+    await assessmentForm.locator('[name="dueAt"]').fill("2026-08-31");
+    await assessmentForm
+      .locator('[name="details"]')
+      .fill("Fictional take-home with a date-only deadline");
+    await assessmentForm
+      .getByRole("button", { name: "Log assessment" })
+      .click();
+
+    assessmentForm = page.locator("[data-assessment-form]");
+    await assessmentForm
+      .locator('[name="actionStatus"]')
+      .selectOption("pending");
+    await assessmentForm
+      .locator('[name="details"]')
+      .fill("Fictional take-home without a deadline");
+    await assessmentForm
+      .getByRole("button", { name: "Log assessment" })
+      .click();
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Export lifecycle CSV" }).click();
+    const download = await downloadPromise;
+    const rows = parseCsv(await readFile(await download.path(), "utf8"));
+    const datedAssessment = rows.find(
+      (row) => row.details === "Fictional take-home with a date-only deadline",
+    );
+    const undatedAssessment = rows.find(
+      (row) => row.details === "Fictional take-home without a deadline",
+    );
+
+    expect(datedAssessment).toMatchObject({
+      event_type: "assessment_take_home",
+      due_at: "2026-08-31",
+      due_at_precision: "date",
+      occurred_at_precision: "instant",
+      inferred: "false",
+    });
+    expect(datedAssessment.due_at).not.toBe("2026-08-31T00:00:00.000Z");
+    expect(undatedAssessment).toMatchObject({
+      event_type: "assessment_take_home",
+      due_at: "",
+      due_at_precision: "",
+      occurred_at_precision: "instant",
+      inferred: "false",
+    });
   });
 
   test("retains IndexedDB data across reload, exports backup, and clears local data", async ({


### PR DESCRIPTION
### Motivation
- A browser `<input type="date">` value was being converted with `isoDate()` which turns `YYYY-MM-DD` into a midnight ISO instant and drops precision, breaking the lifecycle CSV contract that date-only deadlines must remain date-only with `due_at_precision=date`.

### Description
- In `src/web/tracker/tracker.js` the assessment form handler now uses `optionalBlankToUndefined(v.dueAt)` and stores the raw `YYYY-MM-DD` string when present, and sets `dueAtPrecision: "date"` only when a value exists. No other assessment metadata was changed.
- Added a Playwright E2E regression in `test/playwright/browser-tracker.spec.js` named `preserves assessment due-date precision in lifecycle CSV export` which exercises the real UI, logs a dated and an undated assessment, downloads the lifecycle CSV, parses it with the repository `parseCsv()` helper, and asserts the exported cells and precisions.
- Change surface is intentionally minimal and limited to the assessment handler and the new regression test; `isoDate()` and other forms/import/export schemas were not modified.

### Testing
- Ran formatting and lint/type checks: `npx prettier --check src/web/tracker/tracker.js test/playwright/browser-tracker.spec.js` (fixed file with `prettier --write`), `npm run lint -- --quiet`, and `npm run typecheck` — all succeeded.
- Ran focused Vitest suites: `npx vitest run test/web-spreadsheet-import-export.test.js test/web-tracker-lifecycle-persistence.test.js` — 55 tests passed.
- Ran the new Playwright regression: `npx playwright test test/playwright/browser-tracker.spec.js --grep "preserves assessment due-date precision"` — test passed.
- Ran full CI locally: `npm run test:ci` — the suite completed; note a transient Playwright static-smoke SVG visibility check timed out during the first run but passed on an immediate isolated retry and the full `test:ci` run completed successfully.

Files changed
- `src/web/tracker/tracker.js` — use `optionalBlankToUndefined` for `dueAt` and set `dueAtPrecision` when present.
- `test/playwright/browser-tracker.spec.js` — add Playwright regression that verifies date-only persistence and blank-deadline behavior.

Root cause
- Passing the browser's `YYYY-MM-DD` date string through `isoDate()` converted it to an instant timestamp (`YYYY-MM-DDT00:00:00.000Z`) and omitted a `dueAtPrecision`, causing exports to lose the `date` precision semantic.

Verification commands and results (high level)
- `npx prettier --check ...` — passed after formatting changes.
- `npm run lint -- --quiet` — passed.
- `npm run typecheck` — passed.
- `npx vitest run ...` — passed (focused suites).
- `npx playwright test ... --grep "preserves assessment due-date precision"` — passed.
- `npm run test:ci` — passed (full test run with an unrelated transient Playwright flake retried and resolved).

No schema, import behavior, `isoDate()` helper, or unrelated UI changes were made.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b7210f9fc832fb87ccc71df7ebe3c)