### PR TITLE
Preserve assessment due-date precision in tracker (store YYYY-MM-DD and export CSV)

### DIFF
--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -1118,6 +1118,7 @@ function bindDetail(app) {
     const form = e.target;
     await submitWithRecovery(form, async (v) => {
       const operationTime = now();
+      const dueAt = optionalBlankToUndefined(v.dueAt);
       await repo.commitLifecycleMutation({
         records: {
           lifecycleEvents: [
@@ -1132,7 +1133,8 @@ function bindDetail(app) {
               source: "manual",
               provenance: "explicit",
               actionStatus: v.actionStatus,
-              dueAt: isoDate(v.dueAt),
+              dueAt,
+              dueAtPrecision: dueAt ? "date" : undefined,
               details: optionalBlankToUndefined(v.details),
               createdAt: operationTime,
             },

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -6,6 +6,7 @@ import path from "node:path";
 import { expect, test } from "@playwright/test";
 
 import { startWebServer } from "../../src/web/server.js";
+import { parseCsv } from "../../src/web/import-export/spreadsheet.js";
 
 const csvFixture = [
   "application_id,company,role_title,status,applied_at,posting_url," +
@@ -984,6 +985,68 @@ test.describe("browser application tracker", () => {
     await expect((await download).suggestedFilename()).toBe(
       "jobbot3000-backup.json",
     );
+  });
+
+  test("preserves assessment due-date precision in lifecycle CSV export", async ({
+    page,
+  }) => {
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await importFixture(page, "fake-applications.csv", csvFixture);
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Example Labs" }).click();
+
+    const assessmentForm = page.locator("[data-assessment-form]");
+    await assessmentForm
+      .locator('[name="actionStatus"]')
+      .selectOption("started");
+    await assessmentForm.locator('[name="dueAt"]').fill("2026-08-31");
+    await assessmentForm
+      .locator('[name="details"]')
+      .fill("Distinctive fake take-home deadline");
+    await assessmentForm
+      .getByRole("button", { name: "Log assessment" })
+      .click();
+
+    const blankAssessmentForm = page.locator("[data-assessment-form]");
+    await blankAssessmentForm
+      .locator('[name="actionStatus"]')
+      .selectOption("pending");
+    await blankAssessmentForm
+      .locator('[name="details"]')
+      .fill("Distinctive fake take-home without deadline");
+    await blankAssessmentForm
+      .getByRole("button", { name: "Log assessment" })
+      .click();
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    const downloadPromise = page.waitForEvent("download");
+    await page.getByRole("button", { name: "Export lifecycle CSV" }).click();
+    const download = await downloadPromise;
+    const rows = parseCsv(await readFile(await download.path(), "utf8"));
+    const datedRow = rows.find(
+      (row) => row.details === "Distinctive fake take-home deadline",
+    );
+    const blankRow = rows.find(
+      (row) => row.details === "Distinctive fake take-home without deadline",
+    );
+
+    expect(datedRow).toMatchObject({
+      event_type: "assessment_take_home",
+      due_at: "2026-08-31",
+      due_at_precision: "date",
+      occurred_at_precision: "instant",
+      inferred: "false",
+    });
+    expect(datedRow.due_at).not.toBe("2026-08-31T00:00:00.000Z");
+    expect(blankRow).toMatchObject({
+      event_type: "assessment_take_home",
+      due_at: "",
+      due_at_precision: "",
+      occurred_at_precision: "instant",
+      inferred: "false",
+    });
   });
 
   test("retains IndexedDB data across reload, exports backup, and clears local data", async ({


### PR DESCRIPTION
### Motivation

- A browser `<input type="date">` value was being passed through `isoDate()`, which turned user-entered `YYYY-MM-DD` into a midnight UTC timestamp and dropped the `dueAtPrecision`, violating the lifecycle CSV contract that date-only deadlines must remain date-only with `due_at_precision=date`.
- The change is a minimal follow-up to ensure assessment/take-home deadlines entered via the form are stored and exported exactly as the user supplied them.

### Description

- In the assessment submit handler use the existing `optionalBlankToUndefined()` to convert only a blank `dueAt` to `undefined`, persist a nonblank `dueAt` as the original `YYYY-MM-DD` string, and set `dueAtPrecision: "date"` when present, while leaving all other event fields and semantics unchanged; this modifies `src/web/tracker/tracker.js`.
- Add an end-to-end Playwright regression test `preserves assessment due-date precision in lifecycle CSV export` that logs an assessment with `dueAt = 2026-08-31` and a second assessment without a deadline, then exports and parses the lifecycle CSV to assert the exact date, `due_at_precision=date`, `occurred_at_precision=instant`, `inferred=false`, and that no midnight timestamp appears; this adds `test/playwright/browser-tracker.spec.js` assertions and imports `parseCsv()`.
- The shared `isoDate()` helper and interview/application forms are intentionally not changed and their behavior remains the same per the follow-up scope.

### Testing

- Code style and static checks: `npx prettier --check src/web/tracker/tracker.js test/playwright/browser-tracker.spec.js`, `npm run lint -- --quiet`, and `npm run typecheck` all succeeded.
- Focused unit/test suites: `npx vitest run test/web-spreadsheet-import-export.test.js test/web-tracker-lifecycle-persistence.test.js` succeeded (55 tests passed).
- Playwright regression: `npx playwright test test/playwright/browser-tracker.spec.js --grep "preserves assessment due-date precision"` passed (the new test passed).
- Full CI run: `npm run test:ci` completed with Vitest suites passing (1,332 tests passed) and Playwright mostly passing (42/43 Playwright tests passed) with one unrelated pre-existing `static-smoke` lifecycle-diagram smoke test timing out; the failure is unrelated to the assessment change and reproduced locally when running that smoke spec in isolation.

Files changed: `src/web/tracker/tracker.js`, `test/playwright/browser-tracker.spec.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b721432b8832f8c14170a517da673)