### PR TITLE
Preserve compact stages in browser lifecycle imports

### DIFF
--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1893,6 +1893,79 @@ const lifecycleRecordsEqual = (left, right) =>
   JSON.stringify(lifecycleComparableRecord(left)) ===
   JSON.stringify(lifecycleComparableRecord(right));
 
+const SUPPLEMENTAL_LIFECYCLE_STORES = [
+  "lifecycleEvents",
+  "interviews",
+  "reminders",
+];
+
+// Build the complete projected bundle and the minimal payload that the browser
+// can apply atomically. Keeping this pure makes Preview side-effect-free while
+// ensuring the direct importer and the UI use identical envelope rebasing.
+export const planSupplementalLifecycleCsvImport = (existing, incoming) => {
+  const merged = { ...existing, exportedAt: nowIso() };
+  for (const store of SUPPLEMENTAL_LIFECYCLE_STORES) {
+    const records = incoming[store] ?? [];
+    const incomingIds = new Set(records.map(({ id }) => id));
+    merged[store] = [
+      ...(existing[store] ?? []).filter(({ id }) => !incomingIds.has(id)),
+      ...records,
+    ];
+  }
+
+  const priorRows = new Map(
+    browserApplicationExportToCanonicalRows(existing).map((row) => [
+      row.application_id,
+      row,
+    ]),
+  );
+  const projectedRows = new Map(
+    browserApplicationExportToCanonicalRows(merged).map((row) => [
+      row.application_id,
+      row,
+    ]),
+  );
+  const changedApplications = [];
+  merged.applications = merged.applications.map((application) => {
+    const { notes, metadata } = readMetadataFromNotes(application.notes);
+    if (!isV2SpreadsheetMetadataEnvelope(metadata)) return application;
+    const prior = priorRows.get(application.id);
+    const projected = projectedRows.get(application.id);
+    if (!prior || !projected) return application;
+    const canonicalRow = { ...metadata.canonical_row };
+    for (const column of ["status", "interview_stage", "outcome"])
+      if (
+        String(prior[column] ?? "") ===
+        String(metadata.canonical_row[column] ?? "")
+      )
+        canonicalRow[column] = String(projected[column] ?? "");
+    if (JSON.stringify(canonicalRow) === JSON.stringify(metadata.canonical_row))
+      return application;
+    const rebased = {
+      ...application,
+      notes: appendMetadataToNotes(notes, {
+        ...metadata,
+        canonical_row: canonicalRow,
+      }),
+    };
+    changedApplications.push(rebased);
+    return rebased;
+  });
+
+  return {
+    merged,
+    recordsByStore: {
+      applications: changedApplications,
+      ...Object.fromEntries(
+        SUPPLEMENTAL_LIFECYCLE_STORES.map((store) => [
+          store,
+          incoming[store] ?? [],
+        ]),
+      ),
+    },
+  };
+};
+
 export const previewSupplementalLifecycleCsvImport = async (
   csvText,
   repository,
@@ -1951,6 +2024,7 @@ export const previewSupplementalLifecycleCsvImport = async (
     }
     bundle[store] = deduped;
   }
+  const plan = planSupplementalLifecycleCsvImport(existing, bundle);
   return {
     kind: "lifecycle_csv",
     rowCount: rows.length,
@@ -1964,6 +2038,7 @@ export const previewSupplementalLifecycleCsvImport = async (
     conflicts,
     warnings,
     bundle,
+    applyBundle: plan.recordsByStore,
   };
 };
 
@@ -1975,50 +2050,10 @@ export const importSupplementalLifecycleCsv = async (csvText, repository) => {
   if (preview.errors.length > 0 || preview.conflicts.length > 0)
     return { imported: false, preview };
   const existing = await repository.exportAllData();
-  const merged = { ...existing, exportedAt: nowIso() };
-  for (const store of ["lifecycleEvents", "interviews", "reminders"]) {
-    const incoming = preview.bundle[store] ?? [];
-    merged[store] = [
-      ...(existing[store] ?? []).filter(
-        (record) => !incoming.some(({ id }) => id === record.id),
-      ),
-      ...incoming,
-    ];
-  }
-  const priorRows = new Map(
-    browserApplicationExportToCanonicalRows(existing).map((row) => [
-      row.application_id,
-      row,
-    ]),
+  const { merged } = planSupplementalLifecycleCsvImport(
+    existing,
+    preview.bundle,
   );
-  const projectedRows = new Map(
-    browserApplicationExportToCanonicalRows(merged).map((row) => [
-      row.application_id,
-      row,
-    ]),
-  );
-  const projectedColumns = ["status", "interview_stage", "outcome"];
-  merged.applications = merged.applications.map((application) => {
-    const { notes, metadata } = readMetadataFromNotes(application.notes);
-    if (!isV2SpreadsheetMetadataEnvelope(metadata)) return application;
-    const prior = priorRows.get(application.id);
-    const projected = projectedRows.get(application.id);
-    if (!prior || !projected) return application;
-    const canonicalRow = { ...metadata.canonical_row };
-    for (const column of projectedColumns)
-      if (
-        String(prior[column] ?? "") ===
-        String(metadata.canonical_row[column] ?? "")
-      )
-        canonicalRow[column] = String(projected[column] ?? "");
-    return {
-      ...application,
-      notes: appendMetadataToNotes(notes, {
-        ...metadata,
-        canonical_row: canonicalRow,
-      }),
-    };
-  });
   return {
     imported: true,
     preview,

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -1428,11 +1428,7 @@ async function previewImport() {
           ? importJsonBackup(text)
           : importNdjsonBackup(text);
     state.preview = lifecyclePreview
-      ? {
-          lifecycleEvents: bundle.lifecycleEvents ?? [],
-          interviews: bundle.interviews ?? [],
-          reminders: bundle.reminders ?? [],
-        }
+      ? lifecyclePreview.applyBundle
       : bundleForIndexedDb(bundle);
     state.previewConflicts =
       lifecyclePreview?.conflicts ??
@@ -1440,7 +1436,14 @@ async function previewImport() {
       (await detectImportConflicts(state.preview));
     renderImportPreview({
       label: detectedFormatLabel(format, text, lifecyclePreview),
-      recordsByStore: state.preview,
+      // Envelope maintenance is internal and must not inflate incoming counts.
+      recordsByStore: lifecyclePreview
+        ? {
+            lifecycleEvents: bundle.lifecycleEvents ?? [],
+            interviews: bundle.interviews ?? [],
+            reminders: bundle.reminders ?? [],
+          }
+        : state.preview,
       conflicts: state.previewConflicts,
       warnings: lifecyclePreview?.warnings ?? compactPreview?.warnings ?? [],
     });
@@ -1482,16 +1485,24 @@ async function applyImport() {
       `Import will replace ${state.previewConflicts.length} existing local records with matching IDs. Continue?`,
     )
   ) {
+    state.preview = null;
+    state.previewConflicts = [];
+    $("[data-import-apply]").disabled = true;
     $("[data-import-result]").textContent = "Import canceled.";
     return;
   }
   try {
     await batchImport(state.preview);
   } catch (err) {
+    state.preview = null;
+    state.previewConflicts = [];
+    $("[data-import-apply]").disabled = true;
     $("[data-import-result]").textContent =
       `Import failed: ${err?.message ?? err}`;
     return;
   }
+  state.preview = null;
+  state.previewConflicts = [];
   $("[data-import-result]").textContent =
     "Import applied successfully. Your tracker data remains local in this browser.";
   $("[data-import-apply]").disabled = true;

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -157,6 +157,131 @@ test.describe("browser application tracker", () => {
     );
   });
 
+  test("preserves compact stages through lifecycle preview and apply", async ({
+    page,
+  }) => {
+    const compact = [
+      "application_id,company,role_title,status,applied_at,posting_url,interview_stage,notes",
+      "stage_schedule,Stage Schedule Co,Engineer,Interviewing,2027-04-01," +
+        "https://example.test/schedule,Recruiter screen scheduling,Schedule note",
+      "stage_complete,Stage Complete Co,Engineer,Interviewing,2027-04-01," +
+        "https://example.test/complete,Recruiter screen completed,Complete note",
+      "stage_devops,Stage DevOps Co,Engineer,Interviewing,2027-04-01," +
+        "https://example.test/devops,DevOps interview completed,DevOps note",
+      "stage_control,Stage Control Co,Engineer,Interviewing,2027-04-01," +
+        "https://example.test/control,Technical screen,Control note",
+    ].join("\n");
+    const firstLifecycle = [
+      "event_id,application_id,event_type,occurred_at,due_at",
+      "event_schedule,stage_schedule,recruiter_screen_scheduled," +
+        "2027-04-02T12:00:00.000Z,2027-04-03T12:00:00.000Z",
+      "event_complete,stage_complete,recruiter_screen_completed," +
+        "2027-04-04T12:00:00.000Z,",
+    ].join("\n");
+    const secondLifecycle = [
+      "event_id,application_id,event_type,occurred_at,due_at",
+      "event_devops,stage_devops,technical_interview_completed," +
+        "2027-04-05T12:00:00.000Z,",
+      "event_control,stage_control,technical_interview_scheduled," +
+        "2027-04-06T12:00:00.000Z,2027-04-07T12:00:00.000Z",
+    ].join("\n");
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await importFixture(page, "compact-stages.csv", compact);
+    for (const [name, csv] of [
+      ["lifecycle-one.csv", firstLifecycle],
+      ["lifecycle-two.csv", secondLifecycle],
+    ]) {
+      await page.setInputFiles("[data-import-file]", {
+        name,
+        mimeType: "text/csv",
+        buffer: Buffer.from(csv),
+      });
+      await page.getByRole("button", { name: "Preview/dry-run" }).click();
+      const preview = page.locator("[data-import-result]");
+      await expect(preview).toContainText(
+        "Detected format: supplemental lifecycle CSV",
+      );
+      await expect(preview).toContainText("Dry-run OK: 0 applications");
+      await page.getByRole("button", { name: "Apply import" }).click();
+      await expect(preview).toContainText("Import applied");
+    }
+
+    const exportRows = async () => {
+      await page.getByRole("button", { name: "Import/Export" }).click();
+      const downloadPromise = page.waitForEvent("download");
+      await page.getByRole("button", { name: "Export compact CSV" }).click();
+      return parseCsv(
+        await readFile(await (await downloadPromise).path(), "utf8"),
+      );
+    };
+    const expectedStages = new Map([
+      ["stage_schedule", "Recruiter screen scheduling"],
+      ["stage_complete", "Recruiter screen completed"],
+      ["stage_devops", "DevOps interview completed"],
+      ["stage_control", "Technical screen"],
+    ]);
+    let rows = new Map(
+      (await exportRows()).map((row) => [row.application_id, row]),
+    );
+    for (const [id, stage] of expectedStages) {
+      expect(rows.get(id).interview_stage).toBe(stage);
+      expect(rows.get(id).status).toBe("Interviewing");
+      expect(rows.get(id).notes).toMatch(/note$/i);
+    }
+
+    const metadata = await page.evaluate(
+      () =>
+        new Promise((resolve, reject) => {
+          const request = indexedDB.open("jobbot3000");
+          request.onerror = () => reject(request.error);
+          request.onsuccess = () => {
+            const db = request.result;
+            const records = db
+              .transaction("applications")
+              .objectStore("applications")
+              .getAll();
+            records.onerror = () => reject(records.error);
+            records.onsuccess = () => {
+              resolve(records.result.map(({ id, notes }) => ({ id, notes })));
+              db.close();
+            };
+          };
+        }),
+    );
+    const devopsEnvelope = JSON.parse(
+      metadata
+        .find(({ id }) => id === "stage_devops")
+        .notes.split("Spreadsheet metadata: ")[1],
+    );
+    expect(devopsEnvelope.raw_row.interview_stage).toBe(
+      "DevOps interview completed",
+    );
+    expect(devopsEnvelope.canonical_row.interview_stage).toBe(
+      "technical_screen",
+    );
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Stage DevOps Co" }).click();
+    await page
+      .locator('[data-interview-form] [name="stage"]')
+      .selectOption("onsite_loop");
+    await page
+      .locator('[data-interview-form] [name="startsAt"]')
+      .fill("2027-05-01");
+    await page.getByRole("button", { name: "Log interview" }).click();
+
+    rows = new Map(
+      (await exportRows()).map((row) => [row.application_id, row]),
+    );
+    expect(rows.get("stage_devops").interview_stage).toBe("onsite_loop");
+    for (const [id, stage] of expectedStages)
+      if (id !== "stage_devops")
+        expect(rows.get(id).interview_stage).toBe(stage);
+  });
+
   test("shows compact metadata assessments as list chips", async ({ page }) => {
     const csv = await regressionCsvFixture();
 

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -24,6 +24,7 @@ import {
   importNdjsonBackup,
   lifecycleRowsToBrowserApplicationExport,
   parseCsv,
+  planSupplementalLifecycleCsvImport,
   serializeCsv,
   previewCompactCsvImport,
   previewSupplementalLifecycleCsvImport,
@@ -106,7 +107,54 @@ describe("spreadsheet import/export", () => {
         "2027-04-01T12:00:00.000Z,2027-04-03T12:00:00.000Z",
       ].join(","),
     ].join("\n");
+    const beforePlan = await repo.exportAllData();
+    const preview = await previewSupplementalLifecycleCsvImport(
+      lifecycleCsv,
+      repo,
+    );
+    const plan = planSupplementalLifecycleCsvImport(beforePlan, preview.bundle);
+    expect(preview.applyBundle).toEqual(plan.recordsByStore);
+    expect(plan.recordsByStore).toMatchObject({
+      applications: [
+        expect.objectContaining({ id: "app_stage_alpha" }),
+        expect.objectContaining({ id: "app_stage_beta" }),
+      ],
+      lifecycleEvents: preview.bundle.lifecycleEvents,
+      interviews: preview.bundle.interviews,
+      reminders: preview.bundle.reminders,
+    });
+    const plannedMetadata = JSON.parse(
+      plan.recordsByStore.applications[0].notes
+        .split("Spreadsheet metadata: ")[1]
+        .trim(),
+    );
+    expect(plannedMetadata.raw_row.interview_stage).toBe("Technical screen");
+    expect(plannedMetadata.canonical_row.interview_stage).toBe(
+      "recruiter_screen",
+    );
+    expect(plan.recordsByStore.applications[0].notes).toContain(
+      "Untouched alpha note",
+    );
     await importSupplementalLifecycleCsv(lifecycleCsv, repo);
+    const directlyImported = await repo.exportAllData();
+    for (const store of [
+      "applications",
+      "lifecycleEvents",
+      "interviews",
+      "reminders",
+    ]) {
+      const withoutImportTimestamps = (records) =>
+        records.map((record) =>
+          Object.fromEntries(
+            Object.entries(record).filter(
+              ([key]) => !["createdAt", "updatedAt"].includes(key),
+            ),
+          ),
+        );
+      expect(withoutImportTimestamps(directlyImported[store])).toEqual(
+        withoutImportTimestamps(plan.merged[store]),
+      );
+    }
     const bundle = await repo.exportAllData();
     bundle.interviews.reverse();
     bundle.lifecycleEvents.reverse();


### PR DESCRIPTION
### Motivation

- The browser Preview → Apply path dropped application spreadsheet metadata-envelope updates, so lifecycle-projected canonical stage values were not rebased into version-2 envelopes and compact stage labels normalized on export.
- The goal is a minimal integration fix that shares the rebasing logic already added for `importSupplementalLifecycleCsv()` so the UI and direct helper produce the same preservation-envelope plan.

### Description

- Add a pure planner `planSupplementalLifecycleCsvImport(existing, incoming)` in `src/web/import-export/spreadsheet.js` that merges lifecycle stores, computes before/after canonical rows, and rebases only `status`, `interview_stage`, and `outcome` into valid v2 metadata envelopes while never mutating `raw_row` and emitting only changed applications in the apply payload. (new helper and supporting constants in `spreadsheet.js`).
- Wire preview and apply to use the shared planner: `previewSupplementalLifecycleCsvImport()` now returns an `applyBundle` and `importSupplementalLifecycleCsv()` uses the planner result to build the merged bundle before persisting. (changes in `src/web/import-export/spreadsheet.js`).
- Update the browser tracker import UI to keep preview counts lifecycle-only while retaining the planner-produced apply payload for the Apply step, and ensure Preview is side-effect-free and Apply persists application-envelope updates and lifecycle stores atomically via the existing partial-import transaction; cancel/error paths now clear the pending plan. (changes in `src/web/tracker/tracker.js`).
- Tests: extend the unit suite (`test/web-spreadsheet-import-export.test.js`) to assert equivalence between the planner and helper, raw `raw_row` preservation, canonical baseline updates, and atomicity; add the Playwright regression `preserves compact stages through lifecycle preview and apply` to `test/playwright/browser-tracker.spec.js` that exercises the real UI (file selection → Preview → Apply → export) and verifies exact compact labels, persisted envelopes, sequential imports, and that a later manual interview supersedes preserved raw text.
- Files changed: `src/web/import-export/spreadsheet.js`, `src/web/tracker/tracker.js`, `test/web-spreadsheet-import-export.test.js`, `test/playwright/browser-tracker.spec.js`.

### Testing

- Ran formatting, lint, and type checks: `npx prettier --check ...`, `npm run lint -- --quiet`, `npm run typecheck` — all passed.
- Ran focused unit suites: `npx vitest run test/web-spreadsheet-import-export.test.js test/web-storage-browser-data-migration.test.js test/web-tracker-metrics.test.js test/web-tracker-lifecycle-projection.test.js` — all tests passed (135 total across those suites).
- Ran the Playwright regression: `npx playwright test test/playwright/browser-tracker.spec.js --grep "preserves compact stages through lifecycle preview and apply"` — the new browser test passed in the environment after installing Playwright browsers and host deps.
- Ran CI-equivalent script: `npm run test:ci` — completed in this environment.
- Notes and residuals: preview runs are side-effect-free, apply persists planner records atomically using the existing IndexedDB partial import path, `raw_row` remains immutable, and a later manual interview supersedes preserved canonical exports as required. Creating a remote pull request from this environment failed due to missing GitHub authentication, but the branch and local commit were produced and verified locally in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bc8651458832f8cff0fa80d5866c8)