### PR TITLE
Preserve compact stages in browser lifecycle imports

### DIFF
--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1893,6 +1893,57 @@ const lifecycleRecordsEqual = (left, right) =>
   JSON.stringify(lifecycleComparableRecord(left)) ===
   JSON.stringify(lifecycleComparableRecord(right));
 
+export const planSupplementalLifecycleImport = (existing, incomingBundle) => {
+  const merged = { ...existing, exportedAt: nowIso() };
+  const recordsByStore = {};
+  for (const store of ["lifecycleEvents", "interviews", "reminders"]) {
+    const incoming = incomingBundle[store] ?? [];
+    recordsByStore[store] = incoming;
+    const incomingIds = new Set(incoming.map(({ id }) => id));
+    merged[store] = [
+      ...(existing[store] ?? []).filter(({ id }) => !incomingIds.has(id)),
+      ...incoming,
+    ];
+  }
+  const priorRows = new Map(
+    browserApplicationExportToCanonicalRows(existing).map((row) => [
+      row.application_id,
+      row,
+    ]),
+  );
+  const projectedRows = new Map(
+    browserApplicationExportToCanonicalRows(merged).map((row) => [
+      row.application_id,
+      row,
+    ]),
+  );
+  merged.applications = merged.applications.map((application) => {
+    const { notes, metadata } = readMetadataFromNotes(application.notes);
+    if (!isV2SpreadsheetMetadataEnvelope(metadata)) return application;
+    const prior = priorRows.get(application.id);
+    const projected = projectedRows.get(application.id);
+    if (!prior || !projected) return application;
+    const canonicalRow = { ...metadata.canonical_row };
+    for (const column of ["status", "interview_stage", "outcome"])
+      if (
+        String(prior[column] ?? "") ===
+        String(metadata.canonical_row[column] ?? "")
+      )
+        canonicalRow[column] = String(projected[column] ?? "");
+    const updated = {
+      ...application,
+      notes: appendMetadataToNotes(notes, {
+        ...metadata,
+        canonical_row: canonicalRow,
+      }),
+    };
+    if (updated.notes !== application.notes)
+      (recordsByStore.applications ??= []).push(updated);
+    return updated;
+  });
+  return { merged, recordsByStore };
+};
+
 export const previewSupplementalLifecycleCsvImport = async (
   csvText,
   repository,
@@ -1951,6 +2002,7 @@ export const previewSupplementalLifecycleCsvImport = async (
     }
     bundle[store] = deduped;
   }
+  const plan = planSupplementalLifecycleImport(existing, bundle);
   return {
     kind: "lifecycle_csv",
     rowCount: rows.length,
@@ -1964,6 +2016,7 @@ export const previewSupplementalLifecycleCsvImport = async (
     conflicts,
     warnings,
     bundle,
+    plan,
   };
 };
 
@@ -1974,54 +2027,11 @@ export const importSupplementalLifecycleCsv = async (csvText, repository) => {
   );
   if (preview.errors.length > 0 || preview.conflicts.length > 0)
     return { imported: false, preview };
-  const existing = await repository.exportAllData();
-  const merged = { ...existing, exportedAt: nowIso() };
-  for (const store of ["lifecycleEvents", "interviews", "reminders"]) {
-    const incoming = preview.bundle[store] ?? [];
-    merged[store] = [
-      ...(existing[store] ?? []).filter(
-        (record) => !incoming.some(({ id }) => id === record.id),
-      ),
-      ...incoming,
-    ];
-  }
-  const priorRows = new Map(
-    browserApplicationExportToCanonicalRows(existing).map((row) => [
-      row.application_id,
-      row,
-    ]),
-  );
-  const projectedRows = new Map(
-    browserApplicationExportToCanonicalRows(merged).map((row) => [
-      row.application_id,
-      row,
-    ]),
-  );
-  const projectedColumns = ["status", "interview_stage", "outcome"];
-  merged.applications = merged.applications.map((application) => {
-    const { notes, metadata } = readMetadataFromNotes(application.notes);
-    if (!isV2SpreadsheetMetadataEnvelope(metadata)) return application;
-    const prior = priorRows.get(application.id);
-    const projected = projectedRows.get(application.id);
-    if (!prior || !projected) return application;
-    const canonicalRow = { ...metadata.canonical_row };
-    for (const column of projectedColumns)
-      if (
-        String(prior[column] ?? "") ===
-        String(metadata.canonical_row[column] ?? "")
-      )
-        canonicalRow[column] = String(projected[column] ?? "");
-    return {
-      ...application,
-      notes: appendMetadataToNotes(notes, {
-        ...metadata,
-        canonical_row: canonicalRow,
-      }),
-    };
-  });
   return {
     imported: true,
     preview,
-    result: await repository.importAllData(merged, { allowOverwrite: true }),
+    result: await repository.importAllData(preview.plan.merged, {
+      allowOverwrite: true,
+    }),
   };
 };

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -140,6 +140,7 @@ const state = {
   bundle: null,
   preview: null,
   previewConflicts: [],
+  supplementalLifecycleCsv: null,
   sort: "appliedAt",
   dir: -1,
   current: null,
@@ -1430,6 +1431,7 @@ async function previewImport() {
     state.preview = lifecyclePreview
       ? lifecyclePreview.plan.recordsByStore
       : bundleForIndexedDb(bundle);
+    state.supplementalLifecycleCsv = lifecyclePreview ? text : null;
     state.previewConflicts =
       lifecyclePreview?.conflicts ??
       compactPreview?.conflicts ??
@@ -1450,6 +1452,7 @@ async function previewImport() {
   } catch (err) {
     state.preview = null;
     state.previewConflicts = [];
+    state.supplementalLifecycleCsv = null;
     $("[data-import-apply]").disabled = true;
     if (err?.errors) {
       renderImportPreview({
@@ -1469,6 +1472,7 @@ async function previewImport() {
 function resetImportPreview() {
   state.preview = null;
   state.previewConflicts = [];
+  state.supplementalLifecycleCsv = null;
   $("[data-import-apply]").disabled = true;
   $("[data-import-result]").innerHTML =
     "Select Preview/dry-run to validate the selected file before applying.";
@@ -1478,23 +1482,39 @@ async function applyImport() {
     resetImportPreview();
     return;
   }
-  if (
-    state.previewConflicts.length &&
-    !confirm(
-      `Import will replace ${state.previewConflicts.length} existing local records with matching IDs. Continue?`,
-    )
-  ) {
-    state.preview = null;
-    state.previewConflicts = [];
-    $("[data-import-apply]").disabled = true;
-    $("[data-import-result]").textContent = "Import canceled.";
-    return;
-  }
   try {
+    if (state.supplementalLifecycleCsv) {
+      const currentPlan = await previewSupplementalLifecycleCsvImport(
+        state.supplementalLifecycleCsv,
+        { exportAllData: repo.exportAll },
+      );
+      if (currentPlan.errors.length || currentPlan.conflicts.length) {
+        resetImportPreview();
+        $("[data-import-result]").textContent =
+          "Local data changed after Preview. Preview the import again before applying.";
+        return;
+      }
+      state.preview = currentPlan.plan.recordsByStore;
+      state.previewConflicts = currentPlan.conflicts;
+    }
+    if (
+      state.previewConflicts.length &&
+      !confirm(
+        `Import will replace ${state.previewConflicts.length} existing local records with matching IDs. Continue?`,
+      )
+    ) {
+      state.preview = null;
+      state.previewConflicts = [];
+      state.supplementalLifecycleCsv = null;
+      $("[data-import-apply]").disabled = true;
+      $("[data-import-result]").textContent = "Import canceled.";
+      return;
+    }
     await batchImport(state.preview);
   } catch (err) {
     state.preview = null;
     state.previewConflicts = [];
+    state.supplementalLifecycleCsv = null;
     $("[data-import-apply]").disabled = true;
     $("[data-import-result]").textContent =
       `Import failed: ${err?.message ?? err}`;
@@ -1502,6 +1522,7 @@ async function applyImport() {
   }
   state.preview = null;
   state.previewConflicts = [];
+  state.supplementalLifecycleCsv = null;
   $("[data-import-result]").textContent =
     "Import applied successfully. Your tracker data remains local in this browser.";
   $("[data-import-apply]").disabled = true;

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -1428,11 +1428,7 @@ async function previewImport() {
           ? importJsonBackup(text)
           : importNdjsonBackup(text);
     state.preview = lifecyclePreview
-      ? {
-          lifecycleEvents: bundle.lifecycleEvents ?? [],
-          interviews: bundle.interviews ?? [],
-          reminders: bundle.reminders ?? [],
-        }
+      ? lifecyclePreview.plan.recordsByStore
       : bundleForIndexedDb(bundle);
     state.previewConflicts =
       lifecyclePreview?.conflicts ??
@@ -1440,7 +1436,13 @@ async function previewImport() {
       (await detectImportConflicts(state.preview));
     renderImportPreview({
       label: detectedFormatLabel(format, text, lifecyclePreview),
-      recordsByStore: state.preview,
+      recordsByStore: lifecyclePreview
+        ? {
+            lifecycleEvents: bundle.lifecycleEvents ?? [],
+            interviews: bundle.interviews ?? [],
+            reminders: bundle.reminders ?? [],
+          }
+        : state.preview,
       conflicts: state.previewConflicts,
       warnings: lifecyclePreview?.warnings ?? compactPreview?.warnings ?? [],
     });
@@ -1482,16 +1484,24 @@ async function applyImport() {
       `Import will replace ${state.previewConflicts.length} existing local records with matching IDs. Continue?`,
     )
   ) {
+    state.preview = null;
+    state.previewConflicts = [];
+    $("[data-import-apply]").disabled = true;
     $("[data-import-result]").textContent = "Import canceled.";
     return;
   }
   try {
     await batchImport(state.preview);
   } catch (err) {
+    state.preview = null;
+    state.previewConflicts = [];
+    $("[data-import-apply]").disabled = true;
     $("[data-import-result]").textContent =
       `Import failed: ${err?.message ?? err}`;
     return;
   }
+  state.preview = null;
+  state.previewConflicts = [];
   $("[data-import-result]").textContent =
     "Import applied successfully. Your tracker data remains local in this browser.";
   $("[data-import-apply]").disabled = true;

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -1398,6 +1398,7 @@ async function previewImport() {
       });
       state.preview = null;
       state.previewConflicts = [];
+      state.supplementalLifecycleCsv = null;
       $("[data-import-apply]").disabled = true;
       return;
     }
@@ -1418,6 +1419,7 @@ async function previewImport() {
       });
       state.preview = null;
       state.previewConflicts = [];
+      state.supplementalLifecycleCsv = null;
       $("[data-import-apply]").disabled = true;
       return;
     }
@@ -1428,8 +1430,14 @@ async function previewImport() {
         : format === "json"
           ? importJsonBackup(text)
           : importNdjsonBackup(text);
+    // Keep only the incoming lifecycle records from Preview. Application
+    // envelopes are planned again from current IndexedDB data at Apply time.
     state.preview = lifecyclePreview
-      ? lifecyclePreview.plan.recordsByStore
+      ? {
+          lifecycleEvents: bundle.lifecycleEvents ?? [],
+          interviews: bundle.interviews ?? [],
+          reminders: bundle.reminders ?? [],
+        }
       : bundleForIndexedDb(bundle);
     state.supplementalLifecycleCsv = lifecyclePreview ? text : null;
     state.previewConflicts =
@@ -1483,19 +1491,28 @@ async function applyImport() {
     return;
   }
   try {
+    let recordsByStore = state.preview;
     if (state.supplementalLifecycleCsv) {
       const currentPlan = await previewSupplementalLifecycleCsvImport(
         state.supplementalLifecycleCsv,
         { exportAllData: repo.exportAll },
       );
       if (currentPlan.errors.length || currentPlan.conflicts.length) {
-        resetImportPreview();
-        $("[data-import-result]").textContent =
-          "Local data changed after Preview. Preview the import again before applying.";
+        renderImportPreview({
+          label: "supplemental lifecycle CSV",
+          recordsByStore: currentPlan.bundle ?? {},
+          conflicts: currentPlan.conflicts,
+          warnings: currentPlan.warnings,
+          errors: currentPlan.errors,
+          blocking: true,
+        });
+        state.preview = null;
+        state.previewConflicts = [];
+        state.supplementalLifecycleCsv = null;
+        $("[data-import-apply]").disabled = true;
         return;
       }
-      state.preview = currentPlan.plan.recordsByStore;
-      state.previewConflicts = currentPlan.conflicts;
+      recordsByStore = currentPlan.plan.recordsByStore;
     }
     if (
       state.previewConflicts.length &&
@@ -1510,7 +1527,7 @@ async function applyImport() {
       $("[data-import-result]").textContent = "Import canceled.";
       return;
     }
-    await batchImport(state.preview);
+    await batchImport(recordsByStore);
   } catch (err) {
     state.preview = null;
     state.previewConflicts = [];

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -1312,6 +1312,13 @@ function detectedFormatLabel(format, text, lifecyclePreview) {
     ? "compact application CSV"
     : "CSV";
 }
+function supplementalLifecyclePreviewStores(bundle) {
+  return {
+    lifecycleEvents: bundle.lifecycleEvents ?? [],
+    interviews: bundle.interviews ?? [],
+    reminders: bundle.reminders ?? [],
+  };
+}
 function countByStore(recordsByStore) {
   const rows = {
     applications: recordsByStore.applications?.length ?? 0,
@@ -1390,7 +1397,9 @@ async function previewImport() {
     if (lifecyclePreview?.errors.length || lifecyclePreview?.conflicts.length) {
       renderImportPreview({
         label: "supplemental lifecycle CSV",
-        recordsByStore: lifecyclePreview.bundle ?? {},
+        recordsByStore: supplementalLifecyclePreviewStores(
+          lifecyclePreview.bundle ?? {},
+        ),
         conflicts: lifecyclePreview.conflicts ?? [],
         warnings: lifecyclePreview.warnings ?? [],
         errors: lifecyclePreview.errors ?? [],
@@ -1433,11 +1442,7 @@ async function previewImport() {
     // Keep only the incoming lifecycle records from Preview. Application
     // envelopes are planned again from current IndexedDB data at Apply time.
     state.preview = lifecyclePreview
-      ? {
-          lifecycleEvents: bundle.lifecycleEvents ?? [],
-          interviews: bundle.interviews ?? [],
-          reminders: bundle.reminders ?? [],
-        }
+      ? supplementalLifecyclePreviewStores(bundle)
       : bundleForIndexedDb(bundle);
     state.supplementalLifecycleCsv = lifecyclePreview ? text : null;
     state.previewConflicts =
@@ -1447,11 +1452,7 @@ async function previewImport() {
     renderImportPreview({
       label: detectedFormatLabel(format, text, lifecyclePreview),
       recordsByStore: lifecyclePreview
-        ? {
-            lifecycleEvents: bundle.lifecycleEvents ?? [],
-            interviews: bundle.interviews ?? [],
-            reminders: bundle.reminders ?? [],
-          }
+        ? supplementalLifecyclePreviewStores(bundle)
         : state.preview,
       conflicts: state.previewConflicts,
       warnings: lifecyclePreview?.warnings ?? compactPreview?.warnings ?? [],
@@ -1500,7 +1501,9 @@ async function applyImport() {
       if (currentPlan.errors.length || currentPlan.conflicts.length) {
         renderImportPreview({
           label: "supplemental lifecycle CSV",
-          recordsByStore: currentPlan.bundle ?? {},
+          recordsByStore: supplementalLifecyclePreviewStores(
+            currentPlan.bundle ?? {},
+          ),
           conflicts: currentPlan.conflicts,
           warnings: currentPlan.warnings,
           errors: currentPlan.errors,

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -367,6 +367,8 @@ test.describe("browser application tracker", () => {
     ].join("\n");
     const technicalLifecycle = [
       "event_id,application_id,event_type,occurred_at,due_at",
+      "event_preserve_completed_technical,app_preserve_completed," +
+        "technical_interview_completed,2027-02-04T09:00:00.000Z,",
       "event_preserve_devops,app_preserve_devops," +
         "technical_interview_completed,2027-02-04T10:00:00.000Z,",
       "event_preserve_control,app_preserve_control," +
@@ -376,6 +378,30 @@ test.describe("browser application tracker", () => {
 
     await page.getByRole("button", { name: "Import/Export" }).click();
     await importFixture(page, "preserved-compact.csv", compact);
+    const lifecycleSnapshot = () =>
+      page.evaluate(async () => {
+        const request = indexedDB.open("jobbot3000");
+        const database = await new Promise((resolve, reject) => {
+          request.onsuccess = () => resolve(request.result);
+          request.onerror = () => reject(request.error);
+        });
+        const snapshot = {};
+        for (const storeName of [
+          "applications",
+          "lifecycleEvents",
+          "interviews",
+          "reminders",
+        ]) {
+          const transaction = database.transaction(storeName, "readonly");
+          snapshot[storeName] = await new Promise((resolve, reject) => {
+            const getAll = transaction.objectStore(storeName).getAll();
+            getAll.onsuccess = () => resolve(getAll.result);
+            getAll.onerror = () => reject(getAll.error);
+          });
+        }
+        database.close();
+        return snapshot;
+      });
     for (const [name, lifecycle] of [
       ["preserved-recruiter.csv", recruiterLifecycle],
       ["preserved-technical.csv", technicalLifecycle],
@@ -385,38 +411,23 @@ test.describe("browser application tracker", () => {
         mimeType: "text/csv",
         buffer: Buffer.from(lifecycle),
       });
+      const beforePreview = await lifecycleSnapshot();
       await page.getByRole("button", { name: "Preview/dry-run" }).click();
       await expect(page.locator("[data-import-result]")).toContainText(
         "Detected format: supplemental lifecycle CSV",
       );
-      await expect(page.locator("[data-import-result]")).not.toContainText(
-        "applications: 4",
+      await expect(page.locator("[data-import-result]")).toContainText(
+        "Dry-run OK: 0 applications",
       );
+      expect(await lifecycleSnapshot()).toEqual(beforePreview);
       if (name === "preserved-technical.csv") {
-        await page.evaluate(async () => {
-          const request = indexedDB.open("jobbot3000");
-          const database = await new Promise((resolve, reject) => {
-            request.onsuccess = () => resolve(request.result);
-            request.onerror = () => reject(request.error);
-          });
-          const transaction = database.transaction("applications", "readwrite");
-          const store = transaction.objectStore("applications");
-          const application = await new Promise((resolve, reject) => {
-            const get = store.get("app_preserve_devops");
-            get.onsuccess = () => resolve(get.result);
-            get.onerror = () => reject(get.error);
-          });
-          store.put({
-            ...application,
-            company: "Stage DevOps Updated",
-            updatedAt: "2027-02-04T11:00:00.000Z",
-          });
-          await new Promise((resolve, reject) => {
-            transaction.oncomplete = resolve;
-            transaction.onerror = () => reject(transaction.error);
-          });
-          database.close();
-        });
+        await page
+          .getByRole("button", { name: "Applications", exact: true })
+          .click();
+        await page.getByRole("button", { name: "Stage DevOps" }).click();
+        await page.locator('[name="company"]').fill("Stage DevOps Updated");
+        await page.getByRole("button", { name: "Save application" }).click();
+        await page.getByRole("button", { name: "Import/Export" }).click();
       }
       await page.getByRole("button", { name: "Apply import" }).click();
       await expect(page.locator("[data-import-result]")).toContainText(
@@ -468,19 +479,29 @@ test.describe("browser application tracker", () => {
       database.close();
       return applications.map(({ id, notes }) => ({ id, notes }));
     });
-    const devopsMetadataLine = metadata
-      .find(({ id }) => id === "app_preserve_devops")
-      .notes.split("\n")
-      .find((line) => line.startsWith("Spreadsheet metadata:"));
-    const devopsMetadata = JSON.parse(
-      devopsMetadataLine.replace("Spreadsheet metadata:", ""),
+    const metadataById = new Map(
+      metadata.map(({ id, notes }) => {
+        const metadataLine = notes
+          .split("\n")
+          .find((line) => line.startsWith("Spreadsheet metadata:"));
+        return [
+          id,
+          JSON.parse(metadataLine.replace("Spreadsheet metadata:", "")),
+        ];
+      }),
     );
-    expect(devopsMetadata.raw_row.interview_stage).toBe(
-      "DevOps interview completed",
-    );
-    expect(devopsMetadata.canonical_row.interview_stage).toBe(
-      "technical_screen",
-    );
+    const projectedStages = new Map([
+      ["app_preserve_scheduling", "recruiter_screen"],
+      ["app_preserve_completed", "technical_screen"],
+      ["app_preserve_devops", "technical_screen"],
+      ["app_preserve_control", "technical_screen"],
+    ]);
+    for (const [id, originalStage] of originalStages) {
+      expect(metadataById.get(id).raw_row.interview_stage).toBe(originalStage);
+      expect(metadataById.get(id).canonical_row.interview_stage).toBe(
+        projectedStages.get(id),
+      );
+    }
 
     await page
       .getByRole("button", { name: "Applications", exact: true })

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -333,6 +333,57 @@ test.describe("browser application tracker", () => {
     await expect(page.locator("[data-import-result]")).toContainText(
       "unknown_application",
     );
+    await expect(page.locator("[data-import-result]")).not.toContainText(
+      "applications:",
+    );
+    await expect(
+      page.getByRole("button", { name: "Apply import" }),
+    ).toBeDisabled();
+
+    const applyConflictLifecycle = [
+      "event_id,application_id,event_type,occurred_at,due_at",
+      "event_apply_conflict,app_reg_alpha_001,technical_interview_completed," +
+        "2026-03-01T10:00:00.000Z,",
+    ].join("\n");
+    await page.setInputFiles("[data-import-file]", {
+      name: "apply-conflict-lifecycle.csv",
+      mimeType: "text/csv",
+      buffer: Buffer.from(applyConflictLifecycle),
+    });
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+    await expect(page.locator("[data-import-result] p").first()).toHaveText(
+      /^Dry-run OK: 0 applications,/,
+    );
+    await page.evaluate(async () => {
+      const request = indexedDB.open("jobbot3000");
+      const database = await new Promise((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+      const transaction = database.transaction("interviews", "readwrite");
+      transaction.objectStore("interviews").put({
+        id: "interview_event_apply_conflict",
+        applicationId: "app_reg_alpha_001",
+        contactIds: [],
+        stage: "onsite_loop",
+        startsAt: "2026-03-01T10:00:00.000Z",
+        outcome: "scheduled",
+        createdAt: "2026-02-28T10:00:00.000Z",
+        updatedAt: "2026-02-28T10:00:00.000Z",
+      });
+      await new Promise((resolve, reject) => {
+        transaction.oncomplete = () => resolve();
+        transaction.onerror = () => reject(transaction.error);
+      });
+      database.close();
+    });
+    await page.getByRole("button", { name: "Apply import" }).click();
+    await expect(page.locator("[data-import-result]")).toContainText(
+      "duplicate_existing",
+    );
+    await expect(page.locator("[data-import-result]")).not.toContainText(
+      "applications:",
+    );
     await expect(
       page.getByRole("button", { name: "Apply import" }),
     ).toBeDisabled();

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -338,6 +338,142 @@ test.describe("browser application tracker", () => {
     ).toBeDisabled();
   });
 
+  test("preserves compact stages through lifecycle preview and apply", async ({
+    page,
+  }) => {
+    const compact = [
+      "application_id,company,role_title,status,applied_at,posting_url," +
+        "application_channel,interview_stage,notes",
+      "app_preserve_scheduling,Stage Scheduling,Engineer,Interviewing," +
+        "2027-01-01,https://example.test/scheduling,Community board," +
+        "Recruiter screen scheduling,Untouched scheduling note",
+      "app_preserve_completed,Stage Completed,Engineer,Interviewing," +
+        "2027-01-02,https://example.test/completed,Community board," +
+        "Recruiter screen completed,Untouched completed note",
+      "app_preserve_devops,Stage DevOps,Engineer,Interviewing,2027-01-03," +
+        "https://example.test/devops,Community board," +
+        "DevOps interview completed,Untouched DevOps note",
+      "app_preserve_control,Stage Control,Engineer,Interviewing,2027-01-04," +
+        "https://example.test/control,Community board,Technical screen," +
+        "Untouched control note",
+    ].join("\n");
+    const recruiterLifecycle = [
+      "event_id,application_id,event_type,occurred_at,due_at",
+      "event_preserve_scheduling,app_preserve_scheduling," +
+        "recruiter_screen_scheduled,2027-02-01T10:00:00.000Z," +
+        "2027-02-02T10:00:00.000Z",
+      "event_preserve_completed,app_preserve_completed," +
+        "recruiter_screen_completed,2027-02-03T10:00:00.000Z,",
+    ].join("\n");
+    const technicalLifecycle = [
+      "event_id,application_id,event_type,occurred_at,due_at",
+      "event_preserve_devops,app_preserve_devops," +
+        "technical_interview_completed,2027-02-04T10:00:00.000Z,",
+      "event_preserve_control,app_preserve_control," +
+        "technical_interview_scheduled,2027-02-05T10:00:00.000Z," +
+        "2027-02-06T10:00:00.000Z",
+    ].join("\n");
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await importFixture(page, "preserved-compact.csv", compact);
+    for (const [name, lifecycle] of [
+      ["preserved-recruiter.csv", recruiterLifecycle],
+      ["preserved-technical.csv", technicalLifecycle],
+    ]) {
+      await page.setInputFiles("[data-import-file]", {
+        name,
+        mimeType: "text/csv",
+        buffer: Buffer.from(lifecycle),
+      });
+      await page.getByRole("button", { name: "Preview/dry-run" }).click();
+      await expect(page.locator("[data-import-result]")).toContainText(
+        "Detected format: supplemental lifecycle CSV",
+      );
+      await expect(page.locator("[data-import-result]")).not.toContainText(
+        "applications: 4",
+      );
+      await page.getByRole("button", { name: "Apply import" }).click();
+      await expect(page.locator("[data-import-result]")).toContainText(
+        "Import applied",
+      );
+    }
+
+    const exportRows = async () => {
+      const downloadPromise = page.waitForEvent("download");
+      await page.getByRole("button", { name: "Export compact CSV" }).click();
+      const download = await downloadPromise;
+      return new Map(
+        parseCsv(await readFile(await download.path(), "utf8")).map((row) => [
+          row.application_id,
+          row,
+        ]),
+      );
+    };
+    const originalStages = new Map([
+      ["app_preserve_scheduling", "Recruiter screen scheduling"],
+      ["app_preserve_completed", "Recruiter screen completed"],
+      ["app_preserve_devops", "DevOps interview completed"],
+      ["app_preserve_control", "Technical screen"],
+    ]);
+    const rows = await exportRows();
+    for (const [id, stage] of originalStages) {
+      expect(rows.get(id)).toMatchObject({
+        interview_stage: stage,
+        application_channel: "Community board",
+      });
+      expect(rows.get(id).notes).toContain("Untouched");
+    }
+
+    const metadata = await page.evaluate(async () => {
+      const request = indexedDB.open("jobbot3000");
+      const database = await new Promise((resolve, reject) => {
+        request.onsuccess = () => resolve(request.result);
+        request.onerror = () => reject(request.error);
+      });
+      const transaction = database.transaction("applications", "readonly");
+      const applications = await new Promise((resolve, reject) => {
+        const getAll = transaction.objectStore("applications").getAll();
+        getAll.onsuccess = () => resolve(getAll.result);
+        getAll.onerror = () => reject(getAll.error);
+      });
+      database.close();
+      return applications.map(({ id, notes }) => ({ id, notes }));
+    });
+    const devopsMetadataLine = metadata
+      .find(({ id }) => id === "app_preserve_devops")
+      .notes.split("\n")
+      .find((line) => line.startsWith("Spreadsheet metadata:"));
+    const devopsMetadata = JSON.parse(
+      devopsMetadataLine.replace("Spreadsheet metadata:", ""),
+    );
+    expect(devopsMetadata.raw_row.interview_stage).toBe(
+      "DevOps interview completed",
+    );
+    expect(devopsMetadata.canonical_row.interview_stage).toBe(
+      "technical_screen",
+    );
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Stage DevOps" }).click();
+    await page
+      .locator('[data-interview-form] [name="stage"]')
+      .selectOption("onsite_loop");
+    await page
+      .locator('[data-interview-form] [name="startsAt"]')
+      .fill("2027-03-01");
+    await page.getByRole("button", { name: "Log interview" }).click();
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    const editedRows = await exportRows();
+    expect(editedRows.get("app_preserve_devops").interview_stage).toBe(
+      "onsite_loop",
+    );
+    for (const [id, stage] of originalStages)
+      if (id !== "app_preserve_devops")
+        expect(editedRows.get(id).interview_stage).toBe(stage);
+  });
+
   test("surfaces compact CSV conflicts and non-interview stage warnings", async ({
     page,
   }) => {

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -392,6 +392,32 @@ test.describe("browser application tracker", () => {
       await expect(page.locator("[data-import-result]")).not.toContainText(
         "applications: 4",
       );
+      if (name === "preserved-technical.csv") {
+        await page.evaluate(async () => {
+          const request = indexedDB.open("jobbot3000");
+          const database = await new Promise((resolve, reject) => {
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+          });
+          const transaction = database.transaction("applications", "readwrite");
+          const store = transaction.objectStore("applications");
+          const application = await new Promise((resolve, reject) => {
+            const get = store.get("app_preserve_devops");
+            get.onsuccess = () => resolve(get.result);
+            get.onerror = () => reject(get.error);
+          });
+          store.put({
+            ...application,
+            company: "Stage DevOps Updated",
+            updatedAt: "2027-02-04T11:00:00.000Z",
+          });
+          await new Promise((resolve, reject) => {
+            transaction.oncomplete = resolve;
+            transaction.onerror = () => reject(transaction.error);
+          });
+          database.close();
+        });
+      }
       await page.getByRole("button", { name: "Apply import" }).click();
       await expect(page.locator("[data-import-result]")).toContainText(
         "Import applied",
@@ -423,6 +449,9 @@ test.describe("browser application tracker", () => {
       });
       expect(rows.get(id).notes).toContain("Untouched");
     }
+    expect(rows.get("app_preserve_devops").company).toBe(
+      "Stage DevOps Updated",
+    );
 
     const metadata = await page.evaluate(async () => {
       const request = indexedDB.open("jobbot3000");

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -895,6 +895,14 @@ test.describe("browser application tracker", () => {
     );
     await expect(
       page.getByRole("button", { name: "Apply import" }),
+    ).toBeDisabled();
+
+    await page.getByRole("button", { name: "Preview/dry-run" }).click();
+    await expect(page.locator("[data-import-result]")).toContainText(
+      "Dry-run OK: 1 applications",
+    );
+    await expect(
+      page.getByRole("button", { name: "Apply import" }),
     ).toBeEnabled();
   });
 

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -162,9 +162,27 @@ describe("spreadsheet import/export", () => {
       raw_row: { interview_stage: "DevOps interview" },
       canonical_row: { interview_stage: "technical_screen" },
     });
-    await importSupplementalLifecycleCsv(lifecycleCsv, repo);
+    const imported = await importSupplementalLifecycleCsv(lifecycleCsv, repo);
     const bundle = await repo.exportAllData();
-    expect(bundle.applications).toEqual(preview.plan.merged.applications);
+    const stableRecords = (records) =>
+      records.map((record) =>
+        Object.fromEntries(
+          Object.entries(record).filter(
+            ([key]) => !["createdAt", "updatedAt"].includes(key),
+          ),
+        ),
+      );
+    for (const store of [
+      "applications",
+      "lifecycleEvents",
+      "interviews",
+      "reminders",
+    ]) {
+      expect(stableRecords(preview.plan.recordsByStore[store] ?? [])).toEqual(
+        stableRecords(imported.preview.plan.recordsByStore[store] ?? []),
+      );
+      expect(bundle[store]).toEqual(imported.preview.plan.merged[store]);
+    }
     bundle.interviews.reverse();
     bundle.lifecycleEvents.reverse();
 
@@ -262,6 +280,83 @@ describe("spreadsheet import/export", () => {
     );
     expect(edited.get("app_stage_beta").notes).toBe("Untouched beta note");
   });
+
+  it("replans sequential lifecycle imports from the persisted application baseline", async () => {
+    const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
+    await importCompactCsv(
+      serializeCsv([
+        {
+          application_id: "app_sequential_stage",
+          company: "Sequential Example",
+          role_title: "Platform Engineer",
+          status: "Interviewing",
+          posting_url: "https://jobs.example.test/sequential",
+          interview_stage: "Custom recruiter conversation",
+          notes: "Keep this note",
+        },
+      ]),
+      repo,
+      { mode: "replace" },
+    );
+    const firstCsv = [
+      "event_id,application_id,event_type,occurred_at,due_at",
+      "event_sequential_recruiter,app_sequential_stage,recruiter_screen_completed," +
+        "2027-05-01T10:00:00.000Z,",
+    ].join("\n");
+    const firstPlan = await previewSupplementalLifecycleCsvImport(
+      firstCsv,
+      repo,
+    );
+    await repo.importPartialData(firstPlan.plan.recordsByStore);
+
+    const afterFirst = await repo.exportAllData();
+    await repo.upsertApplication({
+      ...afterFirst.applications[0],
+      company: "Sequential Example Updated",
+      role: "Principal Platform Engineer",
+      postingUrl: "https://jobs.example.test/sequential-updated",
+      updatedAt: "2027-05-02T12:00:00.000Z",
+    });
+    const secondCsv = [
+      "event_id,application_id,event_type,occurred_at,due_at",
+      "event_sequential_technical,app_sequential_stage,technical_interview_completed," +
+        "2027-05-03T10:00:00.000Z,",
+    ].join("\n");
+    const secondPlan = await previewSupplementalLifecycleCsvImport(
+      secondCsv,
+      repo,
+    );
+    const plannedApplication = secondPlan.plan.recordsByStore.applications[0];
+    expect(plannedApplication).toMatchObject({
+      company: "Sequential Example Updated",
+      role: "Principal Platform Engineer",
+      postingUrl: "https://jobs.example.test/sequential-updated",
+      updatedAt: "2027-05-02T12:00:00.000Z",
+    });
+    const metadataLine = plannedApplication.notes
+      .split("\n")
+      .find((line) => line.startsWith("Spreadsheet metadata:"));
+    const metadata = JSON.parse(
+      metadataLine.replace("Spreadsheet metadata:", ""),
+    );
+    expect(metadata.raw_row.interview_stage).toBe(
+      "Custom recruiter conversation",
+    );
+    expect(metadata.canonical_row.interview_stage).toBe("technical_screen");
+
+    await repo.importPartialData(secondPlan.plan.recordsByStore);
+    const persisted = await repo.exportAllData();
+    expect(
+      browserApplicationExportToCanonicalRows(persisted)[0].interview_stage,
+    ).toBe("technical_screen");
+    expect(persisted.applications[0]).toMatchObject({
+      company: "Sequential Example Updated",
+      role: "Principal Platform Engineer",
+      postingUrl: "https://jobs.example.test/sequential-updated",
+    });
+    repo.close();
+  });
+
   it("runs a fake full-fidelity backup/restore smoke flow", async () => {
     const repo = await createIndexedDbRepository({ indexedDb: indexedDB });
     const csv = await fixture();

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -95,6 +95,21 @@ describe("spreadsheet import/export", () => {
       },
     ]);
     await importCompactCsv(compactCsv, repo, { mode: "replace" });
+    const beforeMutation = await repo.exportAllData();
+    const alphaBeforeMutation = beforeMutation.applications.find(
+      ({ id }) => id === "app_stage_alpha",
+    );
+    const originalAlphaMetadata = JSON.parse(
+      alphaBeforeMutation.notes
+        .split("\n")
+        .find((line) => line.startsWith("Spreadsheet metadata:"))
+        .replace("Spreadsheet metadata:", ""),
+    );
+    await repo.upsertApplication({
+      ...alphaBeforeMutation,
+      status: "onsite_loop",
+      updatedAt: "2027-03-01T00:00:00.000Z",
+    });
     const lifecycleCsv = [
       "event_id,application_id,event_type,occurred_at,due_at",
       [
@@ -106,8 +121,50 @@ describe("spreadsheet import/export", () => {
         "2027-04-01T12:00:00.000Z,2027-04-03T12:00:00.000Z",
       ].join(","),
     ].join("\n");
+    const preview = await previewSupplementalLifecycleCsvImport(
+      lifecycleCsv,
+      repo,
+    );
+    expect(preview.plan.recordsByStore).toMatchObject({
+      lifecycleEvents: expect.any(Array),
+      interviews: expect.any(Array),
+      reminders: expect.any(Array),
+      applications: expect.arrayContaining([
+        expect.objectContaining({ id: "app_stage_alpha" }),
+        expect.objectContaining({ id: "app_stage_beta" }),
+      ]),
+    });
+    const metadataById = new Map(
+      preview.plan.recordsByStore.applications.map((application) => {
+        const metadataLine = application.notes
+          .split("\n")
+          .find((line) => line.startsWith("Spreadsheet metadata:"));
+        return [
+          application.id,
+          JSON.parse(metadataLine.replace("Spreadsheet metadata:", "")),
+        ];
+      }),
+    );
+    expect(metadataById.get("app_stage_alpha")).toMatchObject({
+      raw_row: {
+        interview_stage: "Technical screen",
+        notes: "Untouched alpha note",
+      },
+      canonical_row: {
+        interview_stage: "recruiter_screen",
+        notes: "Untouched alpha note",
+      },
+    });
+    expect(metadataById.get("app_stage_alpha").canonical_row.status).toBe(
+      originalAlphaMetadata.canonical_row.status,
+    );
+    expect(metadataById.get("app_stage_beta")).toMatchObject({
+      raw_row: { interview_stage: "DevOps interview" },
+      canonical_row: { interview_stage: "technical_screen" },
+    });
     await importSupplementalLifecycleCsv(lifecycleCsv, repo);
     const bundle = await repo.exportAllData();
+    expect(bundle.applications).toEqual(preview.plan.merged.applications);
     bundle.interviews.reverse();
     bundle.lifecycleEvents.reverse();
 


### PR DESCRIPTION
### Motivation

The browser’s supplemental lifecycle CSV Preview → Apply path did not persist required application metadata-envelope rebases. Consequently, compact stage labels could be normalized on later exports even though the direct import helper preserved them correctly.

### Implementation

- Added the pure shared planner `planSupplementalLifecycleImport(existing, incomingBundle)`.
  - Merges `lifecycleEvents`, `interviews`, and `reminders` using existing stable-ID replacement semantics.
  - Computes canonical compact rows before and after the merge.
  - Rebases only `status`, `interview_stage`, and `outcome` for eligible version-2 metadata envelopes when the live value still matches the stored baseline.
  - Preserves `raw_row`, unrelated columns, user notes, genuine manual mutations, and legacy or invalid metadata behavior.
  - Returns both complete merged data and a partial `recordsByStore` payload containing incoming lifecycle records plus only changed applications.
- Reused the planner from `previewSupplementalLifecycleCsvImport()` and `importSupplementalLifecycleCsv()`.
- Updated the browser Preview → Apply flow to:
  - Retain the validated lifecycle-only records and original CSV, not preview-time application snapshots.
  - Re-read current IndexedDB data and replan immediately before Apply, preserving intervening application edits.
  - Revalidate lifecycle errors and conflicts before writing.
  - Persist the fresh partial payload through one validated atomic `batchImport()` transaction.
  - Discard pending import state after cancellation, failure, blocking revalidation, or success.
  - Require a fresh Preview after an Apply failure.
- Scoped every supplemental-lifecycle preview render path to lifecycle-only stores so internal application-envelope maintenance never appears as incoming application records.

### Regression coverage

- Unit coverage verifies planner payloads, immutable raw cells, updated canonical baselines, manual-edit precedence, repeated imports, and equivalence with the direct helper.
- Browser coverage uses the real Preview → Apply and export flows to verify:
  - Exact preservation of `Recruiter screen scheduling`, `Recruiter screen completed`, `DevOps interview completed`, and the `Technical screen` control.
  - Preview remains side-effect-free.
  - Sequential lifecycle imports retain untouched raw cells.
  - An application edit made after Preview survives Apply.
  - A later manual interview supersedes preserved raw text.
  - Initial and Apply-time blocking previews do not report existing applications as incoming records.
  - Failed writes invalidate the pending plan until Preview is run again.

### Compatibility

This change does not alter lifecycle classification, counts, identity, provenance, precision, chronological stage selection, compact Replace/Merge behavior, JSON or NDJSON backups, schemas, or IndexedDB’s browser-first architecture. No migration or documentation change is required.

Files changed:

- `src/web/import-export/spreadsheet.js`
- `src/web/tracker/tracker.js`
- `test/web-spreadsheet-import-export.test.js`
- `test/playwright/browser-tracker.spec.js`

### Verification

- Formatting, lint, and typecheck passed.
- `npx vitest run test/web-spreadsheet-import-export.test.js` — 55 tests passed.
- Targeted supplemental-lifecycle, compact-stage, and import-failure Playwright coverage — 3 tests passed.
- GitHub CI #5162 — passed.
- Build and publish GHCR image #557, including CI tests and image smoke testing — passed.
- Diagram visual review #279 — passed.

---

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bc8751740832fae1c9eb5b1874d69)