### PR TITLE
Project reopen epochs into the lifecycle Sankey

### DIFF
--- a/docs/design/application-lifecycle-diagram.md
+++ b/docs/design/application-lifecycle-diagram.md
@@ -130,7 +130,8 @@ Projection rules:
 - Apply these aliases only to existing structured status and stage fields documented in `src/domain/browserApplication.js`; never infer milestones from free-form `stageLabel`, notes, company, role, or message text.
 - Unknown structured values produce no invented milestone and emit a deterministic warning.
 - Include only persisted milestones.
-- Collapse repeats so an application contributes a milestone at most once.
+- Collapse repeats within one lifecycle epoch. The same milestone may appear once again after an
+  explicit reopen boundary, while milestone totals retain per-application semantic counting.
 - Never invent skipped stages.
 - Sort milestones by fixed rank to keep the graph acyclic.
 - Preserve regressions in event details and warnings without drawing backward Sankey links.
@@ -166,6 +167,28 @@ Deterministic endpoint replay precedence:
 9. Otherwise, insufficient evidence projects to `unknown`.
 
 Assessment action `submitted`, `completed`, or `done` preserves the `assessment_take_home` milestone but is not “in progress.” Current replay must agree with `applications.status` or emit a warning.
+
+## Lifecycle epochs and reopen boundaries
+
+The projection remains one Sankey and one conserved unit per application. Epoch 0 begins at the
+existing origin. When an effective terminal outcome is followed by an explicit structured
+`application_reopened` event, that outcome becomes a historical-terminal node and the reopen starts
+the next epoch. A reopen without an active terminal creates no epoch and emits
+`reopen_without_terminal`; lower-stage activity without a reopen remains suppressed with
+`terminal_without_reopen`. Arbitrary backward links remain prohibited.
+
+Each epoch spans seven ranks: its anchor is `7e`, milestones are `7e + 1` through `7e + 5`, and its
+outcome is `7e + 6`. Epoch 0 retains `origin:<id>`, `milestone:<id>`, and—when there was no
+reopen—`endpoint:<id>`. Later nodes use `reopen:epoch:<e>:application_reopened`,
+`milestone:epoch:<e>:<id>`, and `endpoint:epoch:<e>:<id>`; completed epochs use
+`terminal:epoch:<e>:<id>`. Projection-node metadata supplies the semantic taxonomy ID, label, epoch,
+kind, and authoritative rank.
+
+Only the last node is the current endpoint, so endpoint totals never include historical terminal
+nodes. At a scrubber bucket before a reopen, the terminal is still the final endpoint; after the
+reopen it is reclassified as historical and the forward-only path continues. The DAG and
+conservation invariants require every path edge to increase rank and carry the application's same
+single unit through all epochs.
 
 Current-status agreement and `migration_status_snapshot` fallback use the exact table below. Event replay remains authoritative; this table is only for deterministic migration fallback and current-status agreement checks. Assessment progress must still require the assessment action evidence specified above.
 

--- a/docs/design/lifecycle-diagram-layout-algorithm.md
+++ b/docs/design/lifecycle-diagram-layout-algorithm.md
@@ -5,6 +5,17 @@ design contract (see [application-lifecycle-diagram.md](./application-lifecycle-
 that). This document exists so the next person debugging the solver — including a future instance
 of Claude — doesn't have to re-derive this from scratch.
 
+## Dynamic lifecycle-epoch ranks
+
+Projection-provided non-negative integer ranks are authoritative; ID-derived ranks remain only a
+compatibility fallback for legacy projections. The active maximum rank determines rank count,
+transition count, rank centers, and minimum SVG width using the existing 272-pixel center spacing
+and margins. Consequently the ordinary seven-rank graph is geometrically unchanged, while each
+explicit terminal/reopen cycle extends the same horizontally scrollable canvas by seven ranks.
+Skipped ranks still expand into adjacent, strictly forward private routing segments, and all
+crossing, collision, label-clearance, handle-placement, and route-audit constraints apply across
+the complete dynamic rank range.
+
 ## Why this file exists
 
 `lifecycleDiagramLayout.js` lays out the Sankey-style application lifecycle diagram: it places

--- a/src/web/tracker/lifecycleDiagram.js
+++ b/src/web/tracker/lifecycleDiagram.js
@@ -535,11 +535,15 @@ export function createLifecycleDiagramView(root, options = {}) {
             .filter((path) => path.nodeIds?.includes(feature.id))
             .map((path) => path.applicationId),
     );
+  const projectionNodeLabel = (id) =>
+    projection.nodes.find((node) => node.id === id)?.label ??
+    TAXONOMY.get(id)?.label ??
+    id;
   const featureById = (id) => {
     const branch = displayBranches.find((candidate) => candidate.id === id);
     if (branch) {
-      const from = TAXONOMY.get(branch.source)?.label ?? branch.source;
-      const to = TAXONOMY.get(branch.target)?.label ?? branch.target;
+      const from = projectionNodeLabel(branch.source);
+      const to = projectionNodeLabel(branch.target);
       const outcome =
         LIFECYCLE_DIAGRAM_TAXONOMY.endpoints.find(
           (endpoint) => endpoint.id === branch.endpointId,
@@ -600,8 +604,8 @@ export function createLifecycleDiagramView(root, options = {}) {
         ?.focus();
   };
   const branchLabelFor = (branch) => {
-    const from = TAXONOMY.get(branch.source)?.label ?? branch.source;
-    const to = TAXONOMY.get(branch.target)?.label ?? branch.target;
+    const from = projectionNodeLabel(branch.source);
+    const to = projectionNodeLabel(branch.target);
     const outcome =
       LIFECYCLE_DIAGRAM_TAXONOMY.endpoints.find(
         (endpoint) => endpoint.id === branch.endpointId,
@@ -1327,9 +1331,11 @@ export function createLifecycleDiagramView(root, options = {}) {
             width: Math.max(8, rawWidth),
             height: Math.max(8, rawHeight),
             rx: 4,
-            fill: node.id.startsWith("endpoint:")
-              ? endpointColor(node.id.split(":").at(-1))
-              : "#64748b",
+            fill:
+              node.id.startsWith("endpoint:") ||
+              node.id.startsWith("terminal:epoch:")
+                ? endpointColor(node.id.split(":").at(-1))
+                : "#64748b",
             stroke: selected ? "#F8FAFC" : "#e2e8f0",
             "stroke-width": selected ? "4" : "1",
           });
@@ -1457,8 +1463,8 @@ export function createLifecycleDiagramView(root, options = {}) {
     );
     const endpointRows = makeNodeRows(projection.totals.endpoints, "endpoint");
     const linkRows = displayBranches.map((branch) => {
-      const from = TAXONOMY.get(branch.source)?.label ?? branch.source;
-      const to = TAXONOMY.get(branch.target)?.label ?? branch.target;
+      const from = projectionNodeLabel(branch.source);
+      const to = projectionNodeLabel(branch.target);
       const outcome =
         LIFECYCLE_DIAGRAM_TAXONOMY.endpoints.find(
           (endpoint) => endpoint.id === branch.endpointId,

--- a/src/web/tracker/lifecycleDiagramLayout.js
+++ b/src/web/tracker/lifecycleDiagramLayout.js
@@ -50,7 +50,7 @@ export const MINIMUM_SVG_WIDTH =
 export const BRANCH_STROKE_OPACITY = 0.82;
 export const BRANCH_HANDLE_RADIUS = 22;
 
-const LIFECYCLE_RANKS = Object.freeze([0, 1, 2, 3, 4, 5, 6]);
+const BASELINE_RANK_COUNT = 7;
 const HANDLE_DIAGNOSTIC_TRANSITION_RANKS = Symbol(
   "handleDiagnosticTransitionRanks",
 );
@@ -60,7 +60,7 @@ export function createLifecycleHorizontalGeometry({
   rightMargin = LAYOUT_RIGHT_MARGIN,
   nodeWidth = SANKEY_NODE_WIDTH,
   rankCenters = Object.fromEntries(
-    LIFECYCLE_RANKS.map((rank) => [
+    Array.from({ length: BASELINE_RANK_COUNT }, (_, rank) => [
       rank,
       leftMargin + nodeWidth / 2 + rank * MINIMUM_RANK_CENTER_SPACING,
     ]),
@@ -70,16 +70,19 @@ export function createLifecycleHorizontalGeometry({
   minimumSvgWidth,
   handleRadius = BRANCH_HANDLE_RADIUS,
 } = {}) {
-  const rankKeys = Object.keys(rankCenters).sort();
+  const rankKeys = Object.keys(rankCenters).sort(
+    (a, b) => Number(a) - Number(b),
+  );
+  const ranks = Array.from({ length: rankKeys.length }, (_, rank) => rank);
   if (
-    rankKeys.length !== LIFECYCLE_RANKS.length ||
-    rankKeys.some((rank, index) => rank !== String(LIFECYCLE_RANKS[index]))
+    rankKeys.length < BASELINE_RANK_COUNT ||
+    rankKeys.some((rank, index) => rank !== String(index))
   )
     throw new Error(
-      "Lifecycle horizontal geometry rank centers must cover exactly ranks 0..6",
+      "Lifecycle horizontal geometry rank centers must cover contiguous ranks from 0",
     );
   const centers = {};
-  for (const rank of LIFECYCLE_RANKS) {
+  for (const rank of ranks) {
     const value = rankCenters[rank];
     if (!Number.isFinite(value))
       throw new Error(
@@ -91,10 +94,14 @@ export function createLifecycleHorizontalGeometry({
       );
     centers[rank] = value;
   }
+  const maximumRank = ranks.at(-1);
   const baselineWidth =
-    leftMargin + rightMargin + nodeWidth + 6 * MINIMUM_RANK_CENTER_SPACING;
+    leftMargin +
+    rightMargin +
+    nodeWidth +
+    maximumRank * MINIMUM_RANK_CENTER_SPACING;
   const leftOuterExtent = centers[0] - nodeWidth / 2;
-  const rightOuterExtent = centers[6] + nodeWidth / 2;
+  const rightOuterExtent = centers[maximumRank] + nodeWidth / 2;
   const svgWidth =
     minimumSvgWidth ?? Math.max(baselineWidth, rightOuterExtent + rightMargin);
   const scalars = {
@@ -121,7 +128,7 @@ export function createLifecycleHorizontalGeometry({
       "Lifecycle horizontal geometry SVG width does not cover every rank",
     );
   const hops = {};
-  for (let sourceRank = 0; sourceRank < 6; sourceRank += 1) {
+  for (let sourceRank = 0; sourceRank < maximumRank; sourceRank += 1) {
     const targetRank = sourceRank + 1;
     const sourceCenter = centers[sourceRank];
     const targetCenter = centers[targetRank];
@@ -527,6 +534,12 @@ export const nodeRank = (id) => {
   if (String(id).startsWith("endpoint:")) return 6;
   return MILESTONE_RANKS.get(id) ?? 1;
 };
+const projectionRankMap = (projection) =>
+  new Map(
+    (projection.nodes ?? [])
+      .filter((node) => Number.isInteger(node.rank) && node.rank >= 0)
+      .map((node) => [node.id, node.rank]),
+  );
 export const taxonomyOrder = (nodeId) =>
   TAXONOMY_BY_NODE_ID.get(nodeId)?.rank ?? 999;
 const taxonomyId = (nodeId) => TAXONOMY_BY_NODE_ID.get(nodeId)?.id ?? nodeId;
@@ -551,6 +564,7 @@ export const compareBranches = (a, b) =>
   compareLifecycleIds(a.id, b.id);
 
 export function buildLifecycleDisplayBranches(projection = {}) {
+  const ranks = projectionRankMap(projection);
   const pathByApp = new Map(
     (projection.paths ?? []).map((path) => [String(path.applicationId), path]),
   );
@@ -567,8 +581,8 @@ export function buildLifecycleDisplayBranches(projection = {}) {
     for (const [endpointId, applicationIds] of groups) {
       const sourceNodeId = link.source;
       const targetNodeId = link.target;
-      const sourceRank = nodeRank(sourceNodeId);
-      const targetRank = nodeRank(targetNodeId);
+      const sourceRank = ranks.get(sourceNodeId) ?? nodeRank(sourceNodeId);
+      const targetRank = ranks.get(targetNodeId) ?? nodeRank(targetNodeId);
       const semanticLinkId = link.id;
       const id = `branch:${semanticLinkId}:endpoint:${endpointId}`;
       const branch = {
@@ -648,7 +662,10 @@ export function buildLifecycleRoutingGraph(projection = {}) {
     nodes.set(node.id, {
       ...node,
       applicationIds: [...(node.applicationIds ?? [])],
-      rank: nodeRank(node.id),
+      rank:
+        Number.isInteger(node.rank) && node.rank >= 0
+          ? node.rank
+          : nodeRank(node.id),
       routing: false,
       weightedEndpointMedian: weightedMedianEndpoint(node.id, branches),
     });
@@ -726,14 +743,28 @@ export function calculateLifecycleDiagramLayout(
   projection,
   availableWidth,
   routingGraph,
-  horizontalGeometry = BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY,
+  horizontalGeometry,
 ) {
+  const graph = routingGraph ?? buildLifecycleRoutingGraph(projection);
+  const maximumRank = Math.max(6, ...graph.nodes.map((node) => node.rank));
+  horizontalGeometry ??=
+    maximumRank === 6
+      ? BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY
+      : createLifecycleHorizontalGeometry({
+          rankCenters: Object.fromEntries(
+            Array.from({ length: maximumRank + 1 }, (_, rank) => [
+              rank,
+              LAYOUT_LEFT_MARGIN +
+                SANKEY_NODE_WIDTH / 2 +
+                rank * MINIMUM_RANK_CENTER_SPACING,
+            ]),
+          ),
+        });
   const integerWidth = Math.floor(Number(availableWidth));
   const sanitizedWidth =
     Number.isFinite(integerWidth) && integerWidth > 0
       ? integerWidth
       : horizontalGeometry.svgWidth;
-  const graph = routingGraph ?? buildLifecycleRoutingGraph(projection);
   const rankCounts = new Map();
   for (const node of graph.nodes ?? []) {
     if (node.routing || Number(node.total) > 0 || Number(node.value) > 0) {
@@ -775,7 +806,7 @@ export function calculateLifecycleDiagramLayout(
         ].join(" "),
       );
     }
-    if (sourceRank < 0 || sourceRank >= 6) {
+    if (sourceRank < 0 || sourceRank >= maximumRank) {
       throw new Error(
         [
           "Lifecycle diagram layout invariant violated:",
@@ -949,8 +980,22 @@ function layoutLifecycleRoutingGraphPass(
   availableWidth,
   options = {},
 ) {
+  const graph = options.routingGraph ?? buildLifecycleRoutingGraph(projection);
+  const maximumRank = Math.max(6, ...graph.nodes.map((node) => node.rank));
   const horizontalGeometry =
-    options.horizontalGeometry ?? BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY;
+    options.horizontalGeometry ??
+    (maximumRank === 6
+      ? BASELINE_LIFECYCLE_HORIZONTAL_GEOMETRY
+      : createLifecycleHorizontalGeometry({
+          rankCenters: Object.fromEntries(
+            Array.from({ length: maximumRank + 1 }, (_, rank) => [
+              rank,
+              LAYOUT_LEFT_MARGIN +
+                SANKEY_NODE_WIDTH / 2 +
+                rank * MINIMUM_RANK_CENTER_SPACING,
+            ]),
+          ),
+        }));
   const enableTestDiagnostics = isLifecycleLayoutTestEnvironment();
   const explicitNodeOrderByRank =
     options.authoritativeNodeOrderByRank ??
@@ -958,7 +1003,6 @@ function layoutLifecycleRoutingGraphPass(
   const testOnlyDiagnosticSink = enableTestDiagnostics
     ? options.testOnlyDiagnosticSink
     : null;
-  const graph = options.routingGraph ?? buildLifecycleRoutingGraph(projection);
   // When nothing else supplies a base order, discovery's own first D3 pass
   // would otherwise use plain, rankOrder-blind nodeSort/linkSort at every
   // rank -- the gap documented in

--- a/src/web/tracker/lifecycleProjection.js
+++ b/src/web/tracker/lifecycleProjection.js
@@ -399,7 +399,8 @@ const projectApp = (app, appEvents, isCurrent) => {
     )
     .map((event) => event.time.sort);
   const origin = originFor(app, events, details);
-  const milestoneSet = new Set();
+  const epochs = [{ number: 0, milestones: new Set(), terminal: undefined }];
+  let epoch = epochs[0];
   let highestObservedMilestoneRank = -1;
   let terminal = undefined;
   let awaitingActive = false;
@@ -463,10 +464,23 @@ const projectApp = (app, appEvents, isCurrent) => {
         highestObservedMilestoneRank,
         rank,
       );
-      milestoneSet.add(milestone);
     }
     if (type === "application_reopened") {
+      if (!terminal) {
+        details.push(
+          makeWarning("reopen_without_terminal", app.id, { eventId: event.id }),
+        );
+        continue;
+      }
+      epoch.terminal = terminal;
+      epoch = {
+        number: epochs.length,
+        milestones: new Set(),
+        terminal: undefined,
+      };
+      epochs.push(epoch);
       terminal = undefined;
+      highestObservedMilestoneRank = -1;
       awaitingActive = true;
       interviewActive = false;
       assessmentActive = false;
@@ -485,6 +499,7 @@ const projectApp = (app, appEvents, isCurrent) => {
         );
       continue;
     }
+    if (milestone) epoch.milestones.add(milestone);
     if (TERMINAL_IDS.has(terminalEndpoint)) {
       if (
         event.time.kind === "unknown" &&
@@ -521,9 +536,9 @@ const projectApp = (app, appEvents, isCurrent) => {
         makeWarning("event_type_normalized", app.id, { eventId: event.id }),
       );
   }
-  const milestones = [...milestoneSet].sort(
-    (a, b) => (MILESTONE_RANK.get(a) ?? 0) - (MILESTONE_RANK.get(b) ?? 0),
-  );
+  const milestones = [
+    ...new Set(epochs.flatMap((item) => [...item.milestones])),
+  ].sort((a, b) => (MILESTONE_RANK.get(a) ?? 0) - (MILESTONE_RANK.get(b) ?? 0));
   const endpoint = endpointFromState();
   if (
     isCurrent &&
@@ -536,16 +551,77 @@ const projectApp = (app, appEvents, isCurrent) => {
         statusEndpoint: STATUS_ENDPOINT[normalize(app.status)],
       }),
     );
+  const pathNodes = [
+    {
+      id: `origin:${origin}`,
+      taxonomyId: origin,
+      label: ORIGINS.find(([id]) => id === origin)?.[1] ?? origin,
+      rank: 0,
+      kind: "origin",
+      epoch: 0,
+    },
+  ];
+  for (const item of epochs) {
+    if (item.number > 0)
+      pathNodes.push({
+        id: `reopen:epoch:${item.number}:application_reopened`,
+        taxonomyId: "application_reopened",
+        label: "Application reopened",
+        rank: item.number * 7,
+        kind: "reopen",
+        epoch: item.number,
+      });
+    for (const milestone of [...item.milestones].sort(
+      (a, b) => (MILESTONE_RANK.get(a) ?? 0) - (MILESTONE_RANK.get(b) ?? 0),
+    ))
+      pathNodes.push({
+        id:
+          item.number === 0
+            ? `milestone:${milestone}`
+            : `milestone:epoch:${item.number}:${milestone}`,
+        taxonomyId: milestone,
+        label: MILESTONES.find(([id]) => id === milestone)?.[1] ?? milestone,
+        rank: item.number * 7 + (MILESTONE_RANK.get(milestone) ?? 0) + 1,
+        kind: "milestone",
+        epoch: item.number,
+      });
+    if (item.terminal)
+      pathNodes.push({
+        id: `terminal:epoch:${item.number}:${item.terminal}`,
+        taxonomyId: item.terminal,
+        label:
+          ENDPOINTS.find(([id]) => id === item.terminal)?.[1] ?? item.terminal,
+        rank: item.number * 7 + 6,
+        kind: "historical-terminal",
+        epoch: item.number,
+      });
+  }
+  const finalEpoch = epochs.at(-1).number;
+  pathNodes.push({
+    id:
+      finalEpoch === 0
+        ? `endpoint:${endpoint}`
+        : `endpoint:epoch:${finalEpoch}:${endpoint}`,
+    taxonomyId: endpoint,
+    label: ENDPOINTS.find(([id]) => id === endpoint)?.[1] ?? endpoint,
+    rank: finalEpoch * 7 + 6,
+    kind: "endpoint",
+    epoch: finalEpoch,
+  });
   return {
     applicationId: app.id,
     origin,
     milestones,
     endpoint,
-    nodeIds: [
-      `origin:${origin}`,
-      ...milestones.map((id) => `milestone:${id}`),
-      `endpoint:${endpoint}`,
-    ],
+    epochs: epochs.map((item) => ({
+      number: item.number,
+      milestones: [...item.milestones].sort(
+        (a, b) => (MILESTONE_RANK.get(a) ?? 0) - (MILESTONE_RANK.get(b) ?? 0),
+      ),
+      terminal: item.terminal,
+    })),
+    pathNodes,
+    nodeIds: pathNodes.map((node) => node.id),
     details,
   };
 };
@@ -564,20 +640,12 @@ const makeNodes = (paths) => {
   for (const path of paths)
     for (const nodeId of path.nodeIds)
       totals.set(nodeId, (totals.get(nodeId) ?? 0) + 1);
-  const tax = [
-    ...LIFECYCLE_DIAGRAM_TAXONOMY.origins,
-    ...LIFECYCLE_DIAGRAM_TAXONOMY.milestones,
-    ...LIFECYCLE_DIAGRAM_TAXONOMY.endpoints,
-  ];
-  return tax
-    .filter((item) => totals.has(item.nodeId))
-    .map((item) => ({
-      id: item.nodeId,
-      taxonomyId: item.id,
-      label: item.label,
-      rank: item.rank,
-      total: totals.get(item.nodeId),
-    }));
+  const metadata = new Map(
+    paths.flatMap((path) => path.pathNodes.map((node) => [node.id, node])),
+  );
+  return [...totals.entries()]
+    .map(([id, total]) => ({ ...metadata.get(id), id, total }))
+    .sort((a, b) => a.rank - b.rank || codeCompare(a.id, b.id));
 };
 const makeLinks = (paths) => {
   const map = new Map();

--- a/src/web/tracker/lifecycleProjectionCache.js
+++ b/src/web/tracker/lifecycleProjectionCache.js
@@ -19,7 +19,7 @@ const FNV_SEED_B = 84696351;
 // Bump whenever timeline/projection semantics or their persisted shape changes.
 // This prevents a deployment from reading entries produced by incompatible
 // projection code while the user's source data remains unchanged.
-const PROJECTION_CACHE_VERSION = 1;
+const PROJECTION_CACHE_VERSION = 2;
 
 function fnv1a(input, seed) {
   let hash = seed >>> 0;

--- a/test/web-tracker-lifecycle-projection.test.js
+++ b/test/web-tracker-lifecycle-projection.test.js
@@ -65,6 +65,67 @@ const expectInvariants = (projection) => {
 };
 
 describe("lifecycle projection", () => {
+  it("projects an explicit terminal and reopen as forward lifecycle epochs", () => {
+    const input = bundle(
+      [app("epoch-app", { status: "recruiter_screen" })],
+      [
+        ev("01-submit", "epoch-app", "application_submitted", "2026-01-01"),
+        ev("02-reject", "epoch-app", "employer_rejected", "2026-01-02"),
+        ev("03-reopen", "epoch-app", "application_reopened", "2026-01-03"),
+        ev("04-screen", "epoch-app", "recruiter_screen", "2026-01-04"),
+      ],
+    );
+
+    const projection = projectLifecycleAt(input);
+    const path = projection.paths[0];
+    expect(path.nodeIds).toEqual([
+      "origin:application_submitted",
+      "terminal:epoch:0:employer_rejected",
+      "reopen:epoch:1:application_reopened",
+      "milestone:epoch:1:recruiter_screen",
+      "endpoint:epoch:1:interviewing",
+    ]);
+    expect(
+      projection.nodes.map(({ id, rank, label }) => ({ id, rank, label })),
+    ).toEqual([
+      {
+        id: "origin:application_submitted",
+        rank: 0,
+        label: "Application submitted",
+      },
+      {
+        id: "terminal:epoch:0:employer_rejected",
+        rank: 6,
+        label: "Employer rejected",
+      },
+      {
+        id: "reopen:epoch:1:application_reopened",
+        rank: 7,
+        label: "Application reopened",
+      },
+      {
+        id: "milestone:epoch:1:recruiter_screen",
+        rank: 8,
+        label: "Recruiter screen",
+      },
+      { id: "endpoint:epoch:1:interviewing", rank: 13, label: "Interviewing" },
+    ]);
+    expect(projection.links.every((link) => link.value === 1)).toBe(true);
+    expect(projection.totals.endpoints).toEqual({ interviewing: 1 });
+
+    const reopenWithoutTerminal = projectLifecycleAt(
+      bundle(
+        [app("invalid-reopen")],
+        [ev("reopen", "invalid-reopen", "application_reopened", "2026-02-01")],
+      ),
+    );
+    expect(reopenWithoutTerminal.paths[0].nodeIds).toEqual([
+      "origin:application_submitted",
+      "endpoint:unknown",
+    ]);
+    expect(reopenWithoutTerminal.warningCounts.reopen_without_terminal).toBe(1);
+  });
+
   it("exports the deeply frozen exact taxonomy", () => {
     expect(Object.isFrozen(LIFECYCLE_DIAGRAM_TAXONOMY.origins[0])).toBe(true);
     expect(LIFECYCLE_DIAGRAM_TAXONOMY.origins.map((x) => x.id)).toEqual([
@@ -274,7 +335,8 @@ describe("lifecycle projection", () => {
         shuffledBucketIds[i],
       ];
     }
-    for (const bucketId of shuffledBucketIds) projectLifecycleAt(liveBundle, bucketId);
+    for (const bucketId of shuffledBucketIds)
+      projectLifecycleAt(liveBundle, bucketId);
 
     // Sample buckets and compare the cache-exercised result against a
     // guaranteed-cold computation on a fresh, content-identical bundle


### PR DESCRIPTION
### Motivation
- Represent explicit terminal → reopen → resumed-history cycles as forward-only lifecycle epochs so rejected → reopened → interviewing history appears in the same Sankey path.
- Preserve existing taxonomy, labels, endpoint totals and DAG/conservation invariants while allowing multiple reopen cycles (not limited to one).
- Keep layout geometry and spacing unchanged for the common seven-rank case but allow projection-driven dynamic ranks for extended epochs.

### Description
- Implemented epoch-aware projection in `src/web/tracker/lifecycleProjection.js`, splitting an application's history into epochs, emitting epoch-aware node IDs (`terminal:epoch:…`, `reopen:epoch:…`, `milestone:epoch:…`, `endpoint:epoch:…`), and adding deterministic `reopen_without_terminal` warnings; preserved original seven-rank node IDs for non-reopen paths and retained per-application semantic totals. (See new `epochs`, `pathNodes`, and `nodeIds` construction.)
- Made layout rank-aware and dynamic in `src/web/tracker/lifecycleDiagramLayout.js` by parameterizing rank centers and geometry; introduced `BASELINE_RANK_COUNT` and logic to construct rank centers for arbitrary contiguous ranks while preserving the original spacing and dimensions for seven ranks.
- Resolved user-facing labels and endpoint coloring from projection node metadata in `src/web/tracker/lifecycleDiagram.js` so epoch-aware IDs never surface to users and historical terminals render with endpoint colors while reopen anchors remain visually neutral.
- Bumped `PROJECTION_CACHE_VERSION` from `1` to `2` in `src/web/tracker/lifecycleProjectionCache.js` so older cached projections are invalidated on deploy.
- Added deterministic unit tests and fixtures in `test/web-tracker-lifecycle-projection.test.js` to assert the required submitted → rejected → reopened → recruiter-screen → interviewing path, exact epoch-aware IDs/ranks/labels, endpoint totals, and `reopen_without_terminal` behavior.
- Updated documentation to describe lifecycle epochs, epoch-aware IDs and ranks, reopen boundaries, and dynamic-rank layout behavior in `docs/design/application-lifecycle-diagram.md` and `docs/design/lifecycle-diagram-layout-algorithm.md`.

### Testing
- Ran focused unit suites and tooling locally: `npx vitest run test/web-tracker-lifecycle-projection.test.js` (35 tests) — passed; `npx vitest run test/web-tracker-lifecycle-projection.test.js test/web-tracker-lifecycle-projection-cache.test.js` — passed; `npx vitest run test/web-tracker-lifecycle-projection.test.js test/web-tracker-lifecycle-projection-cache.test.js --reporter=verbose` — passed; `npx vitest run test/web-tracker-lifecycle-diagram.test.js test/web-tracker-lifecycle-diagram-layout.test.js test/web-tracker-lifecycle-diagram-performance.test.js` and individual diagram/layout suites — passed (layout suite exercised dynamic-rank geometry and preserved invariants).
- Lint/typecheck/build/format checks run: `npm run lint -- --quiet` — passed; `npm run typecheck` — passed; `npm run build` — passed; `npx prettier --check` on changed files — passed; `git diff --check` — no issues.
- Test summary: all modified-file-focused Vitest suites passed (projection, projection-cache, diagram, and layout tests exercised and green in local runs reported in the transcript).
- Notes/limits: pushing branch / creating GitHub PR failed in this environment due to missing GitHub authentication (`gh auth login` / `GH_TOKEN` required); the change was committed locally (commit `1beb9e9`).

Residual risks & follow-ups
- The change keeps the existing routing/handle solver untouched but increases dynamic rank span; please run full CI/Playwright visual-review on CI (GH Actions) to produce the diagram visual artifacts and confirm end-to-end rendering in a browser environment.
- Cache bump is intentional; any persisted client projections from older versions will be invalidated on upgrade.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d04f62a3c832f9bde6cb511fb1eb3)