### PR TITLE
Preserve compact stages in browser supplemental lifecycle Preview→Apply

### DIFF
--- a/src/web/import-export/spreadsheet.js
+++ b/src/web/import-export/spreadsheet.js
@@ -1951,6 +1951,7 @@ export const previewSupplementalLifecycleCsvImport = async (
     }
     bundle[store] = deduped;
   }
+  const plan = planSupplementalLifecycleImport(existing, bundle);
   return {
     kind: "lifecycle_csv",
     rowCount: rows.length,
@@ -1964,20 +1965,14 @@ export const previewSupplementalLifecycleCsvImport = async (
     conflicts,
     warnings,
     bundle,
+    applyBundle: plan.recordsByStore,
   };
 };
 
-export const importSupplementalLifecycleCsv = async (csvText, repository) => {
-  const preview = await previewSupplementalLifecycleCsvImport(
-    csvText,
-    repository,
-  );
-  if (preview.errors.length > 0 || preview.conflicts.length > 0)
-    return { imported: false, preview };
-  const existing = await repository.exportAllData();
+export const planSupplementalLifecycleImport = (existing, incomingBundle) => {
   const merged = { ...existing, exportedAt: nowIso() };
   for (const store of ["lifecycleEvents", "interviews", "reminders"]) {
-    const incoming = preview.bundle[store] ?? [];
+    const incoming = incomingBundle[store] ?? [];
     merged[store] = [
       ...(existing[store] ?? []).filter(
         (record) => !incoming.some(({ id }) => id === record.id),
@@ -1998,6 +1993,7 @@ export const importSupplementalLifecycleCsv = async (csvText, repository) => {
     ]),
   );
   const projectedColumns = ["status", "interview_stage", "outcome"];
+  const changedApplications = [];
   merged.applications = merged.applications.map((application) => {
     const { notes, metadata } = readMetadataFromNotes(application.notes);
     if (!isV2SpreadsheetMetadataEnvelope(metadata)) return application;
@@ -2011,14 +2007,36 @@ export const importSupplementalLifecycleCsv = async (csvText, repository) => {
         String(metadata.canonical_row[column] ?? "")
       )
         canonicalRow[column] = String(projected[column] ?? "");
-    return {
+    const rebased = {
       ...application,
       notes: appendMetadataToNotes(notes, {
         ...metadata,
         canonical_row: canonicalRow,
       }),
     };
+    if (rebased.notes !== application.notes) changedApplications.push(rebased);
+    return rebased;
   });
+  return {
+    merged,
+    recordsByStore: {
+      lifecycleEvents: incomingBundle.lifecycleEvents ?? [],
+      interviews: incomingBundle.interviews ?? [],
+      reminders: incomingBundle.reminders ?? [],
+      applications: changedApplications,
+    },
+  };
+};
+
+export const importSupplementalLifecycleCsv = async (csvText, repository) => {
+  const preview = await previewSupplementalLifecycleCsvImport(
+    csvText,
+    repository,
+  );
+  if (preview.errors.length > 0 || preview.conflicts.length > 0)
+    return { imported: false, preview };
+  const existing = await repository.exportAllData();
+  const { merged } = planSupplementalLifecycleImport(existing, preview.bundle);
   return {
     imported: true,
     preview,

--- a/src/web/tracker/tracker.js
+++ b/src/web/tracker/tracker.js
@@ -1428,11 +1428,7 @@ async function previewImport() {
           ? importJsonBackup(text)
           : importNdjsonBackup(text);
     state.preview = lifecyclePreview
-      ? {
-          lifecycleEvents: bundle.lifecycleEvents ?? [],
-          interviews: bundle.interviews ?? [],
-          reminders: bundle.reminders ?? [],
-        }
+      ? lifecyclePreview.applyBundle
       : bundleForIndexedDb(bundle);
     state.previewConflicts =
       lifecyclePreview?.conflicts ??
@@ -1440,7 +1436,13 @@ async function previewImport() {
       (await detectImportConflicts(state.preview));
     renderImportPreview({
       label: detectedFormatLabel(format, text, lifecyclePreview),
-      recordsByStore: state.preview,
+      recordsByStore: lifecyclePreview
+        ? {
+            lifecycleEvents: lifecyclePreview.bundle.lifecycleEvents ?? [],
+            interviews: lifecyclePreview.bundle.interviews ?? [],
+            reminders: lifecyclePreview.bundle.reminders ?? [],
+          }
+        : state.preview,
       conflicts: state.previewConflicts,
       warnings: lifecyclePreview?.warnings ?? compactPreview?.warnings ?? [],
     });

--- a/test/playwright/browser-tracker.spec.js
+++ b/test/playwright/browser-tracker.spec.js
@@ -1049,6 +1049,156 @@ test.describe("browser application tracker", () => {
     });
   });
 
+  test("preserves compact stages through lifecycle preview and apply", async ({
+    page,
+  }) => {
+    const stages = [
+      ["fake_preserve_scheduling", "Recruiter screen scheduling"],
+      ["fake_preserve_completed", "Recruiter screen completed"],
+      ["fake_preserve_devops", "DevOps interview completed"],
+      ["fake_preserve_control", "Technical screen"],
+    ];
+    const compact = [
+      [
+        "application_id",
+        "company",
+        "role_title",
+        "status",
+        "posting_url",
+        "application_channel",
+        "interview_stage",
+        "notes",
+      ].join(","),
+      ...stages.map(([id, stage], index) =>
+        [
+          id,
+          `Example Preserve ${index}`,
+          "Engineer",
+          "Interviewing",
+          `https://example.test/${id}`,
+          `custom-channel-${index}`,
+          stage,
+          `Untouched note ${index}`,
+        ].join(","),
+      ),
+    ].join("\n");
+    const lifecycleOne = [
+      "event_id,application_id,event_type,occurred_at,due_at",
+      [
+        "fake_event_schedule",
+        "fake_preserve_scheduling",
+        "recruiter_screen_scheduled",
+        "2027-04-01T12:00:00.000Z",
+        "2027-04-02T12:00:00.000Z",
+      ].join(","),
+      [
+        "fake_event_complete",
+        "fake_preserve_completed",
+        "recruiter_screen_completed",
+        "2027-04-03T12:00:00.000Z",
+        "",
+      ].join(","),
+    ].join("\n");
+    const lifecycleTwo = [
+      "event_id,application_id,event_type,occurred_at,due_at",
+      [
+        "fake_event_devops",
+        "fake_preserve_devops",
+        "technical_interview_completed",
+        "2027-04-04T12:00:00.000Z",
+        "",
+      ].join(","),
+      [
+        "fake_event_control",
+        "fake_preserve_control",
+        "technical_interview_scheduled",
+        "2027-04-05T12:00:00.000Z",
+        "2027-04-06T12:00:00.000Z",
+      ].join(","),
+    ].join("\n");
+
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    await importFixture(page, "compact-stage-preservation.csv", compact);
+    for (const [name, csv] of [
+      ["lifecycle-preservation-one.csv", lifecycleOne],
+      ["lifecycle-preservation-two.csv", lifecycleTwo],
+    ]) {
+      await page.setInputFiles("[data-import-file]", {
+        name,
+        mimeType: "text/csv",
+        buffer: Buffer.from(csv),
+      });
+      await page.getByRole("button", { name: "Preview/dry-run" }).click();
+      await expect(page.locator("[data-import-result]")).toContainText(
+        "Detected format: supplemental lifecycle CSV",
+      );
+      await expect(page.locator("[data-import-result]")).toContainText(
+        "Dry-run OK: 0 applications",
+      );
+      await page.getByRole("button", { name: "Apply import" }).click();
+    }
+
+    const exportRows = async () => {
+      const downloadPromise = page.waitForEvent("download");
+      await page.getByRole("button", { name: "Export compact CSV" }).click();
+      const download = await downloadPromise;
+      return parseCsv(await readFile(await download.path(), "utf8"));
+    };
+    let rows = new Map(
+      (await exportRows()).map((row) => [row.application_id, row]),
+    );
+    for (const [index, [id, stage]] of stages.entries())
+      expect(rows.get(id)).toMatchObject({
+        interview_stage: stage,
+        application_channel: `custom-channel-${index}`,
+        notes: `Untouched note ${index}`,
+      });
+
+    const persisted = await page.evaluate(
+      () =>
+        new Promise((resolve, reject) => {
+          const request = indexedDB.open("jobbot3000");
+          request.onerror = () => reject(request.error);
+          request.onsuccess = () => {
+            const rowsRequest = request.result
+              .transaction("applications")
+              .objectStore("applications")
+              .getAll();
+            rowsRequest.onerror = () => reject(rowsRequest.error);
+            rowsRequest.onsuccess = () => resolve(rowsRequest.result);
+          };
+        }),
+    );
+    const devops = persisted.find(({ id }) => id === "fake_preserve_devops");
+    expect(devops.notes).toContain(
+      '"interview_stage":"DevOps interview completed"',
+    );
+    expect(devops.notes).toContain('"interview_stage":"technical_screen"');
+
+    await page
+      .getByRole("button", { name: "Applications", exact: true })
+      .click();
+    await page.getByRole("button", { name: "Example Preserve 2" }).click();
+    await page
+      .locator('[data-interview-form] [name="stage"]')
+      .selectOption("onsite_loop");
+    await page
+      .locator('[data-interview-form] [name="startsAt"]')
+      .fill("2028-01-01");
+    await page.getByRole("button", { name: "Log interview" }).click();
+    await page.getByRole("button", { name: "Import/Export" }).click();
+    rows = new Map(
+      (await exportRows()).map((row) => [row.application_id, row]),
+    );
+    expect(rows.get("fake_preserve_devops").interview_stage).toBe(
+      "onsite_loop",
+    );
+    for (const [id, stage] of stages.filter(
+      ([id]) => id !== "fake_preserve_devops",
+    ))
+      expect(rows.get(id).interview_stage).toBe(stage);
+  });
+
   test("retains IndexedDB data across reload, exports backup, and clears local data", async ({
     page,
   }) => {

--- a/test/web-spreadsheet-import-export.test.js
+++ b/test/web-spreadsheet-import-export.test.js
@@ -29,6 +29,7 @@ import {
   previewSupplementalLifecycleCsvImport,
 } from "../src/web/import-export/spreadsheet.js";
 import {
+  readSpreadsheetMetadata,
   recruiterScreenKey,
   selectDashboardMetrics,
 } from "../src/web/tracker/metrics.js";
@@ -106,6 +107,25 @@ describe("spreadsheet import/export", () => {
         "2027-04-01T12:00:00.000Z,2027-04-03T12:00:00.000Z",
       ].join(","),
     ].join("\n");
+    const preview = await previewSupplementalLifecycleCsvImport(
+      lifecycleCsv,
+      repo,
+    );
+    expect(preview.applyBundle).toMatchObject({
+      lifecycleEvents: expect.any(Array),
+      interviews: expect.any(Array),
+      reminders: expect.any(Array),
+      applications: expect.any(Array),
+    });
+    expect(preview.applyBundle.applications).toHaveLength(2);
+    const plannedAlpha = preview.applyBundle.applications.find(
+      ({ id }) => id === "app_stage_alpha",
+    );
+    expect(plannedAlpha.notes).toContain("Untouched alpha note");
+    expect(readSpreadsheetMetadata(plannedAlpha.notes)).toMatchObject({
+      raw_row: { interview_stage: "Technical screen" },
+      canonical_row: { interview_stage: "recruiter_screen" },
+    });
     await importSupplementalLifecycleCsv(lifecycleCsv, repo);
     const bundle = await repo.exportAllData();
     bundle.interviews.reverse();


### PR DESCRIPTION
### Motivation

- The browser Preview → Apply path dropped application metadata envelope rebases, causing compact stage display labels to be normalized on export instead of preserving raw cells when eligible.
- The import helper `importSupplementalLifecycleCsv()` already rebased per-column baselines (PR #1217) but the browser UI did not use that logic.

### Description

- Extracted a shared planner `planSupplementalLifecycleImport(existing, incomingBundle)` and wired it into both preview and direct-import flows so the same rebasing algorithm is used by the helper and the browser path (`src/web/import-export/spreadsheet.js`).
- Planner behavior: merges incoming `lifecycleEvents`/`interviews`/`reminders` by stable id, computes canonical rows before/after projection, and rebases only `status`, `interview_stage`, and `outcome` for valid v2 metadata envelopes when the live canonical value still equals the stored baseline; `raw_row` and non-metadata notes are never mutated and legacy/invalid envelopes are preserved on their compatibility path.
- Preview now returns an `applyBundle` containing deduplicated lifecycle stores plus only the changed application records whose metadata envelopes require rebasing, and the browser Preview → Apply path uses that apply plan instead of discarding envelope changes (`src/web/tracker/tracker.js`).
- Kept atomic, validated partial-import semantics by applying lifecycle stores and application-envelope updates together through the existing IndexedDB partial-import transaction; Preview remains side-effect-free and preview counts still report lifecycle-only records.
- Tests and browser integration added/extended: unit assertions for the browser-oriented apply plan and a Playwright regression test that exercises two sequential Preview→Apply imports, verifies byte-for-byte preservation of compact cells for the three regression labels and a control, checks persisted `raw_row`/`canonical_row`, and confirms a later manual interview supersedes the preserved raw cell (`test/web-spreadsheet-import-export.test.js`, `test/playwright/browser-tracker.spec.js`).

Files changed: `src/web/import-export/spreadsheet.js`, `src/web/tracker/tracker.js`, `test/web-spreadsheet-import-export.test.js`, `test/playwright/browser-tracker.spec.js`.

### Testing

- Formatting: `npx prettier --check src/web/import-export/spreadsheet.js src/web/tracker/tracker.js test/web-spreadsheet-import-export.test.js test/playwright/browser-tracker.spec.js` — passed.
- Lint: `npm run lint -- --quiet` — passed.
- Typecheck: `npm run typecheck` — passed.
- Unit tests: `npx vitest run test/web-spreadsheet-import-export.test.js test/web-storage-browser-data-migration.test.js test/web-tracker-metrics.test.js test/web-tracker-lifecycle-projection.test.js` — passed (focused suites, 135 tests in final focused run passed).
- Playwright: `npx playwright test test/playwright/browser-tracker.spec.js --grep "preserves compact stages through lifecycle preview and apply"` — Playwright regression passed locally (the added test passed).
- Full CI run: `npm run test:ci` was invoked during verification; the directly relevant spreadsheet/lifecycle tests passed, but a pre-existing long-running lifecycle diagram layout test previously timed out in one run (unrelated to this change) and may require increasing its timeout if it flakes in CI; this timeout is not caused by the supplemental-import changes.

Residual notes and risks: the change intentionally confines behavior to the supplemental-import planning/apply path and preserves legacy/compatibility behavior; Preview is still dry-run only and writes occur only on Apply. All added identities, URLs, and fixtures are sanitized. If CI reports the unrelated long-running layout test as flaky, consider a separate follow-up to increase its timeout or rework that test rather than blocking this focused fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7bc87a34d0832f8bea748e73f049b4)