### PR TITLE
Preserve raw compact stages; deterministic stage selection; don't count invite-only recruiter screens

### DIFF
--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1213,7 +1213,9 @@ export const rowsToBrowserApplicationExport = (
     });
     Object.assign(bundle, upgraded.data);
     warnings.push(...upgraded.warnings);
-    const canonicalRows = browserApplicationExportToCanonicalRows(bundle);
+    const canonicalRows = browserApplicationExportToCanonicalRows(bundle, {
+      preserveLegacyMetadata: false,
+    });
     bundle.applications = bundle.applications.map((application, index) => {
       const rawRow = { ...blankRow(), ...(rows[index] ?? {}) };
       const canonicalRow = canonicalRows.find(
@@ -1271,7 +1273,67 @@ const compareIsoDateTimes = (left, right) => {
 const firstBy = (records, predicate) =>
   [...records].sort((a, b) => compareCodePoints(a.id, b.id)).find(predicate) ??
   {};
-export const browserApplicationExportToCanonicalRows = (bundle) => {
+const usableStageTimestamp = (...values) =>
+  values.find(
+    (value) =>
+      value &&
+      !["1970-01-01", "1970-01-01T00:00:00.000Z"].includes(value) &&
+      Number.isFinite(new Date(value).getTime()),
+  );
+const lifecycleStageTimestamp = (event) => {
+  const classification = classifyLifecycleEventType(
+    event.rawEventType || event.eventType,
+  );
+  if (classification.interviewOutcome === "completed")
+    return usableStageTimestamp(
+      event.occurredAt,
+      event.startsAt,
+      event.dueAt,
+      event.createdAt,
+    );
+  if (classification.interviewOutcome === "scheduled")
+    return usableStageTimestamp(
+      event.dueAt,
+      event.startsAt,
+      event.occurredAt,
+      event.createdAt,
+    );
+  return usableStageTimestamp(
+    event.occurredAt,
+    event.dueAt,
+    event.startsAt,
+    event.createdAt,
+  );
+};
+const latestStageRecord = (interviews, events, applicationId) =>
+  [
+    ...interviews
+      .filter((record) => record.applicationId === applicationId)
+      .map((record) => ({
+        id: record.id,
+        stage: record.stage,
+        timestamp: usableStageTimestamp(record.startsAt, record.createdAt),
+      })),
+    ...events
+      .filter(
+        (event) =>
+          event.applicationId === applicationId &&
+          INTERVIEW_STAGES.has(event.status),
+      )
+      .map((event) => ({
+        id: event.id,
+        stage: event.status,
+        timestamp: lifecycleStageTimestamp(event),
+      })),
+  ].sort(
+    (a, b) =>
+      compareIsoDateTimes(b.timestamp, a.timestamp) ||
+      compareCodePoints(b.id, a.id),
+  )[0] ?? {};
+export const browserApplicationExportToCanonicalRows = (
+  bundle,
+  { preserveLegacyMetadata = true } = {},
+) => {
   const parsed = upgradeBrowserExportToV2(bundle).data;
   return [...parsed.applications]
     .sort((a, b) => a.id.localeCompare(b.id))
@@ -1294,16 +1356,10 @@ export const browserApplicationExportToCanonicalRows = (bundle) => {
               compareIsoDateTimes(b.createdAt, a.createdAt) ||
               compareCodePoints(b.id, a.id),
           )[0] ?? {};
-      const interview =
-        firstBy(
-          parsed.interviews,
-          (record) => record.applicationId === application.id,
-        ) ?? {};
-      const interviewStageEvent = firstBy(
+      const stageRecord = latestStageRecord(
+        parsed.interviews,
         parsed.lifecycleEvents,
-        (event) =>
-          event.applicationId === application.id &&
-          INTERVIEW_STAGES.has(event.status),
+        application.id,
       );
       const outcomeEvent = firstBy(
         parsed.lifecycleEvents,
@@ -1349,7 +1405,7 @@ export const browserApplicationExportToCanonicalRows = (bundle) => {
         artifacts,
         ({ name }) => name === "LinkedIn snapshot PDF",
       );
-      const currentStage = interview.stage ?? interviewStageEvent.status ?? "";
+      const currentStage = stageRecord.stage ?? "";
       const currentOutcome =
         outcomeEvent.status ??
         (offer.status === "received" ? "offer" : offer.status) ??
@@ -1370,10 +1426,18 @@ export const browserApplicationExportToCanonicalRows = (bundle) => {
         outreach_sent_at: dateTime(outreach.sentAt),
         outreach_message_text: outreach.body ?? "",
         status:
-          preservedStatus(metadata, application.status) ?? application.status,
+          metadata.spreadsheet_metadata_version === 2 || !preserveLegacyMetadata
+            ? application.status
+            : (preservedStatus(metadata, application.status) ??
+              application.status),
         interview_stage:
-          preservedInterviewStage(metadata, currentStage) ?? currentStage,
-        outcome: preservedOutcome(metadata, currentOutcome) ?? currentOutcome,
+          metadata.spreadsheet_metadata_version === 2 || !preserveLegacyMetadata
+            ? currentStage
+            : (preservedInterviewStage(metadata, currentStage) ?? currentStage),
+        outcome:
+          metadata.spreadsheet_metadata_version === 2 || !preserveLegacyMetadata
+            ? currentOutcome
+            : (preservedOutcome(metadata, currentOutcome) ?? currentOutcome),
       });
       return row;
     });
@@ -1895,6 +1959,45 @@ export const importSupplementalLifecycleCsv = async (csvText, repository) => {
       ...incoming,
     ];
   }
+  const priorRows = new Map(
+    browserApplicationExportToCanonicalRows(existing).map((row) => [
+      row.application_id,
+      row,
+    ]),
+  );
+  const projectedRows = new Map(
+    browserApplicationExportToCanonicalRows(merged).map((row) => [
+      row.application_id,
+      row,
+    ]),
+  );
+  const projectedColumns = ["status", "interview_stage", "outcome"];
+  merged.applications = merged.applications.map((application) => {
+    const { notes, metadata } = readMetadataFromNotes(application.notes);
+    if (
+      metadata.spreadsheet_metadata_version !== 2 ||
+      !metadata.raw_row ||
+      !metadata.canonical_row
+    )
+      return application;
+    const prior = priorRows.get(application.id);
+    const projected = projectedRows.get(application.id);
+    if (!prior || !projected) return application;
+    const canonicalRow = { ...metadata.canonical_row };
+    for (const column of projectedColumns)
+      if (
+        String(prior[column] ?? "") ===
+        String(metadata.canonical_row[column] ?? "")
+      )
+        canonicalRow[column] = String(projected[column] ?? "");
+    return {
+      ...application,
+      notes: appendMetadataToNotes(notes, {
+        ...metadata,
+        canonical_row: canonicalRow,
+      }),
+    };
+  });
   return {
     imported: true,
     preview,

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1,6 +1,9 @@
 import { browserApplicationExportSchema } from "../../domain/browserApplication.js";
 import { upgradeBrowserExportToV2 } from "../storage/browserDataMigration.js";
-import { classifyLifecycleEventType } from "../tracker/lifecycleClassification.js";
+import {
+  classifyLifecycleEventType,
+  LIFECYCLE_EVENT_CATEGORIES,
+} from "../tracker/lifecycleClassification.js";
 
 export const LIFECYCLE_CSV_COLUMNS = [
   "event_id",
@@ -469,6 +472,14 @@ export const createSpreadsheetMetadataEnvelope = (
     ]),
   ),
 });
+const isV2SpreadsheetMetadataEnvelope = (metadata) =>
+  metadata?.spreadsheet_metadata_version === 2 &&
+  metadata.raw_row !== null &&
+  typeof metadata.raw_row === "object" &&
+  !Array.isArray(metadata.raw_row) &&
+  metadata.canonical_row !== null &&
+  typeof metadata.canonical_row === "object" &&
+  !Array.isArray(metadata.canonical_row);
 const appendMetadataToNotes = (notes, metadata) => {
   const entries = Object.keys(metadata).sort();
   if (entries.length === 0) return compact(notes) || undefined;
@@ -499,12 +510,7 @@ const readMetadataFromNotes = (notes) => {
   }
 };
 export const applyPreservedCompactCells = (canonicalRow, metadata) => {
-  if (
-    metadata?.spreadsheet_metadata_version !== 2 ||
-    !metadata.raw_row ||
-    !metadata.canonical_row
-  )
-    return canonicalRow;
+  if (!isV2SpreadsheetMetadataEnvelope(metadata)) return canonicalRow;
   return Object.fromEntries(
     COMPACT_CSV_COLUMNS.map((column) => [
       column,
@@ -1279,9 +1285,12 @@ const usableStageTimestamp = (...values) =>
     return Number.isFinite(timestamp) && timestamp !== 0;
   });
 const lifecycleStageTimestamp = (event) => {
-  const classification = classifyLifecycleEventType(
-    event.rawEventType || event.eventType,
-  );
+  const rawClassification = classifyLifecycleEventType(event.rawEventType);
+  const classification =
+    event.rawEventType &&
+    rawClassification.category !== LIFECYCLE_EVENT_CATEGORIES.UNKNOWN_METADATA
+      ? rawClassification
+      : classifyLifecycleEventType(event.eventType);
   if (classification.interviewOutcome === "completed")
     return usableStageTimestamp(
       event.occurredAt,
@@ -1303,31 +1312,50 @@ const lifecycleStageTimestamp = (event) => {
     event.createdAt,
   );
 };
-const latestStageRecord = (interviews, events, applicationId) =>
-  [
-    ...interviews
-      .filter((record) => record.applicationId === applicationId)
-      .map((record) => ({
-        id: record.id,
-        stage: record.stage,
-        timestamp: usableStageTimestamp(record.startsAt, record.createdAt),
-      })),
-    ...events
-      .filter(
-        (event) =>
-          event.applicationId === applicationId &&
-          INTERVIEW_STAGES.has(event.status),
-      )
-      .map((event) => ({
-        id: event.id,
-        stage: event.status,
-        timestamp: lifecycleStageTimestamp(event),
-      })),
-  ].sort(
-    (a, b) =>
-      compareIsoDateTimes(b.timestamp, a.timestamp) ||
-      compareCodePoints(b.id, a.id),
-  )[0] ?? {};
+const latestStageRecord = (interviews, events, applicationId) => {
+  const applicationEvents = events.filter(
+    (event) => event.applicationId === applicationId,
+  );
+  const supersededEventIds = new Set(
+    applicationEvents
+      .map((event) => event.supersedesEventId)
+      .filter(Boolean)
+      .map(String),
+  );
+  const supersededInterviewIds = new Set(
+    [...supersededEventIds].map((eventId) => stableId("interview", eventId)),
+  );
+  return (
+    [
+      ...interviews
+        .filter(
+          (record) =>
+            record.applicationId === applicationId &&
+            !supersededInterviewIds.has(record.id),
+        )
+        .map((record) => ({
+          id: record.id,
+          stage: record.stage,
+          timestamp: usableStageTimestamp(record.startsAt, record.createdAt),
+        })),
+      ...applicationEvents
+        .filter(
+          (event) =>
+            !supersededEventIds.has(event.id) &&
+            INTERVIEW_STAGES.has(event.status),
+        )
+        .map((event) => ({
+          id: event.id,
+          stage: event.status,
+          timestamp: lifecycleStageTimestamp(event),
+        })),
+    ].sort(
+      (a, b) =>
+        compareIsoDateTimes(b.timestamp, a.timestamp) ||
+        compareCodePoints(b.id, a.id),
+    )[0] ?? {}
+  );
+};
 export const browserApplicationExportToCanonicalRows = (
   bundle,
   { preserveLegacyMetadata = true } = {},
@@ -1424,16 +1452,16 @@ export const browserApplicationExportToCanonicalRows = (
         outreach_sent_at: dateTime(outreach.sentAt),
         outreach_message_text: outreach.body ?? "",
         status:
-          metadata.spreadsheet_metadata_version === 2 || !preserveLegacyMetadata
+          isV2SpreadsheetMetadataEnvelope(metadata) || !preserveLegacyMetadata
             ? application.status
             : (preservedStatus(metadata, application.status) ??
               application.status),
         interview_stage:
-          metadata.spreadsheet_metadata_version === 2 || !preserveLegacyMetadata
+          isV2SpreadsheetMetadataEnvelope(metadata) || !preserveLegacyMetadata
             ? currentStage
             : (preservedInterviewStage(metadata, currentStage) ?? currentStage),
         outcome:
-          metadata.spreadsheet_metadata_version === 2 || !preserveLegacyMetadata
+          isV2SpreadsheetMetadataEnvelope(metadata) || !preserveLegacyMetadata
             ? currentOutcome
             : (preservedOutcome(metadata, currentOutcome) ?? currentOutcome),
       });
@@ -1972,12 +2000,7 @@ export const importSupplementalLifecycleCsv = async (csvText, repository) => {
   const projectedColumns = ["status", "interview_stage", "outcome"];
   merged.applications = merged.applications.map((application) => {
     const { notes, metadata } = readMetadataFromNotes(application.notes);
-    if (
-      metadata.spreadsheet_metadata_version !== 2 ||
-      !metadata.raw_row ||
-      !metadata.canonical_row
-    )
-      return application;
+    if (!isV2SpreadsheetMetadataEnvelope(metadata)) return application;
     const prior = priorRows.get(application.id);
     const projected = projectedRows.get(application.id);
     if (!prior || !projected) return application;

--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1274,12 +1274,10 @@ const firstBy = (records, predicate) =>
   [...records].sort((a, b) => compareCodePoints(a.id, b.id)).find(predicate) ??
   {};
 const usableStageTimestamp = (...values) =>
-  values.find(
-    (value) =>
-      value &&
-      !["1970-01-01", "1970-01-01T00:00:00.000Z"].includes(value) &&
-      Number.isFinite(new Date(value).getTime()),
-  );
+  values.find((value) => {
+    const timestamp = value ? new Date(value).getTime() : Number.NaN;
+    return Number.isFinite(timestamp) && timestamp !== 0;
+  });
 const lifecycleStageTimestamp = (event) => {
   const classification = classifyLifecycleEventType(
     event.rawEventType || event.eventType,

--- a/src/web/tracker/lifecycleClassification.js
+++ b/src/web/tracker/lifecycleClassification.js
@@ -35,6 +35,7 @@ const EVENT_REGISTRY = Object.freeze({
     status: "recruiter_screen",
     interviewStage: "recruiter_screen",
     countsAsResponse: true,
+    countsAsRecruiterScreen: true,
   },
   assessment_take_home: {
     category: LIFECYCLE_EVENT_CATEGORIES.ASSESSMENT,
@@ -58,6 +59,7 @@ const EVENT_REGISTRY = Object.freeze({
     interviewStage: "recruiter_screen",
     interviewOutcome: "scheduled",
     countsAsResponse: true,
+    countsAsRecruiterScreen: true,
   },
   recruiter_screen_completed: {
     category: LIFECYCLE_EVENT_CATEGORIES.RECRUITER_SCREEN,
@@ -65,6 +67,7 @@ const EVENT_REGISTRY = Object.freeze({
     interviewStage: "recruiter_screen",
     interviewOutcome: "completed",
     countsAsResponse: true,
+    countsAsRecruiterScreen: true,
   },
   devops_interview_scheduled: {
     category: LIFECYCLE_EVENT_CATEGORIES.NON_RECRUITER_INTERVIEW,
@@ -219,11 +222,38 @@ const EVENT_REGISTRY = Object.freeze({
   },
 });
 
-export const classifyLifecycleEventType = (eventType) => ({
-  category: LIFECYCLE_EVENT_CATEGORIES.UNKNOWN_METADATA,
-  ...EVENT_REGISTRY[normalize(eventType)],
-  eventType: normalize(eventType),
-});
+export const classifyLifecycleEventType = (eventType) => {
+  const normalized = normalize(eventType);
+  const invitation = /^recruiter_screen_(invite|invited|invitation)(_|$)/.test(
+    normalized,
+  );
+  return {
+    category: invitation
+      ? LIFECYCLE_EVENT_CATEGORIES.RECRUITER_SCREEN
+      : LIFECYCLE_EVENT_CATEGORIES.UNKNOWN_METADATA,
+    ...(invitation
+      ? {
+          status: "recruiter_screen",
+          interviewStage: "recruiter_screen",
+          countsAsResponse: true,
+        }
+      : EVENT_REGISTRY[normalized]),
+    eventType: normalized,
+  };
+};
+
+export const isActualRecruiterScreen = (record = {}) => {
+  const typedEvent =
+    normalize(record.rawEventType) || normalize(record.eventType);
+  if (typedEvent)
+    return Boolean(
+      classifyLifecycleEventType(typedEvent).countsAsRecruiterScreen,
+    );
+  return (
+    normalize(record.stage) === "recruiter_screen" ||
+    normalize(record.status) === "recruiter_screen"
+  );
+};
 
 export const isLifecycleRecruiterScreen = (eventType) =>
   classifyLifecycleEventType(eventType).category ===

--- a/src/web/tracker/lifecycleClassification.js
+++ b/src/web/tracker/lifecycleClassification.js
@@ -234,8 +234,8 @@ export const classifyLifecycleEventType = (eventType) => {
     ...(invitation
       ? {
           status: "recruiter_screen",
-          interviewStage: "recruiter_screen",
           countsAsResponse: true,
+          countsAsRecruiterScreen: false,
         }
       : EVENT_REGISTRY[normalized]),
     eventType: normalized,
@@ -243,12 +243,13 @@ export const classifyLifecycleEventType = (eventType) => {
 };
 
 export const isActualRecruiterScreen = (record = {}) => {
-  const typedEvent =
-    normalize(record.rawEventType) || normalize(record.eventType);
-  if (typedEvent)
-    return Boolean(
-      classifyLifecycleEventType(typedEvent).countsAsRecruiterScreen,
-    );
+  const typedEvents = [record.rawEventType, record.eventType]
+    .map(normalize)
+    .filter(Boolean);
+  for (const typedEvent of typedEvents) {
+    const { countsAsRecruiterScreen } = classifyLifecycleEventType(typedEvent);
+    if (countsAsRecruiterScreen !== undefined) return countsAsRecruiterScreen;
+  }
   return (
     normalize(record.stage) === "recruiter_screen" ||
     normalize(record.status) === "recruiter_screen"

--- a/src/web/tracker/lifecycleClassification.js
+++ b/src/web/tracker/lifecycleClassification.js
@@ -243,12 +243,11 @@ export const classifyLifecycleEventType = (eventType) => {
 };
 
 export const isActualRecruiterScreen = (record = {}) => {
-  const typedEvents = [record.rawEventType, record.eventType]
-    .map(normalize)
-    .filter(Boolean);
-  for (const typedEvent of typedEvents) {
-    const { countsAsRecruiterScreen } = classifyLifecycleEventType(typedEvent);
-    if (countsAsRecruiterScreen !== undefined) return countsAsRecruiterScreen;
+  for (const typedEvent of [record.rawEventType, record.eventType]) {
+    if (!normalize(typedEvent)) continue;
+    const classification = classifyLifecycleEventType(typedEvent);
+    if (classification.category !== LIFECYCLE_EVENT_CATEGORIES.UNKNOWN_METADATA)
+      return classification.countsAsRecruiterScreen === true;
   }
   return (
     normalize(record.stage) === "recruiter_screen" ||

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -1,8 +1,8 @@
 import {
   classifyLifecycleEventType,
+  isActualRecruiterScreen,
   isLifecycleAssessment,
   isLifecycleNonRecruiterInterview,
-  isLifecycleRecruiterScreen,
 } from "./lifecycleClassification.js";
 const TERMINAL_EMPLOYER_STATUSES = new Set([
   "offer",
@@ -363,11 +363,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
       if (event.applicationId)
         assessmentApplicationIds.add(event.applicationId);
     }
-    if (
-      isLifecycleRecruiterScreen(classificationType) ||
-      isLifecycleRecruiterScreen(eventType) ||
-      status === "recruiter_screen"
-    )
+    if (isActualRecruiterScreen(event))
       recruiterScreenKeys.add(
         recruiterScreenKey(event, explicitRecruiterScreenKeys),
       );
@@ -407,7 +403,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
 
   for (const interview of interviews) {
     addResponse(responseApplicationIds, interview.applicationId);
-    if (interview.stage === "recruiter_screen")
+    if (isActualRecruiterScreen(interview))
       recruiterScreenKeys.add(recruiterScreenKey(interview));
   }
   for (const interview of interviews) {

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -14,9 +14,9 @@ import {
 } from "../import-export/spreadsheet.js";
 import {
   classifyLifecycleEventType,
+  isActualRecruiterScreen,
   isLifecycleAssessment,
   isLifecycleNonRecruiterInterview,
-  isLifecycleRecruiterScreen,
 } from "./lifecycleClassification.js";
 import {
   readSpreadsheetMetadata,
@@ -218,10 +218,7 @@ const isAssessmentEvent = (record = {}) =>
     .some(
       (value) => value.includes("assessment") || value.includes("take_home"),
     );
-const isRecruiterScreen = (record = {}) =>
-  normalize(record.stage) === "recruiter_screen" ||
-  normalize(record.status) === "recruiter_screen" ||
-  isLifecycleRecruiterScreen(record.eventType);
+const isRecruiterScreen = (record = {}) => isActualRecruiterScreen(record);
 const isNonRecruiterInterview = (record = {}) =>
   (record.stage && normalize(record.stage) !== "recruiter_screen") ||
   isLifecycleNonRecruiterInterview(record.eventType);

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -136,7 +136,50 @@ describe("spreadsheet import/export", () => {
       "DevOps interview",
     );
 
-    bundle.interviews.push({
+    const firstCompactRows = new Map(
+      parseCsv(exportCompactCsv(bundle)).map((row) => [
+        row.application_id,
+        row,
+      ]),
+    );
+    const restoredRepo = await createIndexedDbRepository({
+      indexedDb: indexedDB,
+    });
+    await importCompactCsv(exportCompactCsv(bundle), restoredRepo, {
+      mode: "replace",
+    });
+    await importSupplementalLifecycleCsv(
+      exportLifecycleCsv(bundle),
+      restoredRepo,
+    );
+    const restoredBundle = await restoredRepo.exportAllData();
+    const restoredCanonical = new Map(
+      browserApplicationExportToCanonicalRows(restoredBundle).map((row) => [
+        row.application_id,
+        row,
+      ]),
+    );
+    expect(restoredCanonical.get("app_stage_alpha").interview_stage).toBe(
+      "recruiter_screen",
+    );
+    expect(restoredCanonical.get("app_stage_beta").interview_stage).toBe(
+      "technical_screen",
+    );
+    const restoredCompactRows = new Map(
+      parseCsv(exportCompactCsv(restoredBundle)).map((row) => [
+        row.application_id,
+        row,
+      ]),
+    );
+    expect(restoredCompactRows).toEqual(firstCompactRows);
+    expect(restoredCompactRows.get("app_stage_alpha").interview_stage).toBe(
+      "Technical screen",
+    );
+    expect(restoredCompactRows.get("app_stage_beta").interview_stage).toBe(
+      "DevOps interview",
+    );
+
+    restoredBundle.interviews.push({
       id: "aa_later_manual",
       applicationId: "app_stage_alpha",
       contactIds: [],
@@ -147,7 +190,7 @@ describe("spreadsheet import/export", () => {
       updatedAt: "2027-04-10T12:00:00.000Z",
     });
     const edited = new Map(
-      browserApplicationExportToRows(bundle).map((row) => [
+      browserApplicationExportToRows(restoredBundle).map((row) => [
         row.application_id,
         row,
       ]),
@@ -160,7 +203,7 @@ describe("spreadsheet import/export", () => {
     expect(edited.get("app_stage_beta").interview_stage).toBe(
       "DevOps interview",
     );
-    repo.close();
+    expect(edited.get("app_stage_beta").notes).toBe("Untouched beta note");
   });
   it("runs a fake full-fidelity backup/restore smoke flow", async () => {
     const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
@@ -194,7 +237,7 @@ describe("spreadsheet import/export", () => {
       direction: "outbound",
       channel: "email",
       body: "Fake outreach body",
-      sentAt: "2027-04-02T12:00:00.000Z",
+      sentAt: "2026-04-02T12:00:00.000Z",
       createdAt: manual.createdAt,
       updatedAt: manual.updatedAt,
     });
@@ -708,6 +751,39 @@ describe("spreadsheet import/export", () => {
         }),
       ]),
     );
+  });
+
+  it("uses legacy flat metadata when a version-two envelope is invalid", () => {
+    const { bundle, errors } = csvToBrowserApplicationExport(
+      serializeCsv([
+        {
+          application_id: "app_invalid_v2_metadata",
+          company: "Invalid Envelope Example",
+          role_title: "Engineer",
+          status: "Interviewing",
+          interview_stage: "DevOps interview",
+          outcome: "Awaiting feedback",
+        },
+      ]),
+      { exportedAt: "2026-03-10T00:00:00.000Z" },
+    );
+    expect(errors).toEqual([]);
+    const application = bundle.applications[0];
+    const metadata = JSON.parse(
+      application.notes.slice("Spreadsheet metadata: ".length),
+    );
+    metadata.raw_row = [];
+    delete metadata.canonical_row;
+    application.notes = `Spreadsheet metadata: ${JSON.stringify(metadata)}`;
+
+    const [row] = browserApplicationExportToCanonicalRows(bundle);
+
+    expect(row).toMatchObject({
+      status: "Interviewing",
+      interview_stage: "DevOps interview",
+      outcome: "Awaiting feedback",
+    });
+    expect(browserApplicationExportToRows(bundle)[0]).toMatchObject(row);
   });
 
   it("preserves ambiguous compact status labels without inventing interviews", async () => {
@@ -2508,12 +2584,15 @@ describe("spreadsheet import/export", () => {
   it("falls back from second-precision epoch stage timestamps", () => {
     const [row] = parseCsv(
       exportCompactCsv({
+        schemaVersion: 2,
+        exportedAt: "2026-03-01T00:00:00.000Z",
         applications: [
           {
             id: "app_epoch_stage",
             company: "Epoch Example",
             role: "Engineer",
-            status: "interviewing",
+            origin: "other_unknown",
+            status: "technical_screen",
             createdAt: "2026-01-01T00:00:00.000Z",
             updatedAt: "2026-03-01T00:00:00.000Z",
           },
@@ -2522,22 +2601,192 @@ describe("spreadsheet import/export", () => {
           {
             id: "event_technical",
             applicationId: "app_epoch_stage",
+            status: "technical_screen",
             eventType: "technical_interview_completed",
             occurredAt: "2026-02-01T00:00:00.000Z",
+            occurredAtPrecision: "instant",
+            inferred: false,
+            source: "manual",
             createdAt: "2026-02-01T00:00:00.000Z",
           },
           {
             id: "event_onsite",
             applicationId: "app_epoch_stage",
+            status: "onsite_loop",
             eventType: "onsite_interview_completed",
             occurredAt: "1970-01-01T00:00:00Z",
+            occurredAtPrecision: "instant",
+            inferred: false,
+            source: "manual",
             createdAt: "2026-03-01T00:00:00.000Z",
           },
         ],
+        contacts: [],
+        outreachMessages: [],
+        interviews: [],
+        offers: [],
+        artifacts: [],
+        reminders: [],
       }),
     );
 
     expect(row.interview_stage).toBe("onsite_loop");
+  });
+
+  it("excludes superseded stages and only their generated interviews", () => {
+    const baseEvent = {
+      applicationId: "app_superseded_stage",
+      occurredAtPrecision: "instant",
+      inferred: false,
+      source: "manual",
+    };
+    const bundle = {
+      schemaVersion: 2,
+      exportedAt: "2026-05-01T00:00:00.000Z",
+      applications: [
+        {
+          id: "app_superseded_stage",
+          company: "Supersession Example",
+          role: "Engineer",
+          origin: "other_unknown",
+          status: "technical_screen",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          updatedAt: "2026-05-01T00:00:00.000Z",
+        },
+      ],
+      lifecycleEvents: [
+        {
+          ...baseEvent,
+          id: "event_obsolete",
+          status: "onsite_loop",
+          eventType: "onsite_interview_completed",
+          occurredAt: "2026-04-20T12:00:00.000Z",
+          createdAt: "2026-04-20T12:00:00.000Z",
+        },
+        {
+          ...baseEvent,
+          id: "event_replacement",
+          status: "recruiter_screen",
+          eventType: "recruiter_screen_completed",
+          supersedesEventId: "event_obsolete",
+          occurredAt: "2026-03-01T12:00:00.000Z",
+          createdAt: "2026-04-21T12:00:00.000Z",
+        },
+      ],
+      interviews: [
+        {
+          id: "interview_event_obsolete",
+          applicationId: "app_superseded_stage",
+          contactIds: [],
+          stage: "onsite_loop",
+          startsAt: "2026-04-20T12:00:00.000Z",
+          outcome: "completed",
+          createdAt: "2026-04-20T12:00:00.000Z",
+          updatedAt: "2026-04-20T12:00:00.000Z",
+        },
+        {
+          id: "manual_interview_kept",
+          applicationId: "app_superseded_stage",
+          contactIds: [],
+          stage: "technical_screen",
+          startsAt: "2026-02-01T12:00:00.000Z",
+          outcome: "completed",
+          createdAt: "2026-02-01T12:00:00.000Z",
+          updatedAt: "2026-02-01T12:00:00.000Z",
+        },
+      ],
+      contacts: [],
+      outreachMessages: [],
+      offers: [],
+      artifacts: [],
+      reminders: [],
+    };
+
+    expect(parseCsv(exportCompactCsv(bundle))[0].interview_stage).toBe(
+      "recruiter_screen",
+    );
+  });
+
+  it("falls back from unknown raw stage types to canonical timestamp semantics", () => {
+    const application = (id) => ({
+      id,
+      company: "Timestamp Semantics Example",
+      role: "Engineer",
+      origin: "other_unknown",
+      status: "technical_screen",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-05-01T00:00:00.000Z",
+    });
+    const event = (values) => ({
+      occurredAtPrecision: "instant",
+      inferred: false,
+      source: "manual",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      ...values,
+    });
+    const bundle = {
+      schemaVersion: 2,
+      exportedAt: "2026-05-01T00:00:00.000Z",
+      applications: [
+        application("app_unknown_completed"),
+        application("app_unknown_scheduled"),
+      ],
+      lifecycleEvents: [
+        event({
+          id: "scheduled_unknown_raw",
+          applicationId: "app_unknown_scheduled",
+          status: "onsite_loop",
+          eventType: "onsite_interview_scheduled",
+          rawEventType: "legacy_future_conversation",
+          occurredAt: "2026-04-20T00:00:00.000Z",
+          dueAt: "2026-02-01T00:00:00.000Z",
+          dueAtPrecision: "instant",
+        }),
+        event({
+          id: "scheduled_comparison",
+          applicationId: "app_unknown_scheduled",
+          status: "technical_screen",
+          eventType: "technical_interview_completed",
+          occurredAt: "2026-03-01T00:00:00.000Z",
+        }),
+        event({
+          id: "completed_unknown_raw",
+          applicationId: "app_unknown_completed",
+          status: "onsite_loop",
+          eventType: "onsite_interview_completed",
+          rawEventType: "legacy_finished_conversation",
+          occurredAt: "2026-04-01T00:00:00.000Z",
+          dueAt: "2026-02-01T00:00:00.000Z",
+          dueAtPrecision: "instant",
+        }),
+        event({
+          id: "completed_comparison",
+          applicationId: "app_unknown_completed",
+          status: "technical_screen",
+          eventType: "technical_interview_completed",
+          occurredAt: "2026-03-01T00:00:00.000Z",
+        }),
+      ],
+      contacts: [],
+      outreachMessages: [],
+      interviews: [],
+      offers: [],
+      artifacts: [],
+      reminders: [],
+    };
+    const rows = new Map(
+      parseCsv(exportCompactCsv(bundle)).map((row) => [
+        row.application_id,
+        row,
+      ]),
+    );
+
+    expect(rows.get("app_unknown_scheduled").interview_stage).toBe(
+      "technical_screen",
+    );
+    expect(rows.get("app_unknown_completed").interview_stage).toBe(
+      "onsite_loop",
+    );
   });
 
   it("reports compensation range errors without undercounting rows", async () => {

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -11,6 +11,8 @@ import {
   COMPACT_CSV_COLUMNS,
   LIFECYCLE_CSV_COLUMNS,
   csvToBrowserApplicationExport,
+  browserApplicationExportToCanonicalRows,
+  browserApplicationExportToRows,
   detectSpreadsheetImportFormat,
   exportCompactCsv,
   exportJsonBackup,
@@ -70,6 +72,96 @@ afterEach(async () => {
 const fixture = () => readFile("test/fixtures/fake-applications.csv", "utf8");
 
 describe("spreadsheet import/export", () => {
+  it("preserves raw stages across supplemental projections until a manual edit", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const compactCsv = serializeCsv([
+      {
+        application_id: "app_stage_alpha",
+        company: "Example Stage Alpha",
+        role_title: "Engineer",
+        status: "Interviewing",
+        posting_url: "https://jobs.example.test/stage-alpha",
+        interview_stage: "Technical screen",
+        notes: "Untouched alpha note",
+      },
+      {
+        application_id: "app_stage_beta",
+        company: "Example Stage Beta",
+        role_title: "Engineer",
+        status: "Interviewing",
+        posting_url: "https://jobs.example.test/stage-beta",
+        interview_stage: "DevOps interview",
+        notes: "Untouched beta note",
+      },
+    ]);
+    await importCompactCsv(compactCsv, repo, { mode: "replace" });
+    const lifecycleCsv = [
+      "event_id,application_id,event_type,occurred_at,due_at",
+      [
+        "zz_older_alpha,app_stage_alpha,recruiter_screen_scheduled",
+        "2027-04-01T12:00:00.000Z,2027-04-02T12:00:00.000Z",
+      ].join(","),
+      [
+        "zz_older_beta,app_stage_beta,technical_interview_scheduled",
+        "2027-04-01T12:00:00.000Z,2027-04-03T12:00:00.000Z",
+      ].join(","),
+    ].join("\n");
+    await importSupplementalLifecycleCsv(lifecycleCsv, repo);
+    const bundle = await repo.exportAllData();
+    bundle.interviews.reverse();
+    bundle.lifecycleEvents.reverse();
+
+    const canonical = new Map(
+      browserApplicationExportToCanonicalRows(bundle).map((row) => [
+        row.application_id,
+        row,
+      ]),
+    );
+    expect(canonical.get("app_stage_alpha").interview_stage).toBe(
+      "recruiter_screen",
+    );
+    expect(canonical.get("app_stage_beta").interview_stage).toBe(
+      "technical_screen",
+    );
+    const preserved = new Map(
+      browserApplicationExportToRows(bundle).map((row) => [
+        row.application_id,
+        row,
+      ]),
+    );
+    expect(preserved.get("app_stage_alpha").interview_stage).toBe(
+      "Technical screen",
+    );
+    expect(preserved.get("app_stage_beta").interview_stage).toBe(
+      "DevOps interview",
+    );
+
+    bundle.interviews.push({
+      id: "aa_later_manual",
+      applicationId: "app_stage_alpha",
+      contactIds: [],
+      stage: "onsite_loop",
+      startsAt: "2027-04-10T12:00:00.000Z",
+      outcome: "scheduled",
+      createdAt: "2027-04-10T12:00:00.000Z",
+      updatedAt: "2027-04-10T12:00:00.000Z",
+    });
+    const edited = new Map(
+      browserApplicationExportToRows(bundle).map((row) => [
+        row.application_id,
+        row,
+      ]),
+    );
+    expect(edited.get("app_stage_alpha")).toMatchObject({
+      company: "Example Stage Alpha",
+      interview_stage: "onsite_loop",
+      notes: "Untouched alpha note",
+    });
+    expect(edited.get("app_stage_beta").interview_stage).toBe(
+      "DevOps interview",
+    );
+    repo.close();
+  });
   it("runs a fake full-fidelity backup/restore smoke flow", async () => {
     const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
     const csv = await fixture();
@@ -102,7 +194,7 @@ describe("spreadsheet import/export", () => {
       direction: "outbound",
       channel: "email",
       body: "Fake outreach body",
-      sentAt: "2026-04-02T12:00:00.000Z",
+      sentAt: "2027-04-02T12:00:00.000Z",
       createdAt: manual.createdAt,
       updatedAt: manual.updatedAt,
     });

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -1603,6 +1603,35 @@ describe("spreadsheet import/export", () => {
     expect(bundle.lifecycleEvents).toHaveLength(1);
   });
 
+  it("does not materialize recruiter-screen invitations with due dates", () => {
+    const { errors, bundle } = lifecycleRowsToBrowserApplicationExport(
+      [
+        {
+          application_id: "app_invited_screen",
+          event_type: "recruiter_screen_invitation_received",
+          occurred_at: "2026-03-02T10:00:00.000Z",
+          due_at: "2026-03-05T10:00:00.000Z",
+        },
+      ],
+      {
+        applications: [
+          {
+            id: "app_invited_screen",
+            company: "Example Systems",
+            role: "Engineer",
+            status: "applied",
+            createdAt: "2026-03-01T00:00:00.000Z",
+            updatedAt: "2026-03-01T00:00:00.000Z",
+          },
+        ],
+      },
+    );
+
+    expect(errors).toEqual([]);
+    expect(bundle.lifecycleEvents).toHaveLength(1);
+    expect(bundle.interviews).toEqual([]);
+  });
+
   it("preserves valid ISO offset datetimes without milliseconds", () => {
     const { bundle, errors } = csvToBrowserApplicationExport(
       serializeCsv([
@@ -2474,6 +2503,41 @@ describe("spreadsheet import/export", () => {
       interview_stage: "onsite_loop",
       outcome: "offer",
     });
+  });
+
+  it("falls back from second-precision epoch stage timestamps", () => {
+    const [row] = parseCsv(
+      exportCompactCsv({
+        applications: [
+          {
+            id: "app_epoch_stage",
+            company: "Epoch Example",
+            role: "Engineer",
+            status: "interviewing",
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-03-01T00:00:00.000Z",
+          },
+        ],
+        lifecycleEvents: [
+          {
+            id: "event_technical",
+            applicationId: "app_epoch_stage",
+            eventType: "technical_interview_completed",
+            occurredAt: "2026-02-01T00:00:00.000Z",
+            createdAt: "2026-02-01T00:00:00.000Z",
+          },
+          {
+            id: "event_onsite",
+            applicationId: "app_epoch_stage",
+            eventType: "onsite_interview_completed",
+            occurredAt: "1970-01-01T00:00:00Z",
+            createdAt: "2026-03-01T00:00:00.000Z",
+          },
+        ],
+      }),
+    );
+
+    expect(row.interview_stage).toBe("onsite_loop");
   });
 
   it("reports compensation range errors without undercounting rows", async () => {

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -42,6 +42,113 @@ const importLifecycle = (csv, existing) =>
   }).bundle;
 
 describe("tracker dashboard metrics", () => {
+  it("excludes recruiter-screen invitations while deduping actual screens", () => {
+    const applications = ["a", "b", "c", "d"].map((id) => ({
+      id: `app_${id}`,
+      company: `Example ${id.toUpperCase()}`,
+      role: "Engineer",
+      status: "recruiter_screen",
+      createdAt: exportedAt,
+      updatedAt: exportedAt,
+    }));
+    const event = (id, applicationId, rawEventType, occurredAt, dueAt) => ({
+      id,
+      applicationId,
+      eventType: "recruiter_screen",
+      rawEventType,
+      status: "recruiter_screen",
+      occurredAt,
+      dueAt,
+      createdAt: exportedAt,
+    });
+    const lifecycleEvents = [
+      event(
+        "invite_a",
+        "app_a",
+        "recruiter_screen_invitation_received",
+        exportedAt,
+      ),
+      event("invite_b", "app_b", "recruiter_screen_invited", exportedAt),
+      event(
+        "scheduled_b",
+        "app_b",
+        "recruiter_screen_scheduled",
+        exportedAt,
+        "2026-04-01T15:00:00.000Z",
+      ),
+      event(
+        "completed_b",
+        "app_b",
+        "recruiter_screen_completed",
+        "2026-04-01T15:00:00.000Z",
+      ),
+      event("invite_c", "app_c", "recruiter_screen_invite", exportedAt),
+      event(
+        "scheduled_c",
+        "app_c",
+        "recruiter_screen_scheduled",
+        exportedAt,
+        "2026-04-02T15:00:00.000Z",
+      ),
+      event(
+        "completed_c",
+        "app_c",
+        "recruiter_screen_completed",
+        "2026-04-02T15:00:00.000Z",
+      ),
+      event(
+        "completed_d",
+        "app_d",
+        "recruiter_screen_completed",
+        "2026-04-03T15:00:00.000Z",
+      ),
+    ];
+    const interviews = lifecycleEvents
+      .filter(({ rawEventType }) => rawEventType.endsWith("completed"))
+      .map((item) => ({
+        id: `interview_${item.id}`,
+        applicationId: item.applicationId,
+        stage: "recruiter_screen",
+        startsAt: item.occurredAt,
+        outcome: "completed",
+      }));
+    const bundle = { applications, lifecycleEvents, interviews };
+    expect(selectDashboardMetrics(bundle)).toMatchObject({
+      recruiterScreens: 3,
+      applicationsWithResponse: 4,
+    });
+    expect(
+      uniqueRecruiterScreens({ lifecycle: lifecycleEvents, interviews }),
+    ).toHaveLength(3);
+    expect(
+      uniqueRecruiterScreens({
+        lifecycle: lifecycleEvents.filter(
+          ({ applicationId }) => applicationId === "app_a",
+        ),
+        interviews: [],
+      }),
+    ).toHaveLength(0);
+    expect(
+      selectDashboardMetrics({
+        ...bundle,
+        lifecycleEvents: [...lifecycleEvents].reverse(),
+        interviews: [...interviews].reverse(),
+      }).recruiterScreens,
+    ).toBe(3);
+
+    const secondScreen = event(
+      "completed_b_second",
+      "app_b",
+      "recruiter_screen_completed",
+      "2026-04-08T15:00:00.000Z",
+    );
+    expect(
+      selectDashboardMetrics({
+        ...bundle,
+        lifecycleEvents: [...lifecycleEvents, secondScreen],
+      }).recruiterScreens,
+    ).toBe(4);
+  });
   it("classifies scheduled lifecycle interview events centrally", () => {
     expect(
       classifyLifecycleEventType("devops_interview_scheduled"),

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   csvToBrowserApplicationExport,
+  exportLifecycleCsv,
   exportJsonBackup,
   exportNdjsonBackup,
   importJsonBackup,
@@ -67,6 +68,28 @@ describe("tracker dashboard metrics", () => {
         status: "recruiter_screen",
       }),
     ).toBe(false);
+    expect(
+      isActualRecruiterScreen({
+        rawEventType: "technical_interview_scheduled",
+        eventType: "recruiter_screen",
+      }),
+    ).toBe(false);
+    expect(
+      isActualRecruiterScreen({
+        rawEventType: "onsite_interview_completed",
+        eventType: "recruiter_screen",
+      }),
+    ).toBe(false);
+    expect(
+      isActualRecruiterScreen({
+        rawEventType: "recruiter_screen_scheduled",
+      }),
+    ).toBe(true);
+    expect(
+      isActualRecruiterScreen({
+        rawEventType: "recruiter_screen_completed",
+      }),
+    ).toBe(true);
   });
 
   it("excludes recruiter-screen invitations while deduping actual screens", () => {
@@ -139,7 +162,33 @@ describe("tracker dashboard metrics", () => {
         startsAt: item.occurredAt,
         outcome: "completed",
       }));
-    const bundle = { applications, lifecycleEvents, interviews };
+    const bundle = {
+      schemaVersion: 2,
+      exportedAt,
+      applications: applications.map((application) => ({
+        ...application,
+        origin: "other_unknown",
+      })),
+      lifecycleEvents: lifecycleEvents.map((item) => ({
+        ...item,
+        source: "csv_import",
+        provenance: "explicit",
+        occurredAtPrecision: "instant",
+        dueAtPrecision: item.dueAt ? "instant" : undefined,
+        inferred: false,
+      })),
+      interviews: interviews.map((interview) => ({
+        ...interview,
+        contactIds: [],
+        createdAt: exportedAt,
+        updatedAt: exportedAt,
+      })),
+      contacts: [],
+      outreachMessages: [],
+      offers: [],
+      artifacts: [],
+      reminders: [],
+    };
     expect(selectDashboardMetrics(bundle)).toMatchObject({
       recruiterScreens: 3,
       applicationsWithResponse: 4,
@@ -162,6 +211,39 @@ describe("tracker dashboard metrics", () => {
         interviews: [...interviews].reverse(),
       }).recruiterScreens,
     ).toBe(3);
+
+    const lifecycleCsv = exportLifecycleCsv(bundle);
+    const exportedInvitation = parseCsv(lifecycleCsv).find(
+      ({ event_id }) => event_id === "invite_a",
+    );
+    expect(exportedInvitation.raw_event_type).toBe(
+      "recruiter_screen_invitation_received",
+    );
+
+    const roundTripped = importLifecycle(lifecycleCsv, { applications });
+    expect(selectDashboardMetrics(roundTripped).recruiterScreens).toBe(3);
+    expect(
+      uniqueRecruiterScreens({
+        lifecycle: roundTripped.lifecycleEvents,
+        interviews: roundTripped.interviews,
+      }),
+    ).toHaveLength(3);
+    const invitationOnly = {
+      ...roundTripped,
+      applications: roundTripped.applications.filter(
+        ({ id }) => id === "app_a",
+      ),
+      lifecycleEvents: roundTripped.lifecycleEvents.filter(
+        ({ applicationId }) => applicationId === "app_a",
+      ),
+      interviews: roundTripped.interviews.filter(
+        ({ applicationId }) => applicationId === "app_a",
+      ),
+    };
+    expect(selectDashboardMetrics(invitationOnly)).toMatchObject({
+      recruiterScreens: 0,
+      applicationsWithResponse: 1,
+    });
 
     const secondScreen = event(
       "completed_b_second",

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -14,6 +14,7 @@ import {
 import {
   LIFECYCLE_EVENT_CATEGORIES,
   classifyLifecycleEventType,
+  isActualRecruiterScreen,
 } from "../src/web/tracker/lifecycleClassification.js";
 import {
   boundedPercentage,
@@ -42,6 +43,32 @@ const importLifecycle = (csv, existing) =>
   }).bundle;
 
 describe("tracker dashboard metrics", () => {
+  it("distinguishes invitations from canonicalized legacy recruiter screens", () => {
+    expect(
+      classifyLifecycleEventType("recruiter_screen_invitation_received"),
+    ).toMatchObject({
+      countsAsRecruiterScreen: false,
+      countsAsResponse: true,
+    });
+    expect(
+      classifyLifecycleEventType("recruiter_screen_invitation_received"),
+    ).not.toHaveProperty("interviewStage");
+    expect(
+      isActualRecruiterScreen({
+        rawEventType: "legacy_vendor_screen",
+        eventType: "recruiter_screen",
+        status: "recruiter_screen",
+      }),
+    ).toBe(true);
+    expect(
+      isActualRecruiterScreen({
+        rawEventType: "recruiter_screen_invited",
+        eventType: "recruiter_screen",
+        status: "recruiter_screen",
+      }),
+    ).toBe(false);
+  });
+
   it("excludes recruiter-screen invitations while deduping actual screens", () => {
     const applications = ["a", "b", "c", "d"].map((id) => ({
       id: `app_${id}`,


### PR DESCRIPTION
## Motivation

Real-data acceptance testing after #1212 and #1215 exposed two regressions:

- Supplemental lifecycle imports could replace preserved compact `interview_stage` text.
- Recruiter-screen invitation transitions could be counted as actual scheduled/completed screens.

## Summary

- Preserve untouched compact cells by rebasing `canonical_row` per column only when the prior live value still matches its stored baseline. `raw_row` remains immutable, while genuine later browser edits still override preserved text.
- Treat metadata as a version-2 preservation envelope only when `raw_row` and `canonical_row` are non-null, non-array objects. Invalid envelopes retain legacy flat-metadata compatibility.
- Keep canonical compact-row generation separate from the final raw-cell overlay.
- Select the latest effective stage chronologically:
  - completed records use occurrence time;
  - scheduled records use due/start time;
  - creation time is the fallback;
  - epoch-zero placeholders are rejected;
  - superseded events and their generated interviews are excluded;
  - recognized raw types remain authoritative, while unknown raw aliases fall back to canonical event semantics;
  - code-point ID ordering is only the final tie-breaker.
- Centralize actual recruiter-screen classification across dashboard metrics and detail helpers. Invitation aliases remain employer responses and lifecycle signals but do not count as screens.
- Preserve `rawEventType` authority, legacy untyped status fallback, scheduled/completed deduplication, and distinct-screen counting.

## Regression coverage

- Compact rows containing `Technical screen` and `DevOps interview` retain those exact values through compact export/import, lifecycle export/import, shuffled stores, and another compact export.
- Canonical rows remain normalized while the final overlay restores unchanged raw labels.
- A later manual interview supersedes the imported raw label without changing untouched cells.
- Invalid version-2 envelopes fall back to legacy flat metadata.
- Superseded stage events and their generated interviews cannot override their replacements.
- Unknown raw stage aliases use canonical scheduled/completed timestamp semantics.
- Recruiter-screen invitation aliases survive lifecycle CSV export/import through `raw_event_type`.
- The production-shaped sanitized recruiter-screen history reports exactly three screens, while invitation-only applications report zero screens and still count as responses.

## Files changed

- `src/web/import-export/spreadsheet.js`
- `src/web/tracker/lifecycleClassification.js`
- `src/web/tracker/metrics.js`
- `src/web/tracker/tracker.js`
- `test/web-spreadsheet-import-export.test.js`
- `test/web-tracker-metrics.test.js`

## Verification

Verified on head `1264463ee029b3d960c0a979ab4b03b4be9e738d`:

- `npx prettier --check src/web/import-export/spreadsheet.js test/web-spreadsheet-import-export.test.js`
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npx vitest run test/web-spreadsheet-import-export.test.js` — 54 tests passed
- `npx vitest run test/web-spreadsheet-import-export.test.js test/web-tracker-metrics.test.js test/web-storage-browser-data-migration.test.js test/web-tracker-lifecycle-projection.test.js` — 135 tests passed
- [CI #5145](https://github.com/futuroptimist/jobbot3000/actions/runs/31547689251) — passed, including the full test suite and secret scan
- [GHCR #548](https://github.com/futuroptimist/jobbot3000/actions/runs/31547689254) — passed, including tests, image build, and smoke test; publication was skipped as expected for a pull request
- [Diagram visual review #271](https://github.com/futuroptimist/jobbot3000/actions/runs/31547689253) — passed

One local `npm run test:ci` attempt completed 1,339 tests before an unrelated lifecycle-diagram test exceeded its 30-second local timeout. The complete latest-head GitHub CI and GHCR test steps subsequently passed.

## Compatibility

- Legacy flat spreadsheet metadata remains supported.
- JSON/NDJSON backup behavior and the two-CSV import/export contract remain unchanged.
- No schema migration, dependency, configuration, or generated-artifact changes are required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b966c3fc8832f957269180b0ad359)