### PR TITLE
Fix lifecycle stage preservation and recruiter-screen counting regressions

### DIFF
--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -515,6 +515,10 @@ export const applyPreservedCompactCells = (canonicalRow, metadata) => {
     ]),
   );
 };
+const hasVersionTwoMetadataEnvelope = (metadata) =>
+  metadata?.spreadsheet_metadata_version === 2 &&
+  metadata.raw_row &&
+  metadata.canonical_row;
 const mapStatus = (row) => {
   const status = normalizeLabelKey(row.status);
   if (KNOWN_STATUSES.has(status) && status !== "applied") return status;
@@ -1213,7 +1217,9 @@ export const rowsToBrowserApplicationExport = (
     });
     Object.assign(bundle, upgraded.data);
     warnings.push(...upgraded.warnings);
-    const canonicalRows = browserApplicationExportToCanonicalRows(bundle);
+    const canonicalRows = browserApplicationExportToCanonicalRows(bundle, {
+      preserveLegacyMetadata: false,
+    });
     bundle.applications = bundle.applications.map((application, index) => {
       const rawRow = { ...blankRow(), ...(rows[index] ?? {}) };
       const canonicalRow = canonicalRows.find(
@@ -1271,7 +1277,55 @@ const compareIsoDateTimes = (left, right) => {
 const firstBy = (records, predicate) =>
   [...records].sort((a, b) => compareCodePoints(a.id, b.id)).find(predicate) ??
   {};
-export const browserApplicationExportToCanonicalRows = (bundle) => {
+const stageTimestamp = (record, classification = {}) => {
+  const placeholder = (value) =>
+    value === "1970-01-01" || String(value ?? "").startsWith("1970-01-01T");
+  const preferred =
+    classification.interviewOutcome === "completed"
+      ? (record.occurredAt ?? record.startsAt ?? record.dueAt)
+      : classification.interviewOutcome === "scheduled"
+        ? (record.startsAt ?? record.dueAt)
+        : (record.startsAt ?? record.occurredAt ?? record.dueAt);
+  return !preferred || placeholder(preferred)
+    ? (record.createdAt ?? "")
+    : preferred;
+};
+const latestInterviewState = (parsed, applicationId) =>
+  [
+    ...parsed.interviews
+      .filter((record) => record.applicationId === applicationId)
+      .map((record) => ({
+        id: record.id,
+        stage: record.stage,
+        outcome: record.outcome,
+        timestamp: stageTimestamp(record, { interviewOutcome: record.outcome }),
+      })),
+    ...parsed.lifecycleEvents
+      .filter(
+        (event) =>
+          event.applicationId === applicationId &&
+          INTERVIEW_STAGES.has(event.status),
+      )
+      .map((event) => ({
+        id: event.id,
+        stage: event.status,
+        outcome: classifyLifecycleEventType(
+          event.rawEventType || event.eventType,
+        ).interviewOutcome,
+        timestamp: stageTimestamp(
+          event,
+          classifyLifecycleEventType(event.rawEventType || event.eventType),
+        ),
+      })),
+  ].sort(
+    (a, b) =>
+      compareIsoDateTimes(b.timestamp, a.timestamp) ||
+      compareCodePoints(b.id, a.id),
+  )[0] ?? {};
+export const browserApplicationExportToCanonicalRows = (
+  bundle,
+  { preserveLegacyMetadata = true } = {},
+) => {
   const parsed = upgradeBrowserExportToV2(bundle).data;
   return [...parsed.applications]
     .sort((a, b) => a.id.localeCompare(b.id))
@@ -1294,17 +1348,6 @@ export const browserApplicationExportToCanonicalRows = (bundle) => {
               compareIsoDateTimes(b.createdAt, a.createdAt) ||
               compareCodePoints(b.id, a.id),
           )[0] ?? {};
-      const interview =
-        firstBy(
-          parsed.interviews,
-          (record) => record.applicationId === application.id,
-        ) ?? {};
-      const interviewStageEvent = firstBy(
-        parsed.lifecycleEvents,
-        (event) =>
-          event.applicationId === application.id &&
-          INTERVIEW_STAGES.has(event.status),
-      );
       const outcomeEvent = firstBy(
         parsed.lifecycleEvents,
         (event) =>
@@ -1349,11 +1392,15 @@ export const browserApplicationExportToCanonicalRows = (bundle) => {
         artifacts,
         ({ name }) => name === "LinkedIn snapshot PDF",
       );
-      const currentStage = interview.stage ?? interviewStageEvent.status ?? "";
+      const currentInterview = latestInterviewState(parsed, application.id);
+      const currentStage = currentInterview.stage ?? "";
       const currentOutcome =
         outcomeEvent.status ??
         (offer.status === "received" ? "offer" : offer.status) ??
+        currentInterview.outcome ??
         "";
+      const preserveFlatMetadata =
+        preserveLegacyMetadata && !hasVersionTwoMetadataEnvelope(metadata);
       Object.assign(row, {
         resume_artifact: resume.name ?? "",
         resume_url: resume.url ?? "",
@@ -1369,11 +1416,16 @@ export const browserApplicationExportToCanonicalRows = (bundle) => {
         outreach_channel: outreach.channel ?? metadata.outreach_channel ?? "",
         outreach_sent_at: dateTime(outreach.sentAt),
         outreach_message_text: outreach.body ?? "",
-        status:
-          preservedStatus(metadata, application.status) ?? application.status,
-        interview_stage:
-          preservedInterviewStage(metadata, currentStage) ?? currentStage,
-        outcome: preservedOutcome(metadata, currentOutcome) ?? currentOutcome,
+        status: preserveFlatMetadata
+          ? (preservedStatus(metadata, application.status) ??
+            application.status)
+          : application.status,
+        interview_stage: preserveFlatMetadata
+          ? (preservedInterviewStage(metadata, currentStage) ?? currentStage)
+          : currentStage,
+        outcome: preserveFlatMetadata
+          ? (preservedOutcome(metadata, currentOutcome) ?? currentOutcome)
+          : currentOutcome,
       });
       return row;
     });
@@ -1885,6 +1937,12 @@ export const importSupplementalLifecycleCsv = async (csvText, repository) => {
   if (preview.errors.length > 0 || preview.conflicts.length > 0)
     return { imported: false, preview };
   const existing = await repository.exportAllData();
+  const beforeRows = new Map(
+    browserApplicationExportToCanonicalRows(existing).map((row) => [
+      row.application_id,
+      row,
+    ]),
+  );
   const merged = { ...existing, exportedAt: nowIso() };
   for (const store of ["lifecycleEvents", "interviews", "reminders"]) {
     const incoming = preview.bundle[store] ?? [];
@@ -1895,6 +1953,34 @@ export const importSupplementalLifecycleCsv = async (csvText, repository) => {
       ...incoming,
     ];
   }
+  const afterRows = new Map(
+    browserApplicationExportToCanonicalRows(merged).map((row) => [
+      row.application_id,
+      row,
+    ]),
+  );
+  const projectedColumns = ["status", "interview_stage", "outcome"];
+  merged.applications = merged.applications.map((application) => {
+    const { notes, metadata } = readMetadataFromNotes(application.notes);
+    if (!hasVersionTwoMetadataEnvelope(metadata)) return application;
+    const before = beforeRows.get(application.id);
+    const after = afterRows.get(application.id);
+    const canonicalRow = { ...metadata.canonical_row };
+    for (const column of projectedColumns) {
+      if (
+        String(before?.[column] ?? "") ===
+        String(metadata.canonical_row[column] ?? "")
+      )
+        canonicalRow[column] = String(after?.[column] ?? "");
+    }
+    return {
+      ...application,
+      notes: appendMetadataToNotes(notes, {
+        ...metadata,
+        canonical_row: canonicalRow,
+      }),
+    };
+  });
   return {
     imported: true,
     preview,

--- a/src/web/tracker/lifecycleClassification.js
+++ b/src/web/tracker/lifecycleClassification.js
@@ -221,9 +221,41 @@ const EVENT_REGISTRY = Object.freeze({
 
 export const classifyLifecycleEventType = (eventType) => ({
   category: LIFECYCLE_EVENT_CATEGORIES.UNKNOWN_METADATA,
+  ...(normalize(eventType).startsWith("recruiter_screen_invite") ||
+  normalize(eventType).startsWith("recruiter_screen_invitation")
+    ? {
+        category: LIFECYCLE_EVENT_CATEGORIES.RECRUITER_SCREEN,
+        status: "recruiter_screen",
+        interviewStage: "recruiter_screen",
+        countsAsResponse: true,
+      }
+    : {}),
   ...EVENT_REGISTRY[normalize(eventType)],
   eventType: normalize(eventType),
 });
+
+const isRecruiterScreenInvitation = (eventType) => {
+  const normalized = normalize(eventType);
+  return (
+    normalized.startsWith("recruiter_screen_invite") ||
+    normalized.startsWith("recruiter_screen_invitation")
+  );
+};
+
+/** Whether a record represents an actual scheduled/completed recruiter screen. */
+export const isActualRecruiterScreen = (record = {}) => {
+  const rawEventType = normalize(record.rawEventType);
+  const eventType = normalize(record.eventType);
+  const authoritativeType = rawEventType || eventType;
+  if (authoritativeType) {
+    if (isRecruiterScreenInvitation(authoritativeType)) return false;
+    return isLifecycleRecruiterScreen(authoritativeType);
+  }
+  return (
+    normalize(record.stage) === "recruiter_screen" ||
+    normalize(record.status) === "recruiter_screen"
+  );
+};
 
 export const isLifecycleRecruiterScreen = (eventType) =>
   classifyLifecycleEventType(eventType).category ===

--- a/src/web/tracker/metrics.js
+++ b/src/web/tracker/metrics.js
@@ -1,8 +1,8 @@
 import {
   classifyLifecycleEventType,
+  isActualRecruiterScreen,
   isLifecycleAssessment,
   isLifecycleNonRecruiterInterview,
-  isLifecycleRecruiterScreen,
 } from "./lifecycleClassification.js";
 const TERMINAL_EMPLOYER_STATUSES = new Set([
   "offer",
@@ -363,11 +363,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
       if (event.applicationId)
         assessmentApplicationIds.add(event.applicationId);
     }
-    if (
-      isLifecycleRecruiterScreen(classificationType) ||
-      isLifecycleRecruiterScreen(eventType) ||
-      status === "recruiter_screen"
-    )
+    if (isActualRecruiterScreen(event))
       recruiterScreenKeys.add(
         recruiterScreenKey(event, explicitRecruiterScreenKeys),
       );
@@ -407,7 +403,7 @@ export const selectDashboardMetrics = (bundle = {}) => {
 
   for (const interview of interviews) {
     addResponse(responseApplicationIds, interview.applicationId);
-    if (interview.stage === "recruiter_screen")
+    if (isActualRecruiterScreen(interview))
       recruiterScreenKeys.add(recruiterScreenKey(interview));
   }
   for (const interview of interviews) {

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -14,9 +14,9 @@ import {
 } from "../import-export/spreadsheet.js";
 import {
   classifyLifecycleEventType,
+  isActualRecruiterScreen,
   isLifecycleAssessment,
   isLifecycleNonRecruiterInterview,
-  isLifecycleRecruiterScreen,
 } from "./lifecycleClassification.js";
 import {
   readSpreadsheetMetadata,
@@ -218,10 +218,7 @@ const isAssessmentEvent = (record = {}) =>
     .some(
       (value) => value.includes("assessment") || value.includes("take_home"),
     );
-const isRecruiterScreen = (record = {}) =>
-  normalize(record.stage) === "recruiter_screen" ||
-  normalize(record.status) === "recruiter_screen" ||
-  isLifecycleRecruiterScreen(record.eventType);
+const isRecruiterScreen = (record = {}) => isActualRecruiterScreen(record);
 const isNonRecruiterInterview = (record = {}) =>
   (record.stage && normalize(record.stage) !== "recruiter_screen") ||
   isLifecycleNonRecruiterInterview(record.eventType);

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -10,6 +10,8 @@ import {
 import {
   COMPACT_CSV_COLUMNS,
   LIFECYCLE_CSV_COLUMNS,
+  applyPreservedCompactCells,
+  browserApplicationExportToCanonicalRows,
   csvToBrowserApplicationExport,
   detectSpreadsheetImportFormat,
   exportCompactCsv,
@@ -1073,6 +1075,108 @@ describe("spreadsheet import/export", () => {
         }),
       ]),
     );
+    repo.close();
+  });
+
+  it("preserves compact stages across supplemental projections until a manual edit", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    const compactRows = [
+      {
+        application_id: "app_stage_alpha",
+        company: "Stage Alpha",
+        role_title: "Platform Engineer",
+        posting_url: "https://example.test/jobs/stage-alpha",
+        interview_stage: "Technical screen",
+        applied_at: "2026-01-01",
+        schema_version: "1",
+      },
+      {
+        application_id: "app_stage_beta",
+        company: "Stage Beta",
+        role_title: "Infrastructure Engineer",
+        posting_url: "https://example.test/jobs/stage-beta",
+        interview_stage: "DevOps interview",
+        applied_at: "2026-01-02",
+        schema_version: "1",
+      },
+    ];
+    await importCompactCsv(serializeCsv(compactRows), repo, {
+      mode: "replace",
+    });
+    const lifecycleCsv = serializeCsv(
+      [
+        {
+          event_id: "zz_old_alpha",
+          application_id: "app_stage_alpha",
+          event_type: "recruiter_screen_scheduled",
+          occurred_at: "2026-02-01T10:00:00.000Z",
+          due_at: "2026-02-03T10:00:00.000Z",
+        },
+        {
+          event_id: "aa_new_beta",
+          application_id: "app_stage_beta",
+          event_type: "technical_interview_scheduled",
+          occurred_at: "2026-02-02T10:00:00.000Z",
+          due_at: "2026-02-04T10:00:00.000Z",
+        },
+      ],
+      LIFECYCLE_CSV_COLUMNS,
+    );
+    await importSupplementalLifecycleCsv(lifecycleCsv, repo);
+
+    const shuffled = await repo.exportAllData();
+    shuffled.interviews.reverse();
+    shuffled.lifecycleEvents.reverse();
+    const canonicalById = new Map(
+      browserApplicationExportToCanonicalRows(shuffled).map((row) => [
+        row.application_id,
+        row,
+      ]),
+    );
+    expect(canonicalById.get("app_stage_alpha").interview_stage).toBe(
+      "recruiter_screen",
+    );
+    expect(canonicalById.get("app_stage_beta").interview_stage).toBe(
+      "technical_screen",
+    );
+    const exportedById = new Map(
+      parseCsv(exportCompactCsv(shuffled)).map((row) => [
+        row.application_id,
+        row,
+      ]),
+    );
+    expect(exportedById.get("app_stage_alpha").interview_stage).toBe(
+      "Technical screen",
+    );
+    expect(exportedById.get("app_stage_beta").interview_stage).toBe(
+      "DevOps interview",
+    );
+
+    shuffled.interviews.push({
+      id: "00_manual_later",
+      applicationId: "app_stage_alpha",
+      contactIds: [],
+      stage: "onsite_loop",
+      startsAt: "2026-03-01T10:00:00.000Z",
+      outcome: "scheduled",
+      createdAt: "2026-03-01T09:00:00.000Z",
+      updatedAt: "2026-03-01T09:00:00.000Z",
+    });
+    const editedCanonical = browserApplicationExportToCanonicalRows(
+      shuffled,
+    ).find(({ application_id: id }) => id === "app_stage_alpha");
+    const alphaMetadata = JSON.parse(
+      shuffled.applications
+        .find(({ id }) => id === "app_stage_alpha")
+        .notes.split("Spreadsheet metadata: ")[1],
+    );
+    expect(
+      applyPreservedCompactCells(editedCanonical, alphaMetadata),
+    ).toMatchObject({
+      company: "Stage Alpha",
+      posting_url: "https://example.test/jobs/stage-alpha",
+      interview_stage: "onsite_loop",
+    });
     repo.close();
   });
 

--- a/test/web-tracker-metrics.test.js
+++ b/test/web-tracker-metrics.test.js
@@ -42,6 +42,131 @@ const importLifecycle = (csv, existing) =>
   }).bundle;
 
 describe("tracker dashboard metrics", () => {
+  it("excludes recruiter-screen invitations while deduplicating actual screens", () => {
+    const applications = ["a", "b", "c", "d"].map((suffix) => ({
+      id: `app_screen_${suffix}`,
+      company: `Screen ${suffix.toUpperCase()}`,
+      role: "Engineer",
+      status: "recruiter_screen",
+      createdAt: exportedAt,
+      updatedAt: exportedAt,
+    }));
+    const event = (id, applicationId, rawEventType, time) => ({
+      id,
+      applicationId,
+      eventType: "recruiter_screen",
+      rawEventType,
+      status: "recruiter_screen",
+      occurredAt: time,
+      dueAt: time,
+      occurredAtHasTime: true,
+      dueAtHasTime: true,
+      createdAt: time,
+    });
+    const lifecycleEvents = [
+      event(
+        "invite_a",
+        "app_screen_a",
+        "recruiter_screen_invitation_received",
+        "2026-04-01T10:00:00.000Z",
+      ),
+      event(
+        "invite_b",
+        "app_screen_b",
+        "recruiter_screen_invited",
+        "2026-04-02T10:00:00.000Z",
+      ),
+      event(
+        "scheduled_b",
+        "app_screen_b",
+        "recruiter_screen_scheduled",
+        "2026-04-03T10:00:00.000Z",
+      ),
+      event(
+        "completed_b",
+        "app_screen_b",
+        "recruiter_screen_completed",
+        "2026-04-03T10:00:00.000Z",
+      ),
+      event(
+        "invite_c",
+        "app_screen_c",
+        "recruiter_screen_invite",
+        "2026-04-04T10:00:00.000Z",
+      ),
+      event(
+        "scheduled_c",
+        "app_screen_c",
+        "recruiter_screen_scheduled",
+        "2026-04-05T10:00:00.000Z",
+      ),
+      event(
+        "completed_c",
+        "app_screen_c",
+        "recruiter_screen_completed",
+        "2026-04-05T10:00:00.000Z",
+      ),
+      event(
+        "completed_d",
+        "app_screen_d",
+        "recruiter_screen_completed",
+        "2026-04-06T10:00:00.000Z",
+      ),
+    ];
+    const interviews = lifecycleEvents
+      .filter(({ rawEventType }) =>
+        ["recruiter_screen_scheduled", "recruiter_screen_completed"].includes(
+          rawEventType,
+        ),
+      )
+      .map((item) => ({
+        id: `interview_${item.id}`,
+        applicationId: item.applicationId,
+        contactIds: [],
+        stage: "recruiter_screen",
+        startsAt: item.dueAt,
+        outcome: item.rawEventType.endsWith("completed")
+          ? "completed"
+          : "scheduled",
+        createdAt: item.createdAt,
+        updatedAt: item.createdAt,
+      }));
+    const bundle = { applications, lifecycleEvents, interviews };
+    expect(selectDashboardMetrics(bundle)).toMatchObject({
+      recruiterScreens: 3,
+      applicationsWithResponse: 4,
+    });
+    expect(
+      uniqueRecruiterScreens({ lifecycle: lifecycleEvents, interviews }),
+    ).toHaveLength(3);
+    expect(
+      uniqueRecruiterScreens({
+        lifecycle: [lifecycleEvents[0]],
+        interviews: [],
+      }),
+    ).toHaveLength(0);
+    expect(
+      selectDashboardMetrics({
+        ...bundle,
+        lifecycleEvents: [...lifecycleEvents].reverse(),
+        interviews: [...interviews].reverse(),
+      }).recruiterScreens,
+    ).toBe(3);
+
+    const secondTime = "2026-04-10T10:00:00.000Z";
+    const second = event(
+      "scheduled_b_second",
+      "app_screen_b",
+      "recruiter_screen_scheduled",
+      secondTime,
+    );
+    expect(
+      selectDashboardMetrics({
+        ...bundle,
+        lifecycleEvents: [...lifecycleEvents, second],
+      }).recruiterScreens,
+    ).toBe(4);
+  });
   it("classifies scheduled lifecycle interview events centrally", () => {
     expect(
       classifyLifecycleEventType("devops_interview_scheduled"),


### PR DESCRIPTION
### Motivation

- Two regressions allowed supplemental lifecycle imports to overwrite preserved free-form compact `interview_stage` text and caused recruiter-screen invitations to be counted as actual screens. The fixes target compact-cell preservation, deterministic stage projection, and accurate recruiter-screen counting without changing upstream contracts.

### Description

- Rebased compact-cell preservation to be provenance-aware for version-2 envelopes by comparing column-by-column baselines before applying supplemental projections, keeping `raw_row` immutable and avoiding wholesale canonical resets; this preserves arbitrary compact labels unless a genuine manual edit occurs. (Changed: `src/web/import-export/spreadsheet.js`)
- Replaced ID-first interview/stage selection with a deterministic chronological selection that prefers completed occurrence time, scheduled starts/due times, falls back to creation, and uses stable ID code-point order only as a final tie-breaker; both interviews and lifecycle events are considered. (Changed: `src/web/import-export/spreadsheet.js`)
- Centralized recruiter-screen semantics to distinguish invitation aliases from actual scheduled/completed screens by making `rawEventType` authoritative when present, and introduced `isActualRecruiterScreen()` used by both metrics and UI helpers so counting and detail lists stay in sync. Invitation aliases still count as employer responses and remain exportable via `rawEventType`. (Changed: `src/web/tracker/lifecycleClassification.js`, `src/web/tracker/metrics.js`, `src/web/tracker/tracker.js`)
- Added focused, sanitized regression tests covering both behaviors using fake IDs and `example.test` artifact URLs: compact-stage preservation and later manual override stability, and recruiter-screen counting / deduplication semantics. (Added: `test/web-spreadsheet-import-export.test.js`, `test/web-tracker-metrics.test.js`)
- No backwards-incompatible changes to the two-CSV contract or legacy flat `Spreadsheet metadata:` behavior; legacy flat metadata remains supported as a compatibility fallback.

Files changed: `src/web/import-export/spreadsheet.js`, `src/web/tracker/lifecycleClassification.js`, `src/web/tracker/metrics.js`, `src/web/tracker/tracker.js`, `test/web-spreadsheet-import-export.test.js`, `test/web-tracker-metrics.test.js`.

### Testing

- Ran formatting and static checks: `npx prettier --check <files>`, `npm run lint -- --quiet`, `npm run typecheck`; all completed without errors.
- Ran the focused Vitest suites: `npx vitest run test/web-spreadsheet-import-export.test.js test/web-tracker-metrics.test.js test/web-storage-browser-data-migration.test.js test/web-tracker-lifecycle-projection.test.js`; result: all targeted tests passed (129 tests across these suites passed in this environment).
- Ran ad-hoc `npx vitest` and the repository test subsets used during development; focused suites covering import/export, lifecycle projection, and metrics passed locally.
- Attempted full CI (`npm run test:ci`) in this environment; the runner began preparing Playwright/browser prerequisites which involve large downloads and took significant time in this container, so the end-to-end CI run was not fully observed here—the focused suites required by this change were executed and passed.

Verification commands used (examples):
- `npx prettier --check src/web/import-export/spreadsheet.js src/web/tracker/lifecycleClassification.js src/web/tracker/metrics.js src/web/tracker/tracker.js test/web-spreadsheet-import-export.test.js test/web-tracker-metrics.test.js`
- `npm run lint -- --quiet`
- `npm run typecheck`
- `npx vitest run test/web-spreadsheet-import-export.test.js test/web-tracker-metrics.test.js test/web-storage-browser-data-migration.test.js test/web-tracker-lifecycle-projection.test.js`

Residual notes and follow-ups:
- The change intentionally keeps legacy flat `Spreadsheet metadata:` behavior as a compatibility path; version-2 envelopes get the new provenance-aware handling. Reviewers may want to audit any downstream consumers expecting canonical rows to carry raw overlays earlier in the pipeline.
- Full CI with Playwright/browser E2E was started but installs are large in this environment; recommend a final CI run in CI (or locally) to confirm Playwright-based suites if required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b9675ed2c832f9ee40a80562f4c0e)