### PR TITLE
Preserve compact stages in lifecycle UI imports

### DIFF
--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1893,6 +1893,78 @@ const lifecycleRecordsEqual = (left, right) =>
   JSON.stringify(lifecycleComparableRecord(left)) ===
   JSON.stringify(lifecycleComparableRecord(right));
 
+const supplementalLifecycleStores = [
+  "lifecycleEvents",
+  "interviews",
+  "reminders",
+];
+
+export const planSupplementalLifecycleCsvImport = (
+  existing,
+  incomingBundle,
+) => {
+  const merged = { ...existing, exportedAt: nowIso() };
+  for (const store of supplementalLifecycleStores) {
+    const incoming = incomingBundle[store] ?? [];
+    const incomingIds = new Set(incoming.map(({ id }) => id));
+    merged[store] = [
+      ...(existing[store] ?? []).filter(({ id }) => !incomingIds.has(id)),
+      ...incoming,
+    ];
+  }
+  const priorRows = new Map(
+    browserApplicationExportToCanonicalRows(existing).map((row) => [
+      row.application_id,
+      row,
+    ]),
+  );
+  const projectedRows = new Map(
+    browserApplicationExportToCanonicalRows(merged).map((row) => [
+      row.application_id,
+      row,
+    ]),
+  );
+  const projectedColumns = ["status", "interview_stage", "outcome"];
+  const changedApplications = [];
+  merged.applications = merged.applications.map((application) => {
+    const { notes, metadata } = readMetadataFromNotes(application.notes);
+    if (!isV2SpreadsheetMetadataEnvelope(metadata)) return application;
+    const prior = priorRows.get(application.id);
+    const projected = projectedRows.get(application.id);
+    if (!prior || !projected) return application;
+    const canonicalRow = { ...metadata.canonical_row };
+    for (const column of projectedColumns)
+      if (
+        String(prior[column] ?? "") ===
+        String(metadata.canonical_row[column] ?? "")
+      )
+        canonicalRow[column] = String(projected[column] ?? "");
+    if (JSON.stringify(canonicalRow) === JSON.stringify(metadata.canonical_row))
+      return application;
+    const changed = {
+      ...application,
+      notes: appendMetadataToNotes(notes, {
+        ...metadata,
+        canonical_row: canonicalRow,
+      }),
+    };
+    changedApplications.push(changed);
+    return changed;
+  });
+  return {
+    merged,
+    recordsByStore: {
+      applications: changedApplications,
+      ...Object.fromEntries(
+        supplementalLifecycleStores.map((store) => [
+          store,
+          incomingBundle[store] ?? [],
+        ]),
+      ),
+    },
+  };
+};
+
 export const previewSupplementalLifecycleCsvImport = async (
   csvText,
   repository,
@@ -1951,6 +2023,7 @@ export const previewSupplementalLifecycleCsvImport = async (
     }
     bundle[store] = deduped;
   }
+  const plan = planSupplementalLifecycleCsvImport(existing, bundle);
   return {
     kind: "lifecycle_csv",
     rowCount: rows.length,
@@ -1964,6 +2037,7 @@ export const previewSupplementalLifecycleCsvImport = async (
     conflicts,
     warnings,
     bundle,
+    applyBundle: plan.recordsByStore,
   };
 };
 
@@ -1975,50 +2049,10 @@ export const importSupplementalLifecycleCsv = async (csvText, repository) => {
   if (preview.errors.length > 0 || preview.conflicts.length > 0)
     return { imported: false, preview };
   const existing = await repository.exportAllData();
-  const merged = { ...existing, exportedAt: nowIso() };
-  for (const store of ["lifecycleEvents", "interviews", "reminders"]) {
-    const incoming = preview.bundle[store] ?? [];
-    merged[store] = [
-      ...(existing[store] ?? []).filter(
-        (record) => !incoming.some(({ id }) => id === record.id),
-      ),
-      ...incoming,
-    ];
-  }
-  const priorRows = new Map(
-    browserApplicationExportToCanonicalRows(existing).map((row) => [
-      row.application_id,
-      row,
-    ]),
+  const { merged } = planSupplementalLifecycleCsvImport(
+    existing,
+    preview.bundle,
   );
-  const projectedRows = new Map(
-    browserApplicationExportToCanonicalRows(merged).map((row) => [
-      row.application_id,
-      row,
-    ]),
-  );
-  const projectedColumns = ["status", "interview_stage", "outcome"];
-  merged.applications = merged.applications.map((application) => {
-    const { notes, metadata } = readMetadataFromNotes(application.notes);
-    if (!isV2SpreadsheetMetadataEnvelope(metadata)) return application;
-    const prior = priorRows.get(application.id);
-    const projected = projectedRows.get(application.id);
-    if (!prior || !projected) return application;
-    const canonicalRow = { ...metadata.canonical_row };
-    for (const column of projectedColumns)
-      if (
-        String(prior[column] ?? "") ===
-        String(metadata.canonical_row[column] ?? "")
-      )
-        canonicalRow[column] = String(projected[column] ?? "");
-    return {
-      ...application,
-      notes: appendMetadataToNotes(notes, {
-        ...metadata,
-        canonical_row: canonicalRow,
-      }),
-    };
-  });
   return {
     imported: true,
     preview,

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -1428,11 +1428,7 @@ async function previewImport() {
           ? importJsonBackup(text)
           : importNdjsonBackup(text);
     state.preview = lifecyclePreview
-      ? {
-          lifecycleEvents: bundle.lifecycleEvents ?? [],
-          interviews: bundle.interviews ?? [],
-          reminders: bundle.reminders ?? [],
-        }
+      ? lifecyclePreview.applyBundle
       : bundleForIndexedDb(bundle);
     state.previewConflicts =
       lifecyclePreview?.conflicts ??
@@ -1440,7 +1436,13 @@ async function previewImport() {
       (await detectImportConflicts(state.preview));
     renderImportPreview({
       label: detectedFormatLabel(format, text, lifecyclePreview),
-      recordsByStore: state.preview,
+      recordsByStore: lifecyclePreview
+        ? {
+            lifecycleEvents: lifecyclePreview.bundle.lifecycleEvents ?? [],
+            interviews: lifecyclePreview.bundle.interviews ?? [],
+            reminders: lifecyclePreview.bundle.reminders ?? [],
+          }
+        : state.preview,
       conflicts: state.previewConflicts,
       warnings: lifecyclePreview?.warnings ?? compactPreview?.warnings ?? [],
     });
@@ -1482,16 +1484,24 @@ async function applyImport() {
       `Import will replace ${state.previewConflicts.length} existing local records with matching IDs. Continue?`,
     )
   ) {
+    state.preview = null;
+    state.previewConflicts = [];
+    $("[data-import-apply]").disabled = true;
     $("[data-import-result]").textContent = "Import canceled.";
     return;
   }
   try {
     await batchImport(state.preview);
   } catch (err) {
+    state.preview = null;
+    state.previewConflicts = [];
+    $("[data-import-apply]").disabled = true;
     $("[data-import-result]").textContent =
       `Import failed: ${err?.message ?? err}`;
     return;
   }
+  state.preview = null;
+  state.previewConflicts = [];
   $("[data-import-result]").textContent =
     "Import applied successfully. Your tracker data remains local in this browser.";
   $("[data-import-apply]").disabled = true;

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -338,6 +338,133 @@ test.describe("browser application tracker", () => {
     ).toBeDisabled();
   });
 
+  test("preserves compact stages through lifecycle preview and apply", async ({
+    page,
+  }) => {
+    const compact = [
+      "application_id,company,role_title,status,posting_url," +
+        "application_channel,interview_stage,notes",
+      "preserve_schedule,Example Schedule,Engineer,Interviewing," +
+        "https://jobs.example.test/schedule,custom-alpha," +
+        "Recruiter screen scheduling,Untouched schedule note",
+      "preserve_complete,Example Complete,Engineer,Interviewing," +
+        "https://jobs.example.test/complete,custom-beta," +
+        "Recruiter screen completed,Untouched complete note",
+      "preserve_devops,Example DevOps,Engineer,Interviewing," +
+        "https://jobs.example.test/devops,custom-gamma," +
+        "DevOps interview completed,Untouched devops note",
+      "preserve_control,Example Control,Engineer,Interviewing," +
+        "https://jobs.example.test/control,custom-delta," +
+        "Technical screen,Untouched control note",
+    ].join("\n");
+    const firstLifecycle = [
+      "event_id,application_id,event_type,occurred_at,due_at",
+      "event_schedule,preserve_schedule,recruiter_screen_scheduled," +
+        "2027-01-01T12:00:00.000Z,2027-01-02T12:00:00.000Z",
+      "event_complete,preserve_complete,recruiter_screen_completed," +
+        "2027-01-03T12:00:00.000Z,",
+    ].join("\n");
+    const secondLifecycle = [
+      "event_id,application_id,event_type,occurred_at,due_at",
+      "event_devops,preserve_devops,technical_interview_completed," +
+        "2027-01-04T12:00:00.000Z,",
+      "event_control,preserve_control,technical_interview_scheduled," +
+        "2027-01-05T12:00:00.000Z,2027-01-06T12:00:00.000Z",
+    ].join("\n");
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await importFixture(page, "preservation-compact.csv", compact);
+    for (const [name, csv] of [
+      ["preservation-lifecycle-one.csv", firstLifecycle],
+      ["preservation-lifecycle-two.csv", secondLifecycle],
+    ]) {
+      await page.setInputFiles("[data-import-file]", {
+        name,
+        mimeType: "text/csv",
+        buffer: Buffer.from(csv),
+      });
+      await page.getByRole("button", { name: "Preview/dry-run" }).click();
+      const result = page.locator("[data-import-result]");
+      await expect(result).toContainText(
+        "Detected format: supplemental lifecycle CSV",
+      );
+      await expect(result).toContainText("Dry-run OK: 0 applications");
+      await page.getByRole("button", { name: "Apply import" }).click();
+    }
+
+    const exportRows = async () => {
+      const downloadPromise = page.waitForEvent("download");
+      await page.getByRole("button", { name: "Export compact CSV" }).click();
+      const download = await downloadPromise;
+      return parseCsv(await readFile(await download.path(), "utf8"));
+    };
+    const expectedStages = new Map([
+      ["preserve_schedule", "Recruiter screen scheduling"],
+      ["preserve_complete", "Recruiter screen completed"],
+      ["preserve_devops", "DevOps interview completed"],
+      ["preserve_control", "Technical screen"],
+    ]);
+    let rows = await exportRows();
+    for (const row of rows) {
+      expect(row.interview_stage).toBe(expectedStages.get(row.application_id));
+      expect(row.application_channel).toMatch(/^custom-/);
+      expect(row.notes).toMatch(/^Untouched/);
+    }
+
+    const envelopes = await page.evaluate(
+      () =>
+        new Promise((resolve, reject) => {
+          const request = indexedDB.open("jobbot3000");
+          request.onerror = () => reject(request.error);
+          request.onsuccess = () => {
+            const db = request.result;
+            const get = db
+              .transaction("applications")
+              .objectStore("applications")
+              .getAll();
+            get.onerror = () => reject(get.error);
+            get.onsuccess = () => {
+              resolve(get.result.map(({ id, notes }) => ({ id, notes })));
+              db.close();
+            };
+          };
+        }),
+    );
+    for (const { id, notes } of envelopes) {
+      const metadata = JSON.parse(
+        notes
+          .split("\n")
+          .find((line) => line.startsWith("Spreadsheet metadata:"))
+          .slice("Spreadsheet metadata:".length),
+      );
+      expect(metadata.raw_row.interview_stage).toBe(expectedStages.get(id));
+      expect(metadata.canonical_row.interview_stage).toMatch(
+        /^(recruiter_screen|technical_screen)$/,
+      );
+    }
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Example DevOps" }).click();
+    const interviewForm = page.locator("[data-interview-form]");
+    await interviewForm.locator('[name="stage"]').selectOption("onsite_loop");
+    await interviewForm.locator('[name="startsAt"]').fill("2027-02-01");
+    await interviewForm.getByRole("button", { name: "Log interview" }).click();
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    rows = await exportRows();
+    expect(
+      rows.find(({ application_id }) => application_id === "preserve_devops")
+        .interview_stage,
+    ).toBe("onsite_loop");
+    for (const [id, stage] of expectedStages)
+      if (id !== "preserve_devops")
+        expect(
+          rows.find(({ application_id }) => application_id === id)
+            .interview_stage,
+        ).toBe(stage);
+  });
+
   test("surfaces compact CSV conflicts and non-interview stage warnings", async ({
     page,
   }) => {

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -24,6 +24,7 @@ import {
   importNdjsonBackup,
   lifecycleRowsToBrowserApplicationExport,
   parseCsv,
+  planSupplementalLifecycleCsvImport,
   serializeCsv,
   previewCompactCsvImport,
   previewSupplementalLifecycleCsvImport,
@@ -106,6 +107,35 @@ describe("spreadsheet import/export", () => {
         "2027-04-01T12:00:00.000Z,2027-04-03T12:00:00.000Z",
       ].join(","),
     ].join("\n");
+    const before = await repo.exportAllData();
+    const preview = await previewSupplementalLifecycleCsvImport(
+      lifecycleCsv,
+      repo,
+    );
+    const plan = planSupplementalLifecycleCsvImport(before, preview.bundle);
+    expect(preview.applyBundle).toEqual(plan.recordsByStore);
+    expect(preview.applyBundle.interviews).toHaveLength(2);
+    expect(preview.applyBundle.applications).toHaveLength(2);
+    const plannedMetadata = new Map(
+      preview.applyBundle.applications.map((application) => [
+        application.id,
+        JSON.parse(
+          application.notes
+            .split("\n")
+            .find((line) => line.startsWith("Spreadsheet metadata:"))
+            .slice("Spreadsheet metadata:".length),
+        ),
+      ]),
+    );
+    expect(plannedMetadata.get("app_stage_alpha").raw_row.interview_stage).toBe(
+      "Technical screen",
+    );
+    expect(
+      plannedMetadata.get("app_stage_alpha").canonical_row.interview_stage,
+    ).toBe("recruiter_screen");
+    expect(preview.applyBundle.applications[0].notes).toContain(
+      "Untouched alpha note",
+    );
     await importSupplementalLifecycleCsv(lifecycleCsv, repo);
     const bundle = await repo.exportAllData();
     bundle.interviews.reverse();


### PR DESCRIPTION
### Motivation

- The browser Preview → Apply path for supplemental lifecycle CSVs dropped application metadata-envelope rebases, causing compact-stage display labels to be normalized on export instead of preserving raw cells where appropriate. The goal is to share the rebasing logic and make Preview produce an atomic apply plan that includes only needed application-envelope updates.

### Description

- Extract a pure planner `planSupplementalLifecycleCsvImport(existing, incomingBundle)` to merge `lifecycleEvents`, `interviews`, and `reminders`, compute prior/projected canonical rows, and rebase only `status`, `interview_stage`, and `outcome` when the live canonical still equals the stored baseline; it never mutates `raw_row` and only returns changed application envelopes plus lifecycle stores (`src/web/import-export/spreadsheet.js`).
- Wire the planner into both import entry points so `importSupplementalLifecycleCsv()` and the browser Preview path use the same algorithm and merged result rather than duplicating logic (`src/web/import-export/spreadsheet.js`).
- Update the browser Preview → Apply flow to expose the planner’s partial-apply bundle in `state.preview` while continuing to display lifecycle-only preview counts, and ensure the apply/cancel/error/reset paths clear the pending plan and keep writes atomic via existing `importPartialData()`/`batchImport()` (`src/web/tracker/tracker.js`).
- Add unit assertions that the browser-oriented plan equals the shared planner and preserves `raw_row` while updating canonical baselines (`test/web-spreadsheet-import-export.test.js`).
- Add a Playwright regression `preserves compact stages through lifecycle preview and apply` that uses the real UI (file selection → Preview/dry-run → Apply import), verifies byte-for-byte preserved labels, checks persisted envelopes in IndexedDB, and confirms a later manual interview supersedes a preserved raw cell (`test/playwright/browser-tracker.spec.js`).

### Testing

- Ran formatting and static checks: `npx prettier --check src/web/import-export/spreadsheet.js src/web/tracker/tracker.js test/web-spreadsheet-import-export.test.js test/playwright/browser-tracker.spec.js` (ok) and `npm run lint -- --quiet` (ok), and `npm run typecheck` (ok).
- Focused unit tests: `npx vitest run test/web-spreadsheet-import-export.test.js test/web-storage-browser-data-migration.test.js test/web-tracker-metrics.test.js test/web-tracker-lifecycle-projection.test.js` — all targeted suites passed.
- Focused Playwright: `npx playwright test test/playwright/browser-tracker.spec.js --grep "preserves compact stages through lifecycle preview and apply"` — the new UI regression passed.
- Full CI run: `npm run test:ci` — 1,338 tests passed; two unrelated timing-sensitive tests failed (a reminders-loaded timeout and one lifecycle-diagram layout timing test), noted as not caused by this change.

Files changed: `src/web/import-export/spreadsheet.js`, `src/web/tracker/tracker.js`, `test/web-spreadsheet-import-export.test.js`, `test/playwright/browser-tracker.spec.js`.

Residual risks and notes: the planner is pure and conservative (only rebases eligible canonical columns and leaves `raw_row` intact); Preview remains side-effect-free; apply is atomic via existing transaction paths; two unrelated long-running tests flaked in the full CI run and should be retried separately if needed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bc8776550832fb268617fa700f257)